### PR TITLE
Check potential fields.epr.yml for modules

### DIFF
--- a/dev/import-beats/docs.go
+++ b/dev/import-beats/docs.go
@@ -73,8 +73,8 @@ func renderExportedFields(packageDataset string, datasets datasetContentArray) (
 
 func collectFields(content fieldsContent) ([]fieldsTableRecord, error) {
 	var records []fieldsTableRecord
-	for fileName, fieldsFile := range content.files {
-		r, err := collectFieldsFromFile(fileName, fieldsFile)
+	for _, fieldsFile := range content.files {
+		r, err := collectFieldsFromFile(fieldsFile)
 		if err != nil {
 			return nil, errors.Wrapf(err, "collecting fields from file failed")
 		}
@@ -99,13 +99,10 @@ func uniqueTableRecords(records []fieldsTableRecord) []fieldsTableRecord {
 	return unique
 }
 
-func collectFieldsFromFile(fileName string, fieldDefinitions []fieldDefinition) ([]fieldsTableRecord, error) {
+func collectFieldsFromFile(fieldDefinitions []fieldDefinition) ([]fieldsTableRecord, error) {
 	var records []fieldsTableRecord
 
 	root := fieldDefinitions
-	if isPackageFields(fileName) {
-		root = fieldDefinitions[0].Fields
-	}
 
 	var err error
 	for _, f := range root {

--- a/dev/import-beats/fields.go
+++ b/dev/import-beats/fields.go
@@ -102,24 +102,29 @@ func loadEcsFields(ecsDir string) ([]fieldDefinition, error) {
 	return fs[0].Fields, nil
 }
 
-func loadModuleFields(modulePath string) ([]fieldDefinition, error) {
+func loadModuleFields(modulePath string) ([]fieldDefinition, string, error) {
 	path := filepath.Join(modulePath, "_meta", "fields.yml")
 	fs, err := loadFieldsFile(path)
 	if err != nil {
-		return nil, errors.Wrapf(err, "loading module fields file failed")
+		return nil, "", errors.Wrapf(err, "loading module fields file failed")
 	}
 	if len(fs) != 1 {
-		return nil, errors.Wrapf(err, "expected single root field")
+		return nil, "", errors.Wrapf(err, "expected single root field")
 	}
+
+	title := fs[0].Title
+
+	var unwrapped []fieldDefinition
+	unwrapped = append(unwrapped, fs[0].Fields...)
 
 	fieldsEpr := filepath.Join(modulePath, "_meta", "fields.epr.yml")
 	efs, err := loadFieldsFile(fieldsEpr)
 	if err != nil {
-		return nil, errors.Wrapf(err, "loading fields.epr.yml file failed")
+		return nil, "", errors.Wrapf(err, "loading fields.epr.yml file failed")
 	}
 
-	fs = append(fs, efs...)
-	return fs, nil
+	unwrapped = append(unwrapped, efs...)
+	return unwrapped, title, nil
 }
 
 func loadDatasetFields(modulePath, moduleName, datasetName string) ([]fieldDefinition, error) {

--- a/dev/import-beats/fields.go
+++ b/dev/import-beats/fields.go
@@ -111,6 +111,14 @@ func loadModuleFields(modulePath string) ([]fieldDefinition, error) {
 	if len(fs) != 1 {
 		return nil, errors.Wrapf(err, "expected single root field")
 	}
+
+	fieldsEpr := filepath.Join(modulePath, "_meta", "fields.epr.yml")
+	efs, err := loadFieldsFile(fieldsEpr)
+	if err != nil {
+		return nil, errors.Wrapf(err, "loading fields.epr.yml file failed")
+	}
+
+	fs = append(fs, efs...)
 	return fs, nil
 }
 

--- a/dev/import-beats/packages.go
+++ b/dev/import-beats/packages.go
@@ -146,7 +146,7 @@ func (r *packageRepository) createPackagesFromSource(beatsDir, beatName, beatTyp
 		manifest.Categories = append(manifest.Categories, beatType)
 
 		// fields
-		moduleFields, err := loadModuleFields(modulePath)
+		moduleFields, maybeTitle, err := loadModuleFields(modulePath)
 		if err != nil {
 			return err
 		}
@@ -156,7 +156,6 @@ func (r *packageRepository) createPackagesFromSource(beatsDir, beatName, beatTyp
 		}
 
 		// title
-		maybeTitle := moduleFields[0].Title
 		if maybeTitle != "" {
 			manifest.Title = &maybeTitle
 			manifest.Description = maybeTitle + " Integration"
@@ -319,14 +318,7 @@ func (r *packageRepository) save(outputDir string) error {
 					fieldsFilePath := filepath.Join(datasetFieldsPath, fieldsFileName)
 					var fieldsFile []byte
 
-					var root fieldDefinitionArray
-					if isPackageFields(fieldsFileName) { // remove the wrapping layer
-						root = definitions[0].Fields
-					} else {
-						root = definitions
-					}
-
-					stripped := root.stripped()
+					stripped := definitions.stripped()
 					fieldsFile, err := yaml.Marshal(&stripped)
 					if err != nil {
 						return errors.Wrapf(err, "marshalling fields file failed (path: %s)", fieldsFilePath)


### PR DESCRIPTION
This PR modifies the import-beats script for visit potential `fields.epr.yml` files.

If there are some ECS fields referred, the script can import them to fields.

Sample fields.epr.yml for aws:

```
- name: cloud.account.name
  type: alias
  path: cloud.account.name
- name: cloud.account.id
  type: alias
  path: cloud.account.id
- name: cloud.provider
  type: alias
  path: cloud.provider
- name: cloud.region
  type: alias
  path: cloud.region
```