### PR TITLE
Fix: packages path

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -40,4 +40,4 @@ services:
       retries: 300
       interval: 1s
     volumes:
-      - ../../public:/go/src/github.com/elastic/package-registry/public
+      - ../../public:/registry/public


### PR DESCRIPTION
This PR fixes the issue with changed path to the `/registry` installation in the Docker image.