### PR TITLE
Fix issues with dashboards

### DIFF
--- a/packages/mysql/dataset/slowlog/fields/fields.yml
+++ b/packages/mysql/dataset/slowlog/fields/fields.yml
@@ -178,3 +178,7 @@
       type: long
       description: |
         Approximated count of pages accessed to execute the query.
+- name: event.duration
+  type: long
+  input_format: nanoseconds
+  description: Duration of the event in nanoseconds.

--- a/packages/mysql/kibana/search/Logs-MySQL-Slow-log-ecs.json
+++ b/packages/mysql/kibana/search/Logs-MySQL-Slow-log-ecs.json
@@ -19,37 +19,11 @@
                             "key": "query",
                             "negate": false,
                             "type": "custom",
-                            "value": "{\"prefix\":{\"stream.dataset\":\"mysql.\"}}"
+                            "value": "{\"prefix\":{\"stream.dataset\":\"mysql.slowlog\"}}"
                         },
                         "query": {
                             "prefix": {
-                                "stream.dataset": "mysql."
-                            }
-                        }
-                    },
-                    {
-                        "$state": {
-                            "store": "appState"
-                        },
-                        "meta": {
-                            "alias": null,
-                            "disabled": false,
-                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[1].meta.index",
-                            "key": "fileset.name",
-                            "negate": false,
-                            "params": {
-                                "query": "slowlog",
-                                "type": "phrase"
-                            },
-                            "type": "phrase",
-                            "value": "slowlog"
-                        },
-                        "query": {
-                            "match": {
-                                "fileset.name": {
-                                    "query": "slowlog",
-                                    "type": "phrase"
-                                }
+                                "stream.dataset": "mysql.slowlog"
                             }
                         }
                     }

--- a/packages/mysql/kibana/search/Logs-MySQL-Slow-log-ecs.json
+++ b/packages/mysql/kibana/search/Logs-MySQL-Slow-log-ecs.json
@@ -14,15 +14,17 @@
                         },
                         "meta": {
                             "alias": null,
-                            "disabled": false,
-                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                            "key": "query",
                             "negate": false,
-                            "type": "custom",
-                            "value": "{\"prefix\":{\"stream.dataset\":\"mysql.slowlog\"}}"
+                            "disabled": false,
+                            "type": "phrase",
+                            "key": "stream.dataset",
+                            "params": {
+                                "query": "mysql.slowlog"
+                            },
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index"
                         },
                         "query": {
-                            "prefix": {
+                            "match_phrase": {
                                 "stream.dataset": "mysql.slowlog"
                             }
                         }

--- a/packages/mysql/kibana/search/Logs-MySQL-error-log-ecs.json
+++ b/packages/mysql/kibana/search/Logs-MySQL-error-log-ecs.json
@@ -15,15 +15,17 @@
                         },
                         "meta": {
                             "alias": null,
-                            "disabled": false,
-                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                            "key": "query",
                             "negate": false,
-                            "type": "custom",
-                            "value": "{\"prefix\":{\"stream.dataset\":\"mysql.error\"}}"
+                            "disabled": false,
+                            "type": "phrase",
+                            "key": "stream.dataset",
+                            "params": {
+                                "query": "mysql.error"
+                            },
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index"
                         },
                         "query": {
-                            "prefix": {
+                            "match_phrase": {
                                 "stream.dataset": "mysql.error"
                             }
                         }

--- a/packages/mysql/kibana/search/Logs-MySQL-error-log-ecs.json
+++ b/packages/mysql/kibana/search/Logs-MySQL-error-log-ecs.json
@@ -20,37 +20,11 @@
                             "key": "query",
                             "negate": false,
                             "type": "custom",
-                            "value": "{\"prefix\":{\"stream.dataset\":\"mysql.\"}}"
+                            "value": "{\"prefix\":{\"stream.dataset\":\"mysql.error\"}}"
                         },
                         "query": {
                             "prefix": {
-                                "stream.dataset": "mysql."
-                            }
-                        }
-                    },
-                    {
-                        "$state": {
-                            "store": "appState"
-                        },
-                        "meta": {
-                            "alias": null,
-                            "disabled": false,
-                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[1].meta.index",
-                            "key": "fileset.name",
-                            "negate": false,
-                            "params": {
-                                "query": "error",
-                                "type": "phrase"
-                            },
-                            "type": "phrase",
-                            "value": "error"
-                        },
-                        "query": {
-                            "match": {
-                                "fileset.name": {
-                                    "query": "error",
-                                    "type": "phrase"
-                                }
+                                "stream.dataset": "mysql.error"
                             }
                         }
                     }

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: mysql
 title: MySQL
-version: 0.1.1
+version: 0.1.2
 license: basic
 description: MySQL Integration
 type: integration

--- a/packages/nginx/dataset/access/fields/fields.yml
+++ b/packages/nginx/dataset/access/fields/fields.yml
@@ -9,3 +9,6 @@
     type: group
   - name: geoip
     type: group
+- name: event.created
+  type: date
+  description: Date/time when the event was first read by an agent, or by your pipeline.

--- a/packages/nginx/dataset/access/fields/fields.yml
+++ b/packages/nginx/dataset/access/fields/fields.yml
@@ -12,3 +12,9 @@
 - name: event.created
   type: date
   description: Date/time when the event was first read by an agent, or by your pipeline.
+- name: user_agent.os.version
+  type: keyword
+  description: Operating system version as a raw string.
+- name: user_agent.version
+  type: keyword
+  description: Version of the user agent.

--- a/packages/nginx/dataset/error/fields/fields.yml
+++ b/packages/nginx/dataset/error/fields/fields.yml
@@ -5,3 +5,6 @@
     type: long
     description: |
       Connection identifier.
+- name: event.created
+  type: date
+  description: Date/time when the event was first read by an agent, or by your pipeline.

--- a/packages/nginx/dataset/ingress_controller/fields/fields.yml
+++ b/packages/nginx/dataset/ingress_controller/fields/fields.yml
@@ -53,3 +53,6 @@
     type: group
   - name: geoip
     type: group
+- name: event.created
+  type: date
+  description: Date/time when the event was first read by an agent, or by your pipeline.

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: nginx
 title: Nginx
-version: 0.1.1
+version: 0.1.2
 license: basic
 description: Nginx Integration
 type: integration

--- a/packages/redis/dataset/info/fields/fields.yml
+++ b/packages/redis/dataset/info/fields/fields.yml
@@ -450,3 +450,9 @@
     type: long
     description: |
       Count of slow operations
+- name: service.address
+  type: keyword
+  description: Client address
+- name: service.version
+  type: keyword
+  description: Version of the service the data was collected from

--- a/packages/redis/dataset/log/fields/fields.yml
+++ b/packages/redis/dataset/log/fields/fields.yml
@@ -5,3 +5,6 @@
     type: keyword
     description: |
       The role of the Redis instance. Can be one of `master`, `slave`, `child` (for RDF/AOF writing child), or `sentinel`.
+- name: event.created
+  type: date
+  description: Date/time when the event was first read by an agent, or by your pipeline.

--- a/packages/redis/dataset/slowlog/fields/fields.yml
+++ b/packages/redis/dataset/slowlog/fields/fields.yml
@@ -21,3 +21,6 @@
     type: keyword
     description: |
       The arguments with which the command was called.
+- name: event.created
+  type: date
+  description: Date/time when the event was first read by an agent, or by your pipeline.

--- a/packages/redis/dataset/slowlog/manifest.yml
+++ b/packages/redis/dataset/slowlog/manifest.yml
@@ -11,7 +11,7 @@ streams:
     required: true
     show_user: true
     default:
-    - localhost:6379
+    - 127.0.0.1:6379
   - name: password
     type: password
     title: Password

--- a/packages/redis/kibana/search/73613570-4791-11e7-be88-2ddb32f3df97-ecs.json
+++ b/packages/redis/kibana/search/73613570-4791-11e7-be88-2ddb32f3df97-ecs.json
@@ -22,37 +22,11 @@
                             "key": "query",
                             "negate": false,
                             "type": "custom",
-                            "value": "{\"prefix\":{\"stream.dataset\":\"redis.\"}}"
+                            "value": "{\"prefix\":{\"stream.dataset\":\"redis.log\"}}"
                         },
                         "query": {
                             "prefix": {
-                                "stream.dataset": "redis."
-                            }
-                        }
-                    },
-                    {
-                        "$state": {
-                            "store": "appState"
-                        },
-                        "meta": {
-                            "alias": null,
-                            "disabled": false,
-                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[1].meta.index",
-                            "key": "fileset.name",
-                            "negate": false,
-                            "params": {
-                                "query": "log",
-                                "type": "phrase"
-                            },
-                            "type": "phrase",
-                            "value": "log"
-                        },
-                        "query": {
-                            "match": {
-                                "fileset.name": {
-                                    "query": "log",
-                                    "type": "phrase"
-                                }
+                                "stream.dataset": "redis.log"
                             }
                         }
                     }

--- a/packages/redis/kibana/search/73613570-4791-11e7-be88-2ddb32f3df97-ecs.json
+++ b/packages/redis/kibana/search/73613570-4791-11e7-be88-2ddb32f3df97-ecs.json
@@ -17,15 +17,17 @@
                         },
                         "meta": {
                             "alias": null,
-                            "disabled": false,
-                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                            "key": "query",
                             "negate": false,
-                            "type": "custom",
-                            "value": "{\"prefix\":{\"stream.dataset\":\"redis.log\"}}"
+                            "disabled": false,
+                            "type": "phrase",
+                            "key": "stream.dataset",
+                            "params": {
+                                "query": "redis.log"
+                            },
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index"
                         },
                         "query": {
-                            "prefix": {
+                            "match_phrase": {
                                 "stream.dataset": "redis.log"
                             }
                         }

--- a/packages/redis/manifest.yml
+++ b/packages/redis/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: redis
 title: Redis
-version: 0.1.1
+version: 0.1.2
 license: basic
 description: Redis Integration
 type: integration


### PR DESCRIPTION
Changes:

* this PR removes references to `fileset`, which apparently is a leftover skipped by the migration.
* added missing `event.created` fields which are used by these dashboards.
* redis: use `127.0.0.1` instead of `localhost`
* mysql: add `event.duration` field
* redis: add `service.address` and `service.duration` fields

Issues:
https://github.com/elastic/kibana/issues/68064