### PR TITLE
Update dependency to only validate fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/elastic/package-registry v0.4.1-0.20200603074902-1b2782f80261
+	github.com/elastic/package-registry v0.4.1-0.20200604092407-21cd9e458fcf
 	github.com/magefile/mage v1.9.0
 	github.com/pkg/errors v0.9.1
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -6,9 +6,11 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/elastic/go-ucfg v0.8.4-0.20200415140258-1232bd4774a6 h1:Ehbr7du4rSSEypR8zePr0XRbMhO4PJgcHC9f8fDbgAg=
 github.com/elastic/go-ucfg v0.8.4-0.20200415140258-1232bd4774a6/go.mod h1:iaiY0NBIYeasNgycLyTvhJftQlQEUO2hpF+FX0JKxzo=
-github.com/elastic/package-registry v0.4.1-0.20200603074902-1b2782f80261 h1:MV7BeARXDw9oUNXelvZvmtVJADZlVjZ8NtzrLYMcNfo=
-github.com/elastic/package-registry v0.4.1-0.20200603074902-1b2782f80261/go.mod h1:na9XU9OeCK7NOcsrpKxtKHgXdysHUJpq4Dam7EgvpyE=
+github.com/elastic/package-registry v0.4.1-0.20200604092407-21cd9e458fcf h1:ppkJJKf9guPKNRK4BEm97a0lwlhXaFQAWFfKAm94iw8=
+github.com/elastic/package-registry v0.4.1-0.20200604092407-21cd9e458fcf/go.mod h1:na9XU9OeCK7NOcsrpKxtKHgXdysHUJpq4Dam7EgvpyE=
+github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 h1:rp+c0RAYOWj8l6qbCUTSiRLG/iKnW3K3/QfPPuSsBt4=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9688Y0wesXCyonoVr47MasHilkuLMqGhRZ4Hpak=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/magefile/mage v1.9.0 h1:t3AU2wNwehMCW97vuqQLtw6puppWXHO+O2MHo5a50XE=

--- a/packages/log/dataset/log/fields/base-fields.yml
+++ b/packages/log/dataset/log/fields/base-fields.yml
@@ -1,0 +1,16 @@
+- name: stream.type
+  type: constant_keyword
+  description: >
+    Stream type
+- name: stream.dataset
+  type: constant_keyword
+  description: >
+    Stream dataset.
+- name: stream.namespace
+  type: constant_keyword
+  description: >
+    Stream namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9,7 +9,7 @@ github.com/blang/semver
 github.com/elastic/go-ucfg
 github.com/elastic/go-ucfg/parse
 github.com/elastic/go-ucfg/yaml
-# github.com/elastic/package-registry v0.4.1-0.20200603074902-1b2782f80261
+# github.com/elastic/package-registry v0.4.1-0.20200604092407-21cd9e458fcf
 github.com/elastic/package-registry/util
 # github.com/magefile/mage v1.9.0
 github.com/magefile/mage/mg


### PR DESCRIPTION
This PR bumps up the dependency on package-registry to only validate presence of base fields.

Also adding a missing file (`log` integration).