### PR TITLE
Fix: handle mod error

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -226,12 +226,12 @@ func Vendor() error {
 		return err
 	}
 
-	sh.RunV("go", "mod", "vendor")
+	err = sh.RunV("go", "mod", "vendor")
 	if err != nil {
 		return err
 	}
 
-	sh.RunV("go", "mod", "verify")
+	err = sh.RunV("go", "mod", "verify")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR fixes `magefile.go` to not ignore errors coming from `go mod`.