### PR TITLE
import-beats: create base fields

### DIFF
--- a/dev/import-beats/datasets.go
+++ b/dev/import-beats/datasets.go
@@ -100,6 +100,8 @@ func createDatasets(beatType, modulePath, moduleName, moduleTitle string, module
 		if len(datasetFields) > 0 {
 			fieldsFiles["fields.yml"] = datasetFields
 		}
+		fieldsFiles["base-fields.yml"] = baseFields
+
 		fields := fieldsContent{
 			files: fieldsFiles,
 		}

--- a/dev/import-beats/fields_base_fields.go
+++ b/dev/import-beats/fields_base_fields.go
@@ -1,0 +1,32 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package main
+
+var baseFields = createBaseFields()
+
+func createBaseFields() []fieldDefinition {
+	return []fieldDefinition{
+		{
+			Name:        "stream.type",
+			Type:        "constant_keyword",
+			Description: "Stream type.",
+		},
+		{
+			Name:        "stream.dataset",
+			Type:        "constant_keyword",
+			Description: "Stream dataset.",
+		},
+		{
+			Name:        "stream.namespace",
+			Type:        "constant_keyword",
+			Description: "Stream namespace.",
+		},
+		{
+			Name:        "@timestamp",
+			Type:        "date",
+			Description: "Event timestamp.",
+		},
+	}
+}


### PR DESCRIPTION
Issue: https://github.com/elastic/package-registry/issues/465#issuecomment-633831298

import-beats: create `base-fields.yml` files for each dataset

Testing:

I used `haproxy` integration for development, but didn't pull it in for clarity.

```
$ PACKAGES=haproxy mage ImportBeats
$ find packages/haproxy | grep base-fields
packages/haproxy/dataset/info/fields/base-fields.yml
packages/haproxy/dataset/stat/fields/base-fields.yml
packages/haproxy/dataset/log/fields/base-fields.yml
$ cat packages/haproxy/dataset/info/fields/base-fields.yml
- name: stream.type
  type: constant_keyword
  description: Stream type.
- name: stream.dataset
  type: constant_keyword
  description: Stream dataset.
- name: stream.namespace
  type: constant_keyword
  description: Stream namespace.
- name: '@timestamp'
  type: date
  description: Event timestamp.
```