### PR TITLE
Release integration only on version bump

### DIFF
--- a/dev/update-package-storage/git.go
+++ b/dev/update-package-storage/git.go
@@ -41,15 +41,6 @@ func addToIndex(err error, options updateOptions, packageName, packageVersion st
 	return runGitCommand(options, "add", "--all", filepath.Join("packages", packageName, packageVersion))
 }
 
-func checkIfEmptyIndex(err error, options updateOptions) (bool, error) {
-	if err != nil {
-		return false, err
-	}
-
-	exitCode := runGitCommand(options, "diff", "--cached", "--exit-code")
-	return sh.ExitStatus(exitCode) != 1, nil
-}
-
 func createBranch(err error, options updateOptions, packageName, packageVersion string) (string, error) {
 	if err != nil {
 		return "", err
@@ -60,12 +51,12 @@ func createBranch(err error, options updateOptions, packageName, packageVersion 
 	return branchName, err
 }
 
-func commitChanges(err error, options updateOptions, packageName, packageVersion string) error {
+func commitChanges(err error, options updateOptions, message string) error {
 	if err != nil {
 		return err
 	}
 
-	return runGitCommand(options, "commit", "-m", fmt.Sprintf(`Update "%s" integration (version: %s)`, packageName, packageVersion))
+	return runGitCommand(options, "commit", "-m", message)
 }
 
 func pushChanges(err error, options updateOptions, branchName string) error {

--- a/dev/update-package-storage/main.go
+++ b/dev/update-package-storage/main.go
@@ -52,6 +52,11 @@ func handlePackageChanges(err error, options updateOptions, packageName string) 
 
 	packageVersion, err := detectPackageVersion(err, options, packageName)
 	err = checkoutMasterBranch(err, options)
+	released, err := checkIfPackageReleased(err, options, packageName, packageVersion)
+	if released {
+		return nil
+	}
+
 	err = copyIntegrationToPackageStorage(err, options, packageName, packageVersion)
 	err = addToIndex(err, options, packageName, packageVersion)
 	empty, err := checkIfEmptyIndex(err, options)

--- a/dev/update-package-storage/packages.go
+++ b/dev/update-package-storage/packages.go
@@ -66,6 +66,22 @@ func loadManifestFile(packageName string, options updateOptions) (*manifest, err
 	err = yaml.Unmarshal(body, &m)
 	return &m, err
 }
+
+func checkIfPackageReleased(err error, options updateOptions, packageName, packageVersion string) (bool, error) {
+	if err != nil {
+		return false, err
+	}
+
+	destinationPath := filepath.Join(options.packageStorageDir, "packages", packageName, packageVersion)
+	_, err = os.Stat(destinationPath)
+	if os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func copyIntegrationToPackageStorage(err error, options updateOptions, packageName, packageVersion string) error {
 	if err != nil {
 		return err
@@ -73,11 +89,6 @@ func copyIntegrationToPackageStorage(err error, options updateOptions, packageNa
 
 	sourcePath := filepath.Join(options.packagesSourceDir, packageName)
 	destinationPath := filepath.Join(options.packageStorageDir, "packages", packageName, packageVersion)
-	err = os.RemoveAll(destinationPath)
-	if err != nil {
-		return err
-	}
-
 	err = os.MkdirAll(destinationPath, 0755)
 	if err != nil {
 		return err


### PR DESCRIPTION
Issue: https://github.com/elastic/integrations/issues/45

This PR modifies `mage UpdatePackageStorage` to create branches with updates if only the version is bumped up.

Testing:

I created this PR https://github.com/elastic/package-storage/pull/50 , because the version of `aws` integration has been bumped up.