### PR TITLE
Filter by stream.dataset in kafka logs dashboard

### DIFF
--- a/packages/kafka/kibana/search/All Kafka logs-ecs.json
+++ b/packages/kafka/kibana/search/All Kafka logs-ecs.json
@@ -18,7 +18,7 @@
                             "alias": null,
                             "disabled": false,
                             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                            "key": "stream.dataset",
+                            "key": "dataset.name",
                             "negate": false,
                             "params": {
                                 "query": "kafka.log",
@@ -29,7 +29,7 @@
                         },
                         "query": {
                             "match": {
-                                "stream.dataset": {
+                                "dataset.name": {
                                     "query": "kafka.log",
                                     "type": "phrase"
                                 }

--- a/packages/kafka/kibana/search/All Kafka logs-ecs.json
+++ b/packages/kafka/kibana/search/All Kafka logs-ecs.json
@@ -18,31 +18,10 @@
                             "alias": null,
                             "disabled": false,
                             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                            "key": "query",
-                            "negate": false,
-                            "type": "custom",
-                            "value": "{\"match_phrase_prefix\":{\"stream.dataset\":{\"query\":\"kafka.\"}}}"
-                        },
-                        "query": {
-                            "match_phrase_prefix": {
-                                "stream.dataset": {
-                                    "query": "kafka."
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "$state": {
-                            "store": "appState"
-                        },
-                        "meta": {
-                            "alias": null,
-                            "disabled": false,
-                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[1].meta.index",
-                            "key": "fileset.name",
+                            "key": "stream.dataset",
                             "negate": false,
                             "params": {
-                                "query": "log",
+                                "query": "kafka.log",
                                 "type": "phrase"
                             },
                             "type": "phrase",
@@ -50,8 +29,8 @@
                         },
                         "query": {
                             "match": {
-                                "fileset.name": {
-                                    "query": "log",
+                                "stream.dataset": {
+                                    "query": "kafka.log",
                                     "type": "phrase"
                                 }
                             }
@@ -86,11 +65,6 @@
         {
             "id": "logs-*",
             "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
-            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[1].meta.index",
             "type": "index-pattern"
         }
     ],


### PR DESCRIPTION
Kafka logs dashboard is not displaying any data, it seems to be using incorrect fields for filtering. Use `stream.dataset` instead of `fileset.name`.