### PR TITLE
Update packages to release stream-to-dataset renaming

### DIFF
--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 0.1.0
+version: 0.1.1
 license: basic
 description: AWS Integration
 type: integration

--- a/packages/cisco/manifest.yml
+++ b/packages/cisco/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco
 title: Cisco
-version: 0.1.1
+version: 0.1.2
 license: basic
 description: Cisco Integration
 type: integration

--- a/packages/kafka/manifest.yml
+++ b/packages/kafka/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kafka
 title: Kafka
-version: 0.1.0
+version: 0.1.1
 license: basic
 description: Kafka Integration
 type: integration

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: mysql
 title: MySQL
-version: 0.1.2
+version: 0.1.3
 license: basic
 description: MySQL Integration
 type: integration

--- a/packages/netflow/manifest.yml
+++ b/packages/netflow/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: netflow
 title: NetFlow
-version: 0.1.0
+version: 0.1.1
 license: basic
 description: NetFlow Integration
 type: integration

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: nginx
 title: Nginx
-version: 0.1.2
+version: 0.1.3
 license: basic
 description: Nginx Integration
 type: integration

--- a/packages/redis/manifest.yml
+++ b/packages/redis/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: redis
 title: Redis
-version: 0.1.2
+version: 0.1.3
 license: basic
 description: Redis Integration
 type: integration


### PR DESCRIPTION
This PR bumps up versions of multiple integrations to release all changes related to a massive fields rename (from `stream.*` to `dataset.*`).