### PR TITLE
Remove empty package-fields.yml files

### DIFF
--- a/packages/cisco/dataset/asa/fields/package-fields.yml
+++ b/packages/cisco/dataset/asa/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: cisco
-  type: group

--- a/packages/cisco/dataset/ftd/fields/package-fields.yml
+++ b/packages/cisco/dataset/ftd/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: cisco
-  type: group

--- a/packages/cisco/dataset/ios/fields/package-fields.yml
+++ b/packages/cisco/dataset/ios/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: cisco
-  type: group

--- a/packages/kafka/dataset/log/fields/package-fields.yml
+++ b/packages/kafka/dataset/log/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: kafka
-  type: group

--- a/packages/mysql/dataset/galera_status/fields/package-fields.yml
+++ b/packages/mysql/dataset/galera_status/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: mysql
-  type: group

--- a/packages/mysql/dataset/status/fields/package-fields.yml
+++ b/packages/mysql/dataset/status/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: mysql
-  type: group

--- a/packages/nginx/dataset/access/fields/package-fields.yml
+++ b/packages/nginx/dataset/access/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: nginx
-  type: group

--- a/packages/nginx/dataset/error/fields/package-fields.yml
+++ b/packages/nginx/dataset/error/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: nginx
-  type: group

--- a/packages/nginx/dataset/ingress_controller/fields/package-fields.yml
+++ b/packages/nginx/dataset/ingress_controller/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: nginx
-  type: group

--- a/packages/nginx/dataset/stubstatus/fields/package-fields.yml
+++ b/packages/nginx/dataset/stubstatus/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: nginx
-  type: group

--- a/packages/redis/dataset/info/fields/package-fields.yml
+++ b/packages/redis/dataset/info/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: redis
-  type: group

--- a/packages/redis/dataset/key/fields/package-fields.yml
+++ b/packages/redis/dataset/key/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: redis
-  type: group

--- a/packages/redis/dataset/keyspace/fields/package-fields.yml
+++ b/packages/redis/dataset/keyspace/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: redis
-  type: group

--- a/packages/redis/dataset/log/fields/package-fields.yml
+++ b/packages/redis/dataset/log/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: redis
-  type: group

--- a/packages/redis/dataset/slowlog/fields/package-fields.yml
+++ b/packages/redis/dataset/slowlog/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: redis
-  type: group

--- a/packages/system/dataset/auth/fields/package-fields.yml
+++ b/packages/system/dataset/auth/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: system
-  type: group

--- a/packages/system/dataset/core/fields/package-fields.yml
+++ b/packages/system/dataset/core/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: system
-  type: group

--- a/packages/system/dataset/cpu/fields/package-fields.yml
+++ b/packages/system/dataset/cpu/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: system
-  type: group

--- a/packages/system/dataset/diskio/fields/package-fields.yml
+++ b/packages/system/dataset/diskio/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: system
-  type: group

--- a/packages/system/dataset/entropy/fields/package-fields.yml
+++ b/packages/system/dataset/entropy/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: system
-  type: group

--- a/packages/system/dataset/filesystem/fields/package-fields.yml
+++ b/packages/system/dataset/filesystem/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: system
-  type: group

--- a/packages/system/dataset/fsstat/fields/package-fields.yml
+++ b/packages/system/dataset/fsstat/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: system
-  type: group

--- a/packages/system/dataset/load/fields/package-fields.yml
+++ b/packages/system/dataset/load/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: system
-  type: group

--- a/packages/system/dataset/memory/fields/package-fields.yml
+++ b/packages/system/dataset/memory/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: system
-  type: group

--- a/packages/system/dataset/network/fields/package-fields.yml
+++ b/packages/system/dataset/network/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: system
-  type: group

--- a/packages/system/dataset/network_summary/fields/package-fields.yml
+++ b/packages/system/dataset/network_summary/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: system
-  type: group

--- a/packages/system/dataset/process/fields/package-fields.yml
+++ b/packages/system/dataset/process/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: system
-  type: group

--- a/packages/system/dataset/process_summary/fields/package-fields.yml
+++ b/packages/system/dataset/process_summary/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: system
-  type: group

--- a/packages/system/dataset/raid/fields/package-fields.yml
+++ b/packages/system/dataset/raid/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: system
-  type: group

--- a/packages/system/dataset/service/fields/package-fields.yml
+++ b/packages/system/dataset/service/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: system
-  type: group

--- a/packages/system/dataset/socket/fields/package-fields.yml
+++ b/packages/system/dataset/socket/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: system
-  type: group

--- a/packages/system/dataset/socket_summary/fields/package-fields.yml
+++ b/packages/system/dataset/socket_summary/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: system
-  type: group

--- a/packages/system/dataset/syslog/fields/package-fields.yml
+++ b/packages/system/dataset/syslog/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: system
-  type: group

--- a/packages/system/dataset/uptime/fields/package-fields.yml
+++ b/packages/system/dataset/uptime/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: system
-  type: group

--- a/packages/system/dataset/users/fields/package-fields.yml
+++ b/packages/system/dataset/users/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: system
-  type: group


### PR DESCRIPTION
This is a followup PR for https://github.com/elastic/integrations/pull/94 to remove all empty `package-fields.yml` files from all packages. 

cc @mtojek We should also consider to adjust `import-beats` script. 