### PR TITLE
Use custom package_paths in EPR

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,3 @@
+package_paths:
+  - ./build/package-storage-packages
+  - ./build/integrations

--- a/config.yml
+++ b/config.yml
@@ -1,3 +1,2 @@
 package_paths:
-  - ./build/package-storage-packages
   - ./build/integrations

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/elastic/package-registry v0.4.1-0.20200623125513-046078adc150
+	github.com/elastic/package-registry v0.4.1-0.20200624083400-5b436bf3479b
 	github.com/magefile/mage v1.9.0
 	github.com/pkg/errors v0.9.1
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/elastic/go-ucfg v0.8.4-0.20200415140258-1232bd4774a6 h1:Ehbr7du4rSSEypR8zePr0XRbMhO4PJgcHC9f8fDbgAg=
 github.com/elastic/go-ucfg v0.8.4-0.20200415140258-1232bd4774a6/go.mod h1:iaiY0NBIYeasNgycLyTvhJftQlQEUO2hpF+FX0JKxzo=
-github.com/elastic/package-registry v0.4.1-0.20200623125513-046078adc150 h1:bNeQkZLto6i6cJgUGCXUrnuQ8IpN6qB5VjIwNLxXDT8=
-github.com/elastic/package-registry v0.4.1-0.20200623125513-046078adc150/go.mod h1:oQx3Tg9ynuC6APd0o0OHud9kyPX6S6IzdJp/R4Hj1HY=
+github.com/elastic/package-registry v0.4.1-0.20200624083400-5b436bf3479b h1:W044lkpjc+GojaciFszMJuXOrUs6w4aZTUQfP/H16mY=
+github.com/elastic/package-registry v0.4.1-0.20200624083400-5b436bf3479b/go.mod h1:oQx3Tg9ynuC6APd0o0OHud9kyPX6S6IzdJp/R4Hj1HY=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 h1:rp+c0RAYOWj8l6qbCUTSiRLG/iKnW3K3/QfPPuSsBt4=

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -3,7 +3,7 @@ name: mysql
 title: MySQL
 version: 0.1.3
 license: basic
-description: MySQL Integration
+description: MySQL Integration-7
 type: integration
 categories:
 - logs

--- a/testing/environments/package-registry.config.yml
+++ b/testing/environments/package-registry.config.yml
@@ -1,0 +1,3 @@
+package_paths:
+  - /registry/packages/package-storage
+  - /registry/packages/integrations

--- a/testing/environments/package-registry.config.yml
+++ b/testing/environments/package-registry.config.yml
@@ -1,3 +1,4 @@
 package_paths:
-  - /registry/packages/package-storage
   - /registry/packages/integrations
+  - /registry/packages/package-storage
+dev_mode: true

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -44,6 +44,7 @@ services:
       retries: 300
       interval: 1s
     volumes:
-      - ../../build/public:/registry/public
+      - ./package-registry.config.yml:/registry/config.yml
+      - ../../build/public:/registry/packages/integrations
     ports:
       - "127.0.0.1:8080:8080"

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -45,6 +45,6 @@ services:
       interval: 1s
     volumes:
       - ./package-registry.config.yml:/registry/config.yml
-      - ../../build/public:/registry/packages/integrations
+      - ../../build/integrations:/registry/packages/integrations
     ports:
       - "127.0.0.1:8080:8080"

--- a/vendor/github.com/elastic/package-registry/devmode/devmode.go
+++ b/vendor/github.com/elastic/package-registry/devmode/devmode.go
@@ -1,0 +1,19 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package devmode
+
+import "log"
+
+var enabled bool
+
+func Enable() {
+	log.Println("Enable development mode")
+
+	enabled = true
+}
+
+func Enabled() bool {
+	return enabled
+}

--- a/vendor/github.com/elastic/package-registry/util/packages.go
+++ b/vendor/github.com/elastic/package-registry/util/packages.go
@@ -10,17 +10,19 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/elastic/package-registry/devmode"
+
 	"github.com/pkg/errors"
 )
 
 var packageList []Package
 
 // GetPackages returns a slice with all existing packages.
-// The list is stored in memory and on the second request directly
-// served from memory. This assumes chnages to packages only happen on restart.
+// The list is stored in memory and on the second request directly served from memory.
+// This assumes changes to packages only happen on restart (unless development mode is enabled).
 // Caching the packages request many file reads every time this method is called.
 func GetPackages(packagesBasePaths []string) ([]Package, error) {
-	if packageList != nil {
+	if !devmode.Enabled() && packageList != nil {
 		return packageList, nil
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -11,7 +11,8 @@ github.com/blang/semver
 github.com/elastic/go-ucfg
 github.com/elastic/go-ucfg/parse
 github.com/elastic/go-ucfg/yaml
-# github.com/elastic/package-registry v0.4.1-0.20200623125513-046078adc150
+# github.com/elastic/package-registry v0.4.1-0.20200624083400-5b436bf3479b
+github.com/elastic/package-registry/devmode
 github.com/elastic/package-registry/util
 # github.com/magefile/mage v1.9.0
 github.com/magefile/mage/mg


### PR DESCRIPTION
This PR uses freshly introduced `package_paths` configuration option to prevent from pulling packages from the package-storage.