### PR TITLE
Fix: use base package

### DIFF
--- a/dev/import-beats/packages.go
+++ b/dev/import-beats/packages.go
@@ -38,9 +38,11 @@ func newPackageContent(name string) packageContent {
 	return packageContent{
 		manifest: util.Package{
 			FormatVersion: "1.0.0",
-			Name:          name,
-			Version:       "0.0.1", // TODO
-			Type:          "integration",
+			BasePackage: util.BasePackage{
+				Name:          name,
+				Version:       "0.0.1", // TODO
+				Type:          "integration",
+			},
 			License:       "basic",
 			Removable:     determineIfPackageIsRemovable(name),
 			Release:       "experimental",


### PR DESCRIPTION
This PR adjusts the `import-beats` script to recent changes in the Package Registry.