### PR TITLE
Adjust import-beats script to avoid empty package-fields.yml files 

### DIFF
--- a/dev/import-beats/datasets.go
+++ b/dev/import-beats/datasets.go
@@ -94,8 +94,8 @@ func createDatasets(beatType, modulePath, moduleName, moduleTitle string, module
 		if len(ecsFields) > 0 {
 			fieldsFiles["ecs.yml"] = ecsFields
 		}
-		if len(moduleFields) > 0 {
-			fieldsFiles["package-fields.yml"] = moduleFields
+		if len(moduleFields) > 0 && len(moduleFields[0].Fields) > 0 {
+				fieldsFiles["package-fields.yml"] = moduleFields
 		}
 		if len(datasetFields) > 0 {
 			fieldsFiles["fields.yml"] = datasetFields

--- a/dev/import-beats/datasets.go
+++ b/dev/import-beats/datasets.go
@@ -95,7 +95,7 @@ func createDatasets(beatType, modulePath, moduleName, moduleTitle string, module
 			fieldsFiles["ecs.yml"] = ecsFields
 		}
 		if len(moduleFields) > 0 && len(moduleFields[0].Fields) > 0 {
-				fieldsFiles["package-fields.yml"] = moduleFields
+			fieldsFiles["package-fields.yml"] = moduleFields
 		}
 		if len(datasetFields) > 0 {
 			fieldsFiles["fields.yml"] = datasetFields


### PR DESCRIPTION
We should not only check the length of the `moduleFields` but also the actual `Fields` to identify empty `package-fields.yml` file.

closes: https://github.com/elastic/integrations/issues/101