### PR TITLE
fix: the distribution copy and mount path

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -75,7 +75,7 @@ pipeline {
       }
       steps {
         dir("${BASE_DIR}"){
-          sh(label: 'Copy Dockerfile', script: 'cp .ci/distribution/Dockerfile .')
+          sh(label: 'Copy Dockerfile', script: 'cp .ci/integrations/Dockerfile .')
           pushDockerImage()
         }
       }

--- a/.ci/integrations/Dockerfile
+++ b/.ci/integrations/Dockerfile
@@ -1,3 +1,3 @@
 FROM docker.elastic.co/package-registry/package-registry:master
 
-COPY build/public /registry/public
+COPY build/integrations /registry/packages/integrations


### PR DESCRIPTION
The path fro the packages changed on https://github.com/elastic/integrations/pull/104 before I merge, this PR fix the issue.