### PR TITLE
Remove os.* vars from integrations

### DIFF
--- a/packages/mongodb/dataset/log/manifest.yml
+++ b/packages/mongodb/dataset/log/manifest.yml
@@ -12,10 +12,6 @@ streams:
     show_user: true
     default:
     - /var/log/mongodb/mongodb.log
-    os:
-      windows:
-        default:
-        - c:\data\log\mongod.log
   template_path: log.yml.hbs
   title: mongodb logs
   description: Collect mongodb logs using log input

--- a/packages/nginx/dataset/access/manifest.yml
+++ b/packages/nginx/dataset/access/manifest.yml
@@ -12,12 +12,5 @@ streams:
     show_user: true
     default:
     - /var/log/nginx/access.log*
-    os:
-      darwin:
-        default:
-        - /usr/local/var/log/nginx/access.log*
-      windows:
-        default:
-        - c:/programdata/nginx/logs/*access.log*
   title: Nginx access logs
   description: Collect Nginx access logs

--- a/packages/nginx/dataset/error/manifest.yml
+++ b/packages/nginx/dataset/error/manifest.yml
@@ -12,12 +12,5 @@ streams:
     show_user: true
     default:
     - /var/log/nginx/error.log*
-    os:
-      darwin:
-        default:
-        - /usr/local/var/log/nginx/error.log*
-      windows:
-        default:
-        - c:/programdata/nginx/logs/error.log*
   title: Nginx error logs
   description: Collect Nginx error logs

--- a/packages/nginx/dataset/ingress_controller/manifest.yml
+++ b/packages/nginx/dataset/ingress_controller/manifest.yml
@@ -13,12 +13,5 @@ streams:
     show_user: true
     default:
     - /var/log/nginx/ingress.log*
-    os:
-      darwin:
-        default:
-        - /usr/local/var/log/nginx/ingress.log*
-      windows:
-        default:
-        - c:/programdata/nginx/logs/*ingress.log*
   title: Nginx ingress controller logs
   description: Collect Nginx ingress controller logs

--- a/packages/redis/dataset/log/manifest.yml
+++ b/packages/redis/dataset/log/manifest.yml
@@ -12,13 +12,5 @@ streams:
     show_user: true
     default:
     - /var/log/redis/redis-server.log*
-    os:
-      darwin:
-        default:
-        - /usr/local/var/log/redis/redis-server.log*
-        - /usr/local/var/db/redis/redis-server.log*
-      windows:
-        default:
-        - c:/program files/Redis/logs/redis.log*
   title: Redis application logs
   description: Collect Redis application logs

--- a/packages/system/dataset/auth/manifest.yml
+++ b/packages/system/dataset/auth/manifest.yml
@@ -13,12 +13,6 @@ streams:
     default:
     - /var/log/auth.log*
     - /var/log/secure*
-    os:
-      darwin:
-        default:
-        - /var/log/secure.log*
-      windows:
-        default: []
   template_path: log.yml.hbs
   title: System auth logs (log)
   description: Collect System auth logs using log input

--- a/packages/system/dataset/syslog/manifest.yml
+++ b/packages/system/dataset/syslog/manifest.yml
@@ -13,12 +13,6 @@ streams:
     default:
     - /var/log/messages*
     - /var/log/syslog*
-    os:
-      darwin:
-        default:
-        - /var/log/system.log*
-      windows:
-        default: []
   template_path: log.yml.hbs
   title: System syslog logs (log)
   description: Collect System syslog logs using log input


### PR DESCRIPTION
## What does this PR do?

This PR remove os.* vars from integrations.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
~~- [ ] I have verified that all datasets collect metrics or logs.~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/elastic/integrations/issues/108