### PR TITLE
Update target branch of release script

### DIFF
--- a/dev/update-package-storage/git.go
+++ b/dev/update-package-storage/git.go
@@ -24,14 +24,14 @@ func checkoutMasterBranch(err error, options updateOptions) error {
 	if err != nil {
 		return err
 	}
-	return runGitCommand(options, "checkout", "master")
+	return runGitCommand(options, "checkout", "production")
 }
 
 func rebaseUpstreamMaster(err error, options updateOptions) error {
 	if err != nil {
 		return err
 	}
-	return runGitCommand(options, "rebase", "upstream/master")
+	return runGitCommand(options, "rebase", "upstream/production")
 }
 
 func addToIndex(err error, options updateOptions, packageName, packageVersion string) error {

--- a/dev/update-package-storage/git.go
+++ b/dev/update-package-storage/git.go
@@ -20,14 +20,14 @@ func fetchUpstream(err error, options updateOptions) error {
 	return runGitCommand(options, "fetch", "upstream")
 }
 
-func checkoutMasterBranch(err error, options updateOptions) error {
+func checkoutProductionBranch(err error, options updateOptions) error {
 	if err != nil {
 		return err
 	}
 	return runGitCommand(options, "checkout", "production")
 }
 
-func rebaseUpstreamMaster(err error, options updateOptions) error {
+func rebaseUpstreamProduction(err error, options updateOptions) error {
 	if err != nil {
 		return err
 	}

--- a/dev/update-package-storage/main.go
+++ b/dev/update-package-storage/main.go
@@ -40,8 +40,8 @@ func main() {
 	}
 
 	err = fetchUpstream(err, options)
-	err = checkoutMasterBranch(err, options)
-	err = rebaseUpstreamMaster(err, options)
+	err = checkoutProductionBranch(err, options)
+	err = rebaseUpstreamProduction(err, options)
 	packageNames, err := listPackages(err, options)
 	err = reviewPackages(err, options, packageNames, handlePackageChanges)
 	if err != nil {
@@ -55,7 +55,7 @@ func handlePackageChanges(err error, options updateOptions, packageName string) 
 	}
 
 	packageVersion, err := detectGreatestBuiltPackageVersion(err, options, packageName)
-	err = checkoutMasterBranch(err, options)
+	err = checkoutProductionBranch(err, options)
 	released, err := checkIfPackageReleased(err, options, packageName, packageVersion)
 	if released {
 		return nil


### PR DESCRIPTION
As part of https://github.com/elastic/package-storage/issues/86 the way packages are released is changed. The release process will be snapshot -> staging -> production. This PR now first switches over to directly open PR's against production to move away from master. This allows us to update the deployment of epr.elastic.co to point to production branch instead and start to cleanup / remove the master branch.

The second step will be to adjust the script that it directly pushed to snapshot and we then have a release script to promote packages from snapshot to staging to production.

Before this is merged, I will update all the packages a last time from master to production and will not accept PR's against master anymore for packages.