### PR TITLE
Define pipeline test cases for nginx.access

### DIFF
--- a/packages/nginx/dataset/access/test/test-access-events.json
+++ b/packages/nginx/dataset/access/test/test-access-events.json
@@ -1,0 +1,95 @@
+{
+  "events": [
+    {
+      "_index": "metrics-nginx.access-default",
+      "_id": "nginx-access-1",
+      "_source": {
+        "message": "77.179.66.156 - - [25/Oct/2016:14:49:33 +0200] \"GET / HTTP/1.1\" 200 612 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.59 Safari/537.36\""
+      }
+    },
+    {
+      "_index": "metrics-nginx.access-default",
+      "_id": "nginx-access-2",
+      "_source": {
+        "message": "77.179.66.156 - - [25/Oct/2016:14:49:34 +0200] \"GET /favicon.ico HTTP/1.1\" 404 571 \"http://localhost:8080/\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.59 Safari/537.36\""
+      }
+    },
+    {
+      "_index": "metrics-nginx.access-default",
+      "_id": "nginx-access-3",
+      "_source": {
+        "message": "77.179.66.156 - - [25/Oct/2016:14:50:44 +0200] \"GET /adsasd HTTP/1.1\" 404 571 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.59 Safari/537.36\""
+      }
+    },
+    {
+      "_index": "metrics-nginx.access-default",
+      "_id": "nginx-access-4",
+      "_source": {
+        "message": "77.179.66.156 - - [07/Dec/2016:10:34:43 +0100] \"GET / HTTP/1.1\" 200 612 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36\""
+      }
+    },
+    {
+      "_index": "metrics-nginx.access-default",
+      "_id": "nginx-access-5",
+      "_source": {
+        "message": "77.179.66.156 - - [07/Dec/2016:10:34:43 +0100] \"GET /favicon.ico HTTP/1.1\" 404 571 \"http://localhost:8080/\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36\""
+      }
+    },
+    {
+      "_index": "metrics-nginx.access-default",
+      "_id": "nginx-access-6",
+      "_source": {
+        "message": "77.179.66.156 - - [07/Dec/2016:10:43:18 +0100] \"GET /test HTTP/1.1\" 404 571 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36\""
+      }
+    },
+    {
+      "_index": "metrics-nginx.access-default",
+      "_id": "nginx-access-7",
+      "_source": {
+        "message": "77.179.66.156 - - [07/Dec/2016:10:43:18 +0100] \"GET /test HTTP/1.1\" 404 571 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36\""
+      }
+    },
+    {
+      "_index": "metrics-nginx.access-default",
+      "_id": "nginx-access-8",
+      "_source": {
+        "message": "77.179.66.156 - - [07/Dec/2016:10:43:21 +0100] \"GET /test HTTP/1.1\" 404 571 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36\""
+      }
+    },
+    {
+      "_index": "metrics-nginx.access-default",
+      "_id": "nginx-access-9",
+      "_source": {
+        "message": "77.179.66.156 - - [07/Dec/2016:10:43:23 +0100] \"GET /test1 HTTP/1.1\" 404 571 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36\""
+      }
+    },
+    {
+      "_index": "metrics-nginx.access-default",
+      "_id": "nginx-access-10",
+      "_source": {
+        "message": "127.0.0.1 - - [07/Dec/2016:11:04:37 +0100] \"GET /test1 HTTP/1.1\" 404 571 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36\""
+      }
+    },
+    {
+      "_index": "metrics-nginx.access-default",
+      "_id": "nginx-access-11",
+      "_source": {
+        "message": "127.0.0.1 - - [07/Dec/2016:11:04:58 +0100] \"GET / HTTP/1.1\" 304 0 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:49.0) Gecko/20100101 Firefox/49.0\""
+      }
+    },
+    {
+      "_index": "metrics-nginx.access-default",
+      "_id": "nginx-access-12",
+      "_source": {
+        "message": "127.0.0.1 - - [07/Dec/2016:11:04:59 +0100] \"GET / HTTP/1.1\" 304 0 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:49.0) Gecko/20100101 Firefox/49.0\""
+      }
+    },
+    {
+      "_index": "metrics-nginx.access-default",
+      "_id": "nginx-access-13",
+      "_source": {
+        "message": "127.0.0.1 - - [07/Dec/2016:11:05:07 +0100] \"GET /taga HTTP/1.1\" 404 169 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:49.0) Gecko/20100101 Firefox/49.0\""
+      }
+    }
+  ]
+}

--- a/packages/nginx/dataset/access/test/test-access-expected.json
+++ b/packages/nginx/dataset/access/test/test-access-expected.json
@@ -1,0 +1,534 @@
+{
+  "expected": [
+    {
+      "@timestamp": "2016-10-25T12:49:33.000Z",
+      "event.category": [
+        "web"
+      ],
+      "event.dataset": "nginx.access",
+      "event.kind": "event",
+      "event.module": "nginx",
+      "event.outcome": "success",
+      "event.timezone": "-02:00",
+      "event.type": [
+        "access"
+      ],
+      "fileset.name": "access",
+      "http.request.method": "GET",
+      "http.response.body.bytes": 612,
+      "http.response.status_code": 200,
+      "http.version": "1.1",
+      "input.type": "log",
+      "log.offset": 0,
+      "nginx.access.remote_ip_list": [
+        "77.179.66.156"
+      ],
+      "related.ip": [
+        "77.179.66.156"
+      ],
+      "service.type": "nginx",
+      "source.address": "77.179.66.156",
+      "source.as.number": 6805,
+      "source.as.organization.name": "Telefonica Germany",
+      "source.geo.city_name": "Germersheim",
+      "source.geo.continent_name": "Europe",
+      "source.geo.country_iso_code": "DE",
+      "source.geo.location.lat": 49.2231,
+      "source.geo.location.lon": 8.3639,
+      "source.geo.region_iso_code": "DE-RP",
+      "source.geo.region_name": "Rheinland-Pfalz",
+      "source.ip": "77.179.66.156",
+      "url.original": "/",
+      "user_agent.device.name": "Other",
+      "user_agent.name": "Chrome",
+      "user_agent.original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.59 Safari/537.36",
+      "user_agent.os.full": "Mac OS X 10.12.0",
+      "user_agent.os.name": "Mac OS X",
+      "user_agent.os.version": "10.12.0",
+      "user_agent.version": "54.0.2840.59"
+    },
+    {
+      "@timestamp": "2016-10-25T12:49:34.000Z",
+      "event.category": [
+        "web"
+      ],
+      "event.dataset": "nginx.access",
+      "event.kind": "event",
+      "event.module": "nginx",
+      "event.outcome": "failure",
+      "event.timezone": "-02:00",
+      "event.type": [
+        "access"
+      ],
+      "fileset.name": "access",
+      "http.request.method": "GET",
+      "http.request.referrer": "http://localhost:8080/",
+      "http.response.body.bytes": 571,
+      "http.response.status_code": 404,
+      "http.version": "1.1",
+      "input.type": "log",
+      "log.offset": 199,
+      "nginx.access.remote_ip_list": [
+        "77.179.66.156"
+      ],
+      "related.ip": [
+        "77.179.66.156"
+      ],
+      "service.type": "nginx",
+      "source.address": "77.179.66.156",
+      "source.as.number": 6805,
+      "source.as.organization.name": "Telefonica Germany",
+      "source.geo.city_name": "Germersheim",
+      "source.geo.continent_name": "Europe",
+      "source.geo.country_iso_code": "DE",
+      "source.geo.location.lat": 49.2231,
+      "source.geo.location.lon": 8.3639,
+      "source.geo.region_iso_code": "DE-RP",
+      "source.geo.region_name": "Rheinland-Pfalz",
+      "source.ip": "77.179.66.156",
+      "url.original": "/favicon.ico",
+      "user_agent.device.name": "Other",
+      "user_agent.name": "Chrome",
+      "user_agent.original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.59 Safari/537.36",
+      "user_agent.os.full": "Mac OS X 10.12.0",
+      "user_agent.os.name": "Mac OS X",
+      "user_agent.os.version": "10.12.0",
+      "user_agent.version": "54.0.2840.59"
+    },
+    {
+      "@timestamp": "2016-10-25T12:50:44.000Z",
+      "event.category": [
+        "web"
+      ],
+      "event.dataset": "nginx.access",
+      "event.kind": "event",
+      "event.module": "nginx",
+      "event.outcome": "failure",
+      "event.timezone": "-02:00",
+      "event.type": [
+        "access"
+      ],
+      "fileset.name": "access",
+      "http.request.method": "GET",
+      "http.response.body.bytes": 571,
+      "http.response.status_code": 404,
+      "http.version": "1.1",
+      "input.type": "log",
+      "log.offset": 430,
+      "nginx.access.remote_ip_list": [
+        "77.179.66.156"
+      ],
+      "related.ip": [
+        "77.179.66.156"
+      ],
+      "service.type": "nginx",
+      "source.address": "77.179.66.156",
+      "source.as.number": 6805,
+      "source.as.organization.name": "Telefonica Germany",
+      "source.geo.city_name": "Germersheim",
+      "source.geo.continent_name": "Europe",
+      "source.geo.country_iso_code": "DE",
+      "source.geo.location.lat": 49.2231,
+      "source.geo.location.lon": 8.3639,
+      "source.geo.region_iso_code": "DE-RP",
+      "source.geo.region_name": "Rheinland-Pfalz",
+      "source.ip": "77.179.66.156",
+      "url.original": "/adsasd",
+      "user_agent.device.name": "Other",
+      "user_agent.name": "Chrome",
+      "user_agent.original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.59 Safari/537.36",
+      "user_agent.os.full": "Mac OS X 10.12.0",
+      "user_agent.os.name": "Mac OS X",
+      "user_agent.os.version": "10.12.0",
+      "user_agent.version": "54.0.2840.59"
+    },
+    {
+      "@timestamp": "2016-12-07T09:34:43.000Z",
+      "event.category": [
+        "web"
+      ],
+      "event.dataset": "nginx.access",
+      "event.kind": "event",
+      "event.module": "nginx",
+      "event.outcome": "success",
+      "event.timezone": "-02:00",
+      "event.type": [
+        "access"
+      ],
+      "fileset.name": "access",
+      "http.request.method": "GET",
+      "http.response.body.bytes": 612,
+      "http.response.status_code": 200,
+      "http.version": "1.1",
+      "input.type": "log",
+      "log.offset": 635,
+      "nginx.access.remote_ip_list": [
+        "77.179.66.156"
+      ],
+      "related.ip": [
+        "77.179.66.156"
+      ],
+      "service.type": "nginx",
+      "source.address": "77.179.66.156",
+      "source.as.number": 6805,
+      "source.as.organization.name": "Telefonica Germany",
+      "source.geo.city_name": "Germersheim",
+      "source.geo.continent_name": "Europe",
+      "source.geo.country_iso_code": "DE",
+      "source.geo.location.lat": 49.2231,
+      "source.geo.location.lon": 8.3639,
+      "source.geo.region_iso_code": "DE-RP",
+      "source.geo.region_name": "Rheinland-Pfalz",
+      "source.ip": "77.179.66.156",
+      "url.original": "/",
+      "user_agent.device.name": "Other",
+      "user_agent.name": "Chrome",
+      "user_agent.original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36",
+      "user_agent.os.full": "Mac OS X 10.12.0",
+      "user_agent.os.name": "Mac OS X",
+      "user_agent.os.version": "10.12.0",
+      "user_agent.version": "54.0.2840.98"
+    },
+    {
+      "@timestamp": "2016-12-07T09:34:43.000Z",
+      "event.category": [
+        "web"
+      ],
+      "event.dataset": "nginx.access",
+      "event.kind": "event",
+      "event.module": "nginx",
+      "event.outcome": "failure",
+      "event.timezone": "-02:00",
+      "event.type": [
+        "access"
+      ],
+      "fileset.name": "access",
+      "http.request.method": "GET",
+      "http.request.referrer": "http://localhost:8080/",
+      "http.response.body.bytes": 571,
+      "http.response.status_code": 404,
+      "http.version": "1.1",
+      "input.type": "log",
+      "log.offset": 834,
+      "nginx.access.remote_ip_list": [
+        "77.179.66.156"
+      ],
+      "related.ip": [
+        "77.179.66.156"
+      ],
+      "service.type": "nginx",
+      "source.address": "77.179.66.156",
+      "source.as.number": 6805,
+      "source.as.organization.name": "Telefonica Germany",
+      "source.geo.city_name": "Germersheim",
+      "source.geo.continent_name": "Europe",
+      "source.geo.country_iso_code": "DE",
+      "source.geo.location.lat": 49.2231,
+      "source.geo.location.lon": 8.3639,
+      "source.geo.region_iso_code": "DE-RP",
+      "source.geo.region_name": "Rheinland-Pfalz",
+      "source.ip": "77.179.66.156",
+      "url.original": "/favicon.ico",
+      "user_agent.device.name": "Other",
+      "user_agent.name": "Chrome",
+      "user_agent.original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36",
+      "user_agent.os.full": "Mac OS X 10.12.0",
+      "user_agent.os.name": "Mac OS X",
+      "user_agent.os.version": "10.12.0",
+      "user_agent.version": "54.0.2840.98"
+    },
+    {
+      "@timestamp": "2016-12-07T09:43:18.000Z",
+      "event.category": [
+        "web"
+      ],
+      "event.dataset": "nginx.access",
+      "event.kind": "event",
+      "event.module": "nginx",
+      "event.outcome": "failure",
+      "event.timezone": "-02:00",
+      "event.type": [
+        "access"
+      ],
+      "fileset.name": "access",
+      "http.request.method": "GET",
+      "http.response.body.bytes": 571,
+      "http.response.status_code": 404,
+      "http.version": "1.1",
+      "input.type": "log",
+      "log.offset": 1065,
+      "nginx.access.remote_ip_list": [
+        "77.179.66.156"
+      ],
+      "related.ip": [
+        "77.179.66.156"
+      ],
+      "service.type": "nginx",
+      "source.address": "77.179.66.156",
+      "source.as.number": 6805,
+      "source.as.organization.name": "Telefonica Germany",
+      "source.geo.city_name": "Germersheim",
+      "source.geo.continent_name": "Europe",
+      "source.geo.country_iso_code": "DE",
+      "source.geo.location.lat": 49.2231,
+      "source.geo.location.lon": 8.3639,
+      "source.geo.region_iso_code": "DE-RP",
+      "source.geo.region_name": "Rheinland-Pfalz",
+      "source.ip": "77.179.66.156",
+      "url.original": "/test",
+      "user_agent.device.name": "Other",
+      "user_agent.name": "Chrome",
+      "user_agent.original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36",
+      "user_agent.os.full": "Mac OS X 10.12.0",
+      "user_agent.os.name": "Mac OS X",
+      "user_agent.os.version": "10.12.0",
+      "user_agent.version": "54.0.2840.98"
+    },
+    {
+      "@timestamp": "2016-12-07T09:43:21.000Z",
+      "event.category": [
+        "web"
+      ],
+      "event.dataset": "nginx.access",
+      "event.kind": "event",
+      "event.module": "nginx",
+      "event.outcome": "failure",
+      "event.timezone": "-02:00",
+      "event.type": [
+        "access"
+      ],
+      "fileset.name": "access",
+      "http.request.method": "GET",
+      "http.response.body.bytes": 571,
+      "http.response.status_code": 404,
+      "http.version": "1.1",
+      "input.type": "log",
+      "log.offset": 1268,
+      "nginx.access.remote_ip_list": [
+        "77.179.66.156"
+      ],
+      "related.ip": [
+        "77.179.66.156"
+      ],
+      "service.type": "nginx",
+      "source.address": "77.179.66.156",
+      "source.as.number": 6805,
+      "source.as.organization.name": "Telefonica Germany",
+      "source.geo.city_name": "Germersheim",
+      "source.geo.continent_name": "Europe",
+      "source.geo.country_iso_code": "DE",
+      "source.geo.location.lat": 49.2231,
+      "source.geo.location.lon": 8.3639,
+      "source.geo.region_iso_code": "DE-RP",
+      "source.geo.region_name": "Rheinland-Pfalz",
+      "source.ip": "77.179.66.156",
+      "url.original": "/test",
+      "user_agent.device.name": "Other",
+      "user_agent.name": "Chrome",
+      "user_agent.original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36",
+      "user_agent.os.full": "Mac OS X 10.12.0",
+      "user_agent.os.name": "Mac OS X",
+      "user_agent.os.version": "10.12.0",
+      "user_agent.version": "54.0.2840.98"
+    },
+    {
+      "@timestamp": "2016-12-07T09:43:23.000Z",
+      "event.category": [
+        "web"
+      ],
+      "event.dataset": "nginx.access",
+      "event.kind": "event",
+      "event.module": "nginx",
+      "event.outcome": "failure",
+      "event.timezone": "-02:00",
+      "event.type": [
+        "access"
+      ],
+      "fileset.name": "access",
+      "http.request.method": "GET",
+      "http.response.body.bytes": 571,
+      "http.response.status_code": 404,
+      "http.version": "1.1",
+      "input.type": "log",
+      "log.offset": 1471,
+      "nginx.access.remote_ip_list": [
+        "77.179.66.156"
+      ],
+      "related.ip": [
+        "77.179.66.156"
+      ],
+      "service.type": "nginx",
+      "source.address": "77.179.66.156",
+      "source.as.number": 6805,
+      "source.as.organization.name": "Telefonica Germany",
+      "source.geo.city_name": "Germersheim",
+      "source.geo.continent_name": "Europe",
+      "source.geo.country_iso_code": "DE",
+      "source.geo.location.lat": 49.2231,
+      "source.geo.location.lon": 8.3639,
+      "source.geo.region_iso_code": "DE-RP",
+      "source.geo.region_name": "Rheinland-Pfalz",
+      "source.ip": "77.179.66.156",
+      "url.original": "/test1",
+      "user_agent.device.name": "Other",
+      "user_agent.name": "Chrome",
+      "user_agent.original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36",
+      "user_agent.os.full": "Mac OS X 10.12.0",
+      "user_agent.os.name": "Mac OS X",
+      "user_agent.os.version": "10.12.0",
+      "user_agent.version": "54.0.2840.98"
+    },
+    {
+      "@timestamp": "2016-12-07T10:04:37.000Z",
+      "event.category": [
+        "web"
+      ],
+      "event.dataset": "nginx.access",
+      "event.kind": "event",
+      "event.module": "nginx",
+      "event.outcome": "failure",
+      "event.timezone": "-02:00",
+      "event.type": [
+        "access"
+      ],
+      "fileset.name": "access",
+      "http.request.method": "GET",
+      "http.response.body.bytes": 571,
+      "http.response.status_code": 404,
+      "http.version": "1.1",
+      "input.type": "log",
+      "log.offset": 1675,
+      "nginx.access.remote_ip_list": [
+        "127.0.0.1"
+      ],
+      "related.ip": [
+        "127.0.0.1"
+      ],
+      "service.type": "nginx",
+      "source.address": "127.0.0.1",
+      "source.ip": "127.0.0.1",
+      "url.original": "/test1",
+      "user_agent.device.name": "Other",
+      "user_agent.name": "Chrome",
+      "user_agent.original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36",
+      "user_agent.os.full": "Mac OS X 10.12.0",
+      "user_agent.os.name": "Mac OS X",
+      "user_agent.os.version": "10.12.0",
+      "user_agent.version": "54.0.2840.98"
+    },
+    {
+      "@timestamp": "2016-12-07T10:04:58.000Z",
+      "event.category": [
+        "web"
+      ],
+      "event.dataset": "nginx.access",
+      "event.kind": "event",
+      "event.module": "nginx",
+      "event.outcome": "success",
+      "event.timezone": "-02:00",
+      "event.type": [
+        "access"
+      ],
+      "fileset.name": "access",
+      "http.request.method": "GET",
+      "http.response.body.bytes": 0,
+      "http.response.status_code": 304,
+      "http.version": "1.1",
+      "input.type": "log",
+      "log.offset": 1875,
+      "nginx.access.remote_ip_list": [
+        "127.0.0.1"
+      ],
+      "related.ip": [
+        "127.0.0.1"
+      ],
+      "service.type": "nginx",
+      "source.address": "127.0.0.1",
+      "source.ip": "127.0.0.1",
+      "url.original": "/",
+      "user_agent.device.name": "Other",
+      "user_agent.name": "Firefox",
+      "user_agent.original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:49.0) Gecko/20100101 Firefox/49.0",
+      "user_agent.os.full": "Mac OS X 10.12",
+      "user_agent.os.name": "Mac OS X",
+      "user_agent.os.version": "10.12",
+      "user_agent.version": "49.0."
+    },
+    {
+      "@timestamp": "2016-12-07T10:04:59.000Z",
+      "event.category": [
+        "web"
+      ],
+      "event.dataset": "nginx.access",
+      "event.kind": "event",
+      "event.module": "nginx",
+      "event.outcome": "success",
+      "event.timezone": "-02:00",
+      "event.type": [
+        "access"
+      ],
+      "fileset.name": "access",
+      "http.request.method": "GET",
+      "http.response.body.bytes": 0,
+      "http.response.status_code": 304,
+      "http.version": "1.1",
+      "input.type": "log",
+      "log.offset": 2030,
+      "nginx.access.remote_ip_list": [
+        "127.0.0.1"
+      ],
+      "related.ip": [
+        "127.0.0.1"
+      ],
+      "service.type": "nginx",
+      "source.address": "127.0.0.1",
+      "source.ip": "127.0.0.1",
+      "url.original": "/",
+      "user_agent.device.name": "Other",
+      "user_agent.name": "Firefox",
+      "user_agent.original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:49.0) Gecko/20100101 Firefox/49.0",
+      "user_agent.os.full": "Mac OS X 10.12",
+      "user_agent.os.name": "Mac OS X",
+      "user_agent.os.version": "10.12",
+      "user_agent.version": "49.0."
+    },
+    {
+      "@timestamp": "2016-12-07T10:05:07.000Z",
+      "event.category": [
+        "web"
+      ],
+      "event.dataset": "nginx.access",
+      "event.kind": "event",
+      "event.module": "nginx",
+      "event.outcome": "failure",
+      "event.timezone": "-02:00",
+      "event.type": [
+        "access"
+      ],
+      "fileset.name": "access",
+      "http.request.method": "GET",
+      "http.response.body.bytes": 169,
+      "http.response.status_code": 404,
+      "http.version": "1.1",
+      "input.type": "log",
+      "log.offset": 2185,
+      "nginx.access.remote_ip_list": [
+        "127.0.0.1"
+      ],
+      "related.ip": [
+        "127.0.0.1"
+      ],
+      "service.type": "nginx",
+      "source.address": "127.0.0.1",
+      "source.ip": "127.0.0.1",
+      "url.original": "/taga",
+      "user_agent.device.name": "Other",
+      "user_agent.name": "Firefox",
+      "user_agent.original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:49.0) Gecko/20100101 Firefox/49.0",
+      "user_agent.os.full": "Mac OS X 10.12",
+      "user_agent.os.name": "Mac OS X",
+      "user_agent.os.version": "10.12",
+      "user_agent.version": "49.0."
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

This PR defines sample pipeline test cases for `nginx.access`. I'm sure that expected results are invalid, but committing them to compare with real data later on.

Files are inline with the proposal for the unified tool for packages and are easy to use with Simulate Pipeline API https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html

## Checklist

~~- [ ] I have reviewed [tips for building integrations]~~(https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
~~- [ ] I have verified that all datasets collect metrics or logs.~~