### PR TITLE
Remove outdated categories

### DIFF
--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.0
 license: basic
 description: Apache Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 removable: true
 requirement:

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.1
 license: basic
 description: AWS Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 requirement:
   kibana:

--- a/packages/cisco/manifest.yml
+++ b/packages/cisco/manifest.yml
@@ -5,8 +5,6 @@ version: 0.1.2
 license: basic
 description: Cisco Integration
 type: integration
-categories:
-  - logs
 release: beta
 requirement:
   kibana:

--- a/packages/kafka/manifest.yml
+++ b/packages/kafka/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.1
 license: basic
 description: Kafka Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 requirement:
   kibana:

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -5,8 +5,6 @@ version: 0.1.0
 license: basic
 description: Kubernetes Integration
 type: integration
-categories:
-- metrics
 release: beta
 requirement:
   kibana:

--- a/packages/log/manifest.yml
+++ b/packages/log/manifest.yml
@@ -5,7 +5,6 @@ title: Custom logs
 description: >
   Collect your custom logs.
 version: 0.1.1
-categories: ["logs"]
 release: ga
 license: basic
 

--- a/packages/mongodb/manifest.yml
+++ b/packages/mongodb/manifest.yml
@@ -10,9 +10,6 @@ icons:
   type: image/svg+xml
 format_version: 1.0.0
 license: basic
-categories:
-- logs
-- metrics
 release: beta
 removable: true
 requirement:

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.3
 license: basic
 description: MySQL Integration-7
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 requirement:
   kibana:

--- a/packages/netflow/manifest.yml
+++ b/packages/netflow/manifest.yml
@@ -5,8 +5,6 @@ version: 0.1.1
 license: basic
 description: NetFlow Integration
 type: integration
-categories:
-- logs
 release: beta
 requirement:
   kibana:

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.3
 license: basic
 description: Nginx Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 requirement:
   kibana:

--- a/packages/postgresql/manifest.yml
+++ b/packages/postgresql/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.0
 license: basic
 description: PostgreSQL Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 requirement:
   kibana:

--- a/packages/rabbitmq/manifest.yml
+++ b/packages/rabbitmq/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.0
 license: basic
 description: RabbitMQ Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 removable: true
 requirement:

--- a/packages/redis/manifest.yml
+++ b/packages/redis/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.3
 license: basic
 description: Redis Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 requirement:
   kibana:

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -5,9 +5,6 @@ version: 0.3.1
 license: basic
 description: System Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 screenshots:
 - src: /img/kibana-system.png

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -10,8 +10,6 @@ icons:
   type: image/svg+xml
 format_version: 1.0.0
 license: basic
-categories:
-- metrics
 release: beta
 removable: true
 requirement:


### PR DESCRIPTION
## What does this PR do?

Removes outdated `categories` from packages. This is because these categories are no longer supported by the package registry (see https://github.com/elastic/package-registry/pull/534). With these outdated categories in place one can no longer load the packages in this repo into a package registry built off `master`. 

Longer term, authors of packages would need to redefine categories for their respective packages, picking from the [list _du jour_](https://github.com/elastic/package-registry/blob/e93e801a6dfbfa6f83c8b69f6e9405603151f937/util/package.go#L27-L51) (see #135).