### PR TITLE
Rename logs to logfile

### DIFF
--- a/dev/import-beats/config_templates.go
+++ b/dev/import-beats/config_templates.go
@@ -144,7 +144,7 @@ func toConfigTemplateInputTitle(moduleTitle, packageType string, datasets []stri
 	description.WriteString(" ")
 	description.WriteString(packageType)
 
-	if packageType == "logs" && inputType != "logs" {
+	if packageType == "logs" && inputType != "logfile" {
 		description.WriteString(fmt.Sprintf(" (input: %s)", inputType))
 	}
 	return description.String()
@@ -172,7 +172,7 @@ func toConfigTemplateInputDescription(moduleTitle, packageType string, datasets 
 	description.WriteString(moduleTitle)
 	description.WriteString(" instances")
 
-	if packageType == "logs" && inputType != "logs" {
+	if packageType == "logs" && inputType != "logfile" {
 		description.WriteString(fmt.Sprintf(" (input: %s)", inputType))
 	}
 	return description.String()

--- a/dev/import-beats/datasets.go
+++ b/dev/import-beats/datasets.go
@@ -118,11 +118,16 @@ func createDatasets(beatType, modulePath, moduleName, moduleTitle string, module
 			return nil, errors.Wrapf(err, "creating streams failed (datasetPath: %s)", datasetPath)
 		}
 
+		aType := beatType
+		if aType == "logs" {
+			aType = "logfile"
+		}
+
 		// manifest
 		manifest := util.Dataset{
 			Title:   fmt.Sprintf("%s %s %s", moduleTitle, datasetName, beatType),
 			Release: "experimental",
-			Type:    beatType,
+			Type:    aType,
 			Streams: streams,
 		}
 

--- a/dev/import-beats/packages.go
+++ b/dev/import-beats/packages.go
@@ -137,7 +137,6 @@ func (r *packageRepository) createPackagesFromSource(beatsDir, beatName, beatTyp
 
 		aPackage := r.packages[moduleName]
 		manifest := aPackage.manifest
-		manifest.Categories = append(manifest.Categories, beatType)
 
 		// fields
 		moduleFields, maybeTitle, err := loadModuleFields(modulePath)

--- a/dev/import-beats/streams.go
+++ b/dev/import-beats/streams.go
@@ -92,7 +92,7 @@ func createLogStreams(modulePath, moduleTitle, datasetName string) ([]util.Strea
 		for _, inputType := range root.inputTypes() {
 			aType := inputType
 			if inputType == "log" {
-				aType = "logs"
+				aType = "logfile"
 			}
 			targetFileName := inputType + ".yml.hbs"
 

--- a/dev/import-beats/streams_config_parser.go
+++ b/dev/import-beats/streams_config_parser.go
@@ -92,7 +92,7 @@ func inputTypesForListNode(listNode *parse.ListNode) []string {
 }
 
 func (scp *streamConfigParsed) configForInput(inputType string) []byte {
-	if inputType == "log" {
+	if inputType == "logfile" {
 		inputType = "file"
 	}
 
@@ -293,7 +293,7 @@ func (scp *streamConfigParsed) filterVarsForInput(inputType string, vars []util.
 }
 
 func (scp *streamConfigParsed) variableNamesForInput(inputType string) []string {
-	if inputType == "log" {
+	if inputType == "logfile" {
 		inputType = "file"
 	}
 

--- a/packages/apache/dataset/access/manifest.yml
+++ b/packages/apache/dataset/access/manifest.yml
@@ -1,8 +1,8 @@
 title: Apache access logs
 release: beta
-type: logs
+type: logfile
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/apache/dataset/error/manifest.yml
+++ b/packages/apache/dataset/error/manifest.yml
@@ -1,8 +1,8 @@
 title: Apache error logs
 release: beta
-type: logs
+type: logfile
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -29,7 +29,7 @@ config_templates:
   title: Apache logs and metrics
   description: Collect logs and metrics from Apache instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from Apache instances
     description: Collecting Apache access and error logs
   - type: apache/metrics

--- a/packages/aws/dataset/cloudtrail/manifest.yml
+++ b/packages/aws/dataset/cloudtrail/manifest.yml
@@ -1,6 +1,6 @@
 title: AWS CloudTrail logs
 release: beta
-type: logs
+type: logfile
 streams:
 - input: s3
   template_path: s3.yml.hbs

--- a/packages/aws/dataset/cloudwatch_logs/manifest.yml
+++ b/packages/aws/dataset/cloudwatch_logs/manifest.yml
@@ -1,6 +1,6 @@
 title: AWS CloudWatch logs
 release: beta
-type: logs
+type: logfile
 streams:
 - input: s3
   template_path: s3.yml.hbs

--- a/packages/aws/dataset/ec2_logs/manifest.yml
+++ b/packages/aws/dataset/ec2_logs/manifest.yml
@@ -1,6 +1,6 @@
 title: AWS EC2 logs
 release: beta
-type: logs
+type: logfile
 streams:
 - input: s3
   template_path: s3.yml.hbs

--- a/packages/aws/dataset/elb_logs/manifest.yml
+++ b/packages/aws/dataset/elb_logs/manifest.yml
@@ -1,6 +1,6 @@
 title: AWS ELB logs
 release: beta
-type: logs
+type: logfile
 streams:
 - input: s3
   template_path: s3.yml.hbs

--- a/packages/aws/dataset/s3access/manifest.yml
+++ b/packages/aws/dataset/s3access/manifest.yml
@@ -1,6 +1,6 @@
 title: AWS s3access logs
 release: beta
-type: logs
+type: logfile
 streams:
 - input: s3
   template_path: s3.yml.hbs

--- a/packages/aws/dataset/vpcflow/manifest.yml
+++ b/packages/aws/dataset/vpcflow/manifest.yml
@@ -1,6 +1,6 @@
 title: AWS vpcflow logs
 release: beta
-type: logs
+type: logfile
 streams:
 - input: s3
   template_path: s3.yml.hbs

--- a/packages/cisco/dataset/asa/manifest.yml
+++ b/packages/cisco/dataset/asa/manifest.yml
@@ -1,6 +1,6 @@
 title: Cisco ASA logs
 release: beta
-type: logs
+type: logfile
 streams:
 - input: udp
   title: Cisco ASA logs
@@ -36,7 +36,7 @@ streams:
     required: true
     show_user: false
     default: 7
-- input: logs
+- input: logfile
   title: Cisco ASA logs
   description: Collect Cisco ASA logs from file
   vars:

--- a/packages/cisco/dataset/ftd/manifest.yml
+++ b/packages/cisco/dataset/ftd/manifest.yml
@@ -1,6 +1,6 @@
 title: Cisco FTD logs
 release: beta
-type: logs
+type: logfile
 streams:
 - input: udp
   title: Cisco FTD logs
@@ -36,7 +36,7 @@ streams:
     required: true
     show_user: false
     default: 7
-- input: logs
+- input: logfile
   title: Cisco FTD logs
   description: Collect Cisco FTD logs from file
   vars:

--- a/packages/cisco/dataset/ios/manifest.yml
+++ b/packages/cisco/dataset/ios/manifest.yml
@@ -1,6 +1,6 @@
 title: Cisco IOS logs
 release: beta
-type: logs
+type: logfile
 streams:
 - input: syslog
   title: Cisco IOS logs
@@ -37,7 +37,7 @@ streams:
     required: true
     show_user: true
     default: 9002
-- input: logs
+- input: logfile
   title: Cisco IOS logs
   description: Collect Cisco IOS logs from file
   vars:

--- a/packages/cisco/manifest.yml
+++ b/packages/cisco/manifest.yml
@@ -32,6 +32,6 @@ config_templates:
       - type: syslog
         title: Collect logs from Cisco via syslog
         description: Collecting logs from Cisco IOS via syslog
-      - type: logs
+      - type: logfile
         title: Collect logs from Cisco via file
         description: Collecting logs from Cisco ASA, FTD, and IOS via file

--- a/packages/kafka/dataset/log/manifest.yml
+++ b/packages/kafka/dataset/log/manifest.yml
@@ -1,8 +1,8 @@
 title: Kafka log logs
 release: beta
-type: logs
+type: logfile
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: kafka_home
     type: text

--- a/packages/kafka/manifest.yml
+++ b/packages/kafka/manifest.yml
@@ -30,7 +30,7 @@ config_templates:
   title: Kafka logs and metrics
   description: Collect logs and metrics from Kafka brokers
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from Kafka brokers
     description: Collecting Kafka log logs
   - type: kafka/metrics

--- a/packages/log/dataset/log/manifest.yml
+++ b/packages/log/dataset/log/manifest.yml
@@ -1,12 +1,12 @@
 title: Log Dataset
 
-type: logs
+type: logfile
 
 default: true
 id: generic
 
 streams:
-  - input: logs
+  - input: logfile
     title: Collect log files
     vars:
       - name: paths

--- a/packages/log/manifest.yml
+++ b/packages/log/manifest.yml
@@ -14,7 +14,7 @@ config_templates:
     title: Custom logs
     description: Collect your custom log files.
     inputs:
-      - type: logs
+      - type: logfile
         title: Custom log file
         description: Collect your custom log files.
 

--- a/packages/mongodb/dataset/log/manifest.yml
+++ b/packages/mongodb/dataset/log/manifest.yml
@@ -1,8 +1,8 @@
 title: mongodb log logs
 release: beta
-type: logs
+type: logfile
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/mongodb/manifest.yml
+++ b/packages/mongodb/manifest.yml
@@ -25,7 +25,7 @@ datasources:
   title: MongoDB logs and metrics
   description: Collect logs and metrics from MongoDB instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect MongoDB application logs
     description: Collecting application logs from MongoDB instances
   - type: mongodb/metrics

--- a/packages/mysql/dataset/error/manifest.yml
+++ b/packages/mysql/dataset/error/manifest.yml
@@ -1,8 +1,8 @@
 title: MySQL error logs
-type: logs
+type: logfile
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/mysql/dataset/slowlog/manifest.yml
+++ b/packages/mysql/dataset/slowlog/manifest.yml
@@ -1,8 +1,8 @@
 title: MySQL slowlog logs
-type: logs
+type: logfile
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -30,7 +30,7 @@ config_templates:
   title: MySQL logs and metrics
   description: Collect logs and metrics from MySQL instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from MySQL hosts
     description: Collecting MySQL error and slowlog logs
   - type: mysql/metrics

--- a/packages/netflow/dataset/log/manifest.yml
+++ b/packages/netflow/dataset/log/manifest.yml
@@ -1,6 +1,6 @@
 title: NetFlow logs
 release: beta
-type: logs
+type: logfile
 streams:
 - input: netflow
   template_path: netflow.yml.hbs

--- a/packages/nginx/dataset/access/manifest.yml
+++ b/packages/nginx/dataset/access/manifest.yml
@@ -1,8 +1,8 @@
 title: Nginx access logs
-type: logs
+type: logfile
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/nginx/dataset/error/manifest.yml
+++ b/packages/nginx/dataset/error/manifest.yml
@@ -1,8 +1,8 @@
 title: Nginx error logs
-type: logs
+type: logfile
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/nginx/dataset/ingress_controller/manifest.yml
+++ b/packages/nginx/dataset/ingress_controller/manifest.yml
@@ -1,8 +1,8 @@
 title: Nginx ingress_controller logs
-type: logs
+type: logfile
 release: beta
 streams:
-- input: logs
+- input: logfile
   enabled: false
   vars:
   - name: paths

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -30,7 +30,7 @@ config_templates:
   title: Nginx logs and metrics
   description: Collect logs and metrics from Nginx instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from Nginx instances
     description: Collecting Nginx access, error and ingress controller logs
   - type: nginx/metrics

--- a/packages/postgresql/dataset/log/manifest.yml
+++ b/packages/postgresql/dataset/log/manifest.yml
@@ -1,8 +1,8 @@
 title: PostgreSQL application logs
 release: beta
-type: logs
+type: logfile
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/postgresql/manifest.yml
+++ b/packages/postgresql/manifest.yml
@@ -32,7 +32,7 @@ config_templates:
   title: PostgreSQL logs and metrics
   description: Collect logs and metrics from PostgreSQL instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect PostgreSQL logs
     description: Collecting application logs from PostgreSQL instances
   - type: postgresql/metrics

--- a/packages/rabbitmq/dataset/log/manifest.yml
+++ b/packages/rabbitmq/dataset/log/manifest.yml
@@ -1,8 +1,8 @@
 title: RabbitMQ application logs
 release: beta
-type: logs
+type: logfile
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/rabbitmq/manifest.yml
+++ b/packages/rabbitmq/manifest.yml
@@ -20,7 +20,7 @@ config_templates:
   title: RabbitMQ logs and metrics
   description: Collect logs and metrics from RabbitMQ instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from RabbitMQ instances
     description: Collecting application logs from RabbitMQ instances
   - type: rabbitmq/metrics

--- a/packages/redis/dataset/log/manifest.yml
+++ b/packages/redis/dataset/log/manifest.yml
@@ -1,8 +1,8 @@
 title: Redis application logs
-type: logs
+type: logfile
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/redis/dataset/slowlog/manifest.yml
+++ b/packages/redis/dataset/slowlog/manifest.yml
@@ -1,5 +1,5 @@
 title: Redis slow logs
-type: logs
+type: logfile
 release: beta
 streams:
 - input: redis

--- a/packages/redis/manifest.yml
+++ b/packages/redis/manifest.yml
@@ -30,7 +30,7 @@ config_templates:
   title: Redis logs and metrics
   description: Collect logs and metrics from Redis instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect Redis application logs
     description: Collecting application logs from Redis instances
   - type: redis

--- a/packages/system/dataset/auth/manifest.yml
+++ b/packages/system/dataset/auth/manifest.yml
@@ -1,8 +1,8 @@
 title: System auth logs
 release: experimental
-type: logs
+type: logfile
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/system/dataset/syslog/manifest.yml
+++ b/packages/system/dataset/syslog/manifest.yml
@@ -1,8 +1,8 @@
 title: System syslog logs
 release: experimental
-type: logs
+type: logfile
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -29,7 +29,7 @@ config_templates:
   title: System logs and metrics
   description: Collect logs and metrics from System instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from System instances
     description: Collecting System auth and syslog logs
   - type: system/metrics


### PR DESCRIPTION
## What does this PR do?

This PR replace "logs" tags with "logfile" in existing integrations and in packages.

## How to test this PR locally

I suggest to import not existing integrations, e.g. o365:

```
PACKAGES=o365 SKIP_KIBANA=true mage ImportBeats
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- https://github.com/elastic/integrations/pull/119