### PR TITLE
Rename logs to logfile

### DIFF
--- a/dev/import-beats/config_templates.go
+++ b/dev/import-beats/config_templates.go
@@ -50,8 +50,12 @@ func (ds configTemplateContent) toMetadataConfigTemplates() []util.ConfigTemplat
 	for _, packageType := range packageTypes {
 		for inputType, input := range ds.inputs {
 			if input.packageType == packageType {
+				aType := input.inputType
+				if aType == "logfile" {
+					aType = "logs"
+				}
 				inputs = append(inputs, util.Input{
-					Type:        input.inputType,
+					Type:        aType,
 					Title:       toConfigTemplateInputTitle(ds.moduleTitle, packageType, ds.inputs[inputType].datasetNames, inputType),
 					Description: toConfigTemplateInputDescription(ds.moduleTitle, packageType, ds.inputs[inputType].datasetNames, inputType),
 					Vars:        input.vars,

--- a/dev/import-beats/config_templates.go
+++ b/dev/import-beats/config_templates.go
@@ -50,12 +50,8 @@ func (ds configTemplateContent) toMetadataConfigTemplates() []util.ConfigTemplat
 	for _, packageType := range packageTypes {
 		for inputType, input := range ds.inputs {
 			if input.packageType == packageType {
-				aType := input.inputType
-				if aType == "logfile" {
-					aType = "logs"
-				}
 				inputs = append(inputs, util.Input{
-					Type:        aType,
+					Type:        input.inputType,
 					Title:       toConfigTemplateInputTitle(ds.moduleTitle, packageType, ds.inputs[inputType].datasetNames, inputType),
 					Description: toConfigTemplateInputDescription(ds.moduleTitle, packageType, ds.inputs[inputType].datasetNames, inputType),
 					Vars:        input.vars,

--- a/dev/import-beats/packages.go
+++ b/dev/import-beats/packages.go
@@ -137,7 +137,6 @@ func (r *packageRepository) createPackagesFromSource(beatsDir, beatName, beatTyp
 
 		aPackage := r.packages[moduleName]
 		manifest := aPackage.manifest
-		manifest.Categories = append(manifest.Categories, beatType)
 
 		// fields
 		moduleFields, maybeTitle, err := loadModuleFields(modulePath)

--- a/dev/import-beats/streams.go
+++ b/dev/import-beats/streams.go
@@ -92,7 +92,7 @@ func createLogStreams(modulePath, moduleTitle, datasetName string) ([]util.Strea
 		for _, inputType := range root.inputTypes() {
 			aType := inputType
 			if inputType == "log" {
-				aType = "logs"
+				aType = "logfile"
 			}
 			targetFileName := inputType + ".yml.hbs"
 

--- a/packages/apache/dataset/access/manifest.yml
+++ b/packages/apache/dataset/access/manifest.yml
@@ -2,7 +2,7 @@ title: Apache access logs
 release: beta
 type: logs
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/apache/dataset/error/manifest.yml
+++ b/packages/apache/dataset/error/manifest.yml
@@ -2,7 +2,7 @@ title: Apache error logs
 release: beta
 type: logs
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -29,7 +29,7 @@ config_templates:
   title: Apache logs and metrics
   description: Collect logs and metrics from Apache instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from Apache instances
     description: Collecting Apache access and error logs
   - type: apache/metrics

--- a/packages/cisco/dataset/asa/manifest.yml
+++ b/packages/cisco/dataset/asa/manifest.yml
@@ -36,7 +36,7 @@ streams:
     required: true
     show_user: false
     default: 7
-- input: logs
+- input: logfile
   title: Cisco ASA logs
   description: Collect Cisco ASA logs from file
   vars:

--- a/packages/cisco/dataset/ftd/manifest.yml
+++ b/packages/cisco/dataset/ftd/manifest.yml
@@ -36,7 +36,7 @@ streams:
     required: true
     show_user: false
     default: 7
-- input: logs
+- input: logfile
   title: Cisco FTD logs
   description: Collect Cisco FTD logs from file
   vars:

--- a/packages/cisco/dataset/ios/manifest.yml
+++ b/packages/cisco/dataset/ios/manifest.yml
@@ -37,7 +37,7 @@ streams:
     required: true
     show_user: true
     default: 9002
-- input: logs
+- input: logfile
   title: Cisco IOS logs
   description: Collect Cisco IOS logs from file
   vars:

--- a/packages/cisco/manifest.yml
+++ b/packages/cisco/manifest.yml
@@ -32,6 +32,6 @@ config_templates:
       - type: syslog
         title: Collect logs from Cisco via syslog
         description: Collecting logs from Cisco IOS via syslog
-      - type: logs
+      - type: logfile
         title: Collect logs from Cisco via file
         description: Collecting logs from Cisco ASA, FTD, and IOS via file

--- a/packages/kafka/dataset/log/manifest.yml
+++ b/packages/kafka/dataset/log/manifest.yml
@@ -2,7 +2,7 @@ title: Kafka log logs
 release: beta
 type: logs
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: kafka_home
     type: text

--- a/packages/kafka/manifest.yml
+++ b/packages/kafka/manifest.yml
@@ -30,7 +30,7 @@ config_templates:
   title: Kafka logs and metrics
   description: Collect logs and metrics from Kafka brokers
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from Kafka brokers
     description: Collecting Kafka log logs
   - type: kafka/metrics

--- a/packages/log/dataset/log/manifest.yml
+++ b/packages/log/dataset/log/manifest.yml
@@ -6,7 +6,7 @@ default: true
 id: generic
 
 streams:
-  - input: logs
+  - input: logfile
     title: Collect log files
     vars:
       - name: paths

--- a/packages/log/manifest.yml
+++ b/packages/log/manifest.yml
@@ -14,7 +14,7 @@ config_templates:
     title: Custom logs
     description: Collect your custom log files.
     inputs:
-      - type: logs
+      - type: logfile
         title: Custom log file
         description: Collect your custom log files.
 

--- a/packages/mongodb/dataset/log/manifest.yml
+++ b/packages/mongodb/dataset/log/manifest.yml
@@ -2,7 +2,7 @@ title: mongodb log logs
 release: beta
 type: logs
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/mongodb/manifest.yml
+++ b/packages/mongodb/manifest.yml
@@ -25,7 +25,7 @@ datasources:
   title: MongoDB logs and metrics
   description: Collect logs and metrics from MongoDB instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect MongoDB application logs
     description: Collecting application logs from MongoDB instances
   - type: mongodb/metrics

--- a/packages/mysql/dataset/error/manifest.yml
+++ b/packages/mysql/dataset/error/manifest.yml
@@ -2,7 +2,7 @@ title: MySQL error logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/mysql/dataset/slowlog/manifest.yml
+++ b/packages/mysql/dataset/slowlog/manifest.yml
@@ -2,7 +2,7 @@ title: MySQL slowlog logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -30,7 +30,7 @@ config_templates:
   title: MySQL logs and metrics
   description: Collect logs and metrics from MySQL instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from MySQL hosts
     description: Collecting MySQL error and slowlog logs
   - type: mysql/metrics

--- a/packages/nginx/dataset/access/manifest.yml
+++ b/packages/nginx/dataset/access/manifest.yml
@@ -2,7 +2,7 @@ title: Nginx access logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/nginx/dataset/error/manifest.yml
+++ b/packages/nginx/dataset/error/manifest.yml
@@ -2,7 +2,7 @@ title: Nginx error logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/nginx/dataset/ingress_controller/manifest.yml
+++ b/packages/nginx/dataset/ingress_controller/manifest.yml
@@ -2,7 +2,7 @@ title: Nginx ingress_controller logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   enabled: false
   vars:
   - name: paths

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -30,7 +30,7 @@ config_templates:
   title: Nginx logs and metrics
   description: Collect logs and metrics from Nginx instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from Nginx instances
     description: Collecting Nginx access, error and ingress controller logs
   - type: nginx/metrics

--- a/packages/postgresql/dataset/log/manifest.yml
+++ b/packages/postgresql/dataset/log/manifest.yml
@@ -2,7 +2,7 @@ title: PostgreSQL application logs
 release: beta
 type: logs
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/postgresql/manifest.yml
+++ b/packages/postgresql/manifest.yml
@@ -32,7 +32,7 @@ config_templates:
   title: PostgreSQL logs and metrics
   description: Collect logs and metrics from PostgreSQL instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect PostgreSQL logs
     description: Collecting application logs from PostgreSQL instances
   - type: postgresql/metrics

--- a/packages/rabbitmq/dataset/log/manifest.yml
+++ b/packages/rabbitmq/dataset/log/manifest.yml
@@ -2,7 +2,7 @@ title: RabbitMQ application logs
 release: beta
 type: logs
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/rabbitmq/manifest.yml
+++ b/packages/rabbitmq/manifest.yml
@@ -20,7 +20,7 @@ config_templates:
   title: RabbitMQ logs and metrics
   description: Collect logs and metrics from RabbitMQ instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from RabbitMQ instances
     description: Collecting application logs from RabbitMQ instances
   - type: rabbitmq/metrics

--- a/packages/redis/dataset/log/manifest.yml
+++ b/packages/redis/dataset/log/manifest.yml
@@ -2,7 +2,7 @@ title: Redis application logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/redis/manifest.yml
+++ b/packages/redis/manifest.yml
@@ -30,7 +30,7 @@ config_templates:
   title: Redis logs and metrics
   description: Collect logs and metrics from Redis instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect Redis application logs
     description: Collecting application logs from Redis instances
   - type: redis

--- a/packages/system/dataset/auth/manifest.yml
+++ b/packages/system/dataset/auth/manifest.yml
@@ -2,7 +2,7 @@ title: System auth logs
 release: experimental
 type: logs
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/system/dataset/syslog/manifest.yml
+++ b/packages/system/dataset/syslog/manifest.yml
@@ -2,7 +2,7 @@ title: System syslog logs
 release: experimental
 type: logs
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -29,7 +29,7 @@ config_templates:
   title: System logs and metrics
   description: Collect logs and metrics from System instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from System instances
     description: Collecting System auth and syslog logs
   - type: system/metrics


### PR DESCRIPTION
What does this PR do?

This PR is another trial of renaming logs to logfile for stream.inputs only.

I didn't update the dependency on the package-registry, as there are breaking changes (ProductRequirement is missing).

## How to test this PR locally

To verify what does the new integration look like:
```
PACKAGES=o365 SKIP_KIBANA=true mage ImportBeats
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- https://github.com/elastic/integrations/pull/119/files