### PR TITLE
Assign owners to packages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -374,6 +374,10 @@ on the business or technical requirements for the entire platform (Elastic Packa
      kibana.version: '^7.9.0'
    ```
 
+5. Set the proper package owner (either Github team or personal account)
+
+   Good candidates for a team: `elastic/integrations-platforms`, `elastic/integrations-services`
+
 ### All integrations
 
 #### Code reviewers

--- a/dev/import-beats/packages.go
+++ b/dev/import-beats/packages.go
@@ -235,7 +235,6 @@ func (r *packageRepository) createPackagesFromSource(beatsDir, beatName, beatTyp
 		aPackage.addKibanaContent(kibana)
 		manifest.Conditions = createConditions()
 
-
 		aPackage.manifest = manifest
 		r.packages[moduleDir.Name()] = aPackage
 	}

--- a/dev/import-beats/packages.go
+++ b/dev/import-beats/packages.go
@@ -43,6 +43,9 @@ func newPackageContent(name string) packageContent {
 			},
 			License: "basic",
 			Release: "experimental",
+			Owner: &util.Owner{
+				Github: "elastic/integrations",
+			},
 		},
 		kibana: kibanaContent{
 			files: map[string]map[string][]byte{},
@@ -231,6 +234,7 @@ func (r *packageRepository) createPackagesFromSource(beatsDir, beatName, beatTyp
 		}
 		aPackage.addKibanaContent(kibana)
 		manifest.Conditions = createConditions()
+
 
 		aPackage.manifest = manifest
 		r.packages[moduleDir.Name()] = aPackage

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -45,3 +45,5 @@ config_templates:
       show_user: true
       default:
       - http://127.0.0.1
+owner:
+  github: elastic/integrations-services

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -255,3 +255,5 @@ config_templates:
       show_user: false
       default: "amazonaws.com"
       description: URL of the entry point for an AWS web service.
+owner:
+  github: elastic/integrations-platforms

--- a/packages/cisco/manifest.yml
+++ b/packages/cisco/manifest.yml
@@ -35,3 +35,5 @@ config_templates:
       - type: logfile
         title: Collect logs from Cisco via file
         description: Collecting logs from Cisco ASA, FTD, and IOS via file
+owner:
+  github: elastic/integrations-services

--- a/packages/kafka/manifest.yml
+++ b/packages/kafka/manifest.yml
@@ -60,3 +60,5 @@ config_templates:
       - name: ssl.key
         type: text
         show_user: true
+owner:
+  github: elastic/integrations-services

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -44,3 +44,5 @@ config_templates:
       Node, Pod, Container, Volume and System metrics from Kubelet and metrics from kube_state_metrics
       (container, cronjob, deployment, node, persistentvolume, persistentvolumeclaim, pod, replicaset, resourcequota,
        service, statefulset, storageclass).
+owner:
+  github: elastic/integrations-platforms

--- a/packages/log/manifest.yml
+++ b/packages/log/manifest.yml
@@ -19,3 +19,5 @@ config_templates:
 icons:
   - src: "/img/icon.svg"
     type: "image/svg+xml"
+owner:
+  github: elastic/integrations-services

--- a/packages/mongodb/manifest.yml
+++ b/packages/mongodb/manifest.yml
@@ -41,3 +41,5 @@ datasources:
       - localhost:27017
     title: Collect MongoDB metrics
     description: Collecting metrics from MongoDB instances
+owner:
+  github: elastic/integrations-services

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -52,3 +52,5 @@ config_templates:
         type: password
         title: Password
         default: test
+owner:
+  github: elastic/integrations-services

--- a/packages/netflow/manifest.yml
+++ b/packages/netflow/manifest.yml
@@ -19,3 +19,5 @@ config_templates:
   - type: netflow
     title: Collect NetFlow logs
     description: Collecting NetFlow logs using the netflow input
+owner:
+  github: elastic/integrations-services

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -45,3 +45,5 @@ config_templates:
       - http://127.0.0.1:80
     title: Collect metrics from Nginx instances
     description: Collecting Nginx stub status metrics
+owner:
+  github: elastic/integrations-services

--- a/packages/postgresql/manifest.yml
+++ b/packages/postgresql/manifest.yml
@@ -54,3 +54,5 @@ config_templates:
       - name: password
         type: password
         title: Password
+owner:
+  github: elastic/integrations-services

--- a/packages/rabbitmq/manifest.yml
+++ b/packages/rabbitmq/manifest.yml
@@ -58,3 +58,5 @@ config_templates:
         required: false
         show_user: false
         default: ""
+owner:
+  github: elastic/integrations-services

--- a/packages/redis/manifest.yml
+++ b/packages/redis/manifest.yml
@@ -76,3 +76,5 @@ config_templates:
       default: ""
     title: Collect Redis metrics
     description: Collecting info, key and keyspace metrics from Redis instances
+owner:
+  github: elastic/integrations-services

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -42,3 +42,5 @@ config_templates:
     description: Collecting System core, cpu, diskio, entropy, filesystem, fsstat,
       load, memory, network, network_summary, process, process_summary, raid, service,
       socket, socket_summary, uptime and users metrics
+owner:
+  github: elastic/integrations-services

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -30,3 +30,5 @@ datasources:
   - type: windows/metrics
     title: Collect Windows perfmon and service metrics
     description: Collecting perfmon and service metrics from Windows instances
+owner:
+  github: elastic/integrations-services


### PR DESCRIPTION
## What does this PR do?

This PR assigns owner teams to packages. It also updates the import-beats script to assign a common team alias.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
~~- [ ] I have verified that all datasets collect metrics or logs.~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- https://github.com/elastic/integrations/issues/103
