### PR TITLE
Make production branch as base branch

### DIFF
--- a/dev/update-package-storage/github.go
+++ b/dev/update-package-storage/github.go
@@ -79,7 +79,7 @@ func buildPullRequestRequestBody(title, username, branchName, description string
 	requestBody := map[string]interface{}{
 		"title":                 title,
 		"head":                  fmt.Sprintf("%s:%s", username, branchName),
-		"base":                  "master",
+		"base":                  "production",
 		"body":                  description,
 		"maintainer_can_modify": true,
 	}


### PR DESCRIPTION
As all the packages are now in the production branch and not master anymore in package-storage, I assume this one should serve as a base.
