### PR TITLE
Attach the registry image to a specific version

### DIFF
--- a/.ci/integrations/Dockerfile
+++ b/.ci/integrations/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.elastic.co/package-registry/package-registry:master
+FROM docker.elastic.co/package-registry/package-registry:41c150c8020efc53ab16e3bba774c62a419b51ea
 
 COPY build/integrations /registry/packages/integrations

--- a/testing/environments/kubernetes/snapshot.yml
+++ b/testing/environments/kubernetes/snapshot.yml
@@ -184,7 +184,7 @@ spec:
             name: registry-yaml-storage
       containers:
         - name: registry-ingest-management
-          image: docker.elastic.co/package-registry/package-registry:master
+          image: docker.elastic.co/package-registry/package-registry:41c150c8020efc53ab16e3bba774c62a419b51ea
           resources:
             limits:
               cpu: 1000m

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -38,7 +38,7 @@ services:
       - "127.0.0.1:5601:5601"
 
   package-registry:
-    image: docker.elastic.co/package-registry/package-registry:master
+    image: docker.elastic.co/package-registry/package-registry:41c150c8020efc53ab16e3bba774c62a419b51ea
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:8080"]
       retries: 300


### PR DESCRIPTION
Builds in the integrations repo should not change over time. Also development in the registry should not directly affect the integrations repo. To have things more reproducible, this changes the docker container which is run for the registry to a specific revision. It is the same revision which is uesd for the golang dependencies. If possible, these two should stay in sync in the future.
