### PR TITLE
Add base package to integrations repository

### DIFF
--- a/packages/base/docs/README.md
+++ b/packages/base/docs/README.md
@@ -1,0 +1,3 @@
+# Base package
+
+This is installed in the background by EPM to setup the Elastic Stack.

--- a/packages/base/elasticsearch/component_template/events-mappings.json
+++ b/packages/base/elasticsearch/component_template/events-mappings.json
@@ -1,0 +1,149 @@
+{
+    "template": {
+        "mappings": {
+            "_meta": {
+            },
+            "dynamic_templates": [
+                {
+                    "strings_as_keyword": {
+                        "mapping": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "match_mapping_type": "string"
+                    }
+                }
+            ],
+            "date_detection": false,
+            "properties": {
+                "@timestamp": {
+                    "type": "date"
+                },
+                "dataset": {
+                    "properties": {
+                        "type": {
+                            "type": "constant_keyword",
+                            "value": "events"
+                        },
+                        "name": {
+                            "type": "constant_keyword"
+                        },
+                        "namespace": {
+                            "type": "constant_keyword"
+                        }
+                    }
+                },
+                "agent": {
+                    "properties": {
+                        "hostname": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "name": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "id": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "ephemeral_id": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "type": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "version": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "ecs": {
+                    "properties": {
+                        "version": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "host": {
+                    "properties": {
+                        "hostname": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "os": {
+                            "properties": {
+                                "build": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "kernel": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "codename": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "name": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "family": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "version": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "platform": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "full": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                }
+                            }
+                        },
+                        "ip": {
+                            "type": "ip"
+                        },
+                        "containerized": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "id": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "type": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "mac": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "architecture": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "message": {
+                    "type": "text"
+                }
+            }
+        },
+        "aliases": {}
+    }
+}

--- a/packages/base/elasticsearch/component_template/events-settings.json
+++ b/packages/base/elasticsearch/component_template/events-settings.json
@@ -1,0 +1,21 @@
+{
+    "template": {
+        "settings": {
+            "index": {
+                "lifecycle": {
+                    "name": "events-default"
+                },
+                "codec": "best_compression",
+                "refresh_interval": "5s",
+                "number_of_shards": "1",
+                "query": {
+                    "default_field": [
+                        "message"
+                    ]
+                },
+                "number_of_routing_shards": "30"
+            }
+        },
+        "aliases": {}
+    }
+}

--- a/packages/base/elasticsearch/component_template/logs-mappings.json
+++ b/packages/base/elasticsearch/component_template/logs-mappings.json
@@ -1,0 +1,149 @@
+{
+    "template": {
+        "mappings": {
+            "_meta": {
+            },
+            "dynamic_templates": [
+                {
+                    "strings_as_keyword": {
+                        "mapping": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "match_mapping_type": "string"
+                    }
+                }
+            ],
+            "date_detection": false,
+            "properties": {
+                "@timestamp": {
+                    "type": "date"
+                },
+                "dataset": {
+                    "properties": {
+                        "type": {
+                            "type": "constant_keyword",
+                            "value": "logs"
+                        },
+                        "name": {
+                            "type": "constant_keyword"
+                        },
+                        "namespace": {
+                            "type": "constant_keyword"
+                        }
+                    }
+                },
+                "agent": {
+                    "properties": {
+                        "hostname": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "name": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "id": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "ephemeral_id": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "type": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "version": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "ecs": {
+                    "properties": {
+                        "version": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "host": {
+                    "properties": {
+                        "hostname": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "os": {
+                            "properties": {
+                                "build": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "kernel": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "codename": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "name": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "family": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "version": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "platform": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "full": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                }
+                            }
+                        },
+                        "ip": {
+                            "type": "ip"
+                        },
+                        "containerized": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "id": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "type": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "mac": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "architecture": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "message": {
+                    "type": "text"
+                }
+            }
+        },
+        "aliases": {}
+    }
+}

--- a/packages/base/elasticsearch/component_template/logs-settings.json
+++ b/packages/base/elasticsearch/component_template/logs-settings.json
@@ -1,0 +1,21 @@
+{
+    "template": {
+        "settings": {
+            "index": {
+                "lifecycle": {
+                    "name": "logs-default"
+                },
+                "codec": "best_compression",
+                "refresh_interval": "5s",
+                "number_of_shards": "1",
+                "query": {
+                    "default_field": [
+                        "message"
+                    ]
+                },
+                "number_of_routing_shards": "30"
+            }
+        },
+        "aliases": {}
+    }
+}

--- a/packages/base/elasticsearch/component_template/metrics-mappings.json
+++ b/packages/base/elasticsearch/component_template/metrics-mappings.json
@@ -1,0 +1,146 @@
+{
+    "template": {
+        "mappings": {
+            "_meta": {
+            },
+            "dynamic_templates": [
+                {
+                    "strings_as_keyword": {
+                        "mapping": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "match_mapping_type": "string"
+                    }
+                }
+            ],
+            "date_detection": false,
+            "properties": {
+                "@timestamp": {
+                    "type": "date"
+                },
+                "dataset": {
+                    "properties": {
+                        "type": {
+                            "type": "constant_keyword",
+                            "value": "metrics"
+                        },
+                        "name": {
+                            "type": "constant_keyword"
+                        },
+                        "namespace": {
+                            "type": "constant_keyword"
+                        }
+                    }
+                },
+                "agent": {
+                    "properties": {
+                        "hostname": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "name": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "id": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "ephemeral_id": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "type": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "version": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "ecs": {
+                    "properties": {
+                        "version": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "host": {
+                    "properties": {
+                        "hostname": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "os": {
+                            "properties": {
+                                "build": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "kernel": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "codename": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "name": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "family": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "version": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "platform": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "full": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                }
+                            }
+                        },
+                        "ip": {
+                            "type": "ip"
+                        },
+                        "containerized": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "id": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "type": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "mac": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "architecture": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        }
+                    }
+                }
+            }
+        },
+        "aliases": {}
+    }
+}

--- a/packages/base/elasticsearch/component_template/metrics-settings.json
+++ b/packages/base/elasticsearch/component_template/metrics-settings.json
@@ -1,0 +1,21 @@
+{
+    "template": {
+        "settings": {
+            "index": {
+                "lifecycle": {
+                    "name": "metrics-default"
+                },
+                "codec": "best_compression",
+                "refresh_interval": "5s",
+                "number_of_shards": "1",
+                "query": {
+                    "default_field": [
+                        "message"
+                    ]
+                },
+                "number_of_routing_shards": "30"
+            }
+        },
+        "aliases": {}
+    }
+}

--- a/packages/base/elasticsearch/ilm_policy/events-default.json
+++ b/packages/base/elasticsearch/ilm_policy/events-default.json
@@ -1,0 +1,15 @@
+{
+    "policy": {
+        "phases": {
+            "hot": {
+                "min_age": "0ms",
+                "actions": {
+                    "rollover": {
+                        "max_size": "50gb",
+                        "max_age": "30d"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/base/elasticsearch/ilm_policy/logs-default.json
+++ b/packages/base/elasticsearch/ilm_policy/logs-default.json
@@ -1,0 +1,15 @@
+{
+        "policy": {
+            "phases": {
+                "hot": {
+                    "min_age": "0ms",
+                    "actions": {
+                        "rollover": {
+                            "max_size": "50gb",
+                            "max_age": "30d"
+                        }
+                    }
+                }
+            }
+        }
+}

--- a/packages/base/elasticsearch/ilm_policy/metrics-default.json
+++ b/packages/base/elasticsearch/ilm_policy/metrics-default.json
@@ -1,0 +1,15 @@
+{
+    "policy": {
+        "phases": {
+            "hot": {
+                "min_age": "0ms",
+                "actions": {
+                    "rollover": {
+                        "max_size": "50gb",
+                        "max_age": "30d"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/base/elasticsearch/index_template/events.json
+++ b/packages/base/elasticsearch/index_template/events.json
@@ -1,0 +1,13 @@
+{
+    "index_patterns": [
+        "events-*-*"
+    ],
+    "priority": 0,
+    "data_stream": {
+        "timestamp_field": "@timestamp"
+    },
+    "composed_of": [
+        "events-mappings",
+        "events-settings"
+    ]
+}

--- a/packages/base/elasticsearch/index_template/logs.json
+++ b/packages/base/elasticsearch/index_template/logs.json
@@ -1,0 +1,13 @@
+{
+    "index_patterns": [
+        "logs-*-*"
+    ],
+    "priority": 0,
+    "data_stream": {
+        "timestamp_field": "@timestamp"
+    },
+    "composed_of": [
+        "logs-mappings",
+        "logs-settings"
+    ]
+}

--- a/packages/base/elasticsearch/index_template/metrics.json
+++ b/packages/base/elasticsearch/index_template/metrics.json
@@ -1,0 +1,13 @@
+{
+    "index_patterns": [
+        "metrics-*-*"
+    ],
+    "priority": 0,
+    "data_stream": {
+        "timestamp_field": "@timestamp"
+    },
+    "composed_of": [
+        "metrics-mappings",
+        "metrics-settings"
+    ]
+}

--- a/packages/base/manifest.yml
+++ b/packages/base/manifest.yml
@@ -1,0 +1,29 @@
+format_version: 1.0.0
+
+name: base
+title: Base package
+description: >
+  The base package contains assets which are needed for the basic setup of the stack.
+
+  It contains the default ILM policies.
+version: 0.4.0
+release: ga
+
+# The base package cannot be removed
+removable: false
+
+# The user should not see this package and not be able to install it
+internal: true
+
+license: basic
+# This is called type integration because it is required for all the integration packages
+type: integration
+
+requirement:
+  elasticsearch:
+    # Requires ILM which was released in 6.6.
+    version: ">6.6.0"
+
+# No icons
+icons:
+


### PR DESCRIPTION
This adds the base package for versioning to the integrations repository. This package is maintained by the ingest-management team but integrations is a good place for this package at the moment until we have found a new home.

As Elasticsearch ships the basic assets, this currently does not need to be released. As soon as we have brought all the assets in line with Elasticsearch and added improvements, we need to start releasing it.
