### PR TITLE
fix nginx search asset id

### DIFF
--- a/packages/nginx/kibana/search/Filebeat-Nginx-module-ecs.json
+++ b/packages/nginx/kibana/search/Filebeat-Nginx-module-ecs.json
@@ -43,7 +43,7 @@
         "title": "Nginx logs [Logs Nginx] ECS",
         "version": 1
     },
-    "id": "Logs-Nginx-integration-ecs",
+    "id": "Filebeat-Nginx-module-ecs",
     "references": [
         {
             "id": "logs-*",


### PR DESCRIPTION
# What does this PR do?
Fixes incorrect installation and errors removing kibana search assets: `Filebeat-Nginx-module-ecs.json` and `Logs-Nginx-integration-ecs.json` have the same id `Logs-Nginx-integration-ecs`.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [x] I have verified that all datasets collect metrics or logs.

