### PR TITLE
Use minimum kibana version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -367,7 +367,7 @@ on the business or technical requirements for the entire platform (Elastic Packa
 
    The list of available categories is present in the Package Registry source: https://github.com/elastic/package-registry/blob/e93e801a6dfbfa6f83c8b69f6e9405603151f937/util/package.go#L27-L51
 
-4. Make sure that the version condition for kibana is set to `>=7.9.0`.
+4. Make sure that the version condition for kibana is set to `>=7.9.0`. This is necessary because Kibana `master` will always send the next major version (at the time of this writing `8.0.0`), and using `^7.9.0` will prevent a package to be shown to Kibana `master`. This is extremely inconvenient for testing and development.
 
    ```yaml
    conditions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -367,11 +367,11 @@ on the business or technical requirements for the entire platform (Elastic Packa
 
    The list of available categories is present in the Package Registry source: https://github.com/elastic/package-registry/blob/e93e801a6dfbfa6f83c8b69f6e9405603151f937/util/package.go#L27-L51
 
-4. Make sure that the version condition for kibana is set to `^7.9.0`.
+4. Make sure that the version condition for kibana is set to `>=7.9.0`.
 
    ```yaml
    conditions:
-     kibana.version: '^7.9.0'
+     kibana.version: '>=7.9.0'
    ```
 
 5. Set the proper package owner (either Github team or personal account)

--- a/dev/import-beats/conditions.go
+++ b/dev/import-beats/conditions.go
@@ -14,6 +14,6 @@ var zeroVersion = semver.MustParse("0.0.0")
 
 func createConditions() *util.Conditions {
 	return &util.Conditions{
-		KibanaVersion: "^7.9.0",
+		KibanaVersion: ">=7.9.0",
 	}
 }

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -10,7 +10,7 @@ categories:
 release: beta
 removable: true
 conditions:
-  kibana.version: '^7.9.0'
+  kibana.version: '>=7.9.0'
 screenshots:
 - src: /img/kibana-apache.png
   title: Apache Integration

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -12,7 +12,7 @@ categories:
 - security
 release: beta
 conditions:
-  kibana.version: '^7.9.0'
+  kibana.version: '>=7.9.0'
 screenshots:
 - src: /img/filebeat-aws-cloudtrail.png
   title: filebeat aws cloudtrail

--- a/packages/cisco/manifest.yml
+++ b/packages/cisco/manifest.yml
@@ -10,7 +10,7 @@ categories:
 - security
 release: beta
 conditions:
-  kibana.version: '^7.9.0'
+  kibana.version: '>=7.9.0'
 screenshots:
   - src: /img/kibana-cisco-asa.png
     title: kibana cisco asa

--- a/packages/iis/manifest.yml
+++ b/packages/iis/manifest.yml
@@ -14,7 +14,7 @@ categories:
   - web
 release: beta
 conditions:
-  kibana.version: ^7.9.0
+  kibana.version: '>=7.9.0'
 screenshots:
 - src: /img/kibana-iis.png
   title: kibana iis

--- a/packages/kafka/manifest.yml
+++ b/packages/kafka/manifest.yml
@@ -9,7 +9,7 @@ categories:
 - message_queue
 release: beta
 conditions:
-  kibana.version: '^7.9.0'
+  kibana.version: '>=7.9.0'
 screenshots:
 - src: /img/filebeat-kafka-logs-overview.png
   title: filebeat kafka logs overview

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -10,7 +10,7 @@ categories:
 - kubernetes
 release: beta
 conditions:
-  kibana.version: '^7.9.0'
+  kibana.version: '>=7.9.0'
 screenshots:
 - src: /img/metricbeat_kubernetes_overview.png
   title: Metricbeat Kubernetes Overview

--- a/packages/mongodb/manifest.yml
+++ b/packages/mongodb/manifest.yml
@@ -15,7 +15,7 @@ license: basic
 release: beta
 removable: true
 conditions:
-  kibana.version: '^7.9.0'
+  kibana.version: '>=7.9.0'
 screenshots:
 - src: /img/filebeat-mongodb-overview.png
   title: filebeat mongodb overview

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -9,7 +9,7 @@ categories:
 - datastore
 release: beta
 conditions:
-  kibana.version: '^7.9.0'
+  kibana.version: '>=7.9.0'
 screenshots:
 - src: /img/kibana-mysql.png
   title: kibana mysql

--- a/packages/netflow/manifest.yml
+++ b/packages/netflow/manifest.yml
@@ -10,7 +10,7 @@ categories:
 - security
 release: beta
 conditions:
-  kibana.version: '^7.9.0'
+  kibana.version: '>=7.9.0'
 config_templates:
 - name: netflow
   title: NetFlow logs

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -10,7 +10,7 @@ categories:
 - security
 release: beta
 conditions:
-  kibana.version: '^7.9.0'
+  kibana.version: '>=7.9.0'
 screenshots:
 - src: /img/kibana-nginx.png
   title: kibana nginx

--- a/packages/postgresql/manifest.yml
+++ b/packages/postgresql/manifest.yml
@@ -9,7 +9,7 @@ categories:
 - datastore
 release: beta
 conditions:
-  kibana.version: '^7.9.0'
+  kibana.version: '>=7.9.0'
 screenshots:
 - src: /img/filebeat-postgresql-overview.png
   title: Filebeat PostgreSQL overview

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -10,7 +10,7 @@ categories:
 - datastore
 release: beta
 conditions:
-  kibana.version: '^7.9.0'
+  kibana.version: '>=7.9.0'
 screenshots:
 - src: /img/metricbeat-prometheus-overview.png
   title: Metricbeat Prometheus Overview

--- a/packages/rabbitmq/manifest.yml
+++ b/packages/rabbitmq/manifest.yml
@@ -10,7 +10,7 @@ categories:
 release: beta
 removable: true
 conditions:
-  kibana.version: '^7.9.0'
+  kibana.version: '>=7.9.0'
 icons:
 - src: /img/logo_rabbitmq.svg
   title: RabbitMQ Logo

--- a/packages/redis/manifest.yml
+++ b/packages/redis/manifest.yml
@@ -10,7 +10,7 @@ categories:
 - message_queue
 release: beta
 conditions:
-  kibana.version: '^7.9.0'
+  kibana.version: '>=7.9.0'
 screenshots:
 - src: /img/kibana-redis.png
   title: kibana redis

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -10,7 +10,7 @@ categories:
 - security
 release: beta
 conditions:
-  kibana.version: '^7.9.0'
+  kibana.version: '>=7.9.0'
 screenshots:
 - src: /img/kibana-system.png
   title: kibana system

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -16,7 +16,7 @@ license: basic
 release: beta
 removable: true
 conditions:
-  kibana.version: '^7.9.0'
+  kibana.version: '>=7.9.0'
 screenshots:
 - src: /img/metricbeat-windows-service.png
   title: metricbeat windows service

--- a/packages/zookeeper/manifest.yml
+++ b/packages/zookeeper/manifest.yml
@@ -15,7 +15,7 @@ categories:
   - config_management
 release: beta
 conditions:
-  kibana.version: ^7.9.0
+  kibana.version: '>=7.9.0'
 screenshots:
 - src: /img/metricbeat-zookeeper.png
   title: Metricbeat ZooKeeper


### PR DESCRIPTION
## What does this PR do?

Changes all occurences of `^7.9.0` to `>=7.9.0` so that the packages also appear in Kibana `master` which sends `kibana.version=8.0.0` to the registry.

## Related issues

- Closes https://github.com/elastic/integrations/issues/172
- Is needed by https://github.com/elastic/kibana/pull/71443

