### PR TITLE
Fix nanocore sum for non default intervals on Kubernetes Overview Dashboard

### DIFF
--- a/packages/kubernetes/kibana/visualization/44f12b40-2bf4-11e7-859b-f78b612cde28-ecs.json
+++ b/packages/kubernetes/kibana/visualization/44f12b40-2bf4-11e7-859b-f78b612cde28-ecs.json
@@ -58,6 +58,28 @@
                                 "field": "kubernetes.container.cpu.usage.nanocores",
                                 "id": "0d5c9221-2bf2-11e7-859b-f78b612cde28",
                                 "type": "sum"
+                            },
+                            {
+                                "field": "metricset.period",
+                                "id": "8b346300-bf95-11ea-a07c-851701f0d645",
+                                "type": "avg"
+                            },
+                            {
+                                "id": "25ae6580-bf95-11ea-a07c-851701f0d645",
+                                "script": "params.sum_nanocores / (params._interval / params.avg_period)",
+                                "type": "calculation",
+                                "variables": [
+                                    {
+                                        "field": "0d5c9221-2bf2-11e7-859b-f78b612cde28",
+                                        "id": "39e40aa0-bf95-11ea-a07c-851701f0d645",
+                                        "name": "sum_nanocores"
+                                    },
+                                    {
+                                        "field": "8b346300-bf95-11ea-a07c-851701f0d645",
+                                        "id": "85213600-bf95-11ea-a07c-851701f0d645",
+                                        "name": "avg_period"
+                                    }
+                                ]
                             }
                         ],
                         "override_index_pattern": 0,

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 0.1.0
+version: 0.1.1
 license: basic
 description: Kubernetes Integration
 type: integration


### PR DESCRIPTION
Updates based on https://github.com/elastic/beats/pull/19675.

Closes https://github.com/elastic/integrations/issues/179.