### PR TITLE
Add restart policy to docker-compose file

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -39,6 +39,7 @@ services:
 
   package-registry:
     image: docker.elastic.co/package-registry/package-registry:41c150c8020efc53ab16e3bba774c62a419b51ea
+    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:8080"]
       retries: 300


### PR DESCRIPTION
## What does this PR do?

Adds a restart policy to the snapshot docker-compose file to workaround panic in the package registry code.

## Related issues

- Closes https://github.com/elastic/integrations/issues/184