### PR TITLE
Fix markdown link to Nginx home page

### DIFF
--- a/dev/import-beats-resources/nginx/docs/README.md
+++ b/dev/import-beats-resources/nginx/docs/README.md
@@ -1,6 +1,6 @@
 # Nginx Integration
 
-This integration periodically fetches metrics from [https://nginx.org/](Nginx) servers. It can parse access and error
+This integration periodically fetches metrics from [Nginx](https://nginx.org/) servers. It can parse access and error
 logs created by the HTTP server. 
 
 ## Compatibility

--- a/packages/nginx/docs/README.md
+++ b/packages/nginx/docs/README.md
@@ -1,6 +1,6 @@
 # Nginx Integration
 
-This integration periodically fetches metrics from [https://nginx.org/](Nginx) servers. It can parse access and error
+This integration periodically fetches metrics from [Nginx](https://nginx.org/) servers. It can parse access and error
 logs created by the HTTP server. 
 
 ## Compatibility


### PR DESCRIPTION
## What does this PR do?

This PR fixes a markdown link typo in the nginx package description.