### PR TITLE
Add template_path to system module

### DIFF
--- a/packages/system/dataset/core/manifest.yml
+++ b/packages/system/dataset/core/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
 - input: system/metrics
+  template_path: stream.yml.hbs
   enabled: false
   vars:
   - name: period

--- a/packages/system/dataset/cpu/manifest.yml
+++ b/packages/system/dataset/cpu/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
 - input: system/metrics
+  template_path: stream.yml.hbs
   vars:
   - name: period
     type: text

--- a/packages/system/dataset/diskio/manifest.yml
+++ b/packages/system/dataset/diskio/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
 - input: system/metrics
+  template_path: stream.yml.hbs
   vars:
     - name: period
       type: text

--- a/packages/system/dataset/entropy/manifest.yml
+++ b/packages/system/dataset/entropy/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
 - input: system/metrics
+  template_path: stream.yml.hbs
   vars:
     - name: period
       type: text

--- a/packages/system/dataset/filesystem/manifest.yml
+++ b/packages/system/dataset/filesystem/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
 - input: system/metrics
+  template_path: stream.yml.hbs
   enabled: false
   vars:
   - name: period

--- a/packages/system/dataset/fsstat/manifest.yml
+++ b/packages/system/dataset/fsstat/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
 - input: system/metrics
+  template_path: stream.yml.hbs
   enabled: false
   vars:
   - name: period

--- a/packages/system/dataset/load/manifest.yml
+++ b/packages/system/dataset/load/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
 - input: system/metrics
+  template_path: stream.yml.hbs
   vars:
     - name: period
       type: text

--- a/packages/system/dataset/memory/manifest.yml
+++ b/packages/system/dataset/memory/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
 - input: system/metrics
+  template_path: stream.yml.hbs
   vars:
     - name: period
       type: text

--- a/packages/system/dataset/network/manifest.yml
+++ b/packages/system/dataset/network/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
 - input: system/metrics
+  template_path: stream.yml.hbs
   vars:
   - name: period
     type: text

--- a/packages/system/dataset/network_summary/manifest.yml
+++ b/packages/system/dataset/network_summary/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
 - input: system/metrics
+  template_path: stream.yml.hbs
   vars:
     - name: period
       type: text

--- a/packages/system/dataset/process/manifest.yml
+++ b/packages/system/dataset/process/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
 - input: system/metrics
+  template_path: stream.yml.hbs
   vars:
   - name: period
     type: text

--- a/packages/system/dataset/process_summary/manifest.yml
+++ b/packages/system/dataset/process_summary/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
 - input: system/metrics
+  template_path: stream.yml.hbs
   vars:
     - name: period
       type: text

--- a/packages/system/dataset/raid/manifest.yml
+++ b/packages/system/dataset/raid/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
 - input: system/metrics
+  template_path: stream.yml.hbs
   vars:
     - name: period
       type: text

--- a/packages/system/dataset/service/manifest.yml
+++ b/packages/system/dataset/service/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
 - input: system/metrics
+  template_path: stream.yml.hbs
   enabled: false
   vars:
     - name: period

--- a/packages/system/dataset/socket/manifest.yml
+++ b/packages/system/dataset/socket/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
 - input: system/metrics
+  template_path: stream.yml.hbs
   enabled: false
   vars:
     - name: period

--- a/packages/system/dataset/socket_summary/manifest.yml
+++ b/packages/system/dataset/socket_summary/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
 - input: system/metrics
+  template_path: stream.yml.hbs
   vars:
     - name: period
       type: text

--- a/packages/system/dataset/uptime/manifest.yml
+++ b/packages/system/dataset/uptime/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
 - input: system/metrics
+  template_path: stream.yml.hbs
   vars:
     - name: period
       type: text

--- a/packages/system/dataset/users/manifest.yml
+++ b/packages/system/dataset/users/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
 - input: system/metrics
+  template_path: stream.yml.hbs
   vars:
     - name: period
       type: text

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 0.5.0
+version: 0.5.1
 license: basic
 description: System Integration
 type: integration


### PR DESCRIPTION

## What does this PR do?

The system module, and most of the integrations, are missing the `template_path` var in the manifest. This fixes the system module.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [X] I have verified that all datasets collect metrics or logs.


## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
