### PR TITLE
Fix mongodb package service.address field and metrics description

### DIFF
--- a/packages/mongodb/dataset/collstats/fields/base-fields.yml
+++ b/packages/mongodb/dataset/collstats/fields/base-fields.yml
@@ -11,5 +11,5 @@
   type: date
   description: Event timestamp.
 - name: service.address
-  type: ip
+  type: keyword
   description: Address of the machine where the service is running.

--- a/packages/mongodb/dataset/collstats/manifest.yml
+++ b/packages/mongodb/dataset/collstats/manifest.yml
@@ -1,5 +1,5 @@
 title: MongoDB collstats metrics
-release: beta
+release: experimental
 type: metrics
 streams:
 - input: mongodb/metrics

--- a/packages/mongodb/dataset/dbstats/fields/base-fields.yml
+++ b/packages/mongodb/dataset/dbstats/fields/base-fields.yml
@@ -11,5 +11,5 @@
   type: date
   description: Event timestamp.
 - name: service.address
-  type: ip
+  type: keyword
   description: Address of the machine where the service is running.

--- a/packages/mongodb/dataset/dbstats/manifest.yml
+++ b/packages/mongodb/dataset/dbstats/manifest.yml
@@ -1,5 +1,5 @@
 title: MongoDB dbstats metrics
-release: beta
+release: experimental
 type: metrics
 streams:
 - input: mongodb/metrics

--- a/packages/mongodb/dataset/log/manifest.yml
+++ b/packages/mongodb/dataset/log/manifest.yml
@@ -13,5 +13,5 @@ streams:
     default:
     - /var/log/mongodb/mongodb.log
   template_path: log.yml.hbs
-  title: mongodb logs
-  description: Collect mongodb logs using log input
+  title: MongoDB logs
+  description: Collect MongoDB logs

--- a/packages/mongodb/dataset/log/manifest.yml
+++ b/packages/mongodb/dataset/log/manifest.yml
@@ -1,5 +1,5 @@
 title: mongodb log logs
-release: beta
+release: experimental
 type: logs
 streams:
 - input: logfile

--- a/packages/mongodb/dataset/metrics/fields/base-fields.yml
+++ b/packages/mongodb/dataset/metrics/fields/base-fields.yml
@@ -11,5 +11,5 @@
   type: date
   description: Event timestamp.
 - name: service.address
-  type: ip
+  type: keyword
   description: Address of the machine where the service is running.

--- a/packages/mongodb/dataset/metrics/manifest.yml
+++ b/packages/mongodb/dataset/metrics/manifest.yml
@@ -12,4 +12,4 @@ streams:
     show_user: true
     default: 10s
   title: MongoDB metrics
-  description: Collect MongoDB metrics that reflect the current use and state of a running `mongod` instance
+  description: Collect MongoDB use and state metrics

--- a/packages/mongodb/dataset/metrics/manifest.yml
+++ b/packages/mongodb/dataset/metrics/manifest.yml
@@ -1,5 +1,5 @@
 title: MongoDB metrics
-release: beta
+release: experimental
 type: metrics
 streams:
 - input: mongodb/metrics

--- a/packages/mongodb/dataset/metrics/manifest.yml
+++ b/packages/mongodb/dataset/metrics/manifest.yml
@@ -12,4 +12,4 @@ streams:
     show_user: true
     default: 10s
   title: MongoDB metrics
-  description: Collect MongoDB metrics
+  description: Collect MongoDB metrics that reflect the current use and state of a running `mongod` instance

--- a/packages/mongodb/dataset/replstatus/fields/base-fields.yml
+++ b/packages/mongodb/dataset/replstatus/fields/base-fields.yml
@@ -11,5 +11,5 @@
   type: date
   description: Event timestamp.
 - name: service.address
-  type: ip
+  type: keyword
   description: Address of the machine where the service is running.

--- a/packages/mongodb/dataset/replstatus/manifest.yml
+++ b/packages/mongodb/dataset/replstatus/manifest.yml
@@ -1,5 +1,5 @@
 title: MongoDB replstatus metrics
-release: beta
+release: experimental
 type: metrics
 streams:
 - input: mongodb/metrics

--- a/packages/mongodb/dataset/status/fields/base-fields.yml
+++ b/packages/mongodb/dataset/status/fields/base-fields.yml
@@ -11,5 +11,5 @@
   type: date
   description: Event timestamp.
 - name: service.address
-  type: ip
+  type: keyword
   description: Address of the machine where the service is running.

--- a/packages/mongodb/dataset/status/manifest.yml
+++ b/packages/mongodb/dataset/status/manifest.yml
@@ -1,5 +1,5 @@
 title: MongoDB status metrics
-release: beta
+release: experimental
 type: metrics
 streams:
 - input: mongodb/metrics

--- a/packages/mongodb/docs/README.md
+++ b/packages/mongodb/docs/README.md
@@ -217,7 +217,7 @@ The fields reported are:
 | mongodb.collstats.total.time.us | Total waiting time for locks in microseconds. | long |
 | mongodb.collstats.update.count | Number of document update events. | long |
 | mongodb.collstats.update.time.us | Time updating documents in microseconds. | long |
-| service.address | Address of the machine where the service is running. | ip |
+| service.address | Address of the machine where the service is running. | keyword |
 
 
 ### dbstats
@@ -332,7 +332,7 @@ The fields reported are:
 | mongodb.dbstats.num_extents |  | long |
 | mongodb.dbstats.objects |  | long |
 | mongodb.dbstats.storage_size.bytes |  | long |
-| service.address | Address of the machine where the service is running. | ip |
+| service.address | Address of the machine where the service is running. | keyword |
 
 
 ### metrics
@@ -738,7 +738,7 @@ The fields reported are:
 | mongodb.metrics.storage.free_list.search.scanned | The number of available record allocations mongod has searched. | long |
 | mongodb.metrics.ttl.deleted_documents.count | The total number of documents deleted from collections with a ttl index. | long |
 | mongodb.metrics.ttl.passes.count | The number of times the background process removes documents from collections with a ttl index. | long |
-| service.address | Address of the machine where the service is running. | ip |
+| service.address | Address of the machine where the service is running. | keyword |
 
 
 ### replstatus
@@ -850,7 +850,7 @@ The fields reported are:
 | mongodb.replstatus.optimes.last_committed | Information, from the viewpoint of this member, regarding the most recent operation that has been written to a majority of replica set members. | long |
 | mongodb.replstatus.server_date | Reflects the current time according to the server that processed the replSetGetStatus command. | date |
 | mongodb.replstatus.set_name | The name of the replica set. | keyword |
-| service.address | Address of the machine where the service is running. | ip |
+| service.address | Address of the machine where the service is running. | keyword |
 
 
 ### status
@@ -1271,6 +1271,6 @@ The fields reported are:
 | mongodb.status.wired_tiger.log.writes | Number of write operations. | long |
 | mongodb.status.write_backs_queued | True when there are operations from a mongos instance queued for retrying. | boolean |
 | process.name | Process name. Sometimes called program name or similar. | keyword |
-| service.address | Address of the machine where the service is running. | ip |
+| service.address | Address of the machine where the service is running. | keyword |
 | service.version | Version of the service the data was collected from. This allows to look at a data set only for a specific version of a service. | keyword |
 

--- a/packages/mongodb/kibana/search/MongoDB-search-ecs.json
+++ b/packages/mongodb/kibana/search/MongoDB-search-ecs.json
@@ -41,6 +41,9 @@
     "migrationVersion": {
         "search": "7.4.0"
     },
+    "namespaces": [
+        "default"
+    ],
     "references": [
         {
             "id": "metrics-*",

--- a/packages/mongodb/kibana/search/bfc96a60-0a80-11e8-bffe-ff7d4f68cf94-ecs.json
+++ b/packages/mongodb/kibana/search/bfc96a60-0a80-11e8-bffe-ff7d4f68cf94-ecs.json
@@ -34,6 +34,9 @@
     "migrationVersion": {
         "search": "7.4.0"
     },
+    "namespaces": [
+        "default"
+    ],
     "references": [
         {
             "id": "logs-*",

--- a/packages/mongodb/kibana/search/e49fe000-0a7e-11e8-bffe-ff7d4f68cf94-ecs.json
+++ b/packages/mongodb/kibana/search/e49fe000-0a7e-11e8-bffe-ff7d4f68cf94-ecs.json
@@ -34,6 +34,9 @@
     "migrationVersion": {
         "search": "7.4.0"
     },
+    "namespaces": [
+        "default"
+    ],
     "references": [
         {
             "id": "logs-*",

--- a/packages/mongodb/kibana/visualization/0fef5710-0a82-11e8-bffe-ff7d4f68cf94-ecs.json
+++ b/packages/mongodb/kibana/visualization/0fef5710-0a82-11e8-bffe-ff7d4f68cf94-ecs.json
@@ -52,6 +52,9 @@
     "migrationVersion": {
         "visualization": "7.8.0"
     },
+    "namespaces": [
+        "default"
+    ],
     "references": [
         {
             "id": "bfc96a60-0a80-11e8-bffe-ff7d4f68cf94-ecs",

--- a/packages/mongodb/kibana/visualization/MongoDB-Concurrent-transactions-Read-ecs.json
+++ b/packages/mongodb/kibana/visualization/MongoDB-Concurrent-transactions-Read-ecs.json
@@ -137,6 +137,9 @@
     "migrationVersion": {
         "visualization": "7.8.0"
     },
+    "namespaces": [
+        "default"
+    ],
     "references": [
         {
             "id": "MongoDB-search-ecs",

--- a/packages/mongodb/kibana/visualization/MongoDB-Concurrent-transactions-Write-ecs.json
+++ b/packages/mongodb/kibana/visualization/MongoDB-Concurrent-transactions-Write-ecs.json
@@ -137,6 +137,9 @@
     "migrationVersion": {
         "visualization": "7.8.0"
     },
+    "namespaces": [
+        "default"
+    ],
     "references": [
         {
             "id": "MongoDB-search-ecs",

--- a/packages/mongodb/kibana/visualization/MongoDB-Engine-ampersand-Version-ecs.json
+++ b/packages/mongodb/kibana/visualization/MongoDB-Engine-ampersand-Version-ecs.json
@@ -64,6 +64,9 @@
     "migrationVersion": {
         "visualization": "7.8.0"
     },
+    "namespaces": [
+        "default"
+    ],
     "references": [
         {
             "id": "MongoDB-search-ecs",

--- a/packages/mongodb/kibana/visualization/MongoDB-WiredTiger-Cache-ecs.json
+++ b/packages/mongodb/kibana/visualization/MongoDB-WiredTiger-Cache-ecs.json
@@ -140,6 +140,9 @@
     "migrationVersion": {
         "visualization": "7.8.0"
     },
+    "namespaces": [
+        "default"
+    ],
     "references": [
         {
             "id": "MongoDB-search-ecs",

--- a/packages/mongodb/kibana/visualization/MongoDB-asserts-ecs.json
+++ b/packages/mongodb/kibana/visualization/MongoDB-asserts-ecs.json
@@ -160,6 +160,9 @@
     "migrationVersion": {
         "visualization": "7.8.0"
     },
+    "namespaces": [
+        "default"
+    ],
     "references": [
         {
             "id": "MongoDB-search-ecs",

--- a/packages/mongodb/kibana/visualization/MongoDB-hosts-ecs.json
+++ b/packages/mongodb/kibana/visualization/MongoDB-hosts-ecs.json
@@ -93,6 +93,9 @@
     "migrationVersion": {
         "visualization": "7.8.0"
     },
+    "namespaces": [
+        "default"
+    ],
     "references": [
         {
             "id": "MongoDB-search-ecs",

--- a/packages/mongodb/kibana/visualization/MongoDB-memory-stats-ecs.json
+++ b/packages/mongodb/kibana/visualization/MongoDB-memory-stats-ecs.json
@@ -151,6 +151,9 @@
     "migrationVersion": {
         "visualization": "7.8.0"
     },
+    "namespaces": [
+        "default"
+    ],
     "references": [
         {
             "id": "MongoDB-search-ecs",

--- a/packages/mongodb/kibana/visualization/MongoDB-operation-counters-ecs.json
+++ b/packages/mongodb/kibana/visualization/MongoDB-operation-counters-ecs.json
@@ -170,6 +170,9 @@
     "migrationVersion": {
         "visualization": "7.8.0"
     },
+    "namespaces": [
+        "default"
+    ],
     "references": [
         {
             "id": "MongoDB-search-ecs",

--- a/packages/mongodb/manifest.yml
+++ b/packages/mongodb/manifest.yml
@@ -39,56 +39,6 @@ config_templates:
       show_user: true
       default:
         - localhost:27017
-    - name: ssl.enabled
-      type: text
-      title: SSL enabled
-      multi: false
-      required: false
-      show_user: false
-      default: false
-    - name: ssl.verification_mode
-      type: text
-      title: Mode of verification of server certificate ('none' or 'full')
-      multi: false
-      required: false
-      show_user: false
-      default: "full"
-    - name: ssl.certificate_authorities
-      type: text
-      title: List of root certificates for TLS server verifications
-      multi: true
-      required: false
-      show_user: false
-      default:
-        - "/etc/pki/root/ca.pem"
-    - name: ssl.certificate
-      type: text
-      title: Certificate for SSL client authentication
-      multi: false
-      required: false
-      show_user: false
-      default: "/etc/pki/client/cert.pem"
-    - name: ssl.key
-      type: text
-      title: Client Certificate Key
-      multi: false
-      required: false
-      show_user: false
-      default: "/etc/pki/client/cert.key"
-    - name: username
-      type: text
-      title: Username to use when connecting to MongoDB. Empty by default.
-      multi: false
-      required: false
-      show_user: false
-      default: ""
-    - name: password
-      type: text
-      title: Password to use when connecting to MongoDB. Empty by default.
-      multi: false
-      required: false
-      show_user: false
-      default: ""
     title: Collect MongoDB metrics
     description: Collecting metrics from MongoDB instances
 owner:

--- a/packages/mongodb/manifest.yml
+++ b/packages/mongodb/manifest.yml
@@ -1,6 +1,6 @@
 name: mongodb
 title: MongoDB
-version: 0.1.0
+version: 0.1.1
 description: MongoDB Integration
 type: integration
 categories:
@@ -38,7 +38,57 @@ config_templates:
       required: true
       show_user: true
       default:
-      - localhost:27017
+        - localhost:27017
+    - name: ssl.enabled
+      type: text
+      title: SSL enabled
+      multi: false
+      required: false
+      show_user: false
+      default: false
+    - name: ssl.verification_mode
+      type: text
+      title: Mode of verification of server certificate ('none' or 'full')
+      multi: false
+      required: false
+      show_user: false
+      default: "full"
+    - name: ssl.certificate_authorities
+      type: text
+      title: List of root certificates for TLS server verifications
+      multi: true
+      required: false
+      show_user: false
+      default:
+        - "/etc/pki/root/ca.pem"
+    - name: ssl.certificate
+      type: text
+      title: Certificate for SSL client authentication
+      multi: false
+      required: false
+      show_user: false
+      default: "/etc/pki/client/cert.pem"
+    - name: ssl.key
+      type: text
+      title: Client Certificate Key
+      multi: false
+      required: false
+      show_user: false
+      default: "/etc/pki/client/cert.key"
+    - name: username
+      type: text
+      title: Username to use when connecting to MongoDB. Empty by default.
+      multi: false
+      required: false
+      show_user: false
+      default: ""
+    - name: password
+      type: text
+      title: Password to use when connecting to MongoDB. Empty by default.
+      multi: false
+      required: false
+      show_user: false
+      default: ""
     title: Collect MongoDB metrics
     description: Collecting metrics from MongoDB instances
 owner:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

1. Fix `service.address` field to keyword
2. Add better description for metrics dataset
3. Change release to experimental for individual datasets under mongodb package
4. Add namespace default in kibana 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [x] I have verified that all datasets collect metrics or logs.

## Screenshots
<img width="1668" alt="Screen Shot 2020-07-27 at 8 16 17 AM" src="https://user-images.githubusercontent.com/14081635/88553381-7292c000-cfe2-11ea-9782-2fe96f9ad971.png">
