### PR TITLE
Remove redundant [Metrics MongoDB] ECS from visualization titles

### DIFF
--- a/packages/mongodb/kibana/dashboard/mongodb-Metrics-MongoDB-ecs.json
+++ b/packages/mongodb/kibana/dashboard/mongodb-Metrics-MongoDB-ecs.json
@@ -132,7 +132,7 @@
             }
         ],
         "timeRestore": false,
-        "title": "[Metrics MongoDB] Overview ECS",
+        "title": "[Metrics MongoDB] Overview",
         "version": 1
     },
     "id": "mongodb-Metrics-MongoDB-ecs",

--- a/packages/mongodb/kibana/dashboard/mongodb-abcf35b0-0a82-11e8-bffe-ff7d4f68cf94-ecs.json
+++ b/packages/mongodb/kibana/dashboard/mongodb-abcf35b0-0a82-11e8-bffe-ff7d4f68cf94-ecs.json
@@ -82,7 +82,7 @@
             }
         ],
         "timeRestore": false,
-        "title": "[Logs MongoDB] Overview ECS",
+        "title": "[Logs MongoDB] Overview",
         "version": 1
     },
     "id": "mongodb-abcf35b0-0a82-11e8-bffe-ff7d4f68cf94-ecs",

--- a/packages/mongodb/kibana/search/MongoDB-search-ecs.json
+++ b/packages/mongodb/kibana/search/MongoDB-search-ecs.json
@@ -34,7 +34,7 @@
                 "desc"
             ]
         ],
-        "title": "MongoDB search ECS",
+        "title": "MongoDB search",
         "version": 1
     },
     "id": "MongoDB-search-ecs",

--- a/packages/mongodb/kibana/search/bfc96a60-0a80-11e8-bffe-ff7d4f68cf94-ecs.json
+++ b/packages/mongodb/kibana/search/bfc96a60-0a80-11e8-bffe-ff7d4f68cf94-ecs.json
@@ -27,7 +27,7 @@
                 "asc"
             ]
         ],
-        "title": "All logs [Logs MongoDB] ECS",
+        "title": "All logs",
         "version": 1
     },
     "id": "bfc96a60-0a80-11e8-bffe-ff7d4f68cf94-ecs",

--- a/packages/mongodb/kibana/search/e49fe000-0a7e-11e8-bffe-ff7d4f68cf94-ecs.json
+++ b/packages/mongodb/kibana/search/e49fe000-0a7e-11e8-bffe-ff7d4f68cf94-ecs.json
@@ -27,7 +27,7 @@
                 "desc"
             ]
         ],
-        "title": "Error logs [Logs MongoDB] ECS",
+        "title": "Error logs",
         "version": 1
     },
     "id": "e49fe000-0a7e-11e8-bffe-ff7d4f68cf94-ecs",

--- a/packages/mongodb/kibana/visualization/0fef5710-0a82-11e8-bffe-ff7d4f68cf94-ecs.json
+++ b/packages/mongodb/kibana/visualization/0fef5710-0a82-11e8-bffe-ff7d4f68cf94-ecs.json
@@ -11,7 +11,7 @@
             }
         },
         "savedSearchRefName": "search_0",
-        "title": "Logs Severity [Logs MongoDB] ECS",
+        "title": "Logs Severity",
         "uiStateJSON": {},
         "version": 1,
         "visState": {

--- a/packages/mongodb/kibana/visualization/MongoDB-Concurrent-transactions-Read-ecs.json
+++ b/packages/mongodb/kibana/visualization/MongoDB-Concurrent-transactions-Read-ecs.json
@@ -7,7 +7,7 @@
             }
         },
         "savedSearchRefName": "search_0",
-        "title": "Concurrent transactions Read [Metrics MongoDB] ECS",
+        "title": "Concurrent transactions Read",
         "uiStateJSON": {
             "vis": {
                 "colors": {

--- a/packages/mongodb/kibana/visualization/MongoDB-Concurrent-transactions-Write-ecs.json
+++ b/packages/mongodb/kibana/visualization/MongoDB-Concurrent-transactions-Write-ecs.json
@@ -7,7 +7,7 @@
             }
         },
         "savedSearchRefName": "search_0",
-        "title": "Concurrent transactions Write [Metrics MongoDB] ECS",
+        "title": "Concurrent transactions Write",
         "uiStateJSON": {
             "vis": {
                 "colors": {

--- a/packages/mongodb/kibana/visualization/MongoDB-Engine-ampersand-Version-ecs.json
+++ b/packages/mongodb/kibana/visualization/MongoDB-Engine-ampersand-Version-ecs.json
@@ -7,7 +7,7 @@
             }
         },
         "savedSearchRefName": "search_0",
-        "title": "Engine \u0026 Version [Metrics MongoDB] ECS",
+        "title": "Engine \u0026 Version",
         "uiStateJSON": {},
         "version": 1,
         "visState": {

--- a/packages/mongodb/kibana/visualization/MongoDB-WiredTiger-Cache-ecs.json
+++ b/packages/mongodb/kibana/visualization/MongoDB-WiredTiger-Cache-ecs.json
@@ -7,7 +7,7 @@
             }
         },
         "savedSearchRefName": "search_0",
-        "title": "WiredTiger Cache [Metrics MongoDB] ECS",
+        "title": "WiredTiger Cache",
         "uiStateJSON": {},
         "version": 1,
         "visState": {

--- a/packages/mongodb/kibana/visualization/MongoDB-asserts-ecs.json
+++ b/packages/mongodb/kibana/visualization/MongoDB-asserts-ecs.json
@@ -7,7 +7,7 @@
             }
         },
         "savedSearchRefName": "search_0",
-        "title": "Asserts [Metrics MongoDB] ECS",
+        "title": "Asserts",
         "uiStateJSON": {},
         "version": 1,
         "visState": {

--- a/packages/mongodb/kibana/visualization/MongoDB-hosts-ecs.json
+++ b/packages/mongodb/kibana/visualization/MongoDB-hosts-ecs.json
@@ -7,7 +7,7 @@
             }
         },
         "savedSearchRefName": "search_0",
-        "title": "Hosts [Metrics MongoDB] ECS",
+        "title": "Hosts",
         "uiStateJSON": {
             "vis": {
                 "params": {

--- a/packages/mongodb/kibana/visualization/MongoDB-memory-stats-ecs.json
+++ b/packages/mongodb/kibana/visualization/MongoDB-memory-stats-ecs.json
@@ -7,7 +7,7 @@
             }
         },
         "savedSearchRefName": "search_0",
-        "title": "Memory stats [Metrics MongoDB] ECS",
+        "title": "Memory stats",
         "uiStateJSON": {},
         "version": 1,
         "visState": {

--- a/packages/mongodb/kibana/visualization/MongoDB-operation-counters-ecs.json
+++ b/packages/mongodb/kibana/visualization/MongoDB-operation-counters-ecs.json
@@ -7,7 +7,7 @@
             }
         },
         "savedSearchRefName": "search_0",
-        "title": "Operation counters [Metrics MongoDB] ECS",
+        "title": "Operation counters",
         "uiStateJSON": {},
         "version": 1,
         "visState": {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR is to remove redundant `[Metrics MongoDB] ECS` from visualization titles and dashboard titles.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [x] I have verified that all datasets collect metrics or logs.

## Screenshots
Before:
<img width="848" alt="Screen Shot 2020-07-27 at 8 19 28 AM" src="https://user-images.githubusercontent.com/14081635/88568776-b5f72980-cff6-11ea-9fd1-60ee873a1a68.png">

After:
<img width="2538" alt="Screen Shot 2020-07-27 at 10 43 58 AM" src="https://user-images.githubusercontent.com/14081635/88568617-7d575000-cff6-11ea-8644-b64ccccf015e.png">

