### PR TITLE
Add optional config parameters for mongodb metrics collection

### DIFF
--- a/packages/mongodb/manifest.yml
+++ b/packages/mongodb/manifest.yml
@@ -39,6 +39,51 @@ config_templates:
       show_user: true
       default:
         - localhost:27017
+    - name: ssl.enabled
+      type: text
+      title: SSL enabled
+      multi: false
+      required: false
+      show_user: false
+      default: false
+    - name: ssl.verification_mode
+      type: text
+      title: Mode of verification of server certificate ('none' or 'full')
+      multi: false
+      required: false
+      show_user: false
+    - name: ssl.certificate_authorities
+      type: text
+      title: List of root certificates for TLS server verifications
+      multi: true
+      required: false
+      show_user: false
+    - name: ssl.certificate
+      type: text
+      title: Certificate for SSL client authentication
+      multi: false
+      required: false
+      show_user: false
+    - name: ssl.key
+      type: text
+      title: Client Certificate Key
+      multi: false
+      required: false
+      show_user: false
+    - name: username
+      type: text
+      title: Username to use when connecting to MongoDB. Empty by default.
+      multi: false
+      required: false
+      show_user: false
+      default: "username"
+    - name: password
+      type: text
+      title: Password to use when connecting to MongoDB. Empty by default.
+      multi: false
+      required: false
+      show_user: false
+      default: "password"
     title: Collect MongoDB metrics
     description: Collecting metrics from MongoDB instances
 owner:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Add all optional config parameters for mongodb metrics collection.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [x] I have verified that all datasets collect metrics or logs.

## Screenshots
<img width="712" alt="Screen Shot 2020-07-27 at 12 14 18 PM" src="https://user-images.githubusercontent.com/14081635/88576950-7aaf2780-d003-11ea-8d9e-8941e2286d5d.png">

