### PR TITLE
Add period options for state_* and scheduler datasets

### DIFF
--- a/packages/kubernetes/dataset/scheduler/manifest.yml
+++ b/packages/kubernetes/dataset/scheduler/manifest.yml
@@ -19,5 +19,12 @@ streams:
     required: true
     show_user: true
     default: 10s
+  - name: period
+    type: text
+    title: Period
+    multi: false
+    required: true
+    show_user: true
+    default: 10s
   title: Kubernetes Scheduler metrics
   description: Collect Kubernetes Scheduler metrics

--- a/packages/kubernetes/dataset/state_container/manifest.yml
+++ b/packages/kubernetes/dataset/state_container/manifest.yml
@@ -19,5 +19,12 @@ streams:
     show_user: true
     default:
     - kube-state-metrics:8080
+  - name: period
+    type: text
+    title: Period
+    multi: false
+    required: true
+    show_user: true
+    default: 10s
   title: Kubernetes Container metrics
   description: Collect Kubernetes Container metrics from kube_state_metrics

--- a/packages/kubernetes/dataset/state_cronjob/manifest.yml
+++ b/packages/kubernetes/dataset/state_cronjob/manifest.yml
@@ -19,5 +19,12 @@ streams:
     show_user: true
     default:
     - kube-state-metrics:8080
+  - name: period
+    type: text
+    title: Period
+    multi: false
+    required: true
+    show_user: true
+    default: 10s
   title: Kubernetes Cronjob metrics
   description: Collect Kubernetes Cronjob metrics from kube_state_metrics

--- a/packages/kubernetes/dataset/state_deployment/manifest.yml
+++ b/packages/kubernetes/dataset/state_deployment/manifest.yml
@@ -19,5 +19,12 @@ streams:
     show_user: true
     default:
     - kube-state-metrics:8080
+  - name: period
+    type: text
+    title: Period
+    multi: false
+    required: true
+    show_user: true
+    default: 10s
   title: Kubernetes Deployment metrics
   description: Collect Kubernetes Deployment metrics from kube_state_metrics

--- a/packages/kubernetes/dataset/state_node/manifest.yml
+++ b/packages/kubernetes/dataset/state_node/manifest.yml
@@ -19,5 +19,12 @@ streams:
     show_user: true
     default:
     - kube-state-metrics:8080
+  - name: period
+    type: text
+    title: Period
+    multi: false
+    required: true
+    show_user: true
+    default: 10s
   title: Kubernetes Node metrics
   description: Collect Kubernetes Node metrics from kube_state_metrics

--- a/packages/kubernetes/dataset/state_persistentvolume/manifest.yml
+++ b/packages/kubernetes/dataset/state_persistentvolume/manifest.yml
@@ -19,5 +19,12 @@ streams:
     show_user: true
     default:
     - kube-state-metrics:8080
+  - name: period
+    type: text
+    title: Period
+    multi: false
+    required: true
+    show_user: true
+    default: 10s
   title: Kubernetes PersistentVolume metrics
   description: Collect Kubernetes PersistentVolume metrics from kube_state_metrics

--- a/packages/kubernetes/dataset/state_persistentvolumeclaim/manifest.yml
+++ b/packages/kubernetes/dataset/state_persistentvolumeclaim/manifest.yml
@@ -19,5 +19,12 @@ streams:
     show_user: true
     default:
     - kube-state-metrics:8080
+  - name: period
+    type: text
+    title: Period
+    multi: false
+    required: true
+    show_user: true
+    default: 10s
   title: Kubernetes PersistentVolumeClaim metrics
   description: Collect Kubernetes PersistentVolumeClaim metrics from kube_state_metrics

--- a/packages/kubernetes/dataset/state_pod/manifest.yml
+++ b/packages/kubernetes/dataset/state_pod/manifest.yml
@@ -19,5 +19,12 @@ streams:
     show_user: true
     default:
     - kube-state-metrics:8080
+  - name: period
+    type: text
+    title: Period
+    multi: false
+    required: true
+    show_user: true
+    default: 10s
   title: Kubernetes Pod metrics
   description: Collect Kubernetes Pod metrics from kube_state_metrics

--- a/packages/kubernetes/dataset/state_replicaset/manifest.yml
+++ b/packages/kubernetes/dataset/state_replicaset/manifest.yml
@@ -19,5 +19,12 @@ streams:
     show_user: true
     default:
     - kube-state-metrics:8080
+  - name: period
+    type: text
+    title: Period
+    multi: false
+    required: true
+    show_user: true
+    default: 10s
   title: Kubernetes state_replicaset metrics
   description: Collect Kubernetes Replicaset metrics from kube_state_metrics

--- a/packages/kubernetes/dataset/state_resourcequota/manifest.yml
+++ b/packages/kubernetes/dataset/state_resourcequota/manifest.yml
@@ -19,5 +19,12 @@ streams:
     show_user: true
     default:
     - kube-state-metrics:8080
+  - name: period
+    type: text
+    title: Period
+    multi: false
+    required: true
+    show_user: true
+    default: 10s
   title: Kubernetes ResourceQuota metrics
   description: Collect Kubernetes ResourceQuota metrics from kube_state_metrics

--- a/packages/kubernetes/dataset/state_service/manifest.yml
+++ b/packages/kubernetes/dataset/state_service/manifest.yml
@@ -19,5 +19,12 @@ streams:
     show_user: true
     default:
     - kube-state-metrics:8080
+  - name: period
+    type: text
+    title: Period
+    multi: false
+    required: true
+    show_user: true
+    default: 10s
   title: Kubernetes Service metrics
   description: Collect Kubernetes Service metrics from kube_state_metrics

--- a/packages/kubernetes/dataset/state_statefulset/manifest.yml
+++ b/packages/kubernetes/dataset/state_statefulset/manifest.yml
@@ -19,5 +19,12 @@ streams:
     show_user: true
     default:
     - kube-state-metrics:8080
+  - name: period
+    type: text
+    title: Period
+    multi: false
+    required: true
+    show_user: true
+    default: 10s
   title: Kubernetes StatefulSet metrics
   description: Collect Kubernetes StatefulSet metrics from kube_state_metrics

--- a/packages/kubernetes/dataset/state_storageclass/manifest.yml
+++ b/packages/kubernetes/dataset/state_storageclass/manifest.yml
@@ -19,5 +19,12 @@ streams:
     show_user: true
     default:
     - kube-state-metrics:8080
+  - name: period
+    type: text
+    title: Period
+    multi: false
+    required: true
+    show_user: true
+    default: 10s
   title: Kubernetes StorageClass metrics
   description: Collect Kubernetes StorageClass metrics from kube_state_metrics

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 0.1.2
+version: 0.1.3
 license: basic
 description: Kubernetes Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?
Adds period options for datasets that was missing.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [x] I have verified that all datasets collect metrics or logs.
