### PR TITLE
Update Kibana version to ^7.9.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -366,11 +366,11 @@ on the business or technical requirements for the entire platform (Elastic Packa
 
    The list of available categories is present in the Package Registry source: https://github.com/elastic/package-registry/blob/e93e801a6dfbfa6f83c8b69f6e9405603151f937/util/package.go#L27-L51
 
-4. Make sure that the version condition for kibana is set to `>=7.9.0`. This is necessary because Kibana `master` will always send the next major version (at the time of this writing `8.0.0`), and using `^7.9.0` will prevent a package to be shown to Kibana `master`. This is extremely inconvenient for testing and development.
+4. Make sure that the version condition for Kibana is set to `^7.9.0` and not `>=7.9.0`. Otherwise the package is also in 8.0.0 but we do not know today if it will actually be compatible with >= 8.0.0.
 
    ```yaml
    conditions:
-     kibana.version: '>=7.9.0'
+     kibana.version: '^7.9.0'
    ```
 
 5. Set the proper package owner (either Github team or personal account)

--- a/dev/import-beats/conditions.go
+++ b/dev/import-beats/conditions.go
@@ -14,6 +14,6 @@ var zeroVersion = semver.MustParse("0.0.0")
 
 func createConditions() *util.Conditions {
 	return &util.Conditions{
-		KibanaVersion: ">=7.9.0",
+		KibanaVersion: "^7.9.0",
 	}
 }

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -10,7 +10,7 @@ categories:
 release: experimental
 removable: true
 conditions:
-  kibana.version: '>=7.9.0'
+  kibana.version: '^7.9.0'
 screenshots:
 - src: /img/kibana-apache.png
   title: Apache Integration

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -12,7 +12,7 @@ categories:
 - security
 release: experimental
 conditions:
-  kibana.version: '>=7.9.0'
+  kibana.version: '^7.9.0'
 screenshots:
 - src: /img/filebeat-aws-cloudtrail.png
   title: filebeat aws cloudtrail

--- a/packages/cisco/manifest.yml
+++ b/packages/cisco/manifest.yml
@@ -10,7 +10,7 @@ categories:
 - security
 release: experimental
 conditions:
-  kibana.version: '>=7.9.0'
+  kibana.version: '^7.9.0'
 screenshots:
   - src: /img/kibana-cisco-asa.png
     title: kibana cisco asa

--- a/packages/haproxy/manifest.yml
+++ b/packages/haproxy/manifest.yml
@@ -15,7 +15,7 @@ categories:
 - web
 release: experimental
 conditions:
-  kibana.version: '>=7.9.0'
+  kibana.version: '^7.9.0'
 screenshots:
 - src: /img/kibana-haproxy-overview.png
   title: Kibana HAProxy overview

--- a/packages/iis/manifest.yml
+++ b/packages/iis/manifest.yml
@@ -14,7 +14,7 @@ categories:
   - web
 release: experimental
 conditions:
-  kibana.version: '>=7.9.0'
+  kibana.version: '^7.9.0'
 screenshots:
 - src: /img/kibana-iis.png
   title: kibana iis

--- a/packages/kafka/manifest.yml
+++ b/packages/kafka/manifest.yml
@@ -9,7 +9,7 @@ categories:
 - message_queue
 release: experimental
 conditions:
-  kibana.version: '>=7.9.0'
+  kibana.version: '^7.9.0'
 screenshots:
 - src: /img/filebeat-kafka-logs-overview.png
   title: filebeat kafka logs overview

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -10,7 +10,7 @@ categories:
 - kubernetes
 release: experimental
 conditions:
-  kibana.version: '>=7.9.0'
+  kibana.version: '^7.9.0'
 screenshots:
 - src: /img/metricbeat_kubernetes_overview.png
   title: Metricbeat Kubernetes Overview

--- a/packages/mongodb/manifest.yml
+++ b/packages/mongodb/manifest.yml
@@ -15,7 +15,7 @@ license: basic
 release: experimental
 removable: true
 conditions:
-  kibana.version: '>=7.9.0'
+  kibana.version: '^7.9.0'
 screenshots:
 - src: /img/filebeat-mongodb-overview.png
   title: filebeat mongodb overview

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -9,7 +9,7 @@ categories:
 - datastore
 release: experimental
 conditions:
-  kibana.version: '>=7.9.0'
+  kibana.version: '^7.9.0'
 screenshots:
 - src: /img/kibana-mysql.png
   title: kibana mysql

--- a/packages/netflow/manifest.yml
+++ b/packages/netflow/manifest.yml
@@ -10,7 +10,7 @@ categories:
 - security
 release: experimental
 conditions:
-  kibana.version: '>=7.9.0'
+  kibana.version: '^7.9.0'
 config_templates:
 - name: netflow
   title: NetFlow logs

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -10,7 +10,7 @@ categories:
 - security
 release: experimental
 conditions:
-  kibana.version: '>=7.9.0'
+  kibana.version: '^7.9.0'
 screenshots:
 - src: /img/kibana-nginx.png
   title: kibana nginx

--- a/packages/postgresql/manifest.yml
+++ b/packages/postgresql/manifest.yml
@@ -9,7 +9,7 @@ categories:
 - datastore
 release: experimental
 conditions:
-  kibana.version: '>=7.9.0'
+  kibana.version: '^7.9.0'
 screenshots:
 - src: /img/filebeat-postgresql-overview.png
   title: Filebeat PostgreSQL overview

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -10,7 +10,7 @@ categories:
 - datastore
 release: experimental
 conditions:
-  kibana.version: '>=7.9.0'
+  kibana.version: '^7.9.0'
 screenshots:
 - src: /img/metricbeat-prometheus-overview.png
   title: Metricbeat Prometheus Overview

--- a/packages/rabbitmq/manifest.yml
+++ b/packages/rabbitmq/manifest.yml
@@ -10,7 +10,7 @@ categories:
 release: experimental
 removable: true
 conditions:
-  kibana.version: '>=7.9.0'
+  kibana.version: '^7.9.0'
 icons:
 - src: /img/logo_rabbitmq.svg
   title: RabbitMQ Logo

--- a/packages/redis/manifest.yml
+++ b/packages/redis/manifest.yml
@@ -10,7 +10,7 @@ categories:
 - message_queue
 release: experimental
 conditions:
-  kibana.version: '>=7.9.0'
+  kibana.version: '^7.9.0'
 screenshots:
 - src: /img/kibana-redis.png
   title: kibana redis

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -10,7 +10,7 @@ categories:
 - security
 release: beta
 conditions:
-  kibana.version: '>=7.9.0'
+  kibana.version: '^7.9.0'
 screenshots:
 - src: /img/kibana-system.png
   title: kibana system

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -16,7 +16,7 @@ license: basic
 release: experimental
 removable: true
 conditions:
-  kibana.version: '>=7.9.0'
+  kibana.version: '^7.9.0'
 screenshots:
 - src: /img/metricbeat-windows-service.png
   title: metricbeat windows service

--- a/packages/zookeeper/manifest.yml
+++ b/packages/zookeeper/manifest.yml
@@ -15,7 +15,7 @@ categories:
   - config_management
 release: experimental
 conditions:
-  kibana.version: '>=7.9.0'
+  kibana.version: '^7.9.0'
 screenshots:
 - src: /img/metricbeat-zookeeper.png
   title: Metricbeat ZooKeeper


### PR DESCRIPTION
This updates the Kibana version on all packages to `^7.9.0` instead of `>=7.9.0`. The problem with `>=7.9.0` is that these packages will potentially also show up in 8.0 without necessarily being compatible as we don't know today what will break in 8.0. It also causes a problem if a package is removed for 8.0. Lets assume the last package we release has `>=7.9.0 <8.0.0` inside. Even though the latest package will not show up, older packages will.

I assume it was changed do `>=7.9.0` to solve an issue with the 8.0.0-SNAPSHOT testing. On the Kibana side this will be solved by https://github.com/elastic/kibana/pull/73415 and on the storage side there is a discussion on what Kibana version to use for testing which should also solve this: https://github.com/elastic/package-storage/issues/163
