### PR TITLE
Change snapshot testing version to 7.9.0-SNAPSHOT

### DIFF
--- a/testing/environments/agent.yml
+++ b/testing/environments/agent.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elastic-agent:
-    image: docker.elastic.co/beats/elastic-agent:8.0.0-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:7.9.0-SNAPSHOT
     depends_on:
       elasticsearch:
         condition: service_healthy

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.0-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "-u", "elastic:changeme", "http://127.0.0.1:9200/"]
       retries: 300
@@ -22,7 +22,7 @@ services:
       - "127.0.0.1:9200:9200"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.9.0-SNAPSHOT
     depends_on:
       elasticsearch:
         condition: service_healthy


### PR DESCRIPTION
Currently for development the 8.0.0-SNAPSHOT builds are used but the packages that we develop are shipped for 7.9. It is possible that a feature in 8.0 does not exist in 7.9 but we use it in a package. Because of this I think it makes more sense to develop against the version we plan to ship the packages to. This also ties into https://github.com/elastic/package-storage/issues/163

A follow up discussion should happen on what happens after 7.9 is released. Should we develop against 7.9 or 7.10.0-SNAPSHOT?
