### PR TITLE
Update scripts to used datastream.dataset for dashboards

### DIFF
--- a/dev/import-beats/kibana.go
+++ b/dev/import-beats/kibana.go
@@ -356,7 +356,7 @@ func stripReferencesToEventModuleInFilter(object mapStr, filterKey, moduleName s
 				return nil, errors.Wrapf(err, "setting meta.type failed")
 			}
 
-			_, err = filterObject.put("meta.value", fmt.Sprintf("{\"prefix\":{\"dataset.name\":\"%s.\"}}", moduleName))
+			_, err = filterObject.put("meta.value", fmt.Sprintf("{\"prefix\":{\"datastream.dataset\":\"%s.\"}}", moduleName))
 			if err != nil {
 				return nil, errors.Wrapf(err, "setting meta.value failed")
 			}
@@ -368,7 +368,7 @@ func stripReferencesToEventModuleInFilter(object mapStr, filterKey, moduleName s
 
 			q := map[string]interface{}{
 				"prefix": map[string]interface{}{
-					"dataset.name": moduleName + ".",
+					"datastream.dataset": moduleName + ".",
 				},
 			}
 			_, err = filterObject.put("query", q)
@@ -415,8 +415,8 @@ func stripReferencesToEventModuleInQuery(object mapStr, objectKey, moduleName st
 	query = strings.ReplaceAll(query, `"`, "")
 	if strings.Contains(query, "event.module:"+moduleName) && (strings.Contains(query, "metricset.name:") || strings.Contains(query, "fileset.name:")) {
 		query = strings.ReplaceAll(query, "event.module:"+moduleName, "")
-		query = strings.ReplaceAll(query, "metricset.name:", fmt.Sprintf("dataset.name:%s.", moduleName))
-		query = strings.ReplaceAll(query, "fileset.name:", fmt.Sprintf("dataset.name:%s.", moduleName))
+		query = strings.ReplaceAll(query, "metricset.name:", fmt.Sprintf("datastream.dataset:%s.", moduleName))
+		query = strings.ReplaceAll(query, "fileset.name:", fmt.Sprintf("datastream.dataset:%s.", moduleName))
 		query = strings.TrimSpace(query)
 		if strings.HasPrefix(query, "AND ") {
 			query = query[4:]
@@ -429,7 +429,7 @@ func stripReferencesToEventModuleInQuery(object mapStr, objectKey, moduleName st
 	} else if strings.Contains(query, "event.module:"+moduleName) {
 		var eventDatasets []string
 		for _, datasetName := range datasetNames {
-			eventDatasets = append(eventDatasets, fmt.Sprintf("dataset.name:%s.%s", moduleName, datasetName))
+			eventDatasets = append(eventDatasets, fmt.Sprintf("datastream.dataset:%s.%s", moduleName, datasetName))
 		}
 
 		value := " (" + strings.Join(eventDatasets, " OR ") + ") "
@@ -450,7 +450,7 @@ func stripReferencesToEventModuleInQuery(object mapStr, objectKey, moduleName st
 }
 
 func replaceFieldEventDatasetWithStreamDataset(data []byte) []byte {
-	return bytes.ReplaceAll(data, []byte("event.dataset"), []byte("dataset.name"))
+	return bytes.ReplaceAll(data, []byte("event.dataset"), []byte("datastream.dataset"))
 }
 
 func replaceBlacklistedWords(data []byte) []byte {

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: apache
 title: Apache
-version: 0.1.2
+version: 0.1.3
 license: basic
 description: Apache Integration
 type: integration

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 0.2.2
+version: 0.2.3
 license: basic
 description: AWS Integration
 type: integration

--- a/packages/cisco/manifest.yml
+++ b/packages/cisco/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco
 title: Cisco
-version: 0.2.1
+version: 0.2.2
 license: basic
 description: Cisco Integration
 type: integration

--- a/packages/haproxy/manifest.yml
+++ b/packages/haproxy/manifest.yml
@@ -1,6 +1,6 @@
 name: haproxy
 title: HAProxy
-version: 0.1.1
+version: 0.1.2
 description: HAProxy Integration
 type: integration
 icons:

--- a/packages/iis/manifest.yml
+++ b/packages/iis/manifest.yml
@@ -1,6 +1,6 @@
 name: iis
 title: IIS
-version: 0.1.1
+version: 0.1.2
 description: IIS Integration
 type: integration
 icons:

--- a/packages/kafka/manifest.yml
+++ b/packages/kafka/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kafka
 title: Kafka
-version: 0.2.2
+version: 0.2.3
 license: basic
 description: Kafka Integration
 type: integration

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 0.1.4
+version: 0.1.5
 license: basic
 description: Kubernetes Integration
 type: integration

--- a/packages/log/manifest.yml
+++ b/packages/log/manifest.yml
@@ -4,7 +4,7 @@ title: Custom logs
 description: >
   Collect your custom logs.
 type: integration
-version: 0.3.2
+version: 0.3.3
 release: experimental
 license: basic
 categories:

--- a/packages/mongodb/manifest.yml
+++ b/packages/mongodb/manifest.yml
@@ -1,6 +1,6 @@
 name: mongodb
 title: MongoDB
-version: 0.1.2
+version: 0.1.3
 description: MongoDB Integration
 type: integration
 categories:

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: mysql
 title: MySQL
-version: 0.2.2
+version: 0.2.3
 license: basic
 description: MySQL Integration
 type: integration

--- a/packages/netflow/manifest.yml
+++ b/packages/netflow/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: netflow
 title: NetFlow
-version: 0.2.1
+version: 0.2.2
 license: basic
 description: NetFlow Integration
 type: integration

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: nginx
 title: Nginx
-version: 0.2.2
+version: 0.2.3
 license: basic
 description: Nginx Integration
 type: integration

--- a/packages/postgresql/manifest.yml
+++ b/packages/postgresql/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: postgresql
 title: PostgreSQL
-version: 0.1.1
+version: 0.1.2
 license: basic
 description: PostgreSQL Integration
 type: integration

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: prometheus
 title: Prometheus
-version: 0.1.1
+version: 0.1.2
 license: basic
 description: Prometheus Integration
 type: integration

--- a/packages/rabbitmq/manifest.yml
+++ b/packages/rabbitmq/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: rabbitmq
 title: RabbitMQ
-version: 0.1.2
+version: 0.1.3
 license: basic
 description: RabbitMQ Integration
 type: integration

--- a/packages/redis/manifest.yml
+++ b/packages/redis/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: redis
 title: Redis
-version: 0.2.2
+version: 0.2.3
 license: basic
 description: Redis Integration
 type: integration

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 0.5.1
+version: 0.5.2
 license: basic
 description: System Integration
 type: integration

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 0.1.2
+version: 0.1.3
 description: Windows Integration
 type: integration
 categories:

--- a/packages/zookeeper/manifest.yml
+++ b/packages/zookeeper/manifest.yml
@@ -1,6 +1,6 @@
 name: zookeeper
 title: ZooKeeper
-version: 0.1.1
+version: 0.1.2
 description: ZooKeeper Integration
 type: integration
 icons:


### PR DESCRIPTION
The agent will ship datastream.* fields. Because of this, the import scripts can be adjusted to only use these fields.

This PR doese not rename any Golang variables. This should be done in a follow up and in sync with potential changes to the registry.