### PR TITLE
Fix a crash during module conversion

### DIFF
--- a/dev/import-beats/streams_config_parser.go
+++ b/dev/import-beats/streams_config_parser.go
@@ -74,7 +74,7 @@ func extractInputTypeFromTextNode(textNode *parse.TextNode) (string, bool) {
 		aType := textNode.Text[i+6:]
 		j := bytes.IndexByte(aType, '\n')
 		if j < 0 {
-			j = len(textNode.Text)
+			j = len(aType)
 		}
 		aType = aType[:j]
 		return string(aType), true


### PR DESCRIPTION
## What does this PR do?

Fixes an out-of-bounds array access when extracting input type from a Filebeat module.

This is a minor bug, probably something is not formatted as expected in one of the filesets:

```
panic: runtime error: slice bounds out of range [:8] with capacity 0

goroutine 1 [running]:
main.extractInputTypeFromTextNode(0xc00029c960, 0x0, 0x0, 0x203000)
	/Users/adrian/go/src/github.com/elastic/integrations/dev/import-beats/streams_config_parser.go:79 +0x183
main.inputTypesForNode(0x1596c40, 0xc00029c960, 0x0, 0x0, 0x0)
	/Users/adrian/go/src/github.com/elastic/integrations/dev/import-beats/streams_config_parser.go:44 +0x354
main.inputTypesForListNode(0xc00029c930, 0xc0003c3500, 0x1, 0x1)
	/Users/adrian/go/src/github.com/elastic/integrations/dev/import-beats/streams_config_parser.go:88 +0xaf
main.inputTypesForNode(0x1596940, 0xc0000a0880, 0x100dfd6, 0xc00009a138, 0x8)
	/Users/adrian/go/src/github.com/elastic/integrations/dev/import-beats/streams_config_parser.go:64 +0xf0
main.inputTypesForListNode(0xc00029c450, 0xc000186888, 0x100e848, 0xc000285e10)
	/Users/adrian/go/src/github.com/elastic/integrations/dev/import-beats/streams_config_parser.go:88 +0xaf
main.inputTypesForNode(0x15969a0, 0xc00029c450, 0xc00029c3f0, 0xc00009a138, 0xc00009a0c0)
	/Users/adrian/go/src/github.com/elastic/integrations/dev/import-beats/streams_config_parser.go:53 +0x30a
main.(*streamConfigParsed).inputTypes(0xc00009a138, 0x35c, 0x55c, 0xc00009a138)
	/Users/adrian/go/src/github.com/elastic/integrations/dev/import-beats/streams_config_parser.go:38 +0x3e
main.createLogStreams(0xc00002d5c0, 0x25, 0xc000092738, 0x5, 0xc00002de86, 0x5, 0x1974108, 0x0, 0xc0003c2180, 0xc0003c2000, ...)
	/Users/adrian/go/src/github.com/elastic/integrations/dev/import-beats/streams.go:92 +0x5c1
main.createStreams(0xc00002d5c0, 0x25, 0xc00002cd70, 0x5, 0xc000092738, 0x5, 0xc00002de86, 0x5, 0x14e2875, 0x4, ...)
	/Users/adrian/go/src/github.com/elastic/integrations/dev/import-beats/streams.go:30 +0x169
main.createDatasets(0x14e2875, 0x4, 0xc00002d5c0, 0x25, 0xc00002cd70, 0x5, 0xc000092738, 0x5, 0x0, 0x0, ...)
	/Users/adrian/go/src/github.com/elastic/integrations/dev/import-beats/datasets.go:116 +0x8cc
main.(*packageRepository).createPackagesFromSource(0xc000187cf8, 0x14e395c, 0x8, 0x14e66d2, 0xf, 0x14e2875, 0x4, 0x0, 0x0)
	/Users/adrian/go/src/github.com/elastic/integrations/dev/import-beats/packages.go:207 +0xaa4
main.build(0x14e395c, 0x8, 0x14e9287, 0x15, 0x14e36bd, 0x7, 0x14e3c24, 0x8, 0x14e3eed, 0x9, ...)
	/Users/adrian/go/src/github.com/elastic/integrations/dev/import-beats/main.go:128 +0x309
main.main()
	/Users/adrian/go/src/github.com/elastic/integrations/dev/import-beats/main.go:102 +0x5e7
exit status 2
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [x] I have verified that all datasets collect metrics or logs.


## How to test this PR locally

> PACKAGES=cisco mage -v ImportBeats