### PR TITLE
Add object field types in prometheus package

### DIFF
--- a/packages/prometheus/dataset/collector/fields/fields.yml
+++ b/packages/prometheus/dataset/collector/fields/fields.yml
@@ -3,10 +3,13 @@
   fields:
   - name: labels.*
     type: object
+    object_type: keyword
     description: |
       Prometheus metric labels
   - name: metrics.*
     type: object
+    object_type: double
+    object_type_mapping_type: "*"
     description: |
       Prometheus metric
 - name: prometheus.*.value

--- a/packages/prometheus/dataset/query/fields/fields.yml
+++ b/packages/prometheus/dataset/query/fields/fields.yml
@@ -3,9 +3,12 @@
   fields:
   - name: labels.*
     type: object
+    object_type: keyword
     description: |
       Prometheus metric labels
   - name: query.*
     type: object
+    object_type: double
+    object_type_mapping_type: "*"
     description: |
       Prometheus value resulted from PromQL

--- a/packages/prometheus/dataset/remote_write/fields/fields.yml
+++ b/packages/prometheus/dataset/remote_write/fields/fields.yml
@@ -3,9 +3,12 @@
   fields:
   - name: labels.*
     type: object
+    object_type: keyword
     description: |
       Prometheus metric labels
   - name: metrics.*
     type: object
+    object_type: double
+    object_type_mapping_type: "*"
     description: |-
       Prometheus metric

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: prometheus
 title: Prometheus
-version: 0.1.3
+version: 0.1.4
 license: basic
 description: Prometheus Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?
Adds missing field mappings for Prometheus package.


## Related issues
Closes https://github.com/elastic/integrations/issues/258

