### PR TITLE
Update test environment to 7.10.0

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.0-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "-u", "elastic:changeme", "http://127.0.0.1:9200/"]
       retries: 300
@@ -22,7 +22,7 @@ services:
       - "127.0.0.1:9200:9200"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.9.0-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.10.0-SNAPSHOT
     depends_on:
       elasticsearch:
         condition: service_healthy


### PR DESCRIPTION
The 7.9 registry was branched off and all future development is currently happening for 7.10. So the testing environment should be updated accordingly.
