### PR TITLE
Fix: use text type instead of integer (earlier: duration)

### DIFF
--- a/packages/system/dataset/socket/manifest.yml
+++ b/packages/system/dataset/socket/manifest.yml
@@ -26,15 +26,15 @@ streams:
     multi: false
     required: false
     show_user: true
-    description: Success TTL for reverse DNS lookup on remote IP addresses in the
-      socket dataset.
+    description: "Success TTL for reverse DNS lookup on remote IP addresses in the
+      socket dataset (sample: 10s)"
   - name: socket.reverse_lookup.failure_ttl
     type: text
     title: Reverse Lookup Success TTL
     multi: false
     required: false
     show_user: true
-    description: Failure TTL for reverse DNS lookup on remote IP addresses in the
-      socket dataset.
+    description: "Failure TTL for reverse DNS lookup on remote IP addresses in the
+      socket dataset (sample: 10s)"
   title: System socket metrics
   description: Collect System socket metrics

--- a/packages/system/dataset/socket/manifest.yml
+++ b/packages/system/dataset/socket/manifest.yml
@@ -18,26 +18,23 @@ streams:
     multi: false
     required: false
     show_user: true
-    description: >
-      Configure reverse DNS lookup on remote IP addresses in the socket metricset.
-
+    description: Configure reverse DNS lookup on remote IP addresses in the socket
+      dataset.
   - name: socket.reverse_lookup.success_ttl
-    type: integer
+    type: text
     title: Reverse Lookup Success TTL
     multi: false
     required: false
     show_user: true
-    description: >
-      Success TTL for reverse DNS lookup on remote IP addresses in the socket metricset.
-
+    description: Success TTL for reverse DNS lookup on remote IP addresses in the
+      socket dataset.
   - name: socket.reverse_lookup.failure_ttl
-    type: integer
+    type: text
     title: Reverse Lookup Success TTL
     multi: false
     required: false
     show_user: true
-    description: >
-      Failiure TTL for reverse DNS lookup on remote IP addresses in the socket metricset.
-
+    description: Failure TTL for reverse DNS lookup on remote IP addresses in the
+      socket dataset.
   title: System socket metrics
   description: Collect System socket metrics


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR fixes variable type for duration-like option (should be text instead of duration).

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [x] I have verified that all datasets collect metrics or logs.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
