### PR TITLE
Update GH team name to security-external-integrations

### DIFF
--- a/packages/checkpoint/manifest.yml
+++ b/packages/checkpoint/manifest.yml
@@ -66,4 +66,4 @@ policy_templates:
         title: "Collect Check Point firewall logs (input: syslog)"
         description: "Collecting firewall logs from Check Point instances (input: syslog)"
 owner:
-  github: elastic/security-ingest
+  github: elastic/security-external-integrations

--- a/packages/cisco/manifest.yml
+++ b/packages/cisco/manifest.yml
@@ -39,4 +39,4 @@ policy_templates:
         title: Collect logs from Cisco Nexus via TCP
         description: Collecting syslog from Cisco Nexus and Meraki via TCP
 owner:
-  github: elastic/security-ingest
+  github: elastic/security-external-integrations

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -41,4 +41,4 @@ policy_templates:
         title: "Collect CrowdStrike Falcon logs (input: logfile)"
         description: "Collecting logs from CrowdStrike Falcon (input: logfile)"
 owner:
-  github: elastic/security-ingest
+  github: elastic/security-external-integrations

--- a/packages/fortinet/manifest.yml
+++ b/packages/fortinet/manifest.yml
@@ -29,4 +29,4 @@ policy_templates:
         title: "Collect Fortinet logs (input: udp)"
         description: "Collecting logs from Fortinet instances (input: udp)"
 owner:
-  github: elastic/security-ingest
+  github: elastic/security-external-integrations

--- a/packages/juniper/manifest.yml
+++ b/packages/juniper/manifest.yml
@@ -29,4 +29,4 @@ icons:
     size: 32x32
     type: image/svg+xml
 owner:
-  github: elastic/security-ingest
+  github: elastic/security-external-integrations

--- a/packages/microsoft/manifest.yml
+++ b/packages/microsoft/manifest.yml
@@ -29,4 +29,4 @@ icons:
     size: 32x32
     type: image/svg+xml
 owner:
-  github: elastic/security-ingest
+  github: elastic/security-external-integrations

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -97,4 +97,4 @@ policy_templates:
         title: "Collect Office 365 logs via log files"
         description: "Collecting logs from Office 365 via log files"
 owner:
-  github: elastic/security-ingest
+  github: elastic/security-external-integrations

--- a/packages/okta/manifest.yml
+++ b/packages/okta/manifest.yml
@@ -128,4 +128,4 @@ policy_templates:
         title: "Collect Okta logs via file"
         description: "Collecting logs from Okta via file"
 owner:
-  github: elastic/security-ingest
+  github: elastic/security-external-integrations

--- a/packages/panw/manifest.yml
+++ b/packages/panw/manifest.yml
@@ -59,4 +59,4 @@ policy_templates:
               - /var/log/pan-os.log
         description: "Collecting logs via log file"
 owner:
-  github: elastic/security-ingest
+  github: elastic/security-external-integrations

--- a/packages/suricata/manifest.yml
+++ b/packages/suricata/manifest.yml
@@ -41,4 +41,4 @@ policy_templates:
         title: 'Collect Suricata eve logs (input: logfile)'
         description: 'Collecting eve logs from Suricata instances (input: logfile)'
 owner:
-  github: elastic/security-ingest
+  github: elastic/security-external-integrations

--- a/packages/zeek/manifest.yml
+++ b/packages/zeek/manifest.yml
@@ -28,4 +28,4 @@ policy_templates:
         title: 'Collect Zeek logs'
         description: 'Collects logs from Zeek instances. Supported logs include: capture_loss, connection, dce_rpc, dhcp, dnp3, dns, dpd, files, ftp, http, intel, irc, kerberos, modbus, mysql, notice, ntlm, ocsp, pe, radius, rdp, rfb, sip, smb_cmd, smb_files, smb_mapping, smtp, snmp, socks, ssh, ssl, stats, syslog, traceroute, tunnel, weird and x509'
 owner:
-  github: elastic/security-ingest
+  github: elastic/security-external-integrations

--- a/packages/zoom/manifest.yml
+++ b/packages/zoom/manifest.yml
@@ -21,7 +21,7 @@ policy_templates:
         title: 'Read Zoom Webhook logs from a file'
         description: 'Read Zoom Webhook logs from a file'
 owner:
-  github: elastic/security-ingest
+  github: elastic/security-external-integrations
 icons:
   - src: /img/zoom_blue.svg
     title: Zoom


### PR DESCRIPTION
## What does this PR do?

The name of the security ingest team was changed to external integrations. This updates the github team same to @elastic/security-external-integrations within manifests.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.

