### PR TITLE
Add common host inventory fields into aws and system package

### DIFF
--- a/packages/aws/data_stream/ec2_metrics/fields/fields.yml
+++ b/packages/aws/data_stream/ec2_metrics/fields/fields.yml
@@ -159,3 +159,34 @@
           type: integer
           description: |
             The number of threads per CPU core.
+- name: host
+  type: group
+  fields:
+    - name: cpu.pct
+      type: scaled_float
+      description: |
+        Percent CPU used. This value is normalized by the number of CPU cores and it ranges from 0 to 1.
+    - name: disk.read.bytes
+      type: scaled_float
+      description: |
+        The total number of bytes read successfully in a given period of time.
+    - name: disk.write.bytes
+      type: scaled_float
+      description: |
+        The total number of bytes write successfully in a given period of time.
+    - name: network.in.bytes
+      type: scaled_float
+      description: |
+        The number of bytes received on all network interfaces by the host in a given period of time.
+    - name: network.out.bytes
+      type: scaled_float
+      description: |
+        The number of bytes sent out on all network interfaces by the host in a given period of time.
+    - name: network.in.packets
+      type: scaled_float
+      description: |
+        The number of packets received on all network interfaces by the host in a given period of time.
+    - name: network.out.packets
+      type: scaled_float
+      description: |
+        The number of packets sent out on all network interfaces by the host in a given period of time.

--- a/packages/aws/docs/README.md
+++ b/packages/aws/docs/README.md
@@ -1081,6 +1081,13 @@ An example event for `ec2` looks as following:
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| host.cpu.pct | Percent CPU used. This value is normalized by the number of CPU cores and it ranges from 0 to 1. | scaled_float |
+| host.disk.read.bytes | The total number of bytes read successfully in a given period of time. | scaled_float |
+| host.disk.write.bytes | The total number of bytes write successfully in a given period of time. | scaled_float |
+| host.network.in.bytes | The number of bytes received on all network interfaces by the host in a given period of time. | scaled_float |
+| host.network.in.packets | The number of packets received on all network interfaces by the host in a given period of time. | scaled_float |
+| host.network.out.bytes | The number of bytes sent out on all network interfaces by the host in a given period of time. | scaled_float |
+| host.network.out.packets | The number of packets sent out on all network interfaces by the host in a given period of time. | scaled_float |
 
 
 ### elb

--- a/packages/system/data_stream/cpu/fields/fields.yml
+++ b/packages/system/data_stream/cpu/fields/fields.yml
@@ -127,3 +127,10 @@
       type: long
       description: |
         The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix.
+- name: host
+  type: group
+  fields:
+    - name: cpu.pct
+      type: scaled_float
+      description: |
+        Percent CPU used. This value is normalized by the number of CPU cores and it ranges from 0 to 1.

--- a/packages/system/data_stream/diskio/fields/fields.yml
+++ b/packages/system/data_stream/diskio/fields/fields.yml
@@ -93,3 +93,14 @@
       type: float
       description: |
         Percentage of CPU time during which I/O requests were issued to the device (bandwidth utilization for the device). Device saturation occurs when this value is close to 100%.
+- name: host
+  type: group
+  fields:
+    - name: disk.read.bytes
+      type: scaled_float
+      description: |
+        The total number of bytes read successfully in a given period of time.
+    - name: disk.write.bytes
+      type: scaled_float
+      description: |
+        The total number of bytes write successfully in a given period of time.

--- a/packages/system/data_stream/network/fields/fields.yml
+++ b/packages/system/data_stream/network/fields/fields.yml
@@ -39,3 +39,22 @@
       type: long
       description: |
         The number of outgoing packets that were dropped. This value is always 0 on Darwin and BSD because it is not reported by the operating system.
+- name: host
+  type: group
+  fields:
+    - name: network.in.bytes
+      type: scaled_float
+      description: |
+        The number of bytes received on all network interfaces by the host in a given period of time.
+    - name: network.out.bytes
+      type: scaled_float
+      description: |
+        The number of bytes sent out on all network interfaces by the host in a given period of time.
+    - name: network.in.packets
+      type: scaled_float
+      description: |
+        The number of packets received on all network interfaces by the host in a given period of time.
+    - name: network.out.packets
+      type: scaled_float
+      description: |
+        The number of packets sent out on all network interfaces by the host in a given period of time.

--- a/packages/system/docs/README.md
+++ b/packages/system/docs/README.md
@@ -90,6 +90,7 @@ This dataset is available on:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
+| host.cpu.pct | Percent CPU used. This value is normalized by the number of CPU cores and it ranges from 0 to 1. | scaled_float |
 | host.ip | Host ip address. | ip |
 | host.mac | Host mac address. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
@@ -150,6 +151,8 @@ This dataset is available on:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
+| host.disk.read.bytes | The total number of bytes read successfully in a given period of time. | scaled_float |
+| host.disk.write.bytes | The total number of bytes write successfully in a given period of time. | scaled_float |
 | host.ip | Host ip address. | ip |
 | host.mac | Host mac address. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
@@ -381,6 +384,10 @@ This dataset is available on:
 | group.id | Unique identifier for the group on the system/platform. | keyword |
 | group.name | Name of the group. | keyword |
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
+| host.network.in.bytes | The number of bytes received on all network interfaces by the host in a given period of time. | scaled_float |
+| host.network.in.packets | The number of packets received on all network interfaces by the host in a given period of time. | scaled_float |
+| host.network.out.bytes | The number of bytes sent out on all network interfaces by the host in a given period of time. | scaled_float |
+| host.network.out.packets | The number of packets sent out on all network interfaces by the host in a given period of time. | scaled_float |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
 | process.name | Process name. Sometimes called program name or similar. | keyword |
 | process.pid | Process id. | long |


### PR DESCRIPTION
## What does this PR do?

For 7.10, we introduced some common fields in Beats for host inventory schema.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [ ] I have verified that all datasets collect metrics or logs.

## Related issues

- Relates https://github.com/elastic/beats/issues/19757
