### PR TITLE
Add fips_enabled config parameter to log data streams

### DIFF
--- a/packages/aws/data_stream/cloudtrail/agent/stream/s3.yml.hbs
+++ b/packages/aws/data_stream/cloudtrail/agent/stream/s3.yml.hbs
@@ -30,6 +30,9 @@ role_arn: {{role_arn}}
 {{#if aws_partition}}
 aws_partition: {{aws_partition}}
 {{/if}}
+{{#if fips_enabled}}
+fips_enabled: {{fips_enabled}}
+{{/if}}
 processors:
   - add_fields:
       target: ''

--- a/packages/aws/data_stream/cloudtrail/manifest.yml
+++ b/packages/aws/data_stream/cloudtrail/manifest.yml
@@ -14,3 +14,11 @@ streams:
         required: true
         show_user: true
         description: URL of the AWS SQS queue that messages will be received from.
+      - name: fips_enabled
+        type: bool
+        title: Enable S3 FIPS
+        default: false
+        multi: false
+        required: false
+        show_user: false
+        description: Enabling this option changes the service name from `s3` to `s3-fips` for connecting to the correct service endpoint.

--- a/packages/aws/data_stream/cloudwatch_logs/agent/stream/s3.yml.hbs
+++ b/packages/aws/data_stream/cloudwatch_logs/agent/stream/s3.yml.hbs
@@ -29,6 +29,9 @@ role_arn: {{role_arn}}
 {{#if aws_partition}}
 aws_partition: {{aws_partition}}
 {{/if}}
+{{#if fips_enabled}}
+fips_enabled: {{fips_enabled}}
+{{/if}}
 processors:
   - add_fields:
       target: ''

--- a/packages/aws/data_stream/cloudwatch_logs/manifest.yml
+++ b/packages/aws/data_stream/cloudwatch_logs/manifest.yml
@@ -14,3 +14,11 @@ streams:
         required: true
         show_user: true
         description: URL of the AWS SQS queue that messages will be received from.
+      - name: fips_enabled
+        type: bool
+        title: Enable S3 FIPS
+        default: false
+        multi: false
+        required: false
+        show_user: false
+        description: Enabling this option changes the service name from `s3` to `s3-fips` for connecting to the correct service endpoint.

--- a/packages/aws/data_stream/ec2_logs/agent/stream/s3.yml.hbs
+++ b/packages/aws/data_stream/ec2_logs/agent/stream/s3.yml.hbs
@@ -29,6 +29,9 @@ role_arn: {{role_arn}}
 {{#if aws_partition}}
 aws_partition: {{aws_partition}}
 {{/if}}
+{{#if fips_enabled}}
+fips_enabled: {{fips_enabled}}
+{{/if}}
 processors:
   - add_fields:
       target: ''

--- a/packages/aws/data_stream/ec2_logs/manifest.yml
+++ b/packages/aws/data_stream/ec2_logs/manifest.yml
@@ -15,7 +15,7 @@ streams:
         show_user: true
         description: URL of the AWS SQS queue that messages will be received from.
       - name: fips_enabled
-        type: boolean
+        type: bool
         title: Enable S3 FIPS
         default: false
         multi: false

--- a/packages/aws/data_stream/ec2_logs/manifest.yml
+++ b/packages/aws/data_stream/ec2_logs/manifest.yml
@@ -14,3 +14,11 @@ streams:
         required: true
         show_user: true
         description: URL of the AWS SQS queue that messages will be received from.
+      - name: fips_enabled
+        type: boolean
+        title: Enable S3 FIPS
+        default: false
+        multi: false
+        required: false
+        show_user: false
+        description: Enabling this option changes the service name from `s3` to `s3-fips` for connecting to the correct service endpoint.

--- a/packages/aws/data_stream/elb_logs/agent/stream/s3.yml.hbs
+++ b/packages/aws/data_stream/elb_logs/agent/stream/s3.yml.hbs
@@ -29,6 +29,9 @@ role_arn: {{role_arn}}
 {{#if aws_partition}}
 aws_partition: {{aws_partition}}
 {{/if}}
+{{#if fips_enabled}}
+fips_enabled: {{fips_enabled}}
+{{/if}}
 processors:
   - add_fields:
       target: ''

--- a/packages/aws/data_stream/elb_logs/manifest.yml
+++ b/packages/aws/data_stream/elb_logs/manifest.yml
@@ -14,3 +14,11 @@ streams:
         required: true
         show_user: true
         description: URL of the AWS SQS queue that messages will be received from.
+      - name: fips_enabled
+        type: bool
+        title: Enable S3 FIPS
+        default: false
+        multi: false
+        required: false
+        show_user: false
+        description: Enabling this option changes the service name from `s3` to `s3-fips` for connecting to the correct service endpoint.

--- a/packages/aws/data_stream/s3access/agent/stream/s3.yml.hbs
+++ b/packages/aws/data_stream/s3access/agent/stream/s3.yml.hbs
@@ -29,6 +29,9 @@ role_arn: {{role_arn}}
 {{#if aws_partition}}
 aws_partition: {{aws_partition}}
 {{/if}}
+{{#if fips_enabled}}
+fips_enabled: {{fips_enabled}}
+{{/if}}
 processors:
   - add_fields:
       target: ''

--- a/packages/aws/data_stream/s3access/manifest.yml
+++ b/packages/aws/data_stream/s3access/manifest.yml
@@ -14,3 +14,11 @@ streams:
         required: true
         show_user: true
         description: URL of the AWS SQS queue that messages will be received from.
+      - name: fips_enabled
+        type: bool
+        title: Enable S3 FIPS
+        default: false
+        multi: false
+        required: false
+        show_user: false
+        description: Enabling this option changes the service name from `s3` to `s3-fips` for connecting to the correct service endpoint.

--- a/packages/aws/data_stream/vpcflow/agent/stream/s3.yml.hbs
+++ b/packages/aws/data_stream/vpcflow/agent/stream/s3.yml.hbs
@@ -29,6 +29,9 @@ role_arn: {{role_arn}}
 {{#if aws_partition}}
 aws_partition: {{aws_partition}}
 {{/if}}
+{{#if fips_enabled}}
+fips_enabled: {{fips_enabled}}
+{{/if}}
 processors:
   - drop_event:
       when.regexp.message: "^version"

--- a/packages/aws/data_stream/vpcflow/manifest.yml
+++ b/packages/aws/data_stream/vpcflow/manifest.yml
@@ -14,3 +14,11 @@ streams:
         required: true
         show_user: true
         description: URL of the AWS SQS queue that messages will be received from.
+      - name: fips_enabled
+        type: bool
+        title: Enable S3 FIPS
+        default: false
+        multi: false
+        required: false
+        show_user: false
+        description: Enabling this option changes the service name from `s3` to `s3-fips` for connecting to the correct service endpoint.


### PR DESCRIPTION
## What does this PR do?

This PR is to add `fips_enabled` config option into the integration as a part of https://github.com/elastic/beats/issues/21286.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [x] I have verified that all datasets collect metrics or logs.

## Screenshots
<img width="723" alt="Screen Shot 2020-10-07 at 1 00 58 PM" src="https://user-images.githubusercontent.com/14081635/95375680-2c3cc580-089d-11eb-91ea-000d7f22b03b.png">

