### PR TITLE
Rename ingest_manager to fleet

### DIFF
--- a/testing/environments/kibana.config.yml
+++ b/testing/environments/kibana.config.yml
@@ -6,11 +6,11 @@ elasticsearch.username: elastic
 elasticsearch.password: changeme
 xpack.monitoring.ui.container.elasticsearch.enabled: true
 
-xpack.ingestManager.enabled: true
-xpack.ingestManager.registryUrl: "http://package-registry:8080"
-xpack.ingestManager.fleet.enabled: true
-xpack.ingestManager.fleet.elasticsearch.host: "http://localhost:9200"
-xpack.ingestManager.fleet.kibana.host: "http://localhost:5601"
-xpack.ingestManager.fleet.tlsCheckDisabled: true
+xpack.fleet.enabled: true
+xpack.fleet.registryUrl: "http://package-registry:8080"
+xpack.fleet.agents.enabled: true
+xpack.fleet.agents.elasticsearch.host: "http://localhost:9200"
+xpack.fleet.agents.kibana.host: "http://localhost:5601"
+xpack.fleet.agents.tlsCheckDisabled: true
 
 xpack.encryptedSavedObjects.encryptionKey: "12345678901234567890123456789012"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR renames `ingest_manager` to `fleet` due to latest breaking changes pushed to Kibana.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [ ] I have verified that all datasets collect metrics or logs.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
