### PR TITLE
Add latency config into aws metrics data stream

### DIFF
--- a/packages/aws/data_stream/billing/manifest.yml
+++ b/packages/aws/data_stream/billing/manifest.yml
@@ -11,5 +11,11 @@ streams:
         required: true
         show_user: true
         default: 12h
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
     title: AWS Billing metrics
     description: Collect AWS billing metrics

--- a/packages/aws/data_stream/cloudwatch_metrics/manifest.yml
+++ b/packages/aws/data_stream/cloudwatch_metrics/manifest.yml
@@ -17,6 +17,12 @@ streams:
         multi: true
         required: false
         show_user: true
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
       - name: metrics
         type: yaml
         title: Metrics

--- a/packages/aws/data_stream/dynamodb/manifest.yml
+++ b/packages/aws/data_stream/dynamodb/manifest.yml
@@ -17,6 +17,12 @@ streams:
         multi: true
         required: false
         show_user: true
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
       - name: tags_filter
         type: yaml
         title: Tags Filter

--- a/packages/aws/data_stream/ebs/manifest.yml
+++ b/packages/aws/data_stream/ebs/manifest.yml
@@ -17,6 +17,12 @@ streams:
         multi: true
         required: false
         show_user: true
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
       - name: tags_filter
         type: yaml
         title: Tags Filter

--- a/packages/aws/data_stream/ec2_metrics/manifest.yml
+++ b/packages/aws/data_stream/ec2_metrics/manifest.yml
@@ -17,6 +17,12 @@ streams:
         multi: true
         required: false
         show_user: true
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
       - name: tags_filter
         type: yaml
         title: Tags Filter

--- a/packages/aws/data_stream/elb_metrics/manifest.yml
+++ b/packages/aws/data_stream/elb_metrics/manifest.yml
@@ -17,6 +17,12 @@ streams:
         multi: true
         required: false
         show_user: true
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
       - name: tags_filter
         type: yaml
         title: Tags Filter

--- a/packages/aws/data_stream/lambda/manifest.yml
+++ b/packages/aws/data_stream/lambda/manifest.yml
@@ -17,6 +17,12 @@ streams:
         multi: true
         required: false
         show_user: true
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
       - name: tags_filter
         type: yaml
         title: Tags Filter

--- a/packages/aws/data_stream/natgateway/manifest.yml
+++ b/packages/aws/data_stream/natgateway/manifest.yml
@@ -17,5 +17,11 @@ streams:
         multi: true
         required: false
         show_user: true
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
     title: AWS NAT gateway metrics
     description: Collect AWS NAT gateway metrics

--- a/packages/aws/data_stream/rds/manifest.yml
+++ b/packages/aws/data_stream/rds/manifest.yml
@@ -17,6 +17,12 @@ streams:
         multi: true
         required: false
         show_user: true
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
       - name: tags_filter
         type: yaml
         title: Tags Filter

--- a/packages/aws/data_stream/s3_daily_storage/manifest.yml
+++ b/packages/aws/data_stream/s3_daily_storage/manifest.yml
@@ -17,5 +17,11 @@ streams:
         multi: true
         required: false
         show_user: true
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
     title: AWS S3 daily storage metrics
     description: Collect AWS S3 daily storage metrics

--- a/packages/aws/data_stream/s3_request/manifest.yml
+++ b/packages/aws/data_stream/s3_request/manifest.yml
@@ -17,5 +17,11 @@ streams:
         multi: true
         required: false
         show_user: true
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
     title: AWS S3 request metrics
     description: Collect AWS S3 request metrics

--- a/packages/aws/data_stream/s3_request/manifest.yml
+++ b/packages/aws/data_stream/s3_request/manifest.yml
@@ -10,7 +10,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        default: 24h
+        default: 1m
       - name: regions
         type: text
         title: Regions

--- a/packages/aws/data_stream/sns/manifest.yml
+++ b/packages/aws/data_stream/sns/manifest.yml
@@ -17,6 +17,12 @@ streams:
         multi: true
         required: false
         show_user: true
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
       - name: tags_filter
         type: yaml
         title: Tags Filter

--- a/packages/aws/data_stream/sqs/manifest.yml
+++ b/packages/aws/data_stream/sqs/manifest.yml
@@ -17,5 +17,11 @@ streams:
         multi: true
         required: false
         show_user: true
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
     title: AWS SQS metrics
     description: Collect AWS SQS metrics

--- a/packages/aws/data_stream/transitgateway/manifest.yml
+++ b/packages/aws/data_stream/transitgateway/manifest.yml
@@ -17,5 +17,11 @@ streams:
         multi: true
         required: false
         show_user: true
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
     title: AWS Transit Gateway metrics
     description: Collect AWS Transit Gateway metrics

--- a/packages/aws/data_stream/usage/manifest.yml
+++ b/packages/aws/data_stream/usage/manifest.yml
@@ -17,5 +17,11 @@ streams:
         multi: true
         required: false
         show_user: true
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
     title: AWS usage metrics
     description: Collect AWS usage metrics

--- a/packages/aws/data_stream/vpn/manifest.yml
+++ b/packages/aws/data_stream/vpn/manifest.yml
@@ -17,6 +17,12 @@ streams:
         multi: true
         required: false
         show_user: true
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
       - name: tags_filter
         type: yaml
         title: Tags Filter

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 0.3.9
+version: 0.3.10
 license: basic
 description: AWS Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?

This PR is to add latency config into aws metrics data stream after merging https://github.com/elastic/beats/pull/20875.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [x] I have verified that all datasets collect metrics or logs.

## Screenshots
<img width="803" alt="Screen Shot 2020-10-13 at 10 42 56 AM" src="https://user-images.githubusercontent.com/14081635/95890460-0ef67400-0d41-11eb-9e87-bd3e463db35e.png">
