### PR TITLE
Add ECS host fields to system package log data streams

### DIFF
--- a/packages/system/data_stream/auth/fields/ecs.yml
+++ b/packages/system/data_stream/auth/fields/ecs.yml
@@ -126,3 +126,62 @@
           type: text
           norms: false
           default_field: false
+- description: "Operating system architecture."
+  ignore_above: 1024
+  name: host.architecture
+  type: keyword
+- description: "Name of the directory the group is a member of."
+  ignore_above: 1024
+  name: host.domain
+  type: keyword
+- description: "Hostname of the host."
+  ignore_above: 1024
+  name: host.hostname
+  type: keyword
+- description: "Unique host id."
+  ignore_above: 1024
+  name: host.id
+  type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
+- description: "Host mac addresses."
+  ignore_above: 1024
+  name: host.mac
+  type: keyword
+- description: "Name of the host."
+  ignore_above: 1024
+  name: host.name
+  type: keyword
+- description: "OS family (such as redhat, debian, freebsd, windows)."
+  ignore_above: 1024
+  name: host.os.family
+  type: keyword
+- description: "Operating system name, including the version or code name."
+  ignore_above: 1024
+  multi_fields:
+    - name: text
+      norms: false
+      type: text
+  name: host.os.full
+  type: keyword
+- description: "Operating system kernel version as a raw string."
+  ignore_above: 1024
+  name: host.os.kernel
+  type: keyword
+- description: "Operating system name, without the version."
+  ignore_above: 1024
+  multi_fields:
+    - name: text
+      norms: false
+      type: text
+  name: host.os.name
+  type: keyword
+- description: "Operating system platform (such centos, ubuntu, windows)."
+  ignore_above: 1024
+  name: host.os.platform
+  type: keyword
+- description: "Operating system version as a raw string."
+  ignore_above: 1024
+  name: version
+  type: keyword

--- a/packages/system/data_stream/syslog/fields/ecs.yml
+++ b/packages/system/data_stream/syslog/fields/ecs.yml
@@ -14,18 +14,6 @@
     For log events the message field contains the log message, optimized for viewing in a log viewer.
     For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event.
     If multiple messages exist, they can be combined into one message.
-- name: host
-  title: Host
-  group: 2
-  type: group
-  fields:
-    - name: hostname
-      level: core
-      type: keyword
-      description: |-
-        Hostname of the host.
-        It normally contains what the `hostname` command returns on the host machine.
-      ignore_above: 1024
 - name: process
   title: Process
   group: 2
@@ -48,3 +36,62 @@
       type: long
       format: string
       description: Process id.
+- description: "Operating system architecture."
+  ignore_above: 1024
+  name: host.architecture
+  type: keyword
+- description: "Name of the directory the group is a member of."
+  ignore_above: 1024
+  name: host.domain
+  type: keyword
+- description: "Hostname of the host."
+  ignore_above: 1024
+  name: host.hostname
+  type: keyword
+- description: "Unique host id."
+  ignore_above: 1024
+  name: host.id
+  type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
+- description: "Host mac addresses."
+  ignore_above: 1024
+  name: host.mac
+  type: keyword
+- description: "Name of the host."
+  ignore_above: 1024
+  name: host.name
+  type: keyword
+- description: "OS family (such as redhat, debian, freebsd, windows)."
+  ignore_above: 1024
+  name: host.os.family
+  type: keyword
+- description: "Operating system name, including the version or code name."
+  ignore_above: 1024
+  multi_fields:
+    - name: text
+      norms: false
+      type: text
+  name: host.os.full
+  type: keyword
+- description: "Operating system kernel version as a raw string."
+  ignore_above: 1024
+  name: host.os.kernel
+  type: keyword
+- description: "Operating system name, without the version."
+  ignore_above: 1024
+  multi_fields:
+    - name: text
+      norms: false
+      type: text
+  name: host.os.name
+  type: keyword
+- description: "Operating system platform (such centos, ubuntu, windows)."
+  ignore_above: 1024
+  name: host.os.platform
+  type: keyword
+- description: "Operating system version as a raw string."
+  ignore_above: 1024
+  name: version
+  type: keyword

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 0.8.0
+version: 0.8.1
 license: basic
 description: System Integration
 type: integration


### PR DESCRIPTION

## What does this PR do?

Add missing field definitions for the ECS host fields to the log data streams of the system package.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [ ] I have verified that all datasets collect metrics or logs.

## Author's Checklist

- [ ] Test this with Elastic Agent (had trouble running latest agent)

## Related issues


- Fixes #291

