### PR TITLE
Fix import-beats: prepend module names to Kibana dashboards

### DIFF
--- a/dev/import-beats/kibana.go
+++ b/dev/import-beats/kibana.go
@@ -240,7 +240,7 @@ func convertToKibanaObjects(dashboardFile []byte, moduleName string, dataStreamN
 		}
 
 		dashboardName := id.(string)
-		if aType == "dashboard" && !strings.HasPrefix(dashboardName, moduleName + "-") {
+		if aType == "dashboard" && !strings.HasPrefix(dashboardName, moduleName+"-") {
 			dashboardName = moduleName + "-" + dashboardName
 		}
 
@@ -263,12 +263,11 @@ func convertToKibanaObjects(dashboardFile []byte, moduleName string, dataStreamN
 			return nil, errors.Wrapf(err, "Kibana object convertion failed")
 		}
 
-
 		if _, ok := extracted[aType.(string)]; !ok {
 			extracted[aType.(string)] = map[string][]byte{}
 		}
 
-		extracted[aType.(string)][dashboardName + ".json"] = data
+		extracted[aType.(string)][dashboardName+".json"] = data
 	}
 
 	return extracted, nil
@@ -476,8 +475,8 @@ func replaceBlacklistedWords(data []byte) []byte {
 }
 
 func prependModuleNameToDashboard(data []byte, moduleName string) []byte {
-	data = bytes.ReplaceAll(data, []byte("/app/kibana#/dashboard/" + moduleName + "-"), []byte("/app/kibana#/dashboard/"))
-	data = bytes.ReplaceAll(data, []byte("/app/kibana#/dashboard/"), []byte("/app/kibana#/dashboard/" + moduleName + "-"))
+	data = bytes.ReplaceAll(data, []byte("/app/kibana#/dashboard/"+moduleName+"-"), []byte("/app/kibana#/dashboard/"))
+	data = bytes.ReplaceAll(data, []byte("/app/kibana#/dashboard/"), []byte("/app/kibana#/dashboard/"+moduleName+"-"))
 	return data
 }
 

--- a/dev/import-beats/kibana.go
+++ b/dev/import-beats/kibana.go
@@ -254,7 +254,7 @@ func convertToKibanaObjects(dashboardFile []byte, moduleName string, dataStreamN
 			return nil, errors.Wrapf(err, "marshalling object failed")
 		}
 
-		data = prependModuleNameToDashboard(replaceBlacklistedWords(
+		data = prependModuleNameToDashboardLinks(replaceBlacklistedWords(
 			replaceFieldEventDatasetWithDataStreamDataset(
 				data)), moduleName)
 
@@ -474,7 +474,7 @@ func replaceBlacklistedWords(data []byte) []byte {
 	return data
 }
 
-func prependModuleNameToDashboard(data []byte, moduleName string) []byte {
+func prependModuleNameToDashboardLinks(data []byte, moduleName string) []byte {
 	data = bytes.ReplaceAll(data, []byte("/app/kibana#/dashboard/"+moduleName+"-"), []byte("/app/kibana#/dashboard/"))
 	data = bytes.ReplaceAll(data, []byte("/app/kibana#/dashboard/"), []byte("/app/kibana#/dashboard/"+moduleName+"-"))
 	return data

--- a/dev/import-beats/kibana.go
+++ b/dev/import-beats/kibana.go
@@ -234,29 +234,41 @@ func convertToKibanaObjects(dashboardFile []byte, moduleName string, dataStreamN
 			return nil, errors.Wrapf(err, "retrieving type failed")
 		}
 
+		id, err := object.getValue("id")
+		if err != nil {
+			return nil, errors.Wrapf(err, "retrieving id failed")
+		}
+
+		dashboardName := id.(string)
+		if aType == "dashboard" && !strings.HasPrefix(dashboardName, moduleName + "-") {
+			dashboardName = moduleName + "-" + dashboardName
+		}
+
+		_, err = object.put("id", dashboardName)
+		if err != nil {
+			return nil, errors.Wrapf(err, "putting new ID failed")
+		}
+
 		data, err := json.MarshalIndent(object, "", "    ")
 		if err != nil {
 			return nil, errors.Wrapf(err, "marshalling object failed")
 		}
 
-		data = replaceBlacklistedWords(
-			replaceFieldEventDataStreamWithStreamDataStream(
-				data))
+		data = prependModuleNameToDashboard(replaceBlacklistedWords(
+			replaceFieldEventDatasetWithDataStreamDataset(
+				data)), moduleName)
 
 		err = verifyKibanaObjectConvertion(data)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Kibana object convertion failed")
 		}
 
-		id, err := object.getValue("id")
-		if err != nil {
-			return nil, errors.Wrapf(err, "retrieving id failed")
-		}
 
 		if _, ok := extracted[aType.(string)]; !ok {
 			extracted[aType.(string)] = map[string][]byte{}
 		}
-		extracted[aType.(string)][id.(string)+".json"] = data
+
+		extracted[aType.(string)][dashboardName + ".json"] = data
 	}
 
 	return extracted, nil
@@ -449,7 +461,7 @@ func stripReferencesToEventModuleInQuery(object mapStr, objectKey, moduleName st
 	return object, nil
 }
 
-func replaceFieldEventDataStreamWithStreamDataStream(data []byte) []byte {
+func replaceFieldEventDatasetWithDataStreamDataset(data []byte) []byte {
 	return bytes.ReplaceAll(data, []byte("event.dataset"), []byte("data_stream.dataset"))
 }
 
@@ -460,6 +472,12 @@ func replaceBlacklistedWords(data []byte) []byte {
 	data = bytes.ReplaceAll(data, []byte("filebeat"), []byte("logs"))
 	data = bytes.ReplaceAll(data, []byte("Module"), []byte("Integration"))
 	data = bytes.ReplaceAll(data, []byte("module"), []byte("integration"))
+	return data
+}
+
+func prependModuleNameToDashboard(data []byte, moduleName string) []byte {
+	data = bytes.ReplaceAll(data, []byte("/app/kibana#/dashboard/" + moduleName + "-"), []byte("/app/kibana#/dashboard/"))
+	data = bytes.ReplaceAll(data, []byte("/app/kibana#/dashboard/"), []byte("/app/kibana#/dashboard/" + moduleName + "-"))
 	return data
 }
 

--- a/dev/import-beats/packages.go
+++ b/dev/import-beats/packages.go
@@ -428,6 +428,9 @@ func writeDoc(docsPath string, doc docContent, aPackage packageContent) error {
 		t = template.Must(t.Parse("TODO"))
 	} else {
 		t, err = t.Funcs(template.FuncMap{
+			"event": func(dataStream string) (string, error) {
+				return "TODO", nil
+			},
 			"fields": func(dataStream string) (string, error) {
 				return renderExportedFields(dataStream, aPackage.dataStreams)
 			},


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR fixes the migration script is to prepend modules names to Kibana dashboards.

Additionally:
- I fixed issue with undefined `event` function in templates (not used in initial migration).

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [ ] I have verified that all datasets collect metrics or logs.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- https://github.com/elastic/integrations/issues/318

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
