### PR TITLE
Windows event log data stream fixes

### DIFF
--- a/packages/windows/data_stream/forwarded/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/forwarded/agent/stream/winlog.yml.hbs
@@ -4,7 +4,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.5.0
+        ecs.version: 1.6.0
   - script:
       when.equals.winlog.channel: Security
       lang: javascript

--- a/packages/windows/data_stream/forwarded/fields/ecs.yml
+++ b/packages/windows/data_stream/forwarded/fields/ecs.yml
@@ -376,3 +376,12 @@
   ignore_above: 1024
   name: rule.name
   type: keyword
+- description: Log level of the log event.
+  name: log.level
+  type: keyword
+- description: Host ip addresses.
+  name: host.ip
+  type: ip
+- description: The outcome of the event. The lowest level categorization field in the hierarchy.
+  name: event.outcome
+  type: keyword

--- a/packages/windows/data_stream/powershell/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/powershell/agent/stream/winlog.yml.hbs
@@ -4,7 +4,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.5.0
+        ecs.version: 1.6.0
   - script:
       lang: javascript
       id: security

--- a/packages/windows/data_stream/powershell/fields/ecs.yml
+++ b/packages/windows/data_stream/powershell/fields/ecs.yml
@@ -115,3 +115,17 @@
 - description: Error message.
   name: error.message
   type: text
+- description: Identification code for this event.
+  example: 4648
+  ignore_above: 1024
+  name: event.code
+  type: keyword
+- description: Log level of the log event.
+  name: log.level
+  type: keyword
+- description: Host ip addresses.
+  name: host.ip
+  type: ip
+- description: The outcome of the event. The lowest level categorization field in the hierarchy.
+  name: event.outcome
+  type: keyword

--- a/packages/windows/data_stream/powershell_operational/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/powershell_operational/agent/stream/winlog.yml.hbs
@@ -4,7 +4,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.5.0
+        ecs.version: 1.6.0
   - script:
       lang: javascript
       id: security

--- a/packages/windows/data_stream/powershell_operational/fields/ecs.yml
+++ b/packages/windows/data_stream/powershell_operational/fields/ecs.yml
@@ -115,3 +115,17 @@
 - description: Error message.
   name: error.message
   type: text
+- description: Identification code for this event.
+  example: 4648
+  ignore_above: 1024
+  name: event.code
+  type: keyword
+- description: Log level of the log event.
+  name: log.level
+  type: keyword
+- description: Host ip addresses.
+  name: host.ip
+  type: ip
+- description: The outcome of the event. The lowest level categorization field in the hierarchy.
+  name: event.outcome
+  type: keyword

--- a/packages/windows/data_stream/security/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/security/agent/stream/winlog.yml.hbs
@@ -3,7 +3,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.5.0
+        ecs.version: 1.6.0
   - script:
       lang: javascript
       id: security

--- a/packages/windows/data_stream/security/fields/ecs.yml
+++ b/packages/windows/data_stream/security/fields/ecs.yml
@@ -131,3 +131,17 @@
       type: text
   name: user.name
   type: keyword
+- description: Identification code for this event.
+  example: 4648
+  ignore_above: 1024
+  name: event.code
+  type: keyword
+- description: Log level of the log event.
+  name: log.level
+  type: keyword
+- description: Host ip addresses.
+  name: host.ip
+  type: ip
+- description: The outcome of the event. The lowest level categorization field in the hierarchy.
+  name: event.outcome
+  type: keyword

--- a/packages/windows/data_stream/security/fields/winlog.yml
+++ b/packages/windows/data_stream/security/fields/winlog.yml
@@ -229,6 +229,10 @@
           type: keyword
         - name: TargetUserName
           type: keyword
+        - name: NewTargetUserName
+          type: keyword
+        - name: OldTargetUserName
+          type: keyword
         - name: TargetUserSid
           type: keyword
         - name: TerminalSessionId

--- a/packages/windows/data_stream/sysmon_operational/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/sysmon_operational/agent/stream/winlog.yml.hbs
@@ -3,7 +3,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.5.0
+        ecs.version: 1.6.0
   - script:
       lang: javascript
       id: security

--- a/packages/windows/data_stream/sysmon_operational/fields/ecs.yml
+++ b/packages/windows/data_stream/sysmon_operational/fields/ecs.yml
@@ -320,3 +320,17 @@
       type: text
   name: user.name
   type: keyword
+- description: Identification code for this event.
+  example: 4648
+  ignore_above: 1024
+  name: event.code
+  type: keyword
+- description: Log level of the log event.
+  name: log.level
+  type: keyword
+- description: Host ip addresses.
+  name: host.ip
+  type: ip
+- description: The outcome of the event. The lowest level categorization field in the hierarchy.
+  name: event.outcome
+  type: keyword

--- a/packages/windows/docs/README.md
+++ b/packages/windows/docs/README.md
@@ -94,6 +94,7 @@ The Windows `forwarded` dataset provides events from the Windows
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.module | Name of the module this data is coming from. | keyword |
 | event.original | Raw text message of entire event. | keyword |
+| event.outcome | The outcome of the event. The lowest level categorization field in the hierarchy. | keyword |
 | event.sequence | Sequence number of the event. | long |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
 | file.code_signature.status | Additional information about the certificate status. | keyword |
@@ -106,6 +107,8 @@ The Windows `forwarded` dataset provides events from the Windows
 | group.domain | Name of the directory the group is a member of. | keyword |
 | group.id | Unique identifier for the group on the system/platform. | keyword |
 | group.name | Name of the group. | keyword |
+| host.ip | Host ip addresses. | ip |
+| log.level | Log level of the log event. | keyword |
 | network.direction | Direction of the network traffic. | keyword |
 | network.protocol | L7 Network protocol name. | keyword |
 | network.transport | Protocol Name corresponding to the field `iana_number`. | keyword |
@@ -299,16 +302,20 @@ The Windows `powershell` dataset provides events from the Windows
 | dataset.type | Dataset type. | constant_keyword |
 | error.message | Error message. | text |
 | event.category | Event category. The second categorization field in the hierarchy. | keyword |
+| event.code | Identification code for this event. | keyword |
 | event.created | Time when the event was first read by an agent or by your pipeline. | date |
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.module | Name of the module this data is coming from. | keyword |
 | event.original | Raw text message of entire event. | keyword |
+| event.outcome | The outcome of the event. The lowest level categorization field in the hierarchy. | keyword |
 | event.sequence | Sequence number of the event. | long |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
 | file.directory | Directory where the file is located. | keyword |
 | file.extension | File extension. | keyword |
 | file.name | Name of the file including the extension, without the directory. | keyword |
 | file.path | Full path to the file, including the file name. | keyword |
+| host.ip | Host ip addresses. | ip |
+| log.level | Log level of the log event. | keyword |
 | powershell.command.invocation_details | An array of objects containing detailed information of the executed command. | array |
 | powershell.command.invocation_details.name | Only used for ParameterBinding detail type. Indicates the parameter name. | keyword |
 | powershell.command.invocation_details.related_command | The command to which the detail is related to. | keyword |
@@ -493,16 +500,20 @@ The Windows `powershell_operational` dataset provides events from the Windows
 | dataset.type | Dataset type. | constant_keyword |
 | error.message | Error message. | text |
 | event.category | Event category. The second categorization field in the hierarchy. | keyword |
+| event.code | Identification code for this event. | keyword |
 | event.created | Time when the event was first read by an agent or by your pipeline. | date |
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.module | Name of the module this data is coming from. | keyword |
 | event.original | Raw text message of entire event. | keyword |
+| event.outcome | The outcome of the event. The lowest level categorization field in the hierarchy. | keyword |
 | event.sequence | Sequence number of the event. | long |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
 | file.directory | Directory where the file is located. | keyword |
 | file.extension | File extension. | keyword |
 | file.name | Name of the file including the extension, without the directory. | keyword |
 | file.path | Full path to the file, including the file name. | keyword |
+| host.ip | Host ip addresses. | ip |
+| log.level | Log level of the log event. | keyword |
 | powershell.command.invocation_details | An array of objects containing detailed information of the executed command. | array |
 | powershell.command.invocation_details.name | Only used for ParameterBinding detail type. Indicates the parameter name. | keyword |
 | powershell.command.invocation_details.related_command | The command to which the detail is related to. | keyword |
@@ -693,10 +704,13 @@ The Windows `security` dataset provides events from the Windows
 | event.created | Time when the event was first read by an agent or by your pipeline. | date |
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.module | Name of the module this data is coming from. | keyword |
+| event.outcome | The outcome of the event. The lowest level categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
 | group.domain | Name of the directory the group is a member of. | keyword |
 | group.id | Unique identifier for the group on the system/platform. | keyword |
 | group.name | Name of the group. | keyword |
+| host.ip | Host ip addresses. | ip |
+| log.level | Log level of the log event. | keyword |
 | process.command_line | Full command line that started the process. | keyword |
 | process.executable | Absolute path to the process executable. | keyword |
 | process.name | Process name. | keyword |
@@ -767,10 +781,12 @@ The Windows `security` dataset provides events from the Windows
 | winlog.event_data.NewProcessId |  | keyword |
 | winlog.event_data.NewProcessName |  | keyword |
 | winlog.event_data.NewSchemeGuid |  | keyword |
+| winlog.event_data.NewTargetUserName |  | keyword |
 | winlog.event_data.NewTime |  | keyword |
 | winlog.event_data.NominalFrequency |  | keyword |
 | winlog.event_data.Number |  | keyword |
 | winlog.event_data.OldSchemeGuid |  | keyword |
+| winlog.event_data.OldTargetUserName |  | keyword |
 | winlog.event_data.OldTime |  | keyword |
 | winlog.event_data.OriginalFileName |  | keyword |
 | winlog.event_data.Path |  | keyword |
@@ -880,9 +896,11 @@ The Windows `sysmon_operational` dataset provides events from the Windows
 | dns.resolved_ip | Array containing all IPs seen in answers.data | ip |
 | error.code | Error code describing the error. | keyword |
 | event.category | Event category. The second categorization field in the hierarchy. | keyword |
+| event.code | Identification code for this event. | keyword |
 | event.created | Time when the event was first read by an agent or by your pipeline. | date |
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.module | Name of the module this data is coming from. | keyword |
+| event.outcome | The outcome of the event. The lowest level categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
 | file.code_signature.status | Additional information about the certificate status. | keyword |
 | file.code_signature.subject_name | Subject name of the code signer | keyword |
@@ -891,6 +909,8 @@ The Windows `sysmon_operational` dataset provides events from the Windows
 | file.extension | File extension. | keyword |
 | file.name | Name of the file including the extension, without the directory. | keyword |
 | file.path | Full path to the file, including the file name. | keyword |
+| host.ip | Host ip addresses. | ip |
+| log.level | Log level of the log event. | keyword |
 | network.direction | Direction of the network traffic. | keyword |
 | network.protocol | L7 Network protocol name. | keyword |
 | network.transport | Protocol Name corresponding to the field `iana_number`. | keyword |

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 0.2.8
+version: 0.2.9
 description: Windows Integration
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

Changes

- Bump ecs.version to 1.6.0.
- Add missing mappings for
  - event.outcome (just missing, no impact)
  - host.ip (bug since it must be mapped to IP)
  - log.level (bug since this is used by dashboards)
  - event.code (bug since it maps to integer otherwise)
  - winlog.event_data.OldTargetUserName (used in dashboard)
  - winlog.event_data.NewTargetUserName (used in dashboard)

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [x] I have verified that all datasets collect metrics or logs.

## Related issues

- Fixes #329 
