### PR TITLE
Bump okta ecs version to 1.6.0

### DIFF
--- a/packages/okta/data_stream/system/agent/stream/httpjson.yml.hbs
+++ b/packages/okta/data_stream/system/agent/stream/httpjson.yml.hbs
@@ -259,4 +259,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.5.0
+        ecs.version: 1.6.0

--- a/packages/okta/data_stream/system/agent/stream/log.yml.hbs
+++ b/packages/okta/data_stream/system/agent/stream/log.yml.hbs
@@ -235,4 +235,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.5.0
+        ecs.version: 1.6.0

--- a/packages/okta/manifest.yml
+++ b/packages/okta/manifest.yml
@@ -1,6 +1,6 @@
 name: okta
 title: Okta
-version: 0.2.1
+version: 0.2.2
 release: experimental
 description: Okta Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?

- set ecs.version to 1.6.0
- bump package version

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [ ] I have verified that all datasets collect metrics or logs.