### PR TITLE
Bump o365 ecs version to 1.6.0

### DIFF
--- a/packages/o365/data_stream/audit/agent/stream/log.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/log.yml.hbs
@@ -894,4 +894,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.5.0
+        ecs.version: 1.6.0

--- a/packages/o365/data_stream/audit/agent/stream/o365audit.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/o365audit.yml.hbs
@@ -900,4 +900,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.5.0
+        ecs.version: 1.6.0

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Office 365
-version: 0.2.1
+version: 0.2.2
 release: experimental
 description: Office 365 Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?

- set ecs.version to 1.6.0
- bump package version

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [ ] I have verified that all datasets collect metrics or logs.