### PR TITLE
Use package wide variable for zeek base path

### DIFF
--- a/packages/zeek/data_stream/capture_loss/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/capture_loss/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/capture_loss/manifest.yml
+++ b/packages/zeek/data_stream/capture_loss/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: capture_loss.log paths
+        title: Filename of capture loss log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/capture_loss.log
+          - capture_loss.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/connection/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/connection/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/connection/manifest.yml
+++ b/packages/zeek/data_stream/connection/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: conn.log paths
+        title: Filename of connection log
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/conn.log
+          - conn.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/dce_rpc/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/dce_rpc/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/dce_rpc/manifest.yml
+++ b/packages/zeek/data_stream/dce_rpc/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: dce_rpc.log paths
+        title: Filename of dce_rpc log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/dce_rpc.log
+          - dce_rpc.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/dhcp/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/dhcp/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/dhcp/manifest.yml
+++ b/packages/zeek/data_stream/dhcp/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: dhcp.log paths
+        title: Filename of dhcp log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/dhcp.log
+          - dhcp.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/dnp3/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/dnp3/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/dnp3/manifest.yml
+++ b/packages/zeek/data_stream/dnp3/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: dnp3.log paths
+        title: Filename of dnp3 log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/dnp3.log
+          - dnp3.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/dns/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/dns/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/dns/manifest.yml
+++ b/packages/zeek/data_stream/dns/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: dns.log paths
+        title: Filename of dns log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/dns.log
+          - dns.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/dpd/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/dpd/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/dpd/manifest.yml
+++ b/packages/zeek/data_stream/dpd/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: dpd.log paths
+        title: Filename of the dpd log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/dpd.log
+          - dpd.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/files/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/files/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/files/manifest.yml
+++ b/packages/zeek/data_stream/files/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: files.log paths
+        title: Filename of the files log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/files.log
+          - files.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/ftp/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/ftp/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/ftp/manifest.yml
+++ b/packages/zeek/data_stream/ftp/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: ftp.log paths
+        title: Filename of ftp log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/ftp.log
+          - ftp.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/http/manifest.yml
+++ b/packages/zeek/data_stream/http/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: http.log paths
+        title: Filename of http log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/http.log
+          - http.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/intel/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/intel/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/intel/manifest.yml
+++ b/packages/zeek/data_stream/intel/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: intel.log paths
+        title: Filename of intel log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/intel.log
+          - intel.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/irc/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/irc/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/irc/manifest.yml
+++ b/packages/zeek/data_stream/irc/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: irc.log paths
+        title: Filename of irc log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/irc.log
+          - irc.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/kerberos/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/kerberos/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/kerberos/manifest.yml
+++ b/packages/zeek/data_stream/kerberos/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: kerberos.log paths
+        title: Filename of kerberos log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/kerberos.log
+          - kerberos.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/modbus/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/modbus/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/modbus/manifest.yml
+++ b/packages/zeek/data_stream/modbus/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: modbus.log paths
+        title: Filename of modbus log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/modbus.log
+          - modbus.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/mysql/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/mysql/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/mysql/manifest.yml
+++ b/packages/zeek/data_stream/mysql/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: mysql.log paths
+        title: Filename of mysql log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/mysql.log
+          - mysql.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/notice/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/notice/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/notice/manifest.yml
+++ b/packages/zeek/data_stream/notice/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: notice.log paths
+        title: Filename of notice log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/notice.log
+          - notice.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/ntlm/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/ntlm/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/ntlm/manifest.yml
+++ b/packages/zeek/data_stream/ntlm/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: ntlm.log paths
+        title: Filename of ntlm log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/ntlm.log
+          - ntlm.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/ocsp/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/ocsp/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/ocsp/manifest.yml
+++ b/packages/zeek/data_stream/ocsp/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: ocsp.log paths
+        title: Filename of ocsp log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/ocsp.log
+          - ocsp.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/pe/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/pe/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/pe/manifest.yml
+++ b/packages/zeek/data_stream/pe/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: pe.log paths
+        title: Filename of pe log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/pe.log
+          - pe.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/radius/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/radius/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/radius/manifest.yml
+++ b/packages/zeek/data_stream/radius/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: radius.log paths
+        title: Filename of radius log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/radius.log
+          - radius.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/rdp/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/rdp/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/rdp/manifest.yml
+++ b/packages/zeek/data_stream/rdp/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: rdp.log paths
+        title: Filename of rdp log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/rdp.log
+          - rdp.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/rfb/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/rfb/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/rfb/manifest.yml
+++ b/packages/zeek/data_stream/rfb/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: rfb.log paths
+        title: Filename of rfb log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/rfb.log
+          - rfb.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/sip/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/sip/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/sip/manifest.yml
+++ b/packages/zeek/data_stream/sip/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: sip.log paths
+        title: Filename of sip log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/sip.log
+          - sip.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/smb_cmd/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/smb_cmd/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/smb_cmd/manifest.yml
+++ b/packages/zeek/data_stream/smb_cmd/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: smb_cmd paths
+        title: Filename of smb_cmd log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/smb_cmd.log
+          - smb_cmd.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/smb_files/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/smb_files/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/smb_files/manifest.yml
+++ b/packages/zeek/data_stream/smb_files/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: smb_files.log paths
+        title: Filename of smb_files log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/smb_files.log
+          - smb_files.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/smb_mapping/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/smb_mapping/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/smb_mapping/manifest.yml
+++ b/packages/zeek/data_stream/smb_mapping/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: smb_mapping.log paths
+        title: Filename of smb_mapping log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/smb_mapping.log
+          - smb_mapping.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/smtp/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/smtp/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/smtp/manifest.yml
+++ b/packages/zeek/data_stream/smtp/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: smtp.log paths
+        title: Filename of smtp log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/smtp.log
+          - smtp.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/snmp/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/snmp/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/snmp/manifest.yml
+++ b/packages/zeek/data_stream/snmp/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: snmp.log paths
+        title: Filename of snmp log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/snmp.log
+          - snmp.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/socks/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/socks/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/socks/manifest.yml
+++ b/packages/zeek/data_stream/socks/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: socks.log paths
+        title: Filename of socks log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/socks.log
+          - socks.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/ssh/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/ssh/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/ssh/manifest.yml
+++ b/packages/zeek/data_stream/ssh/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: ssh.log paths
+        title: Filename of ssh log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/ssh.log
+          - ssh.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/ssl/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/ssl/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/ssl/manifest.yml
+++ b/packages/zeek/data_stream/ssl/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: ssl.log paths
+        title: Filename of ssl log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/ssl.log
+          - ssl.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/stats/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/stats/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/stats/manifest.yml
+++ b/packages/zeek/data_stream/stats/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: stats.log paths
+        title: Filename of stats log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/stats.log
+          - stats.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/syslog/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/syslog/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/syslog/manifest.yml
+++ b/packages/zeek/data_stream/syslog/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: syslog.log paths
+        title: Filename of syslog log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/syslog.log
+          - syslog.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/traceroute/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/traceroute/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/traceroute/manifest.yml
+++ b/packages/zeek/data_stream/traceroute/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: traceroute.log paths
+        title: Filename of traceroute log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/traceroute.log
+          - traceroute.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/tunnel/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/tunnel/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/tunnel/manifest.yml
+++ b/packages/zeek/data_stream/tunnel/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: tunnel.log paths
+        title: Filename of tunnel log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/tunnel.log
+          - tunnel.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/weird/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/weird/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/weird/manifest.yml
+++ b/packages/zeek/data_stream/weird/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: weird.log paths
+        title: Filename of weird log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/weird.log
+          - weird.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/data_stream/x509/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/x509/agent/stream/log.yml.hbs
@@ -1,6 +1,8 @@
 paths:
-{{#each paths as |path i|}}
- - {{path}}
+{{#each base_paths}}
+  {{#each ../filenames}}
+ - {{../this}}/{{this}}
+  {{/each}}
 {{/each}}
 exclude_files: [".gz$"]
 tags:

--- a/packages/zeek/data_stream/x509/manifest.yml
+++ b/packages/zeek/data_stream/x509/manifest.yml
@@ -4,14 +4,14 @@ release: experimental
 streams:
   - input: logfile
     vars:
-      - name: paths
+      - name: filenames
         type: text
-        title: x509.log paths
+        title: Filename of x509 log file
         multi: true
         required: true
         show_user: true
         default:
-          - /var/log/bro/current/x509.log
+          - x509.log
       - name: tags
         type: text
         title: Tags

--- a/packages/zeek/manifest.yml
+++ b/packages/zeek/manifest.yml
@@ -1,6 +1,6 @@
 name: zeek
 title: Zeek
-version: 0.3.0
+version: 0.3.1
 release: beta
 description: Zeek Integration
 type: integration
@@ -27,5 +27,17 @@ policy_templates:
       - type: logfile
         title: 'Collect Zeek logs'
         description: 'Collects logs from Zeek instances. Supported logs include: capture_loss, connection, dce_rpc, dhcp, dnp3, dns, dpd, files, ftp, http, intel, irc, kerberos, modbus, mysql, notice, ntlm, ocsp, pe, radius, rdp, rfb, sip, smb_cmd, smb_files, smb_mapping, smtp, snmp, socks, ssh, ssl, stats, syslog, traceroute, tunnel, weird and x509'
+        vars:
+          - name: base_paths
+            required: true
+            show_user: true
+            title: Base Path
+            description: Base paths to zeek log files (eg. /var/log/bro/current)
+            type: text
+            multi: true
+            default:
+              - /var/log/bro/current
+              - /opt/zeek/logs/current
+              - /usr/local/var/spool/zeek
 owner:
   github: elastic/security-external-integrations


### PR DESCRIPTION
## What does this PR do?

- bump version to 0.3.1
- package wide variable for base path
- filename variable for each data_stream

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [x] I have verified that all datasets collect metrics or logs.


## Screenshots

![zeek_poc_2](https://user-images.githubusercontent.com/57081003/96933719-97ce8780-1486-11eb-9c7e-9c9e82d3f02b.png)


Paths in `action_store.yml` will look like:

``` yaml
paths:
      - /var/log/bro/current/capture_loss.log
      - /opt/zeek/logs/current/capture_loss.log
      - /usr/local/var/spool/zeek/capture_loss.log
```