### PR TITLE
[filebeat][suricata] Change file.x509 mappings to tls.server.x509

### DIFF
--- a/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/default.yml
@@ -247,27 +247,27 @@ processors:
       ignore_missing: true
   - rename:
       field: suricata.eve.tls.kv_issuerdn.C
-      target_field: file.x509.issuer.country
+      target_field: tls.server.x509.issuer.country
       ignore_missing: true
   - rename:
       field: suricata.eve.tls.kv_issuerdn.CN
-      target_field: file.x509.issuer.common_name
+      target_field: tls.server.x509.issuer.common_name
       ignore_missing: true
   - rename:
       field: suricata.eve.tls.kv_issuerdn.L
-      target_field: file.x509.issuer.locality
+      target_field: tls.server.x509.issuer.locality
       ignore_missing: true
   - rename:
       field: suricata.eve.tls.kv_issuerdn.O
-      target_field: file.x509.issuer.organization
+      target_field: tls.server.x509.issuer.organization
       ignore_missing: true
   - rename:
       field: suricata.eve.tls.kv_issuerdn.OU
-      target_field: file.x509.issuer.organizational_unit
+      target_field: tls.server.x509.issuer.organizational_unit
       ignore_missing: true
   - rename:
       field: suricata.eve.tls.kv_issuerdn.ST
-      target_field: file.x509.issuer.state_or_province
+      target_field: tls.server.x509.issuer.state_or_province
       ignore_missing: true
   - gsub:
       field: suricata.eve.tls.subject
@@ -282,34 +282,34 @@ processors:
       ignore_missing: true
   - rename:
       field: suricata.eve.tls.kv_subject.C
-      target_field: file.x509.subject.country
+      target_field: tls.server.x509.subject.country
       ignore_missing: true
   - rename:
       field: suricata.eve.tls.kv_subject.CN
-      target_field: file.x509.subject.common_name
+      target_field: tls.server.x509.subject.common_name
       ignore_missing: true
   - rename:
       field: suricata.eve.tls.kv_subject.L
-      target_field: file.x509.subject.locality
+      target_field: tls.server.x509.subject.locality
       ignore_missing: true
   - rename:
       field: suricata.eve.tls.kv_subject.O
-      target_field: file.x509.subject.organization
+      target_field: tls.server.x509.subject.organization
       ignore_missing: true
   - rename:
       field: suricata.eve.tls.kv_subject.OU
-      target_field: file.x509.subject.organizational_unit
+      target_field: tls.server.x509.subject.organizational_unit
       ignore_missing: true
   - rename:
       field: suricata.eve.tls.kv_subject.ST
-      target_field: file.x509.subject.state_or_province
+      target_field: tls.server.x509.subject.state_or_province
       ignore_missing: true
   - set:
-      field: file.x509.serial_number
+      field: tls.server.x509.serial_number
       value: '{{suricata.eve.tls.serial}}'
       ignore_empty_value: true
   - gsub:
-      field: file.x509.serial_number
+      field: tls.server.x509.serial_number
       pattern: ':'
       replacement: ''
       ignore_missing: true
@@ -326,11 +326,11 @@ processors:
         - ISO8601
       if: ctx.suricata?.eve?.tls?.notbefore != null
   - set:
-      field: file.x509.not_after
+      field: tls.server.x509.not_after
       value: '{{tls.server.not_after}}'
       ignore_empty_value: true
   - set:
-      field: file.x509.not_before
+      field: tls.server.x509.not_before
       value: '{{tls.server.not_before}}'
       ignore_empty_value: true
   - append:

--- a/packages/suricata/data_stream/eve/fields/ecs.yml
+++ b/packages/suricata/data_stream/eve/fields/ecs.yml
@@ -197,49 +197,49 @@
 - name: tags
   type: keyword
   description: List of keywords used to tag each event.
-- name: file.x509.issuer.common_name
+- name: tls.server.x509.issuer.common_name
   description: List of common name (CN) of issuing certificate authority.
   type: keyword
-- name: file.x509.issuer.country
+- name: tls.server.x509.issuer.country
   description: List of country (C) codes
   type: keyword
-- name: file.x509.issuer.locality
+- name: tls.server.x509.issuer.locality
   description: List of locality names (L)
   type: keyword
-- name: file.x509.issuer.organization
+- name: tls.server.x509.issuer.organization
   description: List of organizations (O) of issuing certificate authority.
   type: keyword
-- name: file.x509.issuer.organizational_unit
+- name: tls.server.x509.issuer.organizational_unit
   description: List of organizational units (OU) of issuing certificate authority.
   type: keyword
-- name: file.x509.issuer.state_or_province
+- name: tls.server.x509.issuer.state_or_province
   description: List of state or province names (ST, S, or P)
   type: keyword
-- name: file.x509.not_after
+- name: tls.server.x509.not_after
   description: Time at which the certificate is no longer considered valid.
   type: date
-- name: file.x509.not_before
+- name: tls.server.x509.not_before
   description: Time at which the certificate is first considered valid.
   type: date
-- name: file.x509.serial_number
+- name: tls.server.x509.serial_number
   description: Unique serial number issued by the certificate authority.
   type: keyword
-- name: file.x509.subject.common_name
+- name: tls.server.x509.subject.common_name
   description: List of common names (CN) of subject.
   type: keyword
-- name: file.x509.subject.country
+- name: tls.server.x509.subject.country
   description: List of country (C) code
   type: keyword
-- name: file.x509.subject.locality
+- name: tls.server.x509.subject.locality
   description: List of locality names (L)
   type: keyword
-- name: file.x509.subject.organization
+- name: tls.server.x509.subject.organization
   description: List of organizations (O) of subject.
   type: keyword
-- name: file.x509.subject.organizational_unit
+- name: tls.server.x509.subject.organizational_unit
   description: List of organizational units (OU) of subject.
   type: keyword
-- name: file.x509.subject.state_or_province
+- name: tls.server.x509.subject.state_or_province
   description: List of state or province names (ST, S, or P)
   type: keyword
 - name: related.hosts

--- a/packages/suricata/docs/README.md
+++ b/packages/suricata/docs/README.md
@@ -51,21 +51,6 @@ with other versions of Suricata.
 | event.start | event.start contains the date when the event started or when the activity was first observed. | date |
 | file.path | Full path to the file, including the file name. It should include the drive letter, when appropriate. | keyword |
 | file.size | File size in bytes. Only relevant when `file.type` is "file". | long |
-| file.x509.issuer.common_name | List of common name (CN) of issuing certificate authority. | keyword |
-| file.x509.issuer.country | List of country (C) codes | keyword |
-| file.x509.issuer.locality | List of locality names (L) | keyword |
-| file.x509.issuer.organization | List of organizations (O) of issuing certificate authority. | keyword |
-| file.x509.issuer.organizational_unit | List of organizational units (OU) of issuing certificate authority. | keyword |
-| file.x509.issuer.state_or_province | List of state or province names (ST, S, or P) | keyword |
-| file.x509.not_after | Time at which the certificate is no longer considered valid. | date |
-| file.x509.not_before | Time at which the certificate is first considered valid. | date |
-| file.x509.serial_number | Unique serial number issued by the certificate authority. | keyword |
-| file.x509.subject.common_name | List of common names (CN) of subject. | keyword |
-| file.x509.subject.country | List of country (C) code | keyword |
-| file.x509.subject.locality | List of locality names (L) | keyword |
-| file.x509.subject.organization | List of organizations (O) of subject. | keyword |
-| file.x509.subject.organizational_unit | List of organizational units (OU) of subject. | keyword |
-| file.x509.subject.state_or_province | List of state or province names (ST, S, or P) | keyword |
 | http.request.method | HTTP request method. Prior to ECS 1.6.0 the following guidance was provided: "The field value must be normalized to lowercase for querying." As of ECS 1.6.0, the guidance is deprecated because the original case of the method may be useful in anomaly detection.  Original case will be mandated in ECS 2.0.0 | keyword |
 | http.request.referrer | Referrer for this HTTP request. | keyword |
 | http.response.body.bytes | Size in bytes of the response body. | long |
@@ -269,6 +254,21 @@ with other versions of Suricata.
 | tags | List of keywords used to tag each event. | keyword |
 | tls.server.not_after | Timestamp indicating when server certificate is no longer considered valid. | date |
 | tls.server.not_before | Timestamp indicating when server certificate is first considered valid. | date |
+| tls.server.x509.issuer.common_name | List of common name (CN) of issuing certificate authority. | keyword |
+| tls.server.x509.issuer.country | List of country (C) codes | keyword |
+| tls.server.x509.issuer.locality | List of locality names (L) | keyword |
+| tls.server.x509.issuer.organization | List of organizations (O) of issuing certificate authority. | keyword |
+| tls.server.x509.issuer.organizational_unit | List of organizational units (OU) of issuing certificate authority. | keyword |
+| tls.server.x509.issuer.state_or_province | List of state or province names (ST, S, or P) | keyword |
+| tls.server.x509.not_after | Time at which the certificate is no longer considered valid. | date |
+| tls.server.x509.not_before | Time at which the certificate is first considered valid. | date |
+| tls.server.x509.serial_number | Unique serial number issued by the certificate authority. | keyword |
+| tls.server.x509.subject.common_name | List of common names (CN) of subject. | keyword |
+| tls.server.x509.subject.country | List of country (C) code | keyword |
+| tls.server.x509.subject.locality | List of locality names (L) | keyword |
+| tls.server.x509.subject.organization | List of organizations (O) of subject. | keyword |
+| tls.server.x509.subject.organizational_unit | List of organizational units (OU) of subject. | keyword |
+| tls.server.x509.subject.state_or_province | List of state or province names (ST, S, or P) | keyword |
 | url.domain | Domain of the url, such as "www.elastic.co". In some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `domain` field. | keyword |
 | url.original | Unmodified original url as seen in the event source. Note that in network monitoring, the observed URL may be a full URL, whereas in access logs, the URL is often just represented as a path. This field is meant to represent the URL as it was observed, complete or not. | keyword |
 | user_agent.original | Unparsed user_agent string. | keyword |

--- a/packages/suricata/manifest.yml
+++ b/packages/suricata/manifest.yml
@@ -1,6 +1,6 @@
 name: suricata
 title: Suricata
-version: 0.2.0
+version: 0.3.0
 release: experimental
 description: Suricata Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?

Change file.x509 mappings to tls.server.x509 to be in sync with the module

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [ ] I have verified that all datasets collect metrics or logs.

