### PR TITLE
Add filters to visualizations

### DIFF
--- a/packages/system/kibana/visualization/system-19e123b0-4d5a-11e7-aee5-fdc812cc3bec.json
+++ b/packages/system/kibana/visualization/system-19e123b0-4d5a-11e7-aee5-fdc812cc3bec.json
@@ -18,7 +18,10 @@
             "params": {
                 "axis_formatter": "number",
                 "axis_position": "left",
-                "filter": "",
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.memory\" "
+                },
                 "gauge_color_rules": [
                     {
                         "gauge": "rgba(104,188,0,1)",

--- a/packages/system/kibana/visualization/system-26732e20-1b91-11e7-bec4-a5e9ec5cab8b.json
+++ b/packages/system/kibana/visualization/system-26732e20-1b91-11e7-bec4-a5e9ec5cab8b.json
@@ -16,6 +16,10 @@
         "visState": {
             "aggs": [],
             "params": {
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.load\" "
+                },
                 "axis_formatter": "number",
                 "axis_position": "left",
                 "background_color_rules": [

--- a/packages/system/kibana/visualization/system-2e224660-1b19-11e7-b09e-037021c4f8df.json
+++ b/packages/system/kibana/visualization/system-2e224660-1b19-11e7-b09e-037021c4f8df.json
@@ -18,6 +18,7 @@
             "params": {
                 "axis_formatter": "number",
                 "axis_position": "left",
+                
                 "bar_color_rules": [
                     {
                         "bar_color": "rgba(104,188,0,1)",
@@ -39,7 +40,10 @@
                     }
                 ],
                 "drilldown_url": "",
-                "filter": "",
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.process\" "
+                },
                 "id": "edfceb30-1b18-11e7-b09e-037021c4f8df",
                 "index_pattern": "metrics-*",
                 "interval": "auto",

--- a/packages/system/kibana/visualization/system-4d546850-1b15-11e7-b09e-037021c4f8df.json
+++ b/packages/system/kibana/visualization/system-4d546850-1b15-11e7-b09e-037021c4f8df.json
@@ -16,6 +16,10 @@
         "visState": {
             "aggs": [],
             "params": {
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.load\" "
+                },
                 "axis_formatter": "number",
                 "axis_position": "left",
                 "id": "f6264ad0-1b14-11e7-b09e-037021c4f8df",

--- a/packages/system/kibana/visualization/system-4e4bb1e0-1b1b-11e7-b09e-037021c4f8df.json
+++ b/packages/system/kibana/visualization/system-4e4bb1e0-1b1b-11e7-b09e-037021c4f8df.json
@@ -18,7 +18,10 @@
             "params": {
                 "axis_formatter": "number",
                 "axis_position": "left",
-                "filter": "",
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.diskio\" "
+                },
                 "id": "d3c67db0-1b1a-11e7-b09e-037021c4f8df",
                 "index_pattern": "metrics-*",
                 "interval": "auto",

--- a/packages/system/kibana/visualization/system-590a60f0-5d87-11e7-8884-1bb4c3b890e4.json
+++ b/packages/system/kibana/visualization/system-590a60f0-5d87-11e7-8884-1bb4c3b890e4.json
@@ -35,6 +35,10 @@
             ],
             "listeners": {},
             "params": {
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.process\" "
+                },
                 "addLegend": false,
                 "addTooltip": true,
                 "gauge": {

--- a/packages/system/kibana/visualization/system-7cdb1330-4d1a-11e7-a196-69b9a7a020a9.json
+++ b/packages/system/kibana/visualization/system-7cdb1330-4d1a-11e7-a196-69b9a7a020a9.json
@@ -62,6 +62,10 @@
                 }
             ],
             "params": {
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.cpu\" "
+                },
                 "addLegend": true,
                 "addTooltip": true,
                 "colorSchema": "Greens",

--- a/packages/system/kibana/visualization/system-825fdb80-4d1d-11e7-b5f2-2b7c1895bf32.json
+++ b/packages/system/kibana/visualization/system-825fdb80-4d1d-11e7-b5f2-2b7c1895bf32.json
@@ -16,12 +16,16 @@
         "visState": {
             "aggs": [],
             "params": {
+                
                 "axis_formatter": "number",
                 "axis_position": "left",
                 "axis_scale": "normal",
                 "default_index_pattern": "logs-*",
                 "default_timefield": "@timestamp",
-                "filter": "",
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.fsstat\" "
+                },
                 "gauge_color_rules": [
                     {
                         "gauge": "rgba(104,188,0,1)",

--- a/packages/system/kibana/visualization/system-83e12df0-1b91-11e7-bec4-a5e9ec5cab8b.json
+++ b/packages/system/kibana/visualization/system-83e12df0-1b91-11e7-bec4-a5e9ec5cab8b.json
@@ -18,7 +18,10 @@
             "params": {
                 "axis_formatter": "number",
                 "axis_position": "left",
-                "filter": "",
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.cpu\" "
+                },
                 "gauge_color_rules": [
                     {
                         "gauge": "rgba(104,188,0,1)",

--- a/packages/system/kibana/visualization/system-855899e0-1b1c-11e7-b09e-037021c4f8df.json
+++ b/packages/system/kibana/visualization/system-855899e0-1b1c-11e7-b09e-037021c4f8df.json
@@ -39,7 +39,10 @@
                     }
                 ],
                 "drilldown_url": "../app/kibana#/dashboard/system-79ffd6e0-faa0-11e6-947f-177f697178b8?_a=(query:(language:kuery,query:'host.name:\"{{key}}\"'))",
-                "filter": "",
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.cpu\" "
+                },
                 "id": "31e5afa0-1b1c-11e7-b09e-037021c4f8df",
                 "index_pattern": "metrics-*",
                 "interval": "auto",

--- a/packages/system/kibana/visualization/system-96976150-4d5d-11e7-aa29-87a97a796de6.json
+++ b/packages/system/kibana/visualization/system-96976150-4d5d-11e7-aa29-87a97a796de6.json
@@ -16,6 +16,10 @@
         "visState": {
             "aggs": [],
             "params": {
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.network\" "
+                },
                 "axis_formatter": "number",
                 "axis_position": "left",
                 "background_color_rules": [

--- a/packages/system/kibana/visualization/system-99381c80-4d60-11e7-9a4c-ed99bbcaa42b.json
+++ b/packages/system/kibana/visualization/system-99381c80-4d60-11e7-9a4c-ed99bbcaa42b.json
@@ -16,6 +16,10 @@
         "visState": {
             "aggs": [],
             "params": {
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.network\" "
+                },
                 "axis_formatter": "number",
                 "axis_position": "left",
                 "bar_color_rules": [

--- a/packages/system/kibana/visualization/system-Container-Block-IO.json
+++ b/packages/system/kibana/visualization/system-Container-Block-IO.json
@@ -73,6 +73,10 @@
                 }
             ],
             "params": {
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.process\" "
+                },
                 "perPage": 10,
                 "showMeticsAtAllLevels": false,
                 "showPartialRows": false,

--- a/packages/system/kibana/visualization/system-Container-CPU-usage.json
+++ b/packages/system/kibana/visualization/system-Container-CPU-usage.json
@@ -93,6 +93,10 @@
                 }
             ],
             "params": {
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.process\" "
+                },
                 "perPage": 10,
                 "showMeticsAtAllLevels": false,
                 "showPartialRows": false,

--- a/packages/system/kibana/visualization/system-Container-Memory-stats.json
+++ b/packages/system/kibana/visualization/system-Container-Memory-stats.json
@@ -183,6 +183,10 @@
                 }
             ],
             "params": {
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.process\" "
+                },
                 "perPage": 10,
                 "showMeticsAtAllLevels": false,
                 "showPartialRows": false,

--- a/packages/system/kibana/visualization/system-ab2d1e90-1b1a-11e7-b09e-037021c4f8df.json
+++ b/packages/system/kibana/visualization/system-ab2d1e90-1b1a-11e7-b09e-037021c4f8df.json
@@ -16,6 +16,10 @@
         "visState": {
             "aggs": [],
             "params": {
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.cpu\" "
+                },
                 "axis_formatter": "number",
                 "axis_position": "left",
                 "id": "80a04950-1b19-11e7-b09e-037021c4f8df",

--- a/packages/system/kibana/visualization/system-bfa5e400-1b16-11e7-b09e-037021c4f8df.json
+++ b/packages/system/kibana/visualization/system-bfa5e400-1b16-11e7-b09e-037021c4f8df.json
@@ -16,6 +16,10 @@
         "visState": {
             "aggs": [],
             "params": {
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.memory\" "
+                },
                 "axis_formatter": "number",
                 "axis_position": "left",
                 "id": "32f46f40-1b16-11e7-b09e-037021c4f8df",

--- a/packages/system/kibana/visualization/system-c5e3cf90-4d60-11e7-9a4c-ed99bbcaa42b.json
+++ b/packages/system/kibana/visualization/system-c5e3cf90-4d60-11e7-9a4c-ed99bbcaa42b.json
@@ -16,6 +16,10 @@
         "visState": {
             "aggs": [],
             "params": {
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.network\" "
+                },
                 "axis_formatter": "number",
                 "axis_position": "left",
                 "bar_color_rules": [

--- a/packages/system/kibana/visualization/system-d2e80340-4d5c-11e7-aa29-87a97a796de6.json
+++ b/packages/system/kibana/visualization/system-d2e80340-4d5c-11e7-aa29-87a97a796de6.json
@@ -19,6 +19,10 @@
             "params": {
                 "axis_formatter": "number",
                 "axis_position": "left",
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.memory\" "
+                },
                 "background_color_rules": [
                     {
                         "id": "6f7618b0-4d5c-11e7-aa29-87a97a796de6"

--- a/packages/system/kibana/visualization/system-d3166e80-1b91-11e7-bec4-a5e9ec5cab8b.json
+++ b/packages/system/kibana/visualization/system-d3166e80-1b91-11e7-bec4-a5e9ec5cab8b.json
@@ -16,9 +16,12 @@
         "visState": {
             "aggs": [],
             "params": {
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.memory\" "
+                },
                 "axis_formatter": "number",
                 "axis_position": "left",
-                "filter": "",
                 "gauge_color_rules": [
                     {
                         "gauge": "rgba(104,188,0,1)",

--- a/packages/system/kibana/visualization/system-dc589770-fa2b-11e6-bbd3-29c986c96e5a.json
+++ b/packages/system/kibana/visualization/system-dc589770-fa2b-11e6-bbd3-29c986c96e5a.json
@@ -55,6 +55,10 @@
             ],
             "listeners": {},
             "params": {
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.auth\" "
+                },
                 "perPage": 10,
                 "showMeticsAtAllLevels": false,
                 "showPartialRows": false,

--- a/packages/system/kibana/visualization/system-e0f001c0-1b18-11e7-b09e-037021c4f8df.json
+++ b/packages/system/kibana/visualization/system-e0f001c0-1b18-11e7-b09e-037021c4f8df.json
@@ -16,6 +16,7 @@
         "visState": {
             "aggs": [],
             "params": {
+                
                 "axis_formatter": "number",
                 "axis_position": "left",
                 "bar_color_rules": [
@@ -27,7 +28,10 @@
                     }
                 ],
                 "drilldown_url": "",
-                "filter": "",
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.process\" "
+                },
                 "id": "5f5b8d50-1b18-11e7-b09e-037021c4f8df",
                 "index_pattern": "metrics-*",
                 "interval": "auto",

--- a/packages/system/kibana/visualization/system-e121b140-fa78-11e6-a1df-a78bd7504d38.json
+++ b/packages/system/kibana/visualization/system-e121b140-fa78-11e6-a1df-a78bd7504d38.json
@@ -55,6 +55,10 @@
             ],
             "listeners": {},
             "params": {
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.auth\" "
+                },
                 "addLegend": true,
                 "addTooltip": true,
                 "isDonut": false,

--- a/packages/system/kibana/visualization/system-f398d2f0-fa77-11e6-ae9b-81e5311e8cab.json
+++ b/packages/system/kibana/visualization/system-f398d2f0-fa77-11e6-ae9b-81e5311e8cab.json
@@ -109,6 +109,10 @@
             ],
             "listeners": {},
             "params": {
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.auth\" "
+                },
                 "perPage": 10,
                 "showMeticsAtAllLevels": false,
                 "showPartialRows": false,

--- a/packages/system/kibana/visualization/system-fe064790-1b1f-11e7-bec4-a5e9ec5cab8b.json
+++ b/packages/system/kibana/visualization/system-fe064790-1b1f-11e7-bec4-a5e9ec5cab8b.json
@@ -16,6 +16,10 @@
         "visState": {
             "aggs": [],
             "params": {
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"system.memory\" "
+                },
                 "axis_formatter": "number",
                 "axis_position": "left",
                 "bar_color_rules": [
@@ -39,7 +43,6 @@
                     }
                 ],
                 "drilldown_url": "../app/kibana#/dashboard/system-79ffd6e0-faa0-11e6-947f-177f697178b8?_a=(query:(language:kuery,query:'host.name:\"{{key}}\"'))",
-                "filter": "",
                 "id": "31e5afa0-1b1c-11e7-b09e-037021c4f8df",
                 "index_pattern": "metrics-*",
                 "interval": "auto",

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 0.8.2
+version: 0.8.3
 license: basic
 description: System Integration
 type: integration


### PR DESCRIPTION


## What does this PR do?

This addresses https://github.com/elastic/integrations/issues/314. By adding a filter to the visualizations we cut down on size of the data we're aggregating. There's a few visualizations missing here, as (I think) the visualizations that take data from saved searches are all pulling from a saved search that already filters by `data_stream.dataset`.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [X] I have verified that all datasets collect metrics or logs.



## How to test this PR locally

- Pull down change, build the package registry 
- Run fleet with an agent, ingest data for a few minutes.
- Make sure all system dashboards are visualizing data.

## Related issues

- https://github.com/elastic/integrations/issues/314

