### PR TITLE
Update Kibana asset IDs and titles during migration

### DIFF
--- a/dev/import-beats/kibana.go
+++ b/dev/import-beats/kibana.go
@@ -308,6 +308,7 @@ func convertToKibanaObjects(dashboardFile []byte, moduleName string, dataStreamN
 
 		data = replaceFieldEventDatasetWithDataStreamDataset(data)
 		data = replaceBlacklistedWords(data)
+		data = removeECSTextualSuffixes(data)
 		data = updateDashboardLinks(data, origID, newID)
 
 		err = verifyKibanaObjectConvertion(data)
@@ -528,6 +529,10 @@ func replaceBlacklistedWords(data []byte) []byte {
 
 func updateDashboardLinks(data []byte, origID, newID string) []byte {
 	return bytes.ReplaceAll(data, []byte("/app/kibana#/dashboard/"+origID), []byte("/app/kibana#/dashboard/"+newID))
+}
+
+func removeECSTextualSuffixes(data []byte) []byte {
+	return bytes.ReplaceAll(data, []byte(" ECS"), []byte(""))
 }
 
 func updateObjectID(origID, moduleName string) string {

--- a/dev/import-beats/kibana.go
+++ b/dev/import-beats/kibana.go
@@ -530,7 +530,7 @@ func updateDashboardLinks(data []byte, origID, newID string) []byte {
 	return bytes.ReplaceAll(data, []byte("/app/kibana#/dashboard/"+origID), []byte("/app/kibana#/dashboard/"+newID))
 }
 
-func updateObjectID(origID, moduleName string) (string) {
+func updateObjectID(origID, moduleName string) string {
 	// If object ID starts with the module name, make sure that module name is all lowercase
 	// Else, prefix an all-lowercase module name to the object ID.
 	newID := origID
@@ -544,6 +544,12 @@ func updateObjectID(origID, moduleName string) (string) {
 	ecsSuffix := "-ecs"
 	if strings.HasSuffix(newID, "-ecs") {
 		newID = strings.TrimSuffix(newID, ecsSuffix)
+	}
+
+	// Finally, if after all transformations if the new ID is the same as the
+	// original one, to avoid a collision, we suffix "-pkg"
+	if newID == origID {
+		newID += "-pkg"
 	}
 
 	return newID

--- a/dev/import-beats/kibana_test.go
+++ b/dev/import-beats/kibana_test.go
@@ -1,0 +1,1 @@
+package main

--- a/dev/import-beats/kibana_test.go
+++ b/dev/import-beats/kibana_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package main
 
 import (

--- a/dev/import-beats/kibana_test.go
+++ b/dev/import-beats/kibana_test.go
@@ -1,1 +1,53 @@
 package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateObjectID(t *testing.T) {
+	tests := map[string]struct {
+		OrigID     string
+		ModuleName string
+		ExpectedID string
+	}{
+		"no_ecs_suffix": {
+			"foo",
+			"bar",
+			"bar-foo",
+		},
+		"has_ecs_suffix": {
+			"foo-ecs",
+			"bar",
+			"bar-foo",
+		},
+		"has_pkgname_lowercase_prefix_and_ecs_suffix": {
+			"bar-foo-ecs",
+			"bar",
+			"bar-foo",
+		},
+		"has_pkgname_lowercase_prefix": {
+			"bar-foo",
+			"bar",
+			"bar-foo-pkg",
+		},
+		"has_pkgname_mixedcase_prefix_and_ecs_suffix": {
+			"bAr-foo-ecs",
+			"bar",
+			"bar-foo",
+		},
+		"has_pkgname_mixedcase_prefix": {
+			"BaR-foo",
+			"bar",
+			"bar-foo",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actualID := updateObjectID(test.OrigID, test.ModuleName)
+			require.Equal(t, test.ExpectedID, actualID)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,6 @@ require (
 	github.com/elastic/package-registry v0.12.0
 	github.com/magefile/mage v1.10.0
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.6.1
 	gopkg.in/yaml.v2 v2.3.0
 )


### PR DESCRIPTION
## What does this PR do?

This PR updates all Kibana asset IDs, and their references from other assets, during migration according to these rules:
- [x] if an asset ID does not start with an all-lowercase package ID, one is prefixed. If there was already a package ID as a prefix, but it wasn't all lowercase, it is simply converted to all lowercase.
- [x] if an asset ID ends in `-ecs`, that suffix is removed.
- [x] if, after applying the above two rules, an asset ID is the same as it was before migration, a `-pkg` suffix is added.

It also updates any asset titles, labels, etc. during migration according this rule:
- [x] if any asset titles, labels, etc. end with ` ECS`, that suffix is removed.

## Related issues

- Resolves #344 
- Resolves #339