### PR TITLE
Fix: don't remove children if parent is not available

### DIFF
--- a/dev/update-package-storage/packages.go
+++ b/dev/update-package-storage/packages.go
@@ -188,6 +188,9 @@ func copyIntegrationToPackageStorage(err error, options updateOptions, packageNa
 
 func removeDestinationContent(destinationPath string) error {
 	fis, err := ioutil.ReadDir(destinationPath)
+	if os.IsNotExist(err) {
+		return nil // destination doesn't exist, no need to remove children
+	}
 	if err != nil {
 		return errors.Wrapf(err, "readdir failed (path: %s)", destinationPath)
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR fixes the issue with removing children resources. The build job failed because the parent directory wasn't available, but the job tried to remove its children.

See: https://beats-ci.elastic.co/blue/organizations/jenkins/Beats%2Fintegrations/detail/master/212/pipeline

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [ ] I have verified that all datasets collect metrics or logs.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
