### PR TITLE
Add host.ip to zeek/suricata/nginx

### DIFF
--- a/packages/nginx/data_stream/access/fields/ecs.yml
+++ b/packages/nginx/data_stream/access/fields/ecs.yml
@@ -30,6 +30,9 @@
       type: keyword
       description: HTTP version.
       ignore_above: 1024
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - name: source
   title: Source
   group: 2

--- a/packages/nginx/data_stream/error/fields/ecs.yml
+++ b/packages/nginx/data_stream/error/fields/ecs.yml
@@ -1,3 +1,6 @@
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - name: message
   level: core
   type: text

--- a/packages/nginx/data_stream/ingress_controller/fields/ecs.yml
+++ b/packages/nginx/data_stream/ingress_controller/fields/ecs.yml
@@ -30,6 +30,9 @@
       type: keyword
       description: HTTP version.
       ignore_above: 1024
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - name: source
   title: Source
   group: 2

--- a/packages/nginx/data_stream/stubstatus/fields/ecs.yml
+++ b/packages/nginx/data_stream/stubstatus/fields/ecs.yml
@@ -1,0 +1,3 @@
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip

--- a/packages/nginx/docs/README.md
+++ b/packages/nginx/docs/README.md
@@ -36,6 +36,7 @@ Access logs collects the nginx access logs.
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
 | event.created | Date/time when the event was first read by an agent, or by your pipeline. | date |
+| host.ip | Host ip addresses. | ip |
 | http.request.method | HTTP request method. The field value must be normalized to lowercase for querying. See the documentation section "Implementing ECS". | keyword |
 | http.request.referrer | Referrer for this HTTP request. | keyword |
 | http.response.body.bytes | Size in bytes of the response body. | long |
@@ -78,6 +79,7 @@ Error logs collects the nginx error logs.
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | event.created | Date/time when the event was first read by an agent, or by your pipeline. | date |
+| host.ip | Host ip addresses. | ip |
 | log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
 | nginx.error.connection_id | Connection identifier. | long |
@@ -98,6 +100,7 @@ Error logs collects the ingress controller logs.
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | event.created | Date/time when the event was first read by an agent, or by your pipeline. | date |
+| host.ip | Host ip addresses. | ip |
 | http.request.method | HTTP request method. The field value must be normalized to lowercase for querying. See the documentation section "Implementing ECS". | keyword |
 | http.request.referrer | Referrer for this HTTP request. | keyword |
 | http.response.body.bytes | Size in bytes of the response body. | long |
@@ -200,6 +203,7 @@ An example event for `stubstatus` looks as following:
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| host.ip | Host ip addresses. | ip |
 | nginx.stubstatus.accepts | The total number of accepted client connections. | long |
 | nginx.stubstatus.active | The current number of active client connections including Waiting connections. | long |
 | nginx.stubstatus.current | The current number of client requests. | long |

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: nginx
 title: Nginx
-version: 0.3.5
+version: 0.3.6
 license: basic
 description: Nginx Integration
 type: integration

--- a/packages/suricata/data_stream/eve/fields/ecs.yml
+++ b/packages/suricata/data_stream/eve/fields/ecs.yml
@@ -113,6 +113,9 @@
       type: long
       format: string
       description: HTTP response status code.
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - name: network
   title: Network
   group: 2

--- a/packages/suricata/docs/README.md
+++ b/packages/suricata/docs/README.md
@@ -51,6 +51,7 @@ with other versions of Suricata.
 | event.start | event.start contains the date when the event started or when the activity was first observed. | date |
 | file.path | Full path to the file, including the file name. It should include the drive letter, when appropriate. | keyword |
 | file.size | File size in bytes. Only relevant when `file.type` is "file". | long |
+| host.ip | Host ip addresses. | ip |
 | http.request.method | HTTP request method. Prior to ECS 1.6.0 the following guidance was provided: "The field value must be normalized to lowercase for querying." As of ECS 1.6.0, the guidance is deprecated because the original case of the method may be useful in anomaly detection.  Original case will be mandated in ECS 2.0.0 | keyword |
 | http.request.referrer | Referrer for this HTTP request. | keyword |
 | http.response.body.bytes | Size in bytes of the response body. | long |

--- a/packages/suricata/manifest.yml
+++ b/packages/suricata/manifest.yml
@@ -1,6 +1,6 @@
 name: suricata
 title: Suricata
-version: 0.3.1
+version: 0.3.2
 release: experimental
 description: Suricata Integration
 type: integration

--- a/packages/zeek/data_stream/capture_loss/fields/ecs.yml
+++ b/packages/zeek/data_stream/capture_loss/fields/ecs.yml
@@ -23,3 +23,6 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip

--- a/packages/zeek/data_stream/connection/fields/ecs.yml
+++ b/packages/zeek/data_stream/connection/fields/ecs.yml
@@ -111,6 +111,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: Total bytes transferred in both directions.
   example: 368
   name: network.bytes

--- a/packages/zeek/data_stream/dce_rpc/fields/ecs.yml
+++ b/packages/zeek/data_stream/dce_rpc/fields/ecs.yml
@@ -105,6 +105,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: A hash of source and destination IPs and ports.
   example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
   ignore_above: 1024

--- a/packages/zeek/data_stream/dhcp/fields/ecs.yml
+++ b/packages/zeek/data_stream/dhcp/fields/ecs.yml
@@ -47,6 +47,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: A hash of source and destination IPs and ports.
   example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
   ignore_above: 1024

--- a/packages/zeek/data_stream/dnp3/fields/ecs.yml
+++ b/packages/zeek/data_stream/dnp3/fields/ecs.yml
@@ -105,6 +105,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: A hash of source and destination IPs and ports.
   example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
   ignore_above: 1024

--- a/packages/zeek/data_stream/dns/fields/ecs.yml
+++ b/packages/zeek/data_stream/dns/fields/ecs.yml
@@ -162,6 +162,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: A hash of source and destination IPs and ports.
   example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
   ignore_above: 1024

--- a/packages/zeek/data_stream/dpd/fields/ecs.yml
+++ b/packages/zeek/data_stream/dpd/fields/ecs.yml
@@ -96,6 +96,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: A hash of source and destination IPs and ports.
   example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
   ignore_above: 1024

--- a/packages/zeek/data_stream/files/fields/ecs.yml
+++ b/packages/zeek/data_stream/files/fields/ecs.yml
@@ -61,6 +61,9 @@
   example: 16384
   name: file.size
   type: long
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: All the hashes seen on your event.
   ignore_above: 1024
   name: related.hash

--- a/packages/zeek/data_stream/ftp/fields/ecs.yml
+++ b/packages/zeek/data_stream/ftp/fields/ecs.yml
@@ -114,6 +114,9 @@
   ignore_above: 1024
   name: network.community_id
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: All of the IPs seen on your event.
   name: related.ip
   type: ip

--- a/packages/zeek/data_stream/http/fields/ecs.yml
+++ b/packages/zeek/data_stream/http/fields/ecs.yml
@@ -133,6 +133,9 @@
   ignore_above: 1024
   name: http.version
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: A hash of source and destination IPs and ports.
   example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
   ignore_above: 1024

--- a/packages/zeek/data_stream/intel/fields/ecs.yml
+++ b/packages/zeek/data_stream/intel/fields/ecs.yml
@@ -91,6 +91,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: A hash of source and destination IPs and ports.
   example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
   ignore_above: 1024

--- a/packages/zeek/data_stream/irc/fields/ecs.yml
+++ b/packages/zeek/data_stream/irc/fields/ecs.yml
@@ -114,6 +114,9 @@
   example: 16384
   name: file.size
   type: long
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: A hash of source and destination IPs and ports.
   example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
   ignore_above: 1024

--- a/packages/zeek/data_stream/kerberos/fields/ecs.yml
+++ b/packages/zeek/data_stream/kerberos/fields/ecs.yml
@@ -110,6 +110,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: A hash of source and destination IPs and ports.
   example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
   ignore_above: 1024

--- a/packages/zeek/data_stream/modbus/fields/ecs.yml
+++ b/packages/zeek/data_stream/modbus/fields/ecs.yml
@@ -106,6 +106,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: A hash of source and destination IPs and ports.
   example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
   ignore_above: 1024

--- a/packages/zeek/data_stream/mysql/fields/ecs.yml
+++ b/packages/zeek/data_stream/mysql/fields/ecs.yml
@@ -105,6 +105,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: A hash of source and destination IPs and ports.
   example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
   ignore_above: 1024

--- a/packages/zeek/data_stream/notice/fields/ecs.yml
+++ b/packages/zeek/data_stream/notice/fields/ecs.yml
@@ -104,6 +104,9 @@
   example: 16384
   name: file.size
   type: long
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: A hash of source and destination IPs and ports.
   example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
   ignore_above: 1024

--- a/packages/zeek/data_stream/ntlm/fields/ecs.yml
+++ b/packages/zeek/data_stream/ntlm/fields/ecs.yml
@@ -101,6 +101,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: A hash of source and destination IPs and ports.
   example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
   ignore_above: 1024

--- a/packages/zeek/data_stream/ocsp/fields/ecs.yml
+++ b/packages/zeek/data_stream/ocsp/fields/ecs.yml
@@ -19,6 +19,9 @@
   ignore_above: 1024
   name: event.kind
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: Protocol Name corresponding to the field `iana_number`.
   example: tcp
   ignore_above: 1024

--- a/packages/zeek/data_stream/pe/fields/ecs.yml
+++ b/packages/zeek/data_stream/pe/fields/ecs.yml
@@ -28,3 +28,6 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip

--- a/packages/zeek/data_stream/radius/fields/ecs.yml
+++ b/packages/zeek/data_stream/radius/fields/ecs.yml
@@ -101,6 +101,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: A hash of source and destination IPs and ports.
   example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
   ignore_above: 1024

--- a/packages/zeek/data_stream/rdp/fields/ecs.yml
+++ b/packages/zeek/data_stream/rdp/fields/ecs.yml
@@ -96,6 +96,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: L7 Network protocol name.
   example: http
   ignore_above: 1024

--- a/packages/zeek/data_stream/rfb/fields/ecs.yml
+++ b/packages/zeek/data_stream/rfb/fields/ecs.yml
@@ -96,6 +96,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: A hash of source and destination IPs and ports.
   example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
   ignore_above: 1024

--- a/packages/zeek/data_stream/sip/fields/ecs.yml
+++ b/packages/zeek/data_stream/sip/fields/ecs.yml
@@ -106,6 +106,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: A hash of source and destination IPs and ports.
   example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
   ignore_above: 1024

--- a/packages/zeek/data_stream/smb_cmd/fields/ecs.yml
+++ b/packages/zeek/data_stream/smb_cmd/fields/ecs.yml
@@ -106,6 +106,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: A hash of source and destination IPs and ports.
   example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
   ignore_above: 1024

--- a/packages/zeek/data_stream/smb_files/fields/ecs.yml
+++ b/packages/zeek/data_stream/smb_files/fields/ecs.yml
@@ -132,6 +132,9 @@
   example: 16384
   name: file.size
   type: long
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: A hash of source and destination IPs and ports.
   example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
   ignore_above: 1024

--- a/packages/zeek/data_stream/smb_mapping/fields/ecs.yml
+++ b/packages/zeek/data_stream/smb_mapping/fields/ecs.yml
@@ -96,6 +96,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: A hash of source and destination IPs and ports.
   example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
   ignore_above: 1024

--- a/packages/zeek/data_stream/smtp/fields/ecs.yml
+++ b/packages/zeek/data_stream/smtp/fields/ecs.yml
@@ -96,6 +96,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: A hash of source and destination IPs and ports.
   example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
   ignore_above: 1024

--- a/packages/zeek/data_stream/snmp/fields/ecs.yml
+++ b/packages/zeek/data_stream/snmp/fields/ecs.yml
@@ -96,6 +96,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: A hash of source and destination IPs and ports.
   example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
   ignore_above: 1024

--- a/packages/zeek/data_stream/socks/fields/ecs.yml
+++ b/packages/zeek/data_stream/socks/fields/ecs.yml
@@ -98,6 +98,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: A hash of source and destination IPs and ports.
   example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
   ignore_above: 1024

--- a/packages/zeek/data_stream/ssh/fields/ecs.yml
+++ b/packages/zeek/data_stream/ssh/fields/ecs.yml
@@ -101,6 +101,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: A hash of source and destination IPs and ports.
   example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
   ignore_above: 1024

--- a/packages/zeek/data_stream/ssl/fields/ecs.yml
+++ b/packages/zeek/data_stream/ssl/fields/ecs.yml
@@ -100,6 +100,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: A hash of source and destination IPs and ports.
   example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
   ignore_above: 1024

--- a/packages/zeek/data_stream/stats/fields/ecs.yml
+++ b/packages/zeek/data_stream/stats/fields/ecs.yml
@@ -19,3 +19,6 @@
   ignore_above: 1024
   name: event.kind
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip

--- a/packages/zeek/data_stream/syslog/fields/ecs.yml
+++ b/packages/zeek/data_stream/syslog/fields/ecs.yml
@@ -87,6 +87,9 @@
   ignore_above: 1024
   name: event.kind
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: Syslog text-based facility of the event.
   example: local7
   ignore_above: 1024

--- a/packages/zeek/data_stream/traceroute/fields/ecs.yml
+++ b/packages/zeek/data_stream/traceroute/fields/ecs.yml
@@ -88,6 +88,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: Protocol Name corresponding to the field `iana_number`.
   example: tcp
   ignore_above: 1024

--- a/packages/zeek/data_stream/tunnel/fields/ecs.yml
+++ b/packages/zeek/data_stream/tunnel/fields/ecs.yml
@@ -101,6 +101,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: All of the IPs seen on your event.
   name: related.ip
   type: ip

--- a/packages/zeek/data_stream/weird/fields/ecs.yml
+++ b/packages/zeek/data_stream/weird/fields/ecs.yml
@@ -93,6 +93,9 @@
   ignore_above: 1024
   name: event.type
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip
 - description: All of the IPs seen on your event.
   name: related.ip
   type: ip

--- a/packages/zeek/data_stream/x509/fields/ecs.yml
+++ b/packages/zeek/data_stream/x509/fields/ecs.yml
@@ -123,3 +123,6 @@
   ignore_above: 1024
   name: file.x509.subject.state_or_province
   type: keyword
+- description: "Host ip addresses."
+  name: host.ip
+  type: ip

--- a/packages/zeek/docs/README.md
+++ b/packages/zeek/docs/README.md
@@ -33,6 +33,7 @@ which contains packet loss rate data.
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -85,6 +86,7 @@ contains TCP/UDP/ICMP connection data.
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -163,6 +165,7 @@ contains Distributed Computing Environment/RPC data.
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -217,6 +220,7 @@ DHCP lease data.
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -288,6 +292,7 @@ requests and replies.
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -363,6 +368,7 @@ activity.
 | event.original | Raw text message of entire event. | keyword |
 | event.outcome | The outcome of the event. The lowest level categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -442,6 +448,7 @@ protocol detection failures.
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -498,6 +505,7 @@ file analysis results.
 | file.mime_type | Media type of file, document, or arrangement of bytes. | keyword |
 | file.name | Name of the file including the extension, without the directory. | keyword |
 | file.size | File size in bytes. | long |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -572,6 +580,7 @@ activity.
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
 | file.mime_type | Media type of file, document, or arrangement of bytes. | keyword |
 | file.size | File size in bytes. | long |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -655,6 +664,7 @@ HTTP requests and replies.
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.outcome | The outcome of the event. The lowest level categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | http.request.body.bytes | Size in bytes of the request body. | long |
 | http.request.method | HTTP request method. | keyword |
 | http.request.referrer | Referrer for this HTTP request. | keyword |
@@ -753,6 +763,7 @@ intelligence data matches.
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.original | Raw text message of entire event. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -829,6 +840,7 @@ commands and responses.
 | file.mime_type | Media type of file, document, or arrangement of bytes. | keyword |
 | file.name | Name of the file including the extension, without the directory. | keyword |
 | file.size | File size in bytes. | long |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -903,6 +915,7 @@ contains kerberos data.
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.outcome | The outcome of the event. The lowest level categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -999,6 +1012,7 @@ modbus commands and responses.
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.outcome | The outcome of the event. The lowest level categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -1062,6 +1076,7 @@ MySQL data.
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.outcome | The outcome of the event. The lowest level categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -1127,6 +1142,7 @@ Zeek notices.
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
 | file.mime_type | Media type of file, document, or arrangement of bytes. | keyword |
 | file.size | File size in bytes. | long |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -1213,6 +1229,7 @@ LAN Manager(NTLM) data.
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.outcome | The outcome of the event. The lowest level categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -1267,6 +1284,7 @@ Online Certificate Status Protocol (OCSP) data.
 | event.created | Time when the event was first read by an agent or by your pipeline. | date |
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -1308,6 +1326,7 @@ portable executable data.
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -1369,6 +1388,7 @@ RADIUS authentication attempts.
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.outcome | The outcome of the event. The lowest level categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -1440,6 +1460,7 @@ data.
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -1517,6 +1538,7 @@ Remote Framebuffer (RFB) data.
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -1589,6 +1611,7 @@ data.
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.outcome | The outcome of the event. The lowest level categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -1673,6 +1696,7 @@ contains SMB commands.
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.outcome | The outcome of the event. The lowest level categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -1759,6 +1783,7 @@ contains SMB file data.
 | file.name | Name of the file including the extension, without the directory. | keyword |
 | file.path | Full path to the file, including the file name. | keyword |
 | file.size | File size in bytes. | long |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -1831,6 +1856,7 @@ which contains SMB trees.
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -1895,6 +1921,7 @@ SMTP transactions..
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -1979,6 +2006,7 @@ SNMP messages.
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -2048,6 +2076,7 @@ SOCKS proxy requests.
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.outcome | The outcome of the event. The lowest level categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -2120,6 +2149,7 @@ connection data.
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.outcome | The outcome of the event. The lowest level categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -2193,6 +2223,7 @@ SSL/TLS handshake info.
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -2295,6 +2326,7 @@ memory/event/packet/lag statistics.
 | event.created | Time when the event was first read by an agent or by your pipeline. | date |
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -2361,6 +2393,7 @@ syslog messages.
 | event.id | Unique ID to describe the event. | keyword |
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -2424,6 +2457,7 @@ contains traceroute detections.
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -2482,6 +2516,7 @@ tunneling protocol events.
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -2540,6 +2575,7 @@ unexpected network-level activity.
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
@@ -2609,6 +2645,7 @@ X.509 certificate info.
 | file.x509.subject.organizational_unit | List of organizational units (OU) of subject. | keyword |
 | file.x509.subject.state_or_province | List of state or province names (ST, S, or P) | keyword |
 | file.x509.version_number | Version of x509 format. | keyword |
+| host.ip | Host ip addresses. | ip |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |

--- a/packages/zeek/manifest.yml
+++ b/packages/zeek/manifest.yml
@@ -1,6 +1,6 @@
 name: zeek
 title: Zeek
-version: 0.3.2
+version: 0.3.3
 release: beta
 description: Zeek Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?

Adds a host.ip mapping for the add_host_metadata process to nginx, Suricata, and Zeek.

Relates #291

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [ ] I have verified that all datasets collect metrics or logs.

