### PR TITLE
Fix netflow package fields/config/dashboards

### DIFF
--- a/packages/netflow/data_stream/log/agent/stream/netflow.yml.hbs
+++ b/packages/netflow/data_stream/log/agent/stream/netflow.yml.hbs
@@ -1,7 +1,14 @@
 protocols: [v1, v5, v6, v7, v8, v9, ipfix]
 host: '{{host}}:{{port}}'
-expiration_timeout: '{{timeout}}'
+max_message_size: '{{max_message_size}}'
+expiration_timeout: '{{expiration_timeout}}'
 queue_size: {{queue_size}}
+{{#if timeout}}
+timeout: '{{timeout}}'
+{{/if}}
+{{#if read_buffer}}
+read_buffer: '{{read_buffer}}'
+{{/if}}
 {{#if custom_definitions}}
 custom_definitions:
 {{#each custom_definitions}}
@@ -11,3 +18,16 @@ custom_definitions:
 {{#if detect_sequence_reset}}
 detect_sequence_reset: {{detect_sequence_reset}}
 {{/if}}
+tags:
+{{#each tags as |tag i|}}
+    - {{tag}}
+{{/each}}
+{{#contains tags "forwarded"}}
+publisher_pipeline.disable_host: true
+{{/contains}}
+
+processors:
+  - add_fields:
+      target: ''
+      fields:
+        ecs.version: 1.6.0

--- a/packages/netflow/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/netflow/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -2,6 +2,10 @@
 description: Pipeline for NetFlow
 
 processors:
+  - set:
+      field: event.ingested
+      value: '{{_ingest.timestamp}}'
+
   # IP Geolocation Lookup
   - geoip:
         if: ctx.source?.geo == null

--- a/packages/netflow/data_stream/log/fields/ecs.yml
+++ b/packages/netflow/data_stream/log/fields/ecs.yml
@@ -934,6 +934,9 @@
       description: 'Reserved for future usage.
 
         Please avoid using this field for user data.'
+    - name: ingested
+      type: date
+      description: Timestamp when an event arrived in the central data store.
 - name: file
   title: File
   group: 2

--- a/packages/netflow/data_stream/log/fields/package-fields.yml
+++ b/packages/netflow/data_stream/log/fields/package-fields.yml
@@ -1,3 +1,18 @@
+- name: input.type
+  description: Type of Filebeat input.
+  type: keyword
+- name: flow.locality
+  type: keyword
+  description: Identifies whether the flow involved public IP addresses or only private address.
+- name: flow.id
+  type: keyword
+  description: Hash of source and destination IPs.
+- name: destination.locality
+  type: keyword
+  description: Whether the destination IP is private or public.
+- name: source.locality
+  type: keyword
+  description: Whether the source IP is private or public.
 - name: netflow
   type: group
   description: >

--- a/packages/netflow/data_stream/log/manifest.yml
+++ b/packages/netflow/data_stream/log/manifest.yml
@@ -21,16 +21,16 @@ streams:
         required: true
         show_user: true
         default: 2055
-      - name: timeout
+      - name: expiration_timeout
         type: text
-        title: Timeout duration in a string format
+        title: Time duration before an idle session or unused template is expired
         multi: false
         required: true
         show_user: false
         default: 30m
       - name: queue_size
         type: integer
-        title: Queue size
+        title: Maximum number of packets that can be queued for processing
         multi: false
         required: true
         show_user: false
@@ -49,3 +49,24 @@ streams:
         required: true
         show_user: false
         default: true
+      - name: max_message_size
+        type: text
+        title: Maximum size of the message received over UDP
+        multi: false
+        required: true
+        show_user: false
+        default: 10KiB
+      - name: tags
+        type: text
+        title: Tags
+        multi: true
+        required: false
+        show_user: false
+        default:
+          - forwarded
+      - name: timeout
+        type: text
+        title: Read timeout for socket operations
+        multi: false
+        required: false
+        show_user: false

--- a/packages/netflow/docs/README.md
+++ b/packages/netflow/docs/README.md
@@ -88,6 +88,7 @@ The `log` dataset collects netflow logs.
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. Can be one or multiple IPv4 or IPv6 addresses. | ip |
+| destination.locality | Whether the destination IP is private or public. | keyword |
 | destination.mac | MAC address of the destination. | keyword |
 | destination.nat.ip | Translated ip of destination based NAT sessions (e.g. internet to private DMZ) Typically used with load balancers, firewalls, or routers. | ip |
 | destination.nat.port | Port the source session is translated to by NAT Device. Typically used with load balancers, firewalls, or routers. | long |
@@ -137,6 +138,7 @@ The `log` dataset collects netflow logs.
 | event.end | event.end contains the date when the event ended or when the activity was last observed. | date |
 | event.hash | Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity. | keyword |
 | event.id | Unique ID to describe the event. | keyword |
+| event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.kind | The kind of the event. This gives information about what type of information the event contains, without being specific to the contents of the event.  Examples are `event`, `state`, `alarm`. Warning: In future versions of ECS, we plan to provide a list of acceptable values for this field, please use with caution. | keyword |
 | event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |
 | event.original | Raw text message of entire event. Used to demonstrate log integrity. This field is not indexed and doc_values are disabled. It cannot be searched, but it can be retrieved from `_source`. | keyword |
@@ -171,6 +173,8 @@ The `log` dataset collects netflow logs.
 | file.target_path | Target path for symlinks. | keyword |
 | file.type | File type (file, dir, or symlink). | keyword |
 | file.uid | The user ID (UID) or security identifier (SID) of the file owner. | keyword |
+| flow.id | Hash of source and destination IPs. | keyword |
+| flow.locality | Identifies whether the flow involved public IP addresses or only private address. | keyword |
 | geo.city_name | City name. | keyword |
 | geo.continent_name | Name of the continent. | keyword |
 | geo.country_iso_code | Country ISO code. | keyword |
@@ -227,6 +231,7 @@ The `log` dataset collects netflow logs.
 | http.response.bytes | Total size in bytes of the response (body and headers). | long |
 | http.response.status_code | HTTP response status code. | long |
 | http.version | HTTP version. | keyword |
+| input.type | Type of Filebeat input. | keyword |
 | labels | Custom key/value pairs. Can be used to add meta information to events. Should not contain nested objects. All values are stored as keyword. Example: `docker` and `k8s` labels. | object |
 | log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
 | log.logger | The name of the logger inside an application. This is usually the name of the class which initialized the logger, or can be a custom name. | keyword |
@@ -813,6 +818,7 @@ The `log` dataset collects netflow logs.
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. Can be one or multiple IPv4 or IPv6 addresses. | ip |
+| source.locality | Whether the source IP is private or public. | keyword |
 | source.mac | MAC address of the source. | keyword |
 | source.nat.ip | Translated ip of source based NAT sessions (e.g. internal client to internet) Typically connections traversing load balancers, firewalls, or routers. | ip |
 | source.nat.port | Translated port of source based NAT sessions. (e.g. internal client to internet) Typically used with load balancers, firewalls, or routers. | long |

--- a/packages/netflow/kibana/dashboard/netflow-14387a13-53bc-43a4-b9cd-63977aa8d87c.json
+++ b/packages/netflow/kibana/dashboard/netflow-14387a13-53bc-43a4-b9cd-63977aa8d87c.json
@@ -13,18 +13,18 @@
                             "alias": null,
                             "disabled": false,
                             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                            "key": "input.type",
+                            "key": "data_stream.dataset",
                             "negate": false,
                             "params": {
-                                "query": "netflow"
+                                "query": "netflow.log"
                             },
                             "type": "phrase",
-                            "value": "netflow"
+                            "value": "netflow.log"
                         },
                         "query": {
                             "match": {
-                                "input.type": {
-                                    "query": "netflow",
+                                "data_stream.dataset": {
+                                    "query": "netflow.log",
                                     "type": "phrase"
                                 }
                             }

--- a/packages/netflow/kibana/dashboard/netflow-34e26884-161a-4448-9556-43b5bf2f62a2.json
+++ b/packages/netflow/kibana/dashboard/netflow-34e26884-161a-4448-9556-43b5bf2f62a2.json
@@ -13,18 +13,18 @@
                             "alias": null,
                             "disabled": false,
                             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                            "key": "input.type",
+                            "key": "data_stream.dataset",
                             "negate": false,
                             "params": {
-                                "query": "netflow"
+                                "query": "netflow.log"
                             },
                             "type": "phrase",
-                            "value": "netflow"
+                            "value": "netflow.log"
                         },
                         "query": {
                             "match": {
-                                "input.type": {
-                                    "query": "netflow",
+                                "data_stream.dataset": {
+                                    "query": "netflow.log",
                                     "type": "phrase"
                                 }
                             }

--- a/packages/netflow/kibana/dashboard/netflow-38012abe-c611-4124-8497-381fcd85acc8.json
+++ b/packages/netflow/kibana/dashboard/netflow-38012abe-c611-4124-8497-381fcd85acc8.json
@@ -13,18 +13,18 @@
                             "alias": null,
                             "disabled": false,
                             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                            "key": "input.type",
+                            "key": "data_stream.dataset",
                             "negate": false,
                             "params": {
-                                "query": "netflow"
+                                "query": "netflow.log"
                             },
                             "type": "phrase",
-                            "value": "netflow"
+                            "value": "netflow.log"
                         },
                         "query": {
                             "match": {
-                                "input.type": {
-                                    "query": "netflow",
+                                "data_stream.dataset": {
+                                    "query": "netflow.log",
                                     "type": "phrase"
                                 }
                             }

--- a/packages/netflow/kibana/dashboard/netflow-77326664-23be-4bf1-a126-6d7e60cfc024.json
+++ b/packages/netflow/kibana/dashboard/netflow-77326664-23be-4bf1-a126-6d7e60cfc024.json
@@ -13,18 +13,18 @@
                             "alias": null,
                             "disabled": false,
                             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                            "key": "input.type",
+                            "key": "data_stream.dataset",
                             "negate": false,
                             "params": {
-                                "query": "netflow"
+                                "query": "netflow.log"
                             },
                             "type": "phrase",
-                            "value": "netflow"
+                            "value": "netflow.log"
                         },
                         "query": {
                             "match": {
-                                "input.type": {
-                                    "query": "netflow",
+                                "data_stream.dataset": {
+                                    "query": "netflow.log",
                                     "type": "phrase"
                                 }
                             }

--- a/packages/netflow/kibana/dashboard/netflow-94972700-de4a-4272-9143-2fa8d4981365.json
+++ b/packages/netflow/kibana/dashboard/netflow-94972700-de4a-4272-9143-2fa8d4981365.json
@@ -13,18 +13,18 @@
                             "alias": null,
                             "disabled": false,
                             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                            "key": "input.type",
+                            "key": "data_stream.dataset",
                             "negate": false,
                             "params": {
-                                "query": "netflow"
+                                "query": "netflow.log"
                             },
                             "type": "phrase",
-                            "value": "netflow"
+                            "value": "netflow.log"
                         },
                         "query": {
                             "match": {
-                                "input.type": {
-                                    "query": "netflow",
+                                "data_stream.dataset": {
+                                    "query": "netflow.log",
                                     "type": "phrase"
                                 }
                             }

--- a/packages/netflow/kibana/dashboard/netflow-acd7a630-0c71-4840-bc9e-4a3801374a32.json
+++ b/packages/netflow/kibana/dashboard/netflow-acd7a630-0c71-4840-bc9e-4a3801374a32.json
@@ -13,18 +13,18 @@
                             "alias": null,
                             "disabled": false,
                             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                            "key": "input.type",
+                            "key": "data_stream.dataset",
                             "negate": false,
                             "params": {
-                                "query": "netflow"
+                                "query": "netflow.log"
                             },
                             "type": "phrase",
-                            "value": "netflow"
+                            "value": "netflow.log"
                         },
                         "query": {
                             "match": {
-                                "input.type": {
-                                    "query": "netflow",
+                                "data_stream.dataset": {
+                                    "query": "netflow.log",
                                     "type": "phrase"
                                 }
                             }

--- a/packages/netflow/kibana/dashboard/netflow-c64665f9-d222-421e-90b0-c7310d944b8a.json
+++ b/packages/netflow/kibana/dashboard/netflow-c64665f9-d222-421e-90b0-c7310d944b8a.json
@@ -13,18 +13,18 @@
                             "alias": null,
                             "disabled": false,
                             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                            "key": "input.type",
+                            "key": "data_stream.dataset",
                             "negate": false,
                             "params": {
-                                "query": "netflow"
+                                "query": "netflow.log"
                             },
                             "type": "phrase",
-                            "value": "netflow"
+                            "value": "netflow.log"
                         },
                         "query": {
                             "match": {
-                                "input.type": {
-                                    "query": "netflow",
+                                "data_stream.dataset": {
+                                    "query": "netflow.log",
                                     "type": "phrase"
                                 }
                             }

--- a/packages/netflow/kibana/dashboard/netflow-feebb4e6-b13e-4e4e-b9fc-d3a178276425.json
+++ b/packages/netflow/kibana/dashboard/netflow-feebb4e6-b13e-4e4e-b9fc-d3a178276425.json
@@ -13,18 +13,18 @@
                             "alias": null,
                             "disabled": false,
                             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                            "key": "input.type",
+                            "key": "data_stream.dataset",
                             "negate": false,
                             "params": {
-                                "query": "netflow"
+                                "query": "netflow.log"
                             },
                             "type": "phrase",
-                            "value": "netflow"
+                            "value": "netflow.log"
                         },
                         "query": {
                             "match": {
-                                "input.type": {
-                                    "query": "netflow",
+                                "data_stream.dataset": {
+                                    "query": "netflow.log",
                                     "type": "phrase"
                                 }
                             }

--- a/packages/netflow/kibana/search/netflow-a34c6611-79d8-4b50-ae3f-8b328d28e24a.json
+++ b/packages/netflow/kibana/search/netflow-a34c6611-79d8-4b50-ae3f-8b328d28e24a.json
@@ -13,16 +13,32 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
-                "highlightAll": true,
-                "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 },
-                "version": true
+                "version": true,
+                "filter": [
+                    {
+                        "meta": {
+                            "alias": null,
+                            "negate": false,
+                            "disabled": false,
+                            "type": "phrase",
+                            "key": "data_stream.dataset",
+                            "params": {
+                                "query": "netflow.log"
+                            },
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "netflow.log"
+                            }
+                        }
+                    }
+                ],
+                "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index"
             }
         },
         "sort": [

--- a/packages/netflow/kibana/visualization/netflow-0177bf1a-cba8-4ba6-a1d7-73caed86ffc2.json
+++ b/packages/netflow/kibana/visualization/netflow-0177bf1a-cba8-4ba6-a1d7-73caed86ffc2.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-036aef95-ec90-468d-ad7c-3cc4405e9e81.json
+++ b/packages/netflow/kibana/visualization/netflow-036aef95-ec90-468d-ad7c-3cc4405e9e81.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-0528bc66-6981-400a-a02d-c1d221b38890.json
+++ b/packages/netflow/kibana/visualization/netflow-0528bc66-6981-400a-a02d-c1d221b38890.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-0b2818fd-aecc-4bef-b566-9466eb702ae4.json
+++ b/packages/netflow/kibana/visualization/netflow-0b2818fd-aecc-4bef-b566-9466eb702ae4.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-12aad647-c45d-4667-a029-152c1a97cbbc.json
+++ b/packages/netflow/kibana/visualization/netflow-12aad647-c45d-4667-a029-152c1a97cbbc.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-14c7136d-b4aa-4367-9461-52bf8b5c4796.json
+++ b/packages/netflow/kibana/visualization/netflow-14c7136d-b4aa-4367-9461-52bf8b5c4796.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-15295ea6-ba84-47db-8ced-9312abbf495c.json
+++ b/packages/netflow/kibana/visualization/netflow-15295ea6-ba84-47db-8ced-9312abbf495c.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-1558508d-591c-49be-bef4-85fdac18a960.json
+++ b/packages/netflow/kibana/visualization/netflow-1558508d-591c-49be-bef4-85fdac18a960.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-15e2a267-2495-4df2-a121-abe410d2f18c.json
+++ b/packages/netflow/kibana/visualization/netflow-15e2a267-2495-4df2-a121-abe410d2f18c.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-16262df9-a979-4136-935e-d883c7d373d7.json
+++ b/packages/netflow/kibana/visualization/netflow-16262df9-a979-4136-935e-d883c7d373d7.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-1cd36f5d-d9c7-4098-acdb-14d312ecfb72.json
+++ b/packages/netflow/kibana/visualization/netflow-1cd36f5d-d9c7-4098-acdb-14d312ecfb72.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-1cf30eac-aae8-47fa-a156-37f6346d2d5a.json
+++ b/packages/netflow/kibana/visualization/netflow-1cf30eac-aae8-47fa-a156-37f6346d2d5a.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-1e74d5cb-556d-42ee-8042-88f6c1af47f0.json
+++ b/packages/netflow/kibana/visualization/netflow-1e74d5cb-556d-42ee-8042-88f6c1af47f0.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-201d7dd1-a880-4a64-b631-db5629340db9.json
+++ b/packages/netflow/kibana/visualization/netflow-201d7dd1-a880-4a64-b631-db5629340db9.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-2316bb53-d98a-4f0f-8cd8-51e9fb317823.json
+++ b/packages/netflow/kibana/visualization/netflow-2316bb53-d98a-4f0f-8cd8-51e9fb317823.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-248e00b4-8fc2-406f-8907-729d5380aaa7.json
+++ b/packages/netflow/kibana/visualization/netflow-248e00b4-8fc2-406f-8907-729d5380aaa7.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-2b3d4e86-2254-4033-8fe3-ce4753fafd03.json
+++ b/packages/netflow/kibana/visualization/netflow-2b3d4e86-2254-4033-8fe3-ce4753fafd03.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-2dca3025-692c-4876-8bcc-e0b248dc9819.json
+++ b/packages/netflow/kibana/visualization/netflow-2dca3025-692c-4876-8bcc-e0b248dc9819.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-30cd1009-2925-4c9b-820d-d689f5d1efda.json
+++ b/packages/netflow/kibana/visualization/netflow-30cd1009-2925-4c9b-820d-d689f5d1efda.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-31708a70-4957-4a8a-8065-5c88a344ad02.json
+++ b/packages/netflow/kibana/visualization/netflow-31708a70-4957-4a8a-8065-5c88a344ad02.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },
@@ -33,7 +31,7 @@
                     "id": "2",
                     "params": {
                         "customLabel": "Flow Exporter",
-                        "field": "agent.hostname",
+                        "field": "agent.name",
                         "order": "desc",
                         "orderBy": "1",
                         "size": 50

--- a/packages/netflow/kibana/visualization/netflow-31b5f6fd-eb9d-4e97-90fd-367062ef217f.json
+++ b/packages/netflow/kibana/visualization/netflow-31b5f6fd-eb9d-4e97-90fd-367062ef217f.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-32e712ed-fa15-4db7-8575-8476e8d65b03.json
+++ b/packages/netflow/kibana/visualization/netflow-32e712ed-fa15-4db7-8575-8476e8d65b03.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-3a4209e2-281c-467e-b5cb-315bf4a2661f.json
+++ b/packages/netflow/kibana/visualization/netflow-3a4209e2-281c-467e-b5cb-315bf4a2661f.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-3dec20c0-0d4f-43ef-8864-3779e1a1b33f.json
+++ b/packages/netflow/kibana/visualization/netflow-3dec20c0-0d4f-43ef-8864-3779e1a1b33f.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-3e27fb83-b3e3-4c15-b999-ed6da49b7a86.json
+++ b/packages/netflow/kibana/visualization/netflow-3e27fb83-b3e3-4c15-b999-ed6da49b7a86.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-441c6c50-fa1a-489c-96c6-76f7925dea24.json
+++ b/packages/netflow/kibana/visualization/netflow-441c6c50-fa1a-489c-96c6-76f7925dea24.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },
@@ -30,7 +28,7 @@
                     "id": "2",
                     "params": {
                         "customLabel": "Flow Exporter",
-                        "field": "agent.hostname",
+                        "field": "agent.name",
                         "order": "desc",
                         "orderBy": "1",
                         "size": 50

--- a/packages/netflow/kibana/visualization/netflow-4ac97841-c89f-4d50-b3c6-6253f7e1dd1a.json
+++ b/packages/netflow/kibana/visualization/netflow-4ac97841-c89f-4d50-b3c6-6253f7e1dd1a.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-4bb0255e-18ed-45e4-bfb9-de8e35b12094.json
+++ b/packages/netflow/kibana/visualization/netflow-4bb0255e-18ed-45e4-bfb9-de8e35b12094.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-5292a65b-c532-422a-9008-1251a8073a3a.json
+++ b/packages/netflow/kibana/visualization/netflow-5292a65b-c532-422a-9008-1251a8073a3a.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-5303e99b-389c-47b7-ae7a-945c5a92ba49.json
+++ b/packages/netflow/kibana/visualization/netflow-5303e99b-389c-47b7-ae7a-945c5a92ba49.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-57e13a20-e94f-4465-a942-42148634a1d2.json
+++ b/packages/netflow/kibana/visualization/netflow-57e13a20-e94f-4465-a942-42148634a1d2.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-5ccac452-e90a-4dde-ae9b-1be36ce3f761.json
+++ b/packages/netflow/kibana/visualization/netflow-5ccac452-e90a-4dde-ae9b-1be36ce3f761.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-5cfb2c9a-4815-4a25-9d7e-ab0ef55ffe63.json
+++ b/packages/netflow/kibana/visualization/netflow-5cfb2c9a-4815-4a25-9d7e-ab0ef55ffe63.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-5d868836-c7b2-4812-bf47-4838aac281d9.json
+++ b/packages/netflow/kibana/visualization/netflow-5d868836-c7b2-4812-bf47-4838aac281d9.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-63ef5338-fdf2-488e-b78a-f0e98daccc95.json
+++ b/packages/netflow/kibana/visualization/netflow-63ef5338-fdf2-488e-b78a-f0e98daccc95.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-67fdca65-a9df-47f0-a8a4-1e8b056325de.json
+++ b/packages/netflow/kibana/visualization/netflow-67fdca65-a9df-47f0-a8a4-1e8b056325de.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-681f0ce4-d828-4a99-b643-0c0715530050.json
+++ b/packages/netflow/kibana/visualization/netflow-681f0ce4-d828-4a99-b643-0c0715530050.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-6bbd6712-494a-4fd9-b3d3-757304681f0f.json
+++ b/packages/netflow/kibana/visualization/netflow-6bbd6712-494a-4fd9-b3d3-757304681f0f.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-717cd7c7-bfca-435d-8ee7-38259927aade.json
+++ b/packages/netflow/kibana/visualization/netflow-717cd7c7-bfca-435d-8ee7-38259927aade.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-751ecb6f-11c3-458d-b039-f6d57a6379fa.json
+++ b/packages/netflow/kibana/visualization/netflow-751ecb6f-11c3-458d-b039-f6d57a6379fa.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-7d447b22-89dc-4f32-b549-4b8620af4d76.json
+++ b/packages/netflow/kibana/visualization/netflow-7d447b22-89dc-4f32-b549-4b8620af4d76.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-7fa6cb0a-518d-46e9-a228-15cd4253a957.json
+++ b/packages/netflow/kibana/visualization/netflow-7fa6cb0a-518d-46e9-a228-15cd4253a957.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-85ebf558-402b-45d2-a186-e15f8673ec07.json
+++ b/packages/netflow/kibana/visualization/netflow-85ebf558-402b-45d2-a186-e15f8673ec07.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-8f83cf97-4a48-421f-8db5-690297d1f4fb.json
+++ b/packages/netflow/kibana/visualization/netflow-8f83cf97-4a48-421f-8db5-690297d1f4fb.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-a14c3248-952d-42aa-bd7d-9b39157a776f.json
+++ b/packages/netflow/kibana/visualization/netflow-a14c3248-952d-42aa-bd7d-9b39157a776f.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-a1704d46-15fc-41c2-851d-796ceb49877f.json
+++ b/packages/netflow/kibana/visualization/netflow-a1704d46-15fc-41c2-851d-796ceb49877f.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-a5efa3dd-f53a-4d14-9d3f-ee73345fd93d.json
+++ b/packages/netflow/kibana/visualization/netflow-a5efa3dd-f53a-4d14-9d3f-ee73345fd93d.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-a685420e-c45f-4b62-932b-5b76ac8b8ca2.json
+++ b/packages/netflow/kibana/visualization/netflow-a685420e-c45f-4b62-932b-5b76ac8b8ca2.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-abfa0b19-60cd-4984-9c3d-02ebf0aa1dfb.json
+++ b/packages/netflow/kibana/visualization/netflow-abfa0b19-60cd-4984-9c3d-02ebf0aa1dfb.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-ae334aec-31fa-4df7-a064-40b18831d819.json
+++ b/packages/netflow/kibana/visualization/netflow-ae334aec-31fa-4df7-a064-40b18831d819.json
@@ -6,13 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "language": "lucene",
-                    "query": {
-                        "query_string": {
-                            "analyze_wildcard": true,
-                            "query": "*"
-                        }
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-aed09724-0a69-4331-84f5-3d2067c43930.json
+++ b/packages/netflow/kibana/visualization/netflow-aed09724-0a69-4331-84f5-3d2067c43930.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-af707b01-29f1-462b-b279-6d2e803f3645.json
+++ b/packages/netflow/kibana/visualization/netflow-af707b01-29f1-462b-b279-6d2e803f3645.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-b02c2713-17f0-41dd-88a3-ce33b446f19d.json
+++ b/packages/netflow/kibana/visualization/netflow-b02c2713-17f0-41dd-88a3-ce33b446f19d.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-b677cd82-b33e-49b3-8b6e-0e110177b163.json
+++ b/packages/netflow/kibana/visualization/netflow-b677cd82-b33e-49b3-8b6e-0e110177b163.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-c27c6a3b-93ee-44d5-8d0c-9b097e575f52.json
+++ b/packages/netflow/kibana/visualization/netflow-c27c6a3b-93ee-44d5-8d0c-9b097e575f52.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-c54f5529-e6d7-4c26-8e8e-3b35de132035.json
+++ b/packages/netflow/kibana/visualization/netflow-c54f5529-e6d7-4c26-8e8e-3b35de132035.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-cccff92f-cb71-49a9-9caf-84867751d31e.json
+++ b/packages/netflow/kibana/visualization/netflow-cccff92f-cb71-49a9-9caf-84867751d31e.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },
@@ -61,7 +59,7 @@
                     "id": "4",
                     "params": {
                         "customLabel": "Flow Exporter",
-                        "field": "agent.hostname",
+                        "field": "agent.name",
                         "order": "desc",
                         "orderBy": "2",
                         "size": 500

--- a/packages/netflow/kibana/visualization/netflow-cf399a85-e348-4ac1-a399-e8f5a44114c4.json
+++ b/packages/netflow/kibana/visualization/netflow-cf399a85-e348-4ac1-a399-e8f5a44114c4.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-d27b5d74-b3b4-4311-a0e6-08ff8f4345df.json
+++ b/packages/netflow/kibana/visualization/netflow-d27b5d74-b3b4-4311-a0e6-08ff8f4345df.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-d3df8d28-65f8-4ea1-8b33-f479380a0600.json
+++ b/packages/netflow/kibana/visualization/netflow-d3df8d28-65f8-4ea1-8b33-f479380a0600.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-d41a9663-e5ad-47a7-955e-3803ae4e23c0.json
+++ b/packages/netflow/kibana/visualization/netflow-d41a9663-e5ad-47a7-955e-3803ae4e23c0.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-d4e6520a-9ced-47c9-a8f2-7246e8cbd2d3.json
+++ b/packages/netflow/kibana/visualization/netflow-d4e6520a-9ced-47c9-a8f2-7246e8cbd2d3.json
@@ -5,10 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-d5568704-e30b-4108-bb49-06a9b8dce6a6.json
+++ b/packages/netflow/kibana/visualization/netflow-d5568704-e30b-4108-bb49-06a9b8dce6a6.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-d59a031c-70d6-47d7-966d-7fcb805be9be.json
+++ b/packages/netflow/kibana/visualization/netflow-d59a031c-70d6-47d7-966d-7fcb805be9be.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-ddd27657-c3c8-4f82-8059-6d7763dd599b.json
+++ b/packages/netflow/kibana/visualization/netflow-ddd27657-c3c8-4f82-8059-6d7763dd599b.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-e822f94c-5f65-4963-a540-74ca9c25bd2d.json
+++ b/packages/netflow/kibana/visualization/netflow-e822f94c-5f65-4963-a540-74ca9c25bd2d.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-e99dc327-03de-4561-9e0c-f550710125c2.json
+++ b/packages/netflow/kibana/visualization/netflow-e99dc327-03de-4561-9e0c-f550710125c2.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-e9ad835b-b2f2-42d3-a3e7-555a593deacf.json
+++ b/packages/netflow/kibana/visualization/netflow-e9ad835b-b2f2-42d3-a3e7-555a593deacf.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-ebea013f-9b5b-4f61-a9c8-c62bebf62ae9.json
+++ b/packages/netflow/kibana/visualization/netflow-ebea013f-9b5b-4f61-a9c8-c62bebf62ae9.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-f27c1479-0625-4cdc-92de-672e47db0f87.json
+++ b/packages/netflow/kibana/visualization/netflow-f27c1479-0625-4cdc-92de-672e47db0f87.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-f4c8cb5a-7336-449e-ab99-6e867b435b85.json
+++ b/packages/netflow/kibana/visualization/netflow-f4c8cb5a-7336-449e-ab99-6e867b435b85.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-f531f957-e8c0-497a-ad41-ef39c2d29671.json
+++ b/packages/netflow/kibana/visualization/netflow-f531f957-e8c0-497a-ad41-ef39c2d29671.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-f668ecdb-eec7-44c6-9060-26aaf9fc8404.json
+++ b/packages/netflow/kibana/visualization/netflow-f668ecdb-eec7-44c6-9060-26aaf9fc8404.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-f75063c7-48b7-4de4-b8cb-d07eb2cea0e9.json
+++ b/packages/netflow/kibana/visualization/netflow-f75063c7-48b7-4de4-b8cb-d07eb2cea0e9.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-f772028b-d5a6-4d55-b441-493871981a60.json
+++ b/packages/netflow/kibana/visualization/netflow-f772028b-d5a6-4d55-b441-493871981a60.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-f7808e70-df2a-4532-a350-966704567c24.json
+++ b/packages/netflow/kibana/visualization/netflow-f7808e70-df2a-4532-a350-966704567c24.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-f86a7769-8ef6-408d-bbe3-985d0ea0a3f7.json
+++ b/packages/netflow/kibana/visualization/netflow-f86a7769-8ef6-408d-bbe3-985d0ea0a3f7.json
@@ -5,9 +5,8 @@
             "searchSourceJSON": {
                 "filter": [],
                 "query": {
-                    "query_string": {
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/kibana/visualization/netflow-fd6c1144-5026-4795-b7af-a9aa3fc28c56.json
+++ b/packages/netflow/kibana/visualization/netflow-fd6c1144-5026-4795-b7af-a9aa3fc28c56.json
@@ -6,10 +6,8 @@
                 "filter": [],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
-                    "query_string": {
-                        "analyze_wildcard": true,
-                        "query": "*"
-                    }
+                    "query": "",
+                    "language": "kuery"
                 }
             }
         },

--- a/packages/netflow/manifest.yml
+++ b/packages/netflow/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: netflow
 title: NetFlow
-version: 0.3.4
+version: 0.3.5
 license: basic
 description: NetFlow Integration
 type: integration
@@ -20,4 +20,4 @@ policy_templates:
         title: Collect NetFlow logs
         description: Collecting NetFlow logs using the netflow input
 owner:
-  github: elastic/integrations-services
+  github: elastic/security-external-integrations


### PR DESCRIPTION

## What does this PR do?

The netflow package was missing a few configuraiton options that the Filebeat package had.
There were also some fields that were not documented and those affected the dashboards.
And some queries in the dashboard were defaulting to Lucene rather than KQL causing
nothing to load.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [x] I have verified that all datasets collect metrics or logs.

## How to test this PR locally

Install the netflow package. Then stream in some flow data with
```
cd github.com/elastic/beats/x-pack/filebeat/input/netflow/testdata/dat
cat *.dat | nc -4u -w1 localhost 2055
```

## Screenshots

![overview](https://user-images.githubusercontent.com/4565752/98058484-de22cf80-1e12-11eb-95f4-c7d78ee80e78.png)
![conversation-partners](https://user-images.githubusercontent.com/4565752/98058485-de22cf80-1e12-11eb-9cb4-b092b5ee383f.png)
![traffic-analysis](https://user-images.githubusercontent.com/4565752/98058487-debb6600-1e12-11eb-820a-baf2a7195dda.png)
![top-n](https://user-images.githubusercontent.com/4565752/98058488-debb6600-1e12-11eb-997d-67afc15bd51a.png)
![geo-location](https://user-images.githubusercontent.com/4565752/98058489-debb6600-1e12-11eb-9ff5-6c99bd8c00d8.png)
![as](https://user-images.githubusercontent.com/4565752/98058490-debb6600-1e12-11eb-842e-3e06edda3333.png)
![flow-exporters](https://user-images.githubusercontent.com/4565752/98058491-df53fc80-1e12-11eb-8e8b-abd7ee9562d3.png)
![flow-records](https://user-images.githubusercontent.com/4565752/98058492-df53fc80-1e12-11eb-9b8c-d92acd5af54f.png)
