### PR TITLE
ci: Update Package Storage only on master branch

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
      */
     stage('Update Package Storage') {
       when {
-        not { changeRequest() }
+        branch 'master'
       }
       steps {
         cleanup()


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->
it changes when to run the Update Package Storage stage, not it only runs on the master branch
