### PR TITLE
Fix Office 365 package configuration

### DIFF
--- a/packages/o365/_dev/build/docs/README.md
+++ b/packages/o365/_dev/build/docs/README.md
@@ -2,6 +2,21 @@
 
 This integration is for Microsoft Office 365. It currently supports user, admin, system, and policy actions and events from Office 365 and Azure AD activity logs exposed by the Office 365 Management Activity API.
 
+## Configuration
+
+To use this package you need to enable _Audit Log Search_ and register an application in Azure AD.
+
+Once this application is registered note the _Application (client) ID_ and the _Directory (tenant) ID._ Then configure the authentication in the _Certificates & Secrets_ section.
+
+For each entry in _Directory (tenant) IDs,_ add the hostname that this tenant identifies in _Directory (tenant) names._ For example:
+
+Directory IDs: `my-id-a` `my-id-b`
+Directory names: `a.onmicrosoft.com` `b.onmicrosoft.com`.
+
+To use client-secret authentication, add you secret to the _Client Secret (API key)_ field.
+
+To use certificate-based authentication, set the paths to the certificate and private key files. If the key file is protected with a passphrase, set this passphrase in the _Private key passphrase_ field. Paths must be absolute and files must exist in the host where _Elastic Agent_ is running.
+
 ## Compatibility
 
 The `ingest-geoip` and `ingest-user_agent` Elasticsearch plugins are required to run this module.

--- a/packages/o365/_dev/build/docs/README.md
+++ b/packages/o365/_dev/build/docs/README.md
@@ -8,14 +8,14 @@ To use this package you need to enable _Audit Log Search_ and register an applic
 
 Once this application is registered note the _Application (client) ID_ and the _Directory (tenant) ID._ Then configure the authentication in the _Certificates & Secrets_ section.
 
-For each entry in _Directory (tenant) IDs,_ add the hostname that this tenant identifies in _Directory (tenant) names._ For example:
-
-Directory IDs: `my-id-a` `my-id-b`
-Directory names: `a.onmicrosoft.com` `b.onmicrosoft.com`.
-
 To use client-secret authentication, add you secret to the _Client Secret (API key)_ field.
 
 To use certificate-based authentication, set the paths to the certificate and private key files. If the key file is protected with a passphrase, set this passphrase in the _Private key passphrase_ field. Paths must be absolute and files must exist in the host where _Elastic Agent_ is running.
+
+
+Add your tenant ID(s) to the _Directory (tenant) IDs_ field, then add the hostname that this tenant identifies to the _Directory (tenant) domains_ field. For example:
+- Directory IDs: `my-id-a` `my-id-b`
+- Directory domains: `a.onmicrosoft.com` `b.onmicrosoft.com`
 
 ## Compatibility
 

--- a/packages/o365/data_stream/audit/agent/stream/log.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/log.yml.hbs
@@ -23,6 +23,13 @@ processors:
   - script:
       when.has_fields: ['o365audit']
       lang: javascript
+      params:
+        debug: false
+        tenants:
+          {{#each tenants}}
+          - id: "{{.}}"
+            name: "{{lookup ../tenant_names @index}}"
+          {{/each}}
       id: o365audit_script
       source: |
         // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
@@ -884,13 +891,6 @@ processors:
         function process(evt) {
             return audit.process(evt);
         }
-      params:
-        debug: false
-        tenants:
-          {{#each tenants}}
-          - id: "{{id}}"
-            name: "{{name}}"
-          {{/each}}
   - add_fields:
       target: ''
       fields:

--- a/packages/o365/data_stream/audit/agent/stream/o365audit.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/o365audit.yml.hbs
@@ -1,20 +1,16 @@
 {{#if application_id}}application_id: {{application_id}}{{/if}}
 tenant_id:
-{{#each tenants}}
- - {{id}}
+{{#each tenants as |tenant i|}}
+ - "{{tenant}}"
 {{/each}}
 {{#if certificate}}certificate: {{certificate}}{{/if}}
 {{#if key}}key: {{key}}{{/if}}
 {{#if key_passphrase}}key_passphrase: {{key_passphrase}}{{/if}}
 {{#if client_secret}}client_secret: {{client_secret}}{{/if}}
-{{#if eq "string" (printf "%T" .content_type)}}
-content_type: {{content_type}}
-{{else}}
 content_type:
 {{#each content_type}}
- - {{this}}
+ - "{{this}}"
 {{/each}}
-{{/if}}
 {{#if api}}
 api: {{api}}
 {{/if}}
@@ -28,6 +24,13 @@ publisher_pipeline.disable_host: true
 processors:
   - script:
       when.has_fields: ['o365audit']
+      params:
+        debug: false
+        tenants:
+          {{#each tenants as |tenant i|}}
+          - id: "{{tenant}}"
+            name: "{{tenant}}"
+          {{/each}}
       lang: javascript
       id: o365audit_script
       source: |
@@ -890,13 +893,6 @@ processors:
         function process(evt) {
             return audit.process(evt);
         }
-      params:
-        debug: false
-        tenants:
-          {{#each tenants}}
-          - id: "{{id}}"
-            name: "{{name}}"
-          {{/each}}
   - add_fields:
       target: ''
       fields:

--- a/packages/o365/data_stream/audit/agent/stream/o365audit.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/o365audit.yml.hbs
@@ -1,7 +1,7 @@
 {{#if application_id}}application_id: {{application_id}}{{/if}}
 tenant_id:
-{{#each tenants as |tenant i|}}
- - "{{tenant}}"
+{{#each tenants}}
+ - "{{this}}"
 {{/each}}
 {{#if certificate}}certificate: {{certificate}}{{/if}}
 {{#if key}}key: {{key}}{{/if}}
@@ -27,9 +27,9 @@ processors:
       params:
         debug: false
         tenants:
-          {{#each tenants as |tenant i|}}
-          - id: "{{tenant}}"
-            name: "{{tenant}}"
+          {{#each tenants}}
+          - id: "{{.}}"
+            name: "{{lookup ../tenant_names @index}}"
           {{/each}}
       lang: javascript
       id: o365audit_script

--- a/packages/o365/data_stream/audit/manifest.yml
+++ b/packages/o365/data_stream/audit/manifest.yml
@@ -40,7 +40,13 @@ streams:
         type: text
         multi: true
         title: Directory (tenant) IDs
-        required: false
+        required: true
+        show_user: true
+      - name: tenant_names
+        type: text
+        multi: true
+        title: Directory (tenant) domains
+        required: true
         show_user: true
       - name: content_type
         type: text
@@ -83,9 +89,15 @@ streams:
         show_user: true
       - name: tenants
         type: text
-        title: Tenants
         multi: true
-        required: false
+        title: Directory (tenant) IDs
+        required: true
+        show_user: true
+      - name: tenant_names
+        type: text
+        multi: true
+        title: Directory (tenant) domains
+        required: true
         show_user: true
       - name: tags
         type: text

--- a/packages/o365/data_stream/audit/manifest.yml
+++ b/packages/o365/data_stream/audit/manifest.yml
@@ -3,28 +3,95 @@ title: Office 365 audit logs
 release: experimental
 streams:
   - input: o365audit
+    title: "Collect Office 365 audit logs"
+    description: "Collect audit logs from Office 365 via the Management Activity API"
     vars:
+      - name: application_id
+        type: text
+        title: Application (client) ID
+        multi: false
+        required: true
+        show_user: true
+      - name: client_secret
+        title: Client secret (API key)
+        type: password
+        multi: false
+        required: false
+        show_user: true
+      - name: certificate
+        type: text
+        title: Path to certificate file
+        multi: false
+        required: false
+        show_user: true
+      - name: key
+        type: text
+        title: Path to private key file
+        multi: false
+        required: false
+        show_user: true
+      - name: key_passphrase
+        type: text
+        title: Private key passphrase
+        multi: false
+        required: false
+        show_user: true
+      - name: tenants
+        type: text
+        multi: true
+        title: Directory (tenant) IDs
+        required: false
+        show_user: true
+      - name: content_type
+        type: text
+        title: Content types
+        multi: true
+        default:
+          - "Audit.AzureActiveDirectory"
+          - "Audit.Exchange"
+          - "Audit.SharePoint"
+          - "Audit.General"
+          - "DLP.All"
+        required: true
+        show_user: true
+      - name: api
+        type: text
+        title: Advanced API settings
+        multi: false
+        required: false
+        show_user: false
       - name: tags
         type: text
         title: Tags
         multi: true
         required: true
-        show_user: true
+        show_user: false
         default:
           - forwarded
     template_path: o365audit.yml.hbs
-    title: Office 365 audit logs
-    description: Collect Office 365 audit logs using Azure api input
   - input: logfile
+    title: "Collect Office 365 audit logs via log files"
+    description: "Collecting audit logs from Office 365 via log files"
+    enabled: false
+    template_path: log.yml.hbs
     vars:
+      - name: paths
+        type: text
+        title: Paths
+        multi: true
+        required: false
+        show_user: true
+      - name: tenants
+        type: text
+        title: Tenants
+        multi: true
+        required: false
+        show_user: true
       - name: tags
         type: text
         title: Tags
         multi: true
         required: true
-        show_user: true
+        show_user: false
         default:
           - forwarded
-    template_path: log.yml.hbs
-    title: Office 365 audit logs
-    description: Collect Office 365 audit logs using log input

--- a/packages/o365/docs/README.md
+++ b/packages/o365/docs/README.md
@@ -2,6 +2,21 @@
 
 This integration is for Microsoft Office 365. It currently supports user, admin, system, and policy actions and events from Office 365 and Azure AD activity logs exposed by the Office 365 Management Activity API.
 
+## Configuration
+
+To use this package you need to enable _Audit Log Search_ and register an application in Azure AD.
+
+Once this application is registered note the _Application (client) ID_ and the _Directory (tenant) ID._ Then configure the authentication in the _Certificates & Secrets_ section.
+
+To use client-secret authentication, add you secret to the _Client Secret (API key)_ field.
+
+To use certificate-based authentication, set the paths to the certificate and private key files. If the key file is protected with a passphrase, set this passphrase in the _Private key passphrase_ field. Paths must be absolute and files must exist in the host where _Elastic Agent_ is running.
+
+
+Add your tenant ID(s) to the _Directory (tenant) IDs_ field, then add the hostname that this tenant identifies to the _Directory (tenant) domains_ field. For example:
+- Directory IDs: `my-id-a` `my-id-b`
+- Directory domains: `a.onmicrosoft.com` `b.onmicrosoft.com`
+
 ## Compatibility
 
 The `ingest-geoip` and `ingest-user_agent` Elasticsearch plugins are required to run this module.

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Office 365
-version: 0.2.4
+version: 0.2.5
 release: experimental
 description: Office 365 Integration
 type: integration
@@ -26,75 +26,13 @@ screenshots:
 policy_templates:
   - name: o365
     title: Office 365 logs
-    description: Collect logs from Office 365 instances
+    description: Collect logs from Office 365
     inputs:
       - type: o365audit
-        vars:
-          - name: certificate
-            type: text
-            title: Certificate
-            multi: false
-            required: false
-            show_user: true
-          - name: key
-            type: text
-            title: Key
-            multi: false
-            required: false
-            show_user: true
-          - name: key_passphrase
-            type: text
-            title: Key Passphrase
-            multi: false
-            required: false
-            show_user: true
-          - name: application_id
-            type: text
-            title: Application Id
-            multi: false
-            required: false
-            show_user: true
-          - name: client_secret
-            type: text
-            title: Client Secret
-            multi: false
-            required: false
-            show_user: true
-          - name: tenants
-            type: text
-            title: Tenants
-            multi: true
-            required: false
-            show_user: true
-          - name: content_type
-            type: text
-            title: Content Type
-            multi: false
-            required: false
-            show_user: true
-          - name: api
-            type: text
-            title: Api
-            multi: false
-            required: false
-            show_user: true
-        title: "Collect Office 365 logs via the Azure API"
-        description: "Collecting logs from Office 365 via the Azure API"
+        title: "Collect Office 365 audit logs"
+        description: "Collect audit logs from Office 365 via the Management Activity API"
       - type: logfile
-        vars:
-          - name: paths
-            type: text
-            title: Paths
-            multi: true
-            required: false
-            show_user: true
-          - name: tenants
-            type: text
-            title: Tenants
-            multi: true
-            required: false
-            show_user: true
-        title: "Collect Office 365 logs via log files"
-        description: "Collecting logs from Office 365 via log files"
+        title: "Collect Office 365 audit logs via log files"
+        description: "Collecting audit logs from Office 365 via log files"
 owner:
   github: elastic/security-external-integrations


### PR DESCRIPTION
## What does this PR do?

This updates the `o365` package to `0.2.5`. Some configuration was broken, preventing it to work against o365 API.

- Re-writes and reorganizes the vars configurations.
- Split the tenant ID/name list in two separate vars (can't get YAML working).
- Fix broken agent stream.
- Made log (file) input disabled by default.
- Add docs explaining how to configure.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [x] I have verified that all datasets collect metrics or logs.

## Author's Checklist

- [ ] Review docs

## How to test this PR locally

Ask me for an o365 account for testing.
## Screenshots

<img width="1226" alt="Screen Shot 2020-11-16 at 15 33 50" src="https://user-images.githubusercontent.com/15056957/99265719-48c80800-2822-11eb-924f-592d0b238fc2.png">

<img width="818" alt="Screen Shot 2020-11-16 at 15 37 25" src="https://user-images.githubusercontent.com/15056957/99265738-5087ac80-2822-11eb-8afb-2af19127c576.png">

<img width="818" alt="Screen Shot 2020-11-16 at 15 37 48" src="https://user-images.githubusercontent.com/15056957/99265778-5da49b80-2822-11eb-849c-4284cded3212.png">
