### PR TITLE
Strip mage targets from Magefile

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -66,7 +66,7 @@ pipeline {
     stage('Test integrations') {
       steps {
         dir("${BASE_DIR}") {
-          sh(label: "Boot up Elastic stack", script: 'build/elastic-package stack up -d -v')
+          sh(label: "Boot up the Elastic stack", script: 'build/elastic-package stack up -d -v')
         }
         script {
           dir("${BASE_DIR}/packages") {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -68,7 +68,8 @@ pipeline {
         }
         script {
           dir("${BASE_DIR}/packages") {
-            // Include hack to skip temporary files with "@tmp" suffix:
+            // Include hack to skip temporary files with "@tmp" suffix.
+            // For reference: https://issues.jenkins.io/browse/JENKINS-52750
             findFiles()?.findAll{ !it.name.endsWith('@tmp') }?.collect{ it.name }?.sort()?.each {
               dir("${it}"){
                 sh(label: "Test integration: ${it}", script: '''

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -56,9 +56,7 @@ pipeline {
         }
         script {
           dir("${BASE_DIR}/packages") {
-            def packagePaths = findFiles()
-            echo "$packagePaths"
-            packagePaths.each {
+            findFiles().each {
               dir("${it}"){
                 sh(label: "Check integration: ${it}", script: '../../build/elastic-package check -v')
               }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -51,6 +51,7 @@ pipeline {
         script {
           dir("${BASE_DIR}/packages") {
             packages = findFiles()
+            packages.sort()
             packages.each {
               dir("${it.name}"){
                 sh(label: "Check integration: ${it.name}", script: '../../build/elastic-package check -v')
@@ -72,6 +73,7 @@ pipeline {
         script {
           dir("${BASE_DIR}/packages") {
             packages = findFiles()
+            packages.sort()
             packages = packages.findAll { !it.name.endsWith('@tmp') }
             packages.each {
               dir("${it.name}"){

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -90,6 +90,7 @@ pipeline {
             junit(allowEmptyResults: false,
                   keepLongStdio: true,
                   testResults: "build/test-results/*.xml")
+            sh(label: "Take down the Elastic stack", script: 'build/elastic-package stack down -v')
           }
         }
       }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -11,6 +11,7 @@ pipeline {
     PACKAGE_STORAGE_BASE_DIR = "src/github.com/elastic/package-storage"
     PIPELINE_LOG_LEVEL='INFO'
     TEST_RUNNER_CMD_ARGS='--report-format xUnit --report-output file'
+    HOME = "${env.WORKSPACE}"
   }
   options {
     timeout(time: 1, unit: 'HOURS')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
             sh(label: 'Install elastic-package', script: 'go build github.com/elastic/elastic-package')
           }
         }
-        stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+        stash allowEmpty: true, name: 'source', useDefaultExcludes: false, excludes: '.gvm'
       }
     }
     stage('Check Go sources') {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -50,8 +50,8 @@ pipeline {
     stage('Check integrations') {
       steps {
         withMageEnv(){
-          dir("${BASE_DIR}") {
-            sh(label: 'Install elastic-package', script: 'mkdir build && go build -o build/elastic-package github.com/elastic/elastic-package')
+          dir("${BASE_DIR}/build") {
+            sh(label: 'Install elastic-package', script: 'go build -o build/elastic-package github.com/elastic/elastic-package')
           }
         }
         script {
@@ -59,7 +59,7 @@ pipeline {
             def packagePaths = findFiles()
             echo "$packagePaths"
             packagePaths.each {
-              dir("${BASE_DIR}/packages/${it}"){
+              dir("${it}"){
                 sh(label: "Check integration: ${it}", script: '../../build/elastic-package check -v')
               }
             }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -36,7 +36,6 @@ pipeline {
     }
     stage('Check Go sources') {
       steps {
-        cleanup()
         withMageEnv(){
           dir("${BASE_DIR}"){
             sh(label: 'Checks and builds Go sources', script: 'mage -debug check')
@@ -50,10 +49,8 @@ pipeline {
     }
     stage('Check integrations') {
       steps {
-        withMageEnv(){
-          dir("${BASE_DIR}/build") {
-            sh(label: 'Install elastic-package', script: 'go build github.com/elastic/elastic-package')
-          }
+        dir("${BASE_DIR}/build") {
+          sh(label: 'Install elastic-package', script: 'go build github.com/elastic/elastic-package')
         }
         script {
           dir("${BASE_DIR}/packages") {
@@ -68,6 +65,7 @@ pipeline {
           sh(label: "git update-index", script: 'git update-index --refresh')
           sh(label: "git diff-index", script: 'git diff-index --exit-code HEAD --')
         }
+        stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }
     stage('Update Package Storage') {
@@ -75,7 +73,6 @@ pipeline {
         branch 'master'
       }
       steps {
-        cleanup()
         gitCheckout(basedir: "${PACKAGE_STORAGE_BASE_DIR}", branch: 'master', repo: 'git@github.com:elastic/package-storage.git', credentialsId: "${JOB_GIT_CREDENTIALS}")
         dir("${PACKAGE_STORAGE_BASE_DIR}"){
           sh(label: 'Configure Git user.name', script: 'git config user.name "Elastic Machine"')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -37,6 +37,7 @@ pipeline {
       steps {
         withMageEnv(){
           dir("${BASE_DIR}") {
+            sh(label: 'DEBUG', script: 'pwd && ls -la')
             sh(label: 'Install Go deps', script: 'mage')
             sh(label: 'Install elastic-package', script: 'mkdir build && go build -o build/elastic-package github.com/elastic/elastic-package')
           }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -64,7 +64,7 @@ pipeline {
     }
     stage('Find packages') {
       steps {
-        def packagePaths = findFiles(glob: 'packages/*')
+        packagePaths = findFiles(glob: 'packages/*')
       }
     }
     stage('Check') {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -66,7 +66,7 @@ pipeline {
     stage('Test integrations') {
       steps {
         dir("${BASE_DIR}") {
-          sh(label: "Boot up Elastic stack", script: '../../build/elastic-package stack up -d -v')
+          sh(label: "Boot up Elastic stack", script: 'build/elastic-package stack up -d -v')
         }
         script {
           dir("${BASE_DIR}/packages") {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -93,6 +93,9 @@ pipeline {
       }
     }
     stage('Update Package Storage') {
+      when {
+        branch 'master'
+      }
       steps {
         gitCheckout(basedir: "${PACKAGE_STORAGE_BASE_DIR}", branch: 'master', repo: 'git@github.com:elastic/package-storage.git', credentialsId: "${JOB_GIT_CREDENTIALS}")
         dir("${PACKAGE_STORAGE_BASE_DIR}"){

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
         script {
           dir("${BASE_DIR}/packages") {
             packages = findFiles()
-            packages = packages.sort(true, { it.name })
+            packages = packages.sort { it.name }
             packages.each {
               dir("${it.name}"){
                 sh(label: "Check integration: ${it.name}", script: '../../build/elastic-package check -v')
@@ -73,7 +73,7 @@ pipeline {
         script {
           dir("${BASE_DIR}/packages") {
             packages = findFiles()
-            packages = packages.sort(true, { it.name })
+            packages = packages.sort { it.name }
             packages = packages.findAll { it -> !it.name.endsWith('@tmp') }
             packages.each {
               dir("${it.name}"){

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
       steps {
         withMageEnv(){
           dir("${BASE_DIR}/build") {
-            sh(label: 'Install elastic-package', script: 'go build -o build/elastic-package github.com/elastic/elastic-package')
+            sh(label: 'Install elastic-package', script: 'go build -o elastic-package github.com/elastic/elastic-package')
           }
         }
         script {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -10,7 +10,6 @@ pipeline {
     JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
     PACKAGE_STORAGE_BASE_DIR = "src/github.com/elastic/package-storage"
     PIPELINE_LOG_LEVEL='INFO'
-    TEST_RUNNER_CMD_ARGS='--report-format xUnit --report-output file'
     HOME = "${env.WORKSPACE}"
   }
   options {
@@ -51,8 +50,6 @@ pipeline {
         script {
           dir("${BASE_DIR}/packages") {
             packages = findFiles()
-            pp = packages.sort()
-            echo "${pp[0]} ${pp[1]} ${pp[2]} ${pp[3]}"
             packages.each {
               dir("${it.name}"){
                 sh(label: "Check integration: ${it.name}", script: '../../build/elastic-package check -v')
@@ -74,14 +71,13 @@ pipeline {
         script {
           dir("${BASE_DIR}/packages") {
             packages = findFiles()
-            packages.sort()
             // Hack to skip temporary files with "@tmp" suffix:
             packages = packages.findAll { !it.name.endsWith('@tmp') }
             packages.each {
               dir("${it.name}"){
                 sh(label: "Test integration: ${it.name}", script: '''
                 eval "$(../../build/elastic-package stack shellinit)"
-                ../../build/elastic-package test -v
+                ../../build/elastic-package test -v --report-format xUnit --report-output file
                 ''')
               }
             }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -48,12 +48,11 @@ pipeline {
     stage('Check integrations') {
       steps {
         script {
-          withElasticPackage() {
-            dir("${BASE_DIR}/packages") {
-              findFiles().each {
-                dir("${it}"){
-                  sh(label: "Check integration: ${it}", script: '../../build/elastic-package check -v')
-                }
+          useElasticPackage()
+          dir("${BASE_DIR}/packages") {
+            findFiles().each {
+              dir("${it}"){
+                sh(label: "Check integration: ${it}", script: '../../build/elastic-package check -v')
               }
             }
           }
@@ -62,7 +61,20 @@ pipeline {
           sh(label: "git update-index", script: 'git update-index --refresh')
           sh(label: "git diff-index", script: 'git diff-index --exit-code HEAD --')
         }
-        stash allowEmpty: true, name: 'source', useDefaultExcludes: false, excludes: '**/.gvm'
+      }
+    }
+    stage('Test integrations') {
+      steps {
+        script {
+          useElasticPackage()
+          dir("${BASE_DIR}/packages") {
+            findFiles().each {
+              dir("${it}"){
+                sh(label: "Test integration: ${it}", script: '../../build/elastic-package test -v')
+              }
+            }
+          }
+        }
       }
     }
     stage('Update Package Storage') {
@@ -104,7 +116,7 @@ def cleanup(){
   unstash 'source'
 }
 
-def withElasticPackage() {
+def useElasticPackage() {
   withGoEnv() {
     dir("${BASE_DIR}/build") {
       sh(label: 'Install elastic-package', script: 'go build github.com/elastic/elastic-package')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -27,16 +27,11 @@ pipeline {
     issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
   }
   stages {
-    stage('Prepare workspace') {
+    stage('Checkout') {
       steps {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
-        withGoEnv() {
-          dir("${BASE_DIR}/build") {
-            sh(label: 'Install elastic-package', script: 'go build github.com/elastic/elastic-package')
-          }
-        }
-        stash allowEmpty: true, name: 'source', useDefaultExcludes: false, excludes: '.gvm'
+        stash allowEmpty: true, name: 'source', useDefaultExcludes: false, excludes: '**/.gvm'
       }
     }
     stage('Check Go sources') {
@@ -53,10 +48,12 @@ pipeline {
     stage('Check integrations') {
       steps {
         script {
-          dir("${BASE_DIR}/packages") {
-            findFiles().each {
-              dir("${it}"){
-                sh(label: "Check integration: ${it}", script: '../../build/elastic-package check -v')
+          withElasticPackage() {
+            dir("${BASE_DIR}/packages") {
+              findFiles().each {
+                dir("${it}"){
+                  sh(label: "Check integration: ${it}", script: '../../build/elastic-package check -v')
+                }
               }
             }
           }
@@ -65,7 +62,7 @@ pipeline {
           sh(label: "git update-index", script: 'git update-index --refresh')
           sh(label: "git diff-index", script: 'git diff-index --exit-code HEAD --')
         }
-        stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+        stash allowEmpty: true, name: 'source', useDefaultExcludes: false, excludes: '**/.gvm'
       }
     }
     stage('Update Package Storage') {
@@ -105,4 +102,11 @@ def cleanup(){
     deleteDir()
   }
   unstash 'source'
+}
+
+def withElasticPackage() {
+  withGoEnv() {
+    dir("${BASE_DIR}/build") {
+    sh(label: 'Install elastic-package', script: 'go build github.com/elastic/elastic-package')
+  }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -50,7 +50,8 @@ pipeline {
       steps {
         script {
           dir("${BASE_DIR}/packages") {
-            packages = findFiles().sort { it.path }
+            packages = findFiles()
+            packages.sort { it.path }
             packages.each {
               dir("${it}"){
                 sh(label: "Check integration: ${it}", script: '../../build/elastic-package check -v')
@@ -71,7 +72,8 @@ pipeline {
         }
         script {
           dir("${BASE_DIR}/packages") {
-            packages = findFiles().sort { it.path }
+            packages = findFiles()
+            packages.sort { it.path }
             packages.each {
               dir("${it}"){
                 sh(label: "Test integration: ${it}", script: '''

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -27,12 +27,12 @@ pipeline {
     issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
   }
   stages {
-    stage('Checkout') {
+    stage('Prepare workspace') {
       steps {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
+        stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         useElasticPackage()
-        stash allowEmpty: true, name: 'source', useDefaultExcludes: false, excludes: '**/.gvm'
       }
     }
     stage('Check Go sources') {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -93,9 +93,6 @@ pipeline {
       }
     }
     stage('Update Package Storage') {
-      when {
-        branch 'master'
-      }
       steps {
         gitCheckout(basedir: "${PACKAGE_STORAGE_BASE_DIR}", branch: 'master', repo: 'git@github.com:elastic/package-storage.git', credentialsId: "${JOB_GIT_CREDENTIALS}")
         dir("${PACKAGE_STORAGE_BASE_DIR}"){

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -65,13 +65,15 @@ pipeline {
     }
     stage('Test integrations') {
       steps {
-        sh(label: "Boot up Elastic stack", script: '../../build/elastic-package stack up -d -v')
+        dir("${BASE_DIR}") {
+          sh(label: "Boot up Elastic stack", script: '../../build/elastic-package stack up -d -v')
+        }
         script {
           dir("${BASE_DIR}/packages") {
             findFiles().each {
               dir("${it}"){
                 sh(label: "Test integration: ${it}", script: '''
-                eval "$(elastic-package stack shellinit)"
+                eval "$(../../build/elastic-package stack shellinit)"
                 ../../build/elastic-package test -v
                 ''')
               }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -48,10 +48,12 @@ pipeline {
     }
     stage('Check integrations') {
       steps {
-        dir("${BASE_DIR}/packages") {
-          findFiles().each {
-            dir("${it}"){
-              sh(label: "Check integration: ${it}", script: '../../build/elastic-package check -v')
+        script {
+          dir("${BASE_DIR}/packages") {
+            findFiles().each {
+              dir("${it}"){
+                sh(label: "Check integration: ${it}", script: '../../build/elastic-package check -v')
+              }
             }
           }
         }
@@ -63,11 +65,15 @@ pipeline {
     }
     stage('Test integrations') {
       steps {
+        sh(label: "Boot up Elastic stack", script: '../../build/elastic-package stack up -d -v')
         script {
           dir("${BASE_DIR}/packages") {
             findFiles().each {
               dir("${it}"){
-                sh(label: "Test integration: ${it}", script: '../../build/elastic-package test -v')
+                sh(label: "Test integration: ${it}", script: '''
+                eval "$(elastic-package stack shellinit)"
+                ../../build/elastic-package test -v
+                ''')
               }
             }
           }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -48,10 +48,9 @@ pipeline {
       steps {
         script {
           dir("${BASE_DIR}/packages") {
-            packages = findFiles().sort()
-            packages.each {
-              dir("${it.name}"){
-                sh(label: "Check integration: ${it.name}", script: '../../build/elastic-package check -v')
+            findFiles()?.collect{ it.name }?.sort()?.each {
+              dir("${it}"){
+                sh(label: "Check integration: ${it}", script: '../../build/elastic-package check -v')
               }
             }
           }
@@ -69,10 +68,8 @@ pipeline {
         }
         script {
           dir("${BASE_DIR}/packages") {
-            packages = findFiles()
-            // Hack to skip temporary files with "@tmp" suffix:
-            packages = packages.findAll { !it.name.endsWith('@tmp') }
-            packages.each {
+            // Include hack to skip temporary files with "@tmp" suffix:
+            findFiles()?.findAll{ !it.name.endsWith('@tmp') }?.collect{ it.name }?.sort()?.each {
               dir("${it.name}"){
                 sh(label: "Test integration: ${it.name}", script: '''
                 eval "$(../../build/elastic-package stack shellinit)"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -74,6 +74,7 @@ pipeline {
           dir("${BASE_DIR}/packages") {
             packages = findFiles()
             packages = packages.sort(true, { it.name })
+            packages = packages.findAll { it -> !it.name.endsWith('@tmp') }
             packages.each {
               dir("${it.name}"){
                 sh(label: "Test integration: ${it.name}", script: '''

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -48,12 +48,10 @@ pipeline {
     }
     stage('Check integrations') {
       steps {
-        script {
-          dir("${BASE_DIR}/packages") {
-            findFiles().each {
-              dir("${it}"){
-                sh(label: "Check integration: ${it}", script: '../../build/elastic-package check -v')
-              }
+        dir("${BASE_DIR}/packages") {
+          findFiles().each {
+            dir("${it}"){
+              sh(label: "Check integration: ${it}", script: '../../build/elastic-package check -v')
             }
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -51,7 +51,6 @@ pipeline {
         script {
           dir("${BASE_DIR}/packages") {
             packages = findFiles()
-            packages = packages.sort { it.name }
             packages.each {
               dir("${it.name}"){
                 sh(label: "Check integration: ${it.name}", script: '../../build/elastic-package check -v')
@@ -73,7 +72,6 @@ pipeline {
         script {
           dir("${BASE_DIR}/packages") {
             packages = findFiles()
-            packages = packages.sort { it.name }
             packages = packages.findAll { !it.name.endsWith('@tmp') }
             packages.each {
               dir("${it.name}"){

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -37,8 +37,8 @@ pipeline {
       steps {
         withMageEnv(){
           dir("${BASE_DIR}") {
-            sh(label: 'Create build directory', script: 'mkdir build')
-            sh(label: 'Install elastic-package', script: 'go build -o build/elastic-package github.com/elastic/elastic-package')
+            sh(label: 'Install Go deps', script: 'mage')
+            sh(label: 'Install elastic-package', script: 'mkdir build && go build -o build/elastic-package github.com/elastic/elastic-package')
           }
         }
       }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -81,6 +81,16 @@ pipeline {
           }
         }
       }
+      post {
+        always {
+          dir("${BASE_DIR}") {
+            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/test-results/*.xml')
+            junit(allowEmptyResults: false,
+                  keepLongStdio: true,
+                  testResults: "build/test-results/*.xml")
+          }
+        }
+      }
     }
     stage('Update Package Storage') {
       when {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -50,8 +50,7 @@ pipeline {
       steps {
         script {
           dir("${BASE_DIR}/packages") {
-            packages = findFiles()
-            packages.sort { it.path }
+            packages = findFiles().sort { it.path }
             packages.each {
               dir("${it}"){
                 sh(label: "Check integration: ${it}", script: '../../build/elastic-package check -v')
@@ -72,8 +71,7 @@ pipeline {
         }
         script {
           dir("${BASE_DIR}/packages") {
-            packages = findFiles()
-            packages.sort { it.path }
+            packages = findFiles().sort { it.path }
             packages.each {
               dir("${it}"){
                 sh(label: "Test integration: ${it}", script: '''

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -74,7 +74,7 @@ pipeline {
           dir("${BASE_DIR}/packages") {
             packages = findFiles()
             packages = packages.sort { it.name }
-            packages = packages.findAll { it -> !it.name.endsWith('@tmp') }
+            packages = packages.findAll { !it.name.endsWith('@tmp') }
             packages.each {
               dir("${it.name}"){
                 sh(label: "Test integration: ${it.name}", script: '''

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -64,7 +64,9 @@ pipeline {
     }
     stage('Find packages') {
       steps {
-        packagePaths = findFiles(glob: 'packages/*')
+        script {
+          packagePaths = findFiles(glob: 'packages/*')
+        }
       }
     }
     stage('Check') {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -107,6 +107,7 @@ def cleanup(){
 def withElasticPackage() {
   withGoEnv() {
     dir("${BASE_DIR}/build") {
-    sh(label: 'Install elastic-package', script: 'go build github.com/elastic/elastic-package')
+      sh(label: 'Install elastic-package', script: 'go build github.com/elastic/elastic-package')
+    )
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -47,14 +47,7 @@ pipeline {
         }
       }
     }
-    stage('Find packages') {
-      steps {
-        script {
-          packagePaths = findFiles(glob: 'packages/*')
-        }
-      }
-    }
-    stage('Check') {
+    stage('Check integrations') {
       steps {
         withMageEnv(){
           dir("${BASE_DIR}") {
@@ -62,6 +55,7 @@ pipeline {
           }
         }
         script {
+          packagePaths = findFiles(glob: 'packages/*')
           for(int i=0; i < packagePaths.size(); i++) {
             dir("${BASE_DIR}/${list[i]}"){
               sh(label: "Check integration: ${list[i]}", script: '../../build/elastic-package check -v')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
         script {
           dir("${BASE_DIR}/packages") {
             packages = findFiles()
-            packages.sort()
+            echo packages.sort()
             packages.each {
               dir("${it.name}"){
                 sh(label: "Check integration: ${it.name}", script: '../../build/elastic-package check -v')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -56,9 +56,10 @@ pipeline {
         }
         script {
           packagePaths = findFiles(glob: 'packages/*')
+          echo "$packagePaths"
           for(int i=0; i < packagePaths.size(); i++) {
-            dir("${BASE_DIR}/${list[i]}"){
-              sh(label: "Check integration: ${list[i]}", script: '../../build/elastic-package check -v')
+            dir("${BASE_DIR}/${packagePaths[i]}"){
+              sh(label: "Check integration: ${packagePaths[i]}", script: '../../build/elastic-package check -v')
             }
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -26,25 +26,28 @@ pipeline {
     issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
   }
   stages {
-    /**
-     Checkout the code and stash it, to use it on other stages.
-     */
     stage('Checkout') {
       steps {
         deleteDir()
-        gitCheckout(basedir: "${BASE_DIR}")
+        gitCheckout(basedir: '${BASE_DIR}')
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }
-    /**
-     Checks source code
-     */
-    stage('Check') {
+    stage('Prepare tools') {
+      steps {
+        withMageEnv(){
+          dir("${BASE_DIR}") {
+            sh(label: 'Install elastic-package', script: 'go get github.com/elastic/elastic-package')
+          }
+        }
+      }
+    }
+    stage('Check Go sources') {
       steps {
         cleanup()
         withMageEnv(){
           dir("${BASE_DIR}"){
-            sh(label: 'Checks and builds integration sources', script: 'mage -debug check')
+            sh(label: 'Checks and builds Go sources', script: 'mage -debug check')
           }
         }
       }
@@ -59,9 +62,30 @@ pipeline {
         }
       }
     }
-    /**
-     Update Package Storage
-     */
+    stage('Find packages') {
+      steps {
+        def packagePaths = findFiles(glob: 'packages/*')
+      }
+    }
+    stage('Check') {
+      steps {
+        script {
+          for(int i=0; i < packagePaths.size(); i++) {
+            dir("${BASE_DIR}/${list[i]}"){
+              sh(label: "Check integration: ${list[i]}", script: 'elastic-package check -v')
+            }
+          }
+        }
+      }
+    }
+    stage('Verify: no changes') {
+      steps {
+        dir("${BASE_DIR}") {
+          sh(label: "git update-index", script: 'git update-index --refresh')
+          sh(label: "git diff-index", script: 'git diff-index --exit-code HEAD --')
+        }
+      }
+    }
     stage('Update Package Storage') {
       when {
         branch 'master'

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
         script {
           dir("${BASE_DIR}/packages") {
             packages = findFiles()
-            packages.sort { it.name }
+            packages = packages.sort true, { it.name }
             packages.each {
               dir("${it.name}"){
                 sh(label: "Check integration: ${it.name}", script: '../../build/elastic-package check -v')
@@ -73,7 +73,7 @@ pipeline {
         script {
           dir("${BASE_DIR}/packages") {
             packages = findFiles()
-            packages.sort { it.name }
+            packages = packages.sort true, { it.name }
             packages.each {
               dir("${it.name}"){
                 sh(label: "Test integration: ${it.name}", script: '''

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -48,7 +48,7 @@ pipeline {
       steps {
         script {
           dir("${BASE_DIR}/packages") {
-            packages = findFiles()
+            packages = findFiles().sort()
             packages.each {
               dir("${it.name}"){
                 sh(label: "Check integration: ${it.name}", script: '../../build/elastic-package check -v')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -51,10 +51,10 @@ pipeline {
         script {
           dir("${BASE_DIR}/packages") {
             packages = findFiles()
-            packages.sort { it.path }
+            packages.sort { it.name }
             packages.each {
-              dir("${it}"){
-                sh(label: "Check integration: ${it}", script: '../../build/elastic-package check -v')
+              dir("${it.name}"){
+                sh(label: "Check integration: ${it.name}", script: '../../build/elastic-package check -v')
               }
             }
           }
@@ -73,10 +73,10 @@ pipeline {
         script {
           dir("${BASE_DIR}/packages") {
             packages = findFiles()
-            packages.sort { it.path }
+            packages.sort { it.name }
             packages.each {
-              dir("${it}"){
-                sh(label: "Test integration: ${it}", script: '''
+              dir("${it.name}"){
+                sh(label: "Test integration: ${it.name}", script: '''
                 eval "$(../../build/elastic-package stack shellinit)"
                 ../../build/elastic-package test -v
                 ''')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -51,7 +51,8 @@ pipeline {
         script {
           dir("${BASE_DIR}/packages") {
             packages = findFiles()
-            echo packages.sort()
+            pp = packages.sort()
+            echo "${pp[0]} ${pp[1]} ${pp[2]} ${pp[3]}"
             packages.each {
               dir("${it.name}"){
                 sh(label: "Check integration: ${it.name}", script: '../../build/elastic-package check -v')
@@ -74,6 +75,7 @@ pipeline {
           dir("${BASE_DIR}/packages") {
             packages = findFiles()
             packages.sort()
+            // Hack to skip temporary files with "@tmp" suffix:
             packages = packages.findAll { !it.name.endsWith('@tmp') }
             packages.each {
               dir("${it.name}"){

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -33,17 +33,6 @@ pipeline {
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }
-    stage('Prepare tools') {
-      steps {
-        withMageEnv(){
-          dir("${BASE_DIR}") {
-            sh(label: 'DEBUG', script: 'pwd && ls -la')
-            sh(label: 'Install Go deps', script: 'mage')
-            sh(label: 'Install elastic-package', script: 'mkdir build && go build -o build/elastic-package github.com/elastic/elastic-package')
-          }
-        }
-      }
-    }
     stage('Check Go sources') {
       steps {
         cleanup()
@@ -52,15 +41,9 @@ pipeline {
             sh(label: 'Checks and builds Go sources', script: 'mage -debug check')
           }
         }
-      }
-      post {
-        always {
-          dir("${BASE_DIR}") {
-          archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/test-results/*.xml')
-          junit(allowEmptyResults: false,
-                keepLongStdio: true,
-                testResults: "build/test-results/*.xml")
-          }
+        dir("${BASE_DIR}") {
+          sh(label: "git update-index", script: 'git update-index --refresh')
+          sh(label: "git diff-index", script: 'git diff-index --exit-code HEAD --')
         }
       }
     }
@@ -73,6 +56,11 @@ pipeline {
     }
     stage('Check') {
       steps {
+        withMageEnv(){
+          dir("${BASE_DIR}") {
+            sh(label: 'Install elastic-package', script: 'mkdir build && go build -o build/elastic-package github.com/elastic/elastic-package')
+          }
+        }
         script {
           for(int i=0; i < packagePaths.size(); i++) {
             dir("${BASE_DIR}/${list[i]}"){
@@ -80,10 +68,6 @@ pipeline {
             }
           }
         }
-      }
-    }
-    stage('Verify: no changes') {
-      steps {
         dir("${BASE_DIR}") {
           sh(label: "git update-index", script: 'git update-index --refresh')
           sh(label: "git diff-index", script: 'git diff-index --exit-code HEAD --')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -70,8 +70,8 @@ pipeline {
           dir("${BASE_DIR}/packages") {
             // Include hack to skip temporary files with "@tmp" suffix:
             findFiles()?.findAll{ !it.name.endsWith('@tmp') }?.collect{ it.name }?.sort()?.each {
-              dir("${it.name}"){
-                sh(label: "Test integration: ${it.name}", script: '''
+              dir("${it}"){
+                sh(label: "Test integration: ${it}", script: '''
                 eval "$(../../build/elastic-package stack shellinit)"
                 ../../build/elastic-package test -v --report-format xUnit --report-output file
                 ''')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -50,7 +50,9 @@ pipeline {
       steps {
         script {
           dir("${BASE_DIR}/packages") {
-            findFiles().each {
+            packages = findFiles()
+            packages.sort { it.path }
+            packages.each {
               dir("${it}"){
                 sh(label: "Check integration: ${it}", script: '../../build/elastic-package check -v')
               }
@@ -70,7 +72,9 @@ pipeline {
         }
         script {
           dir("${BASE_DIR}/packages") {
-            findFiles().each {
+            packages = findFiles()
+            packages.sort { it.path }
+            packages.each {
               dir("${it}"){
                 sh(label: "Test integration: ${it}", script: '''
                 eval "$(../../build/elastic-package stack shellinit)"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -38,8 +38,7 @@ pipeline {
         withMageEnv(){
           dir("${BASE_DIR}"){
             sh(label: 'Checks and builds Go sources', script: 'mage -debug check')
-            sh(label: "git update-index", script: 'git update-index --refresh')
-            sh(label: "git diff-index", script: 'git diff-index --exit-code HEAD --')
+            checkGitDiff()
           }
         }
       }
@@ -55,10 +54,7 @@ pipeline {
             }
           }
         }
-        dir("${BASE_DIR}") {
-          sh(label: "git update-index", script: 'git update-index --refresh')
-          sh(label: "git diff-index", script: 'git diff-index --exit-code HEAD --')
-        }
+        checkGitDiff()
       }
     }
     stage('Test integrations') {
@@ -137,5 +133,14 @@ def useElasticPackage() {
     dir("${BASE_DIR}/build") {
       sh(label: 'Install elastic-package', script: 'go build github.com/elastic/elastic-package')
     }
+  }
+}
+
+// Check if there are non-versioned local changes.
+// For reference: https://stackoverflow.com/questions/34807971/why-does-git-diff-index-head-result-change-for-touched-files-after-git-diff-or-g
+def checkGitDiff() {
+  dir("${BASE_DIR}") {
+    sh(label: "git update-index", script: 'git update-index --refresh')
+    sh(label: "git diff-index", script: 'git diff-index --exit-code HEAD --')
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
       steps {
         withMageEnv(){
           dir("${BASE_DIR}/build") {
-            sh(label: 'Install elastic-package', script: 'go build -o elastic-package github.com/elastic/elastic-package')
+            sh(label: 'Install elastic-package', script: 'go build github.com/elastic/elastic-package')
           }
         }
         script {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -27,10 +27,15 @@ pipeline {
     issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
   }
   stages {
-    stage('Checkout') {
+    stage('Prepare workspace') {
       steps {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
+        withGoEnv() {
+          dir("${BASE_DIR}/build") {
+            sh(label: 'Install elastic-package', script: 'go build github.com/elastic/elastic-package')
+          }
+        }
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }
@@ -39,19 +44,14 @@ pipeline {
         withMageEnv(){
           dir("${BASE_DIR}"){
             sh(label: 'Checks and builds Go sources', script: 'mage -debug check')
+            sh(label: "git update-index", script: 'git update-index --refresh')
+            sh(label: "git diff-index", script: 'git diff-index --exit-code HEAD --')
           }
-        }
-        dir("${BASE_DIR}") {
-          sh(label: "git update-index", script: 'git update-index --refresh')
-          sh(label: "git diff-index", script: 'git diff-index --exit-code HEAD --')
         }
       }
     }
     stage('Check integrations') {
       steps {
-        dir("${BASE_DIR}/build") {
-          sh(label: 'Install elastic-package', script: 'go build github.com/elastic/elastic-package')
-        }
         script {
           dir("${BASE_DIR}/packages") {
             findFiles().each {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -31,6 +31,7 @@ pipeline {
       steps {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
+        useElasticPackage()
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false, excludes: '**/.gvm'
       }
     }
@@ -48,7 +49,6 @@ pipeline {
     stage('Check integrations') {
       steps {
         script {
-          useElasticPackage()
           dir("${BASE_DIR}/packages") {
             findFiles().each {
               dir("${it}"){
@@ -66,7 +66,6 @@ pipeline {
     stage('Test integrations') {
       steps {
         script {
-          useElasticPackage()
           dir("${BASE_DIR}/packages") {
             findFiles().each {
               dir("${it}"){

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
         script {
           dir("${BASE_DIR}/packages") {
             packages = findFiles()
-            packages = packages.sort true, { it.name }
+            packages = packages.sort(true, { it.name })
             packages.each {
               dir("${it.name}"){
                 sh(label: "Check integration: ${it.name}", script: '../../build/elastic-package check -v')
@@ -73,7 +73,7 @@ pipeline {
         script {
           dir("${BASE_DIR}/packages") {
             packages = findFiles()
-            packages = packages.sort true, { it.name }
+            packages = packages.sort(true, { it.name })
             packages.each {
               dir("${it.name}"){
                 sh(label: "Test integration: ${it.name}", script: '''

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
     stage('Checkout') {
       steps {
         deleteDir()
-        gitCheckout(basedir: '${BASE_DIR}')
+        gitCheckout(basedir: "${BASE_DIR}")
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -9,7 +9,6 @@ pipeline {
     GITHUB_TOKEN_CREDENTIALS = "2a9602aa-ab9f-4e52-baf3-b71ca88469c7"
     JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
     PACKAGE_STORAGE_BASE_DIR = "src/github.com/elastic/package-storage"
-    PIPELINE_LOG_LEVEL='INFO'
     HOME = "${env.WORKSPACE}"
   }
   options {
@@ -50,8 +49,6 @@ pipeline {
         script {
           dir("${BASE_DIR}/packages") {
             packages = findFiles()
-            pp = list.sort( false ) { it.name }
-            echo "${pp[0]} ${pp[1]} ${pp[2]}"
             packages.each {
               dir("${it.name}"){
                 sh(label: "Check integration: ${it.name}", script: '../../build/elastic-package check -v')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -55,11 +55,13 @@ pipeline {
           }
         }
         script {
-          packagePaths = findFiles(glob: 'packages/*')
-          echo "$packagePaths"
-          for(int i=0; i < packagePaths.size(); i++) {
-            dir("${BASE_DIR}/${packagePaths[i]}"){
-              sh(label: "Check integration: ${packagePaths[i]}", script: '../../build/elastic-package check -v')
+          dir("${BASE_DIR}/packages") {
+            def packagePaths = findFiles()
+            echo "$packagePaths"
+            packagePaths.each {
+              dir("${BASE_DIR}/packages/${it}"){
+                sh(label: "Check integration: ${it}", script: '../../build/elastic-package check -v')
+              }
             }
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -50,6 +50,8 @@ pipeline {
         script {
           dir("${BASE_DIR}/packages") {
             packages = findFiles()
+            pp = list.sort( false ) { it.name }
+            echo "${pp[0]} ${pp[1]} ${pp[2]}"
             packages.each {
               dir("${it.name}"){
                 sh(label: "Check integration: ${it.name}", script: '../../build/elastic-package check -v')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -37,7 +37,8 @@ pipeline {
       steps {
         withMageEnv(){
           dir("${BASE_DIR}") {
-            sh(label: 'Install elastic-package', script: 'go get github.com/elastic/elastic-package')
+            sh(label: 'Create build directory', script: 'mkdir build')
+            sh(label: 'Install elastic-package', script: 'go build -o build/elastic-package github.com/elastic/elastic-package')
           }
         }
       }
@@ -74,7 +75,7 @@ pipeline {
         script {
           for(int i=0; i < packagePaths.size(); i++) {
             dir("${BASE_DIR}/${list[i]}"){
-              sh(label: "Check integration: ${list[i]}", script: 'elastic-package check -v')
+              sh(label: "Check integration: ${list[i]}", script: '../../build/elastic-package check -v')
             }
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -108,6 +108,6 @@ def withElasticPackage() {
   withGoEnv() {
     dir("${BASE_DIR}/build") {
       sh(label: 'Install elastic-package', script: 'go build github.com/elastic/elastic-package')
-    )
+    }
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /build
 
 dev/packages
+
+elastic-package

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -268,9 +268,10 @@ _The `elastic-package stack` provides an enrolled instance of the Elastic Agent.
 if you can run the service (you're integrating with) in the Docker network. The service Docker image can be used for [system
 testing](https://github.com/elastic/elastic-package/blob/master/docs/howto/system_testing.md).
 
-1. Build `packages` directory with package data:
+1. Build the package you'd like to verify (e.g. `apache`):
    ```bash
-   $ mage build
+   $ cd apache
+   $ elastic-package build
    ```
 
 2. Start testing environment:
@@ -282,7 +283,7 @@ testing](https://github.com/elastic/elastic-package/blob/master/docs/howto/syste
    ```
 
    The command above will boot up the Elastic stack (Elasticsearch, Kibana, Package Registry) using Docker containers.
-   It rebuilds the Package Registry Docker image using local packages and boots up the Package Registry.
+   It rebuilds the Package Registry Docker image using packages built in step 1. and boots up the Package Registry.
 
    To reload the already deployed Package Registry use the following command:
 
@@ -411,6 +412,28 @@ on the business or technical requirements for the entire platform (Elastic Packa
    Explanation: it's much faster to rebuild and restart the container with the Package Registry, than work with
    mounted volumes.
 
+#### Testing
+
+The `elastic-package` provides different types of test runners. Review [howto](https://github.com/elastic/elastic-package/tree/master/docs/howto) guides
+to find the best option for testing packages.
+
+The `test` subcommand requires a reference to the live Elastic stack. Service endpoints can be defined via environment variables.
+If you're using the Elastic stack created with `elastic-package`, you can use export endpoints with `elastic-package stack shellinit`:
+
+```bash
+$ eval "$(elastic-package stack shellinit)"
+```
+
+To preview environment variables:
+
+```bash
+$ elastic-package stack shellinit
+export ELASTIC_PACKAGE_ELASTICSEARCH_HOST=http://127.0.0.1:9200
+export ELASTIC_PACKAGE_ELASTICSEARCH_USERNAME=elastic
+export ELASTIC_PACKAGE_ELASTICSEARCH_PASSWORD=changeme
+export ELASTIC_PACKAGE_KIBANA_HOST=http://127.0.0.1:5601
+```
+
 #### Code reviewers
 
 1. Ping "Team:Integrations".
@@ -449,10 +472,19 @@ on the business or technical requirements for the entire platform (Elastic Packa
 
 #### CI
 
-1. Run `mage check` locally.
+1. Run `elastic-package check` and `elastic-package test` locally.
 
-   Before pushing commits to the repository, verify if the change complete with `mage check`. This command target is
-   used by the CI while validating your code changes.
+   If you want to verify if your integration works as intended, you can execute the same steps as CI:
+
+   ```bash
+   $ cd packages/apache
+   $ elastic-package check -v
+   $ elastic-package test -v
+   ```
+
+   Keep in mind that the `elastic-package test` command requires a live cluster running and exported environment variables.
+   The environment variables can be set with `eval "$(elastic-package stack shellinit)"`.
+
 
 #### Fields
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -361,6 +361,20 @@ The section offers a set of tips for developers to improve integrations that the
 recommendations and tricks. Please consider this section as a live document that may evolve in the future, depending
 on the business or technical requirements for the entire platform (Elastic Package Registry, Elastic Agent and Kibana).
 
+### elastic-package
+
+The [elastic-package](https://github.com/elastic/elastic-package) is a command line tool, written in Go, used for developing Elastic packages. It can help you lint,
+format, test, build, and promote your packages. This is the official builder tool to develop Integrations. See the
+[Getting started](https://github.com/elastic/elastic-package#getting-started) section to ramp up quickly and review its features.
+
+If you need the revision of elastic-package in the correct version (the same one as the CI uses), which is defined in `go.mod`, use the following command
+(in the Integrations repository):
+
+```bash
+$ go build github.com/elastic/elastic-package
+$ ./elastic-package help
+```
+
 ### New integrations
 
 #### Manifest files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -429,7 +429,7 @@ $ ./elastic-package help
 #### Testing
 
 `elastic-package` provides different types of test runners. Review [howto](https://github.com/elastic/elastic-package/tree/master/docs/howto) guides
-to find the best option for testing packages.
+to learn about the various methods for testing packages.
 
 The `test` subcommand requires a reference to the live Elastic stack. Service endpoints can be defined via environment variables.
 If you're using the Elastic stack created with `elastic-package`, you can use export endpoints with `elastic-package stack shellinit`:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -428,7 +428,7 @@ $ ./elastic-package help
 
 #### Testing
 
-The `elastic-package` provides different types of test runners. Review [howto](https://github.com/elastic/elastic-package/tree/master/docs/howto) guides
+`elastic-package` provides different types of test runners. Review [howto](https://github.com/elastic/elastic-package/tree/master/docs/howto) guides
 to find the best option for testing packages.
 
 The `test` subcommand requires a reference to the live Elastic stack. Service endpoints can be defined via environment variables.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -363,7 +363,7 @@ on the business or technical requirements for the entire platform (Elastic Packa
 
 ### elastic-package
 
-The [elastic-package](https://github.com/elastic/elastic-package) is a command line tool, written in Go, used for developing Elastic packages. It can help you lint,
+[elastic-package](https://github.com/elastic/elastic-package) is a command line tool, written in Go, used for developing Elastic packages. It can help you lint,
 format, test, build, and promote your packages. This is the official builder tool to develop Integrations. See the
 [Getting started](https://github.com/elastic/elastic-package#getting-started) section to ramp up quickly and review its features.
 

--- a/dev/update-package-storage/README.md
+++ b/dev/update-package-storage/README.md
@@ -16,7 +16,7 @@ the `update-package-storage` should work without any additional changes._
 
 ## Principle of operation
 
-Once a developer runs `mage UpdatePackageStorage`, the script iterates over all integrations in the repository and
+Once a developer runs `mage UpdatePackageStorage`, the script iterates over all built integrations (`build/integrations`) in the repository and
 checks if the current version has been released (exists in the `package-storage`). If not, it creates a branch for it
 in the `package-storage` and copies the content of the unreleased integration. Once changes are pushed to the repository,
 it opens a PR with updates to the single integration against the `package-storage`.
@@ -25,6 +25,6 @@ Sample PR (fake change, only version bumped up): https://github.com/elastic/inte
 
 ## Release updated integrations
 
-1. Commit changes in integrations and put them in the `master` branch.
-2. Bump up the version of the integration (see `manifest.yml` file of the AWS integration: https://github.com/elastic/integrations/blob/master/packages/aws/manifest.yml#L4)
-3. Run the script: `mage UpdatePackageStorage`
+1. Bump up the version of the integration (see `manifest.yml` file of the AWS integration: https://github.com/elastic/integrations/blob/master/packages/aws/manifest.yml#L4)
+2. Commit changes in integrations and put them in the `master` branch.
+3. The CI builds all integrations and executes the mage goal: `mage UpdatePackageStorage`

--- a/magefile.go
+++ b/magefile.go
@@ -7,10 +7,8 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
@@ -22,63 +20,18 @@ var (
 	// grouped after third-party packages.
 	GoImportsLocalPrefix = "github.com/elastic"
 
-	buildDir        = "./build"
-	integrationsDir = "./packages"
+	buildDir = "./build"
 )
 
 func Check() error {
-	mg.Deps(Format)
-	mg.Deps(Lint)
-	mg.Deps(Build)
-	mg.Deps(ModTidy)
-	mg.Deps(Test)
-
-	// Check if no changes are shown
-	err := sh.RunV("git", "update-index", "--refresh")
-	if err != nil {
-		return err
-	}
-	return sh.RunV("git", "diff-index", "--exit-code", "HEAD", "--")
-}
-
-// Lint lint checks every package.
-func Lint() error {
-	return runElasticPackageOnAllIntegrations(true, "lint")
-}
-
-// Format adds license headers, formats .go files with goimports, and formats
-// .py files with autopep8.
-func Format() {
-	// Don't run AddLicenseHeaders and GoImports concurrently because they
-	// both can modify the same files.
-	mg.Deps(addLicenseHeaders)
-	mg.Deps(goImports)
-	mg.Deps(formatIntegrations)
-}
-
-func Build() error {
-	err := buildIntegrations()
-	if err != nil {
-		return err
-	}
-
-	err = buildImportBeats()
-	if err != nil {
-		return err
-	}
+	mg.Deps(build)
+	mg.Deps(format)
+	mg.Deps(modTidy)
 	return nil
 }
 
-func buildIntegrations() error {
-	return runElasticPackageOnAllIntegrations(true, "build")
-}
-
-func buildImportBeats() error {
-	err := sh.Run("go", "build", "-o", "/dev/null", "./dev/import-beats")
-	if err != nil {
-		return errors.Wrap(err, "building import-beats failed")
-	}
-	return nil
+func Clean() error {
+	return os.RemoveAll(buildDir)
 }
 
 func ImportBeats() error {
@@ -94,11 +47,6 @@ func ImportBeats() error {
 }
 
 func UpdatePackageStorage() error {
-	err := Build()
-	if err != nil {
-		return err
-	}
-
 	args := []string{"run", "./dev/update-package-storage/"}
 	if os.Getenv("SKIP_PULL_REQUEST") == "true" {
 		args = append(args, "-skipPullRequest")
@@ -110,16 +58,39 @@ func UpdatePackageStorage() error {
 	return sh.Run("go", args...)
 }
 
-// Format method formats integrations.
-func formatIntegrations() error {
-	return runElasticPackageOnAllIntegrations(true, "format")
+func build() error {
+	mg.Deps(buildImportBeats, buildUpdatePackageStorage)
+	return nil
 }
 
-// GoImports executes goimports against all .go files in and below the CWD. It
-// ignores vendor/ directories.
+func buildImportBeats() error {
+	err := sh.Run("go", "build", "-o", "/dev/null", "./dev/import-beats")
+	if err != nil {
+		return errors.Wrap(err, "building import-beats failed")
+	}
+	return nil
+}
+
+func buildUpdatePackageStorage() error {
+	err := sh.Run("go", "build", "-o", "/dev/null", "./dev/update-package-storage")
+	if err != nil {
+		return errors.Wrap(err, "building update-package-storage failed")
+	}
+	return nil
+}
+
+func format() {
+	mg.Deps(addLicenseHeaders)
+	mg.Deps(goImports)
+}
+
+func addLicenseHeaders() error {
+	return sh.RunV("go-licenser", "-license", "Elastic")
+}
+
 func goImports() error {
 	goFiles, err := findFilesRecursive(func(path string, _ os.FileInfo) bool {
-		return filepath.Ext(path) == ".go" && !strings.Contains(path, "vendor/")
+		return filepath.Ext(path) == ".go"
 	})
 	if err != nil {
 		return err
@@ -128,25 +99,13 @@ func goImports() error {
 		return nil
 	}
 
-	fmt.Println(">> fmt - goimports: Formatting Go code")
 	args := append(
 		[]string{"-local", GoImportsLocalPrefix, "-l", "-w"},
 		goFiles...,
 	)
-
 	return sh.RunV("goimports", args...)
 }
 
-// AddLicenseHeaders adds license headers to .go files. It applies the
-// appropriate license header based on the value of mage.BeatLicense.
-func addLicenseHeaders() error {
-	fmt.Println(">> fmt - go-licenser: Adding missing headers")
-	return sh.RunV("go-licenser", "-license", "Elastic")
-}
-
-// findFilesRecursive recursively traverses from the CWD and invokes the given
-// match function on each regular file to determine if the given path should be
-// returned as a match.
 func findFilesRecursive(match func(path string, info os.FileInfo) bool) ([]string, error) {
 	var matches []string
 	err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
@@ -167,188 +126,6 @@ func findFilesRecursive(match func(path string, info os.FileInfo) bool) ([]strin
 	return matches, err
 }
 
-func Clean() error {
-	return os.RemoveAll(buildDir)
-}
-
-func ModTidy() error {
-	fmt.Println(">> mod - updating vendor directory")
-
-	err := sh.RunV("go", "mod", "tidy")
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func Test() {
-	mg.Deps(bootUpStack)
-	defer tearDownStack()
-
-	var failed bool
-	err := testPipeline()
-	if err != nil {
-		failed = true
-	}
-
-	err = testSystem()
-	if err != nil {
-		failed = true
-	}
-
-	if failed {
-		panic("testing failed")
-	}
-}
-
-func testPipeline() error {
-	cmdArgs := []string{"test", "pipeline"}
-	cmdArgs = append(cmdArgs, strings.Split(os.Getenv("TEST_RUNNER_CMD_ARGS"), " ")...)
-	return runElasticPackageOnAllIntegrations(false, cmdArgs...)
-}
-
-func testSystem() error {
-	cmdArgs := []string{"test", "system"}
-	cmdArgs = append(cmdArgs, strings.Split(os.Getenv("TEST_RUNNER_CMD_ARGS"), " ")...)
-	return runElasticPackageOnAllIntegrations(false, cmdArgs...)
-}
-
-func bootUpStack() error {
-	err := runElasticPackage("stack", "up", "-d")
-	if err != nil {
-		return err
-	}
-	return loadStackEnvs()
-}
-
-func loadStackEnvs() error {
-	mg.Deps(buildElasticPackageBinary)
-
-	workDir, err := os.Getwd()
-	if err != nil {
-		return errors.Wrap(err, "getwd failed")
-	}
-
-	exports, err := sh.Output(filepath.Join(workDir, "build", "elastic-package"), "stack", "shellinit")
-	if err != nil {
-		return errors.Wrap(err, "shellinit failed")
-	}
-
-	exports = strings.ReplaceAll(exports, "export ", "")
-	exportPerLine := strings.Split(exports, "\n")
-	for _, record := range exportPerLine {
-		keyValue := strings.Split(record, "=")
-		if len(keyValue) != 2 {
-			return fmt.Errorf("invalid export line: %s", record)
-		}
-
-		err = os.Setenv(keyValue[0], keyValue[1])
-		if err != nil {
-			return errors.Wrap(err, "can't set env variable")
-		}
-	}
-	return nil
-}
-
-func tearDownStack() error {
-	return runElasticPackage("stack", "down")
-}
-
-// runElasticPackageOnAllIntegrations runs the `elastic-package <subCommand>` tool on all
-// packages with the given subCommand.
-func runElasticPackageOnAllIntegrations(failFast bool, subCommandWithArgs ...string) error {
-	packagePaths, err := findIntegrations()
-	if err != nil {
-		return err
-	}
-
-	workDir, err := os.Getwd()
-	if err != nil {
-		return errors.Wrap(err, "getwd failed")
-	}
-
-	var failed bool
-	for _, packagePath := range packagePaths {
-		fmt.Printf("%s:\n", packagePath)
-		err = runElasticPackageInWorkDir(filepath.Join(workDir, packagePath), subCommandWithArgs...)
-		if err != nil && failFast {
-			return err
-		}
-		if err != nil {
-			failed = true
-		}
-	}
-	if failed {
-		return fmt.Errorf("command failed: elastic-package %s", strings.TrimSpace(strings.Join(subCommandWithArgs, " ")))
-	}
-	return nil
-}
-
-func runElasticPackage(subCommandWithArgs ...string) error {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		return errors.Wrap(err, "getwd failed")
-	}
-	return runElasticPackageInWorkDir(currentDir, subCommandWithArgs...)
-}
-
-func runElasticPackageInWorkDir(workDir string, subCommandWithArgs ...string) error {
-	mg.Deps(buildElasticPackageBinary)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		return errors.Wrap(err, "getwd failed")
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(workDir)
-	if err != nil {
-		return errors.Wrapf(err, "chdir failed (path: %s)", workDir)
-	}
-
-	fmt.Printf("elastic-package %s\n", strings.Join(subCommandWithArgs, " "))
-	err = sh.RunV(filepath.Join(currentDir, "build", "elastic-package"), subCommandWithArgs...)
-	if err != nil {
-		return errors.Wrapf(err, "running elastic-package failed")
-	}
-	return nil
-}
-
-func buildElasticPackageBinary() error {
-	err := sh.Run("go", "build", "-o", "./build/elastic-package", "github.com/elastic/elastic-package")
-	if err != nil {
-		return errors.Wrapf(err, "building elastic-package failed")
-	}
-	return nil
-}
-
-func findIntegrations() ([]string, error) {
-	var matches []string
-
-	err := filepath.Walk(integrationsDir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-
-		f, err := os.Stat(path)
-		if err != nil {
-			return err
-		}
-
-		if !f.IsDir() {
-			return nil // skip as the path is not a directory
-		}
-
-		manifestPath := filepath.Join(path, "manifest.yml")
-		_, err = os.Stat(manifestPath)
-		if os.IsNotExist(err) {
-			return nil
-		}
-		matches = append(matches, path)
-		return filepath.SkipDir
-	})
-	if err != nil {
-		return nil, err
-	}
-	return matches, nil
+func modTidy() error {
+	return sh.RunV("go", "mod", "tidy")
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR strips mage targets from the Magefile. Since that moment packages can be built using the `elastic-package` tool.

## Still TODOs

- [x] Take down the Elastic down after tests
- [x] Collect test results
- [x] Test `UpdatePackageStorage`
- [x] Doc update `CONTRIBUTING.md`
- [x] Doc update `UpdatePackageStorage` (README.md)

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Resolves https://github.com/elastic/integrations/issues/407

