### PR TITLE
Add system test for CrowdStrike Falcon

### DIFF
--- a/packages/crowdstrike/_dev/deploy/docker/Dockerfile
+++ b/packages/crowdstrike/_dev/deploy/docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine
+
+COPY ./falcon-audit-events.log /sample_logs/
+COPY ./falcon-events.log /sample_logs/
+COPY ./falcon-sample.log /sample_logs/
+
+ENTRYPOINT [ "/bin/sh" ]

--- a/packages/crowdstrike/_dev/deploy/docker/docker-compose.yml
+++ b/packages/crowdstrike/_dev/deploy/docker/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '2.3'
+services:
+  crowdstrike:
+    tty: true
+    build: .
+    volumes:
+      - ${SERVICE_LOGS_DIR}:/logs
+    command: -c "cp /sample_logs/*.log /logs/"

--- a/packages/crowdstrike/_dev/deploy/docker/falcon-audit-events.log
+++ b/packages/crowdstrike/_dev/deploy/docker/falcon-audit-events.log
@@ -1,0 +1,277 @@
+{
+    "metadata": {
+        "customerIDString": "8f69fe9e-b995-4204-95ad-44f9bcf75b6b",
+        "offset": 1045,
+        "eventType": "RemoteResponseSessionStartEvent",
+        "eventCreationTime": 1582830734000,
+        "version": "1.0"
+    },
+    "event": {
+        "SessionId": "6020260b-0398-4d41-999d-5531b55522de",
+        "HostnameField": "hostnameofmachine",
+        "UserName": "first.last@company.com",
+        "StartTimestamp": 1582830734
+    }
+}
+{
+    "metadata": {
+        "customerIDString": "8f69fe9e-b995-4204-95ad-44f9bcf75b6b",
+        "offset": 1046,
+        "eventType": "RemoteResponseSessionEndEvent",
+        "eventCreationTime": 1582830772000,
+        "version": "1.0"
+    },
+    "event": {
+        "SessionId": "6020260b-0398-4d41-999d-5531b55522de",
+        "HostnameField": "hostnameofmachine",
+        "UserName": "first.last@company.com",
+        "EndTimestamp": 1582830772
+    }
+}
+{
+    "metadata": {
+        "customerIDString": "8f69fe9e-b995-4204-95ad-44f9bcf75b6b",
+        "offset": 0,
+        "eventType": "AuthActivityAuditEvent",
+        "eventCreationTime": 1581542950710,
+        "version": "1.0"
+    },
+    "event": {
+        "UserId": "api-client-id:1234567890abcdefghijklmnopqrstuvwxyz",
+        "UserIp": "10.10.0.8",
+        "OperationName": "streamStarted",
+        "ServiceName": "Crowdstrike Streaming API",
+        "Success": true,
+        "UTCTimestamp": 1581542950,
+        "AuditKeyValues": [
+            {
+                "Key": "APIClientID",
+                "ValueString": "1234567890abcdefghijklmnopqr"
+            },
+            {
+                "Key": "partition",
+                "ValueString": "0"
+            },
+            {
+                "Key": "offset",
+                "ValueString": "-1"
+            },
+            {
+                "Key": "appId",
+                "ValueString": "siem-connector-v2.0.0"
+            },
+            {
+                "Key": "eventType",
+                "ValueString": "[UserActivityAuditEvent HashSpreadingEvent RemoteResponseSessionStartEvent RemoteResponseSessionEndEvent DetectionSummaryEvent AuthActivityAuditEvent]"
+            }
+        ]
+    }
+}
+{
+    "metadata": {
+        "customerIDString": "8f69fe9e-b995-4204-95ad-44f9bcf75b6b",
+        "offset": 1,
+        "eventType": "AuthActivityAuditEvent",
+        "eventCreationTime": 1581543577147,
+        "version": "1.0"
+    },
+    "event": {
+        "UserId": "alice@company.com",
+        "UserIp": "192.168.6.8",
+        "OperationName": "twoFactorAuthenticate",
+        "ServiceName": "CrowdStrike Authentication",
+        "Success": true,
+        "UTCTimestamp": 1581543577147
+    }
+}
+{
+    "metadata": {
+        "customerIDString": "8f69fe9e-b995-4204-95ad-44f9bcf75b6b",
+        "offset": 2,
+        "eventType": "AuthActivityAuditEvent",
+        "eventCreationTime": 1581545677554,
+        "version": "1.0"
+    },
+    "event": {
+        "UserId": "bob@company.com",
+        "UserIp": "192.168.6.3",
+        "OperationName": "twoFactorAuthenticate",
+        "ServiceName": "CrowdStrike Authentication",
+        "Success": true,
+        "UTCTimestamp": 1581545677554
+    }
+}
+{
+    "metadata": {
+        "customerIDString": "8f69fe9e-b995-4204-95ad-44f9bcf75b6b",
+        "offset": 3,
+        "eventType": "UserActivityAuditEvent",
+        "eventCreationTime": 1581546248000,
+        "version": "1.0"
+    },
+    "event": {
+        "UserId": "chris@company.com",
+        "UserIp": "192.168.6.13",
+        "OperationName": "update_group",
+        "ServiceName": "groups",
+        "AuditKeyValues": [
+            {
+                "Key": "group_id",
+                "ValueString": "3c80ce30b9654cb4bd15beec6a517e65"
+            },
+            {
+                "Key": "action_name",
+                "ValueString": "add_group_member"
+            }
+        ],
+        "UTCTimestamp": 1581546248
+    }
+}
+{
+    "metadata": {
+        "customerIDString": "8f69fe9e-b995-4204-95ad-44f9bcf75b6b",
+        "offset": 4,
+        "eventType": "AuthActivityAuditEvent",
+        "eventCreationTime": 1581601312140,
+        "version": "1.0"
+    },
+    "event": {
+        "UserId": "alice@company.com",
+        "UserIp": "192.168.6.8",
+        "OperationName": "requestResetPassword",
+        "ServiceName": "CrowdStrike Authentication",
+        "Success": true,
+        "UTCTimestamp": 1581601312140,
+        "AuditKeyValues": [
+            {
+                "Key": "target_name",
+                "ValueString": "alice@company.com"
+            }
+        ]
+    }
+}
+{
+    "metadata": {
+        "customerIDString": "8f69fe9e-b995-4204-95ad-44f9bcf75b6b",
+        "offset": 5,
+        "eventType": "AuthActivityAuditEvent",
+        "eventCreationTime": 1581601341730,
+        "version": "1.0"
+    },
+    "event": {
+        "UserId": "alice@company.com",
+        "UserIp": "192.168.6.8",
+        "OperationName": "twoFactorAuthenticate",
+        "ServiceName": "CrowdStrike Authentication",
+        "Success": true,
+        "UTCTimestamp": 1581601341730
+    }
+}
+{
+    "metadata": {
+        "customerIDString": "8f69fe9e-b995-4204-95ad-44f9bcf75b6b",
+        "offset": 6,
+        "eventType": "AuthActivityAuditEvent",
+        "eventCreationTime": 1581601520236,
+        "version": "1.0"
+    },
+    "event": {
+        "UserId": "alice@company.com",
+        "UserIp": "192.168.6.8",
+        "OperationName": "changePassword",
+        "ServiceName": "CrowdStrike Authentication",
+        "Success": true,
+        "UTCTimestamp": 1581601520236,
+        "AuditKeyValues": [
+            {
+                "Key": "target_name",
+                "ValueString": "first.last@company.com"
+            }
+        ]
+    }
+}
+{
+    "metadata": {
+        "customerIDString": "8f69fe9e-b995-4204-95ad-44f9bcf75b6b",
+        "offset": 7,
+        "eventType": "AuthActivityAuditEvent",
+        "eventCreationTime": 1581601572362,
+        "version": "1.0"
+    },
+    "event": {
+        "UserId": "alice@company.com",
+        "UserIp": "192.168.6.8",
+        "OperationName": "userAuthenticate",
+        "ServiceName": "CrowdStrike Authentication",
+        "Success": true,
+        "UTCTimestamp": 1581601572362
+    }
+}
+{
+    "metadata": {
+        "customerIDString": "8f69fe9e-b995-4204-95ad-44f9bcf75b6b",
+        "offset": 8,
+        "eventType": "AuthActivityAuditEvent",
+        "eventCreationTime": 1581601814754,
+        "version": "1.0"
+    },
+    "event": {
+        "UserId": "alice@company.com",
+        "UserIp": "192.168.6.8",
+        "OperationName": "twoFactorAuthenticate",
+        "ServiceName": "CrowdStrike Authentication",
+        "Success": true,
+        "UTCTimestamp": 1581601814754
+    }
+}
+{
+    "metadata": {
+        "customerIDString": "8f69fe9e-b995-4204-95ad-44f9bcf75b6b",
+        "offset": 9,
+        "eventType": "AuthActivityAuditEvent",
+        "eventCreationTime": 1581601820289,
+        "version": "1.0"
+    },
+    "event": {
+        "UserId": "alice@company.com",
+        "UserIp": "192.168.6.8",
+        "OperationName": "selfAcceptEula",
+        "ServiceName": "CrowdStrike Authentication",
+        "Success": true,
+        "UTCTimestamp": 1581601820289
+    }
+}
+{
+    "metadata": {
+        "customerIDString": "8f69fe9e-b995-4204-95ad-44f9bcf75b6b",
+        "offset": 10,
+        "eventType": "UserActivityAuditEvent",
+        "eventCreationTime": 1581603262000,
+        "version": "1.0"
+    },
+    "event": {
+        "UserId": "alice@company.com",
+        "UserIp": "192.168.6.8",
+        "OperationName": "detection_update",
+        "ServiceName": "detections",
+        "AuditKeyValues": [
+            {
+                "Key": "detection_id",
+                "ValueString": "ldt:5a6fd0b7347440cd74cb84855a8aee18:17180539745"
+            },
+            {
+                "Key": "new_state",
+                "ValueString": "in_progress"
+            },
+            {
+                "Key": "assigned_to",
+                "ValueString": "First Last"
+            },
+            {
+                "Key": "assigned_to_uid",
+                "ValueString": "first.last@company.com"
+            }
+        ],
+        "UTCTimestamp": 1581603262
+    }
+}

--- a/packages/crowdstrike/_dev/deploy/docker/falcon-events.log
+++ b/packages/crowdstrike/_dev/deploy/docker/falcon-events.log
@@ -1,0 +1,94 @@
+{
+    "metadata": {
+        "customerIDString": "8f69fe9e-b995-4204-95ad-44f9bcf75b6b",
+        "offset": 294564,
+        "eventType": "DetectionSummaryEvent",
+        "eventCreationTime": 1582101000000,
+        "version": "1.0"
+    },
+    "event": {
+        "ProcessStartTime": 1536846339,
+        "ProcessEndTime": 0,
+        "ProcessId": 38684386611,
+        "ParentProcessId": 38682494050,
+        "ComputerName": "alice-laptop",
+        "UserName": "alice",
+        "DetectName": "Process Terminated",
+        "DetectDescription": "Terminated a process related to the deletion of backups, which is often indicative of ransomware activity.",
+        "Severity": 4,
+        "SeverityName": "High",
+        "FileName": "explorer.exe",
+        "FilePath": "\\Device\\HarddiskVolume1\\Windows",
+        "CommandLine": "C:\\Windows\\Explorer.EXE",
+        "SHA256String": "6a671b92a69755de6fd063fcbe4ba926d83b49f78c42dbaeed8cdb6bbc57576a",
+        "MD5String": "ac4c51eb24aa95b77f705ab159189e24",
+        "MachineDomain": "CORP-DOMAIN",
+        "FalconHostLink": "https://falcon.crowdstrike.com/ec86abd353824e96765ecbe18eb4f0b4",
+        "SensorId": "7c808b4c8878433287eea53d4a8c3268",
+        "DetectId": "ldt:ec86abd353824e96765ecbe18eb4f0b4:38655257584",
+        "LocalIP": "192.168.12.51",
+        "MACAddress": "00-00-00-11-22-33",
+        "Tactic": "Malware",
+        "Technique": "Ransomware",
+        "Objective": "Falcon Detection Method",
+        "PatternDispositionDescription": "Prevention, process killed.",
+        "PatternDispositionValue": 16,
+        "PatternDispositionFlags": {
+            "Indicator": false,
+            "Detect": false,
+            "InddetMask": false,
+            "SensorOnly": false,
+            "Rooting": false,
+            "KillProcess": true,
+            "KillSubProcess": false,
+            "QuarantineMachine": false,
+            "QuarantineFile": false,
+            "PolicyDisabled": false,
+            "KillParent": false,
+            "OperationBlocked": false,
+            "ProcessBlocked": false
+        }
+    }
+}
+{
+    "metadata": {
+        "customerIDString": "8f69fe9e-b995-4204-95ad-44f9bcf75b6b",
+        "offset": 1824,
+        "eventType": "IncidentSummaryEvent",
+        "eventCreationTime": 1583295476766,
+        "version": "1.0"
+    },
+    "event": {
+        "IncidentStartTime": 1583295228,
+        "IncidentEndTime": 1583295470,
+        "FalconHostLink": "https://falcon.crowdstrike.com/crowdscore/incidents/details/inc:8f69fe9e-b995-4204-95ad-44f9bcf75b6b",
+        "State": "open",
+        "FineScore": 1.2
+    }
+}
+{
+    "metadata": {
+        "customerIDString": "8f69fe9e-b995-4204-95ad-44f9bcf75b6b",
+        "offset": 22865,
+        "eventType": "UserActivityAuditEvent",
+        "eventCreationTime": 1593186952000,
+        "version": "1.0"
+    },
+    "event": {
+        "UserId": "Crowdstrike",
+        "UserIp": "",
+        "OperationName": "quarantined_file_update",
+        "ServiceName": "quarantined_files",
+        "AuditKeyValues": [
+            {
+                "Key": "quarantined_file_id",
+                "ValueString": "35b35a53da374816a6b471cf09e12019_a076d3121743755f2d4f8d4d5807f0bc013177f7847d09b48e76de88ace08c78"
+            },
+            {
+                "Key": "action_taken",
+                "ValueString": "quarantined"
+            }
+        ],
+        "UTCTimestamp": 1593186952
+    }
+}

--- a/packages/crowdstrike/_dev/deploy/docker/falcon-sample.log
+++ b/packages/crowdstrike/_dev/deploy/docker/falcon-sample.log
@@ -1,0 +1,254 @@
+{
+    "metadata": {
+        "customerIDString": "12345a1bc2d34fghi56jk7890lmno12p",
+        "offset": 70689,
+        "eventType": "FirewallMatchEvent",
+        "eventCreationTime": 1595248906000,
+        "version": "1.0"
+    },
+    "event": {
+        "DeviceId": "718af202ab2c4ba5b6a5d10d39c0e0a5",
+        "CustomerId": "12345a1bc2d34fghi56jk7890lmno12p",
+        "Ipv": "ipv4",
+        "CommandLine": "",
+        "ConnectionDirection": "1",
+        "EventType": "FirewallRuleIP4Matched",
+        "Flags": {
+            "Audit": false,
+            "Log": false,
+            "Monitor": true
+        },
+        "HostName": "TESTDEVICE01",
+        "ICMPCode": "",
+        "ICMPType": "",
+        "ImageFileName": "",
+        "LocalAddress": "10.37.60.194",
+        "LocalPort": "445",
+        "MatchCount": 1,
+        "MatchCountSinceLastReport": 1,
+        "NetworkProfile": "2",
+        "PID": "206158879910",
+        "PolicyName": "PROD-FW-Workstations-General",
+        "PolicyID": "74e7f1552a3a4d90a6d65578642c8584",
+        "Protocol": "6",
+        "RemoteAddress": "10.37.60.21",
+        "RemotePort": "54952",
+        "RuleAction": "2",
+        "RuleDescription": "",
+        "RuleFamilyID": "fec73e96a1bf4481be582c3f89b234fa",
+        "RuleGroupName": "SMB Rules",
+        "RuleName": "Inbound SMB Block \u0026 Log Private",
+        "RuleId": "4877172638743447345",
+        "Status": "",
+        "Timestamp": "2020-07-20T12:41:44Z",
+        "TreeID": ""
+    }
+}
+{
+    "metadata": {
+        "customerIDString": "12345a1bc2d34fghi56jk7890lmno12p",
+        "offset": 57181,
+        "eventType": "IncidentSummaryEvent",
+        "eventCreationTime": 1595005328414,
+        "version": "1.0"
+    },
+    "event": {
+        "IncidentStartTime": 1595005316,
+        "IncidentEndTime": 1595005316,
+        "FalconHostLink": "https://falcon.crowdstrike.com/crowdscore/incidents/details/inc:1234567893cd4e55b3a832ba2140478e:72e291e40c1544d390eabf135d875e54",
+        "State": "open",
+        "FineScore": 0.1,
+        "LateralMovement": 0
+    }
+}
+{
+    "metadata": {
+        "customerIDString": "12345a1bc2d34fghi56jk7890lmno12p",
+        "offset": 70509,
+        "eventType": "AuthActivityAuditEvent",
+        "eventCreationTime": 1595247970093,
+        "version": "1.0"
+    },
+    "event": {
+        "UserId": "first.last@company.com",
+        "UserIp": "165.225.220.184",
+        "OperationName": "saml2Assert",
+        "ServiceName": "Crowdstrike Authentication",
+        "Success": true,
+        "UTCTimestamp": 1595247970,
+        "AuditKeyValues": [
+            {
+                "Key": "trace_id",
+                "ValueString": "b0b33836-555c-4e0e-a5ef-d368f6799f6b"
+            },
+            {
+                "Key": "actor_user",
+                "ValueString": "first.last@company.com"
+            },
+            {
+                "Key": "actor_user_uuid",
+                "ValueString": "123ab141-fab1-41c9-85c5-43a1ef90d2c2"
+            },
+            {
+                "Key": "actor_cid",
+                "ValueString": "774694c2ef8c43fdb64ec3056ddfb96d"
+            },
+            {
+                "Key": "target_user",
+                "ValueString": "first.last@company.com"
+            }
+        ]
+    }
+}
+{
+    "metadata": {
+        "customerIDString": "12345a1bc2d34fghi56jk7890lmno12p",
+        "offset": 70683,
+        "eventType": "UserActivityAuditEvent",
+        "eventCreationTime": 1595248885000,
+        "version": "1.0"
+    },
+    "event": {
+        "UserId": "Crowdstrike",
+        "UserIp": "",
+        "OperationName": "quarantined_file_update",
+        "ServiceName": "quarantined_files",
+        "AuditKeyValues": [
+            {
+                "Key": "quarantined_file_id",
+                "ValueString": "ab1cde05567b455b93afbe2d3df352c9_328024a065630f897f09963d4b67b0c95d4054f540c2ca8014d5b012718bfa21"
+            },
+            {
+                "Key": "action_taken",
+                "ValueString": "quarantined"
+            }
+        ],
+        "UTCTimestamp": 1595248885
+    }
+}
+{
+    "metadata": {
+        "customerIDString": "12345a1bc2d34fghi56jk7890lmno12p",
+        "offset": 57217,
+        "eventType": "RemoteResponseSessionStartEvent",
+        "eventCreationTime": 1595006093000,
+        "version": "1.0"
+    },
+    "event": {
+        "SessionId": "330633db-1cda-4355-b0d8-2c2edc91fe3e",
+        "HostnameField": "TESTDEVICE01",
+        "UserName": "first.last@company.com",
+        "StartTimestamp": 1595006093
+    }
+}
+{
+    "metadata": {
+        "customerIDString": "12345a1bc2d34fghi56jk7890lmno12p",
+        "offset": 57269,
+        "eventType": "RemoteResponseSessionEndEvent",
+        "eventCreationTime": 1595006899000,
+        "version": "1.0"
+    },
+    "event": {
+        "SessionId": "330633db-1cda-4355-b0d8-2c2edc91fe3e",
+        "HostnameField": "TESTDEVICE01",
+        "UserName": "first.last@company.com",
+        "EndTimestamp": 1595006899,
+        "Commands": [
+            "cd \\Program Files (x86)\\Symantec",
+            "ls .",
+            "cd \\Program Files (x86)",
+            "ls .",
+            "reg query HKEY_LOCAL_MACHINE\\SYSTEM\\CrowdStrike\\{9b03c1d9-3138-44ed-9fae-d9f4c034b88d}\\{16e0423f-7058-48c9-a204-725362b67639}\\Default",
+            "reg set HKEY_LOCAL_MACHINE\\SYSTEM\\CrowdStrike\\{9b03c1d9-3138-44ed-9fae-d9f4c034b88d}\\{16e0423f-7058-48c9-a204-725362b67639}\\Default GroupingTags -ValueType=```REG_SZ``` -Value=```Protect```",
+            "reg query HKEY_LOCAL_MACHINE\\SYSTEM\\CrowdStrike\\{9b03c1d9-3138-44ed-9fae-d9f4c034b88d}\\{16e0423f-7058-48c9-a204-725362b67639}\\Default",
+            "restart",
+            "restart -Confirm"
+        ]
+    }
+}
+{
+    "metadata": {
+        "customerIDString": "12345a1bc2d34fghi56jk7890lmno12p",
+        "offset": 57047,
+        "eventType": "DetectionSummaryEvent",
+        "eventCreationTime": 1595002291000,
+        "version": "1.0"
+    },
+    "event": {
+        "ProcessStartTime": 1595002290,
+        "ProcessEndTime": 1595002290,
+        "ProcessId": 663790158277,
+        "ParentProcessId": 627311656469,
+        "ComputerName": "TESTDEVICE01",
+        "UserName": "First.last",
+        "DetectName": "NGAV",
+        "DetectDescription": "This file meets the machine learning-based on-sensor AV protection's low confidence threshold for malicious files.",
+        "Severity": 2,
+        "SeverityName": "Low",
+        "FileName": "filename.exe",
+        "FilePath": "\\Device\\HarddiskVolume2\\ProgramData\\file\\path",
+        "CommandLine": "\"C:\\ProgramData\\file\\path\\filename.exe\" ",
+        "SHA256String": "0a123b185f9a32fde1df59897089014c92e3d08a0533b54baa72ba2a93d64deb",
+        "MD5String": "0ab1235adca04aef6239f5496ef0a5df",
+        "SHA1String": "0000000000000000000000000000000000000000",
+        "MachineDomain": "NA",
+        "ExecutablesWritten": [
+            {
+                "Timestamp": 1595002290,
+                "FileName": "NEURO_200_J1939Configuration.mexw64",
+                "FilePath": "\\Device\\HarddiskVolume2\\ProgramData\\file\\path\\is\\right\\here\\folder"
+            },
+            {
+                "Timestamp": 1595002290,
+                "FileName": "NEURO_200_J1939Configuration.mexw64",
+                "FilePath": "\\Device\\HarddiskVolume2\\ProgramData\\file\\path\\is\\right\\here\\folder"
+            },
+            {
+                "Timestamp": 1595002290,
+                "FileName": "NEURO_200_J1939CanPackMessage.mexw64",
+                "FilePath": "\\Device\\HarddiskVolume2\\ProgramData\\file\\path\\is\\right\\here\\folder"
+            },
+            {
+                "Timestamp": 1595002290,
+                "FileName": "NEURO_200_J1939CanPackMessage.mexw64",
+                "FilePath": "\\Device\\HarddiskVolume2\\ProgramData\\file\\path\\is\\right\\here\\folder"
+            }
+        ],
+        "FalconHostLink": "https://falcon.crowdstrike.com/activity/detections/detail/1abcd2345b8c4151a0cb45dcfbe6d3d0/124559902719?_cid=12345a1bc2d34fghi56jk7890lmno12p",
+        "SensorId": "1abcd2345b8c4151a0cb45dcfbe6d3d0",
+        "IOCType": "hash_sha256",
+        "IOCValue": "0a123b185f9a32fde1df59897089014c92e3d08a0533b54baa72ba2a93d64deb",
+        "DetectId": "ldt:1abcd2345b8c4151a0cb45dcfbe6d3d0:124559902719",
+        "LocalIP": "10.1.190.117",
+        "MACAddress": "54-ad-d4-d2-a8-0b",
+        "Tactic": "Machine Learning",
+        "Technique": "Sensor-based ML",
+        "Objective": "Falcon Detection Method",
+        "PatternDispositionDescription": "Detection, process would have been blocked if related prevention policy setting was enabled.",
+        "PatternDispositionValue": 2304,
+        "PatternDispositionFlags": {
+            "Indicator": false,
+            "Detect": false,
+            "InddetMask": false,
+            "SensorOnly": false,
+            "Rooting": false,
+            "KillProcess": false,
+            "KillSubProcess": false,
+            "QuarantineMachine": false,
+            "QuarantineFile": false,
+            "PolicyDisabled": true,
+            "KillParent": false,
+            "OperationBlocked": false,
+            "ProcessBlocked": true,
+            "RegistryOperationBlocked": false,
+            "CriticalProcessDisabled": false,
+            "BootupSafeguardEnabled": false,
+            "FsOperationBlocked": false
+        },
+        "ParentImageFileName": "\\Device\\HarddiskVolume2\\Windows\\explorer.exe",
+        "ParentCommandLine": "C:\\Windows\\Explorer.EXE",
+        "GrandparentImageFileName": "\\Device\\HarddiskVolume2\\Windows\\System32\\userinit.exe",
+        "GrandparentCommandLine": "C:\\Windows\\system32\\userinit.exe"
+    }
+}

--- a/packages/crowdstrike/data_stream/falcon/_dev/test/system/config.yml
+++ b/packages/crowdstrike/data_stream/falcon/_dev/test/system/config.yml
@@ -1,0 +1,6 @@
+input: logfile
+vars: ~
+data_stream:
+  vars:
+    paths:
+      - "{{SERVICE_LOGS_DIR}}/*.log"

--- a/packages/crowdstrike/data_stream/falcon/agent/stream/log.yml.hbs
+++ b/packages/crowdstrike/data_stream/falcon/agent/stream/log.yml.hbs
@@ -35,6 +35,10 @@ processors:
 
             function convertToMSEpoch(evt, field) {
                 var timestamp = evt.Get(field);
+                if (timestamp == 0) {
+                    evt.Delete(field)
+                    return
+                }
                 if (timestamp) {
                     if (timestamp < 100000000000) { // check if we have a seconds timestamp, this is roughly 1973 in MS
                         evt.Put(field, timestamp * 1000);
@@ -126,7 +130,8 @@ processors:
                                 type: "ip"
                             }, {
                                 from: "crowdstrike.event.ProcessId",
-                                to: "process.pid"
+                                to: "process.pid",
+                                type: "long"
                             }, {
                                 from: "crowdstrike.event.ParentImageFileName",
                                 to: "process.parent.executable"
@@ -307,6 +312,7 @@ processors:
                             }, {
                                 from: "crowdstrike.event.PID",
                                 to: "process.pid",
+                                type: "long",
                             },
                             {
                                 from: "crowdstrike.event.RuleId",
@@ -443,6 +449,44 @@ processors:
                     mode: "copy",
                     ignore_missing: false,
                     fail_on_error: true
+                })
+                .Convert({
+                    fields: [
+                        {
+                            from: "crowdstrike.event.LateralMovement",
+                            type: "long",
+                        },
+                        {
+                            from: "crowdstrike.event.LocalPort",
+                            type: "long",
+                        },
+                        {
+                            from: "crowdstrike.event.MatchCount",
+                            type: "long",
+                        },
+                        {
+                            from: "crowdstrike.event.MatchCountSinceLastReport",
+                            type: "long",
+                        },
+                        {
+                            from: "crowdstrike.event.PID",
+                            type: "long",
+                        },
+                        {
+                            from: "crowdstrike.event.RemotePort",
+                            type: "long",
+                        },
+                        {
+                            from: "source.port",
+                            type: "long",
+                        },
+                        {
+                            from: "destination.port",
+                            type: "long",
+                        }
+                    ],
+                    ignore_missing: true,
+                    fail_on_error: false
                 })
                 .Build()
                 .Run

--- a/packages/crowdstrike/data_stream/falcon/fields/fields.yml
+++ b/packages/crowdstrike/data_stream/falcon/fields/fields.yml
@@ -135,9 +135,36 @@
       description: |
         Unique ID associated with action taken.
     - name: PatternDispositionFlags
-      type: object
+      type: group
       description: |
         Flags indicating actions taken.
+      fields:
+        - name: Detect
+          type: boolean
+        - name: InddetMask
+          type: boolean
+        - name: Indicator
+          type: boolean
+        - name: KillParent
+          type: boolean
+        - name: KillProcess
+          type: boolean
+        - name: KillSubProcess
+          type: boolean
+        - name: OperationBlocked
+          type: boolean
+        - name: PolicyDisabled
+          type: boolean
+        - name: ProcessBlocked
+          type: boolean
+        - name: QuarantineFile
+          type: boolean
+        - name: QuarantineMachine
+          type: boolean
+        - name: Rooting
+          type: boolean
+        - name: SensorOnly
+          type: boolean
     - name: State
       type: keyword
       description: |

--- a/packages/crowdstrike/docs/README.md
+++ b/packages/crowdstrike/docs/README.md
@@ -85,7 +85,19 @@ Contains endpoint data and CrowdStrike Falcon platform audit data forwarded from
 | crowdstrike.event.ParentImageFileName | Path to the parent process. | keyword |
 | crowdstrike.event.ParentProcessId | Parent process ID related to the detection. | integer |
 | crowdstrike.event.PatternDispositionDescription | Action taken by Falcon. | keyword |
-| crowdstrike.event.PatternDispositionFlags | Flags indicating actions taken. | object |
+| crowdstrike.event.PatternDispositionFlags.Detect |  | boolean |
+| crowdstrike.event.PatternDispositionFlags.InddetMask |  | boolean |
+| crowdstrike.event.PatternDispositionFlags.Indicator |  | boolean |
+| crowdstrike.event.PatternDispositionFlags.KillParent |  | boolean |
+| crowdstrike.event.PatternDispositionFlags.KillProcess |  | boolean |
+| crowdstrike.event.PatternDispositionFlags.KillSubProcess |  | boolean |
+| crowdstrike.event.PatternDispositionFlags.OperationBlocked |  | boolean |
+| crowdstrike.event.PatternDispositionFlags.PolicyDisabled |  | boolean |
+| crowdstrike.event.PatternDispositionFlags.ProcessBlocked |  | boolean |
+| crowdstrike.event.PatternDispositionFlags.QuarantineFile |  | boolean |
+| crowdstrike.event.PatternDispositionFlags.QuarantineMachine |  | boolean |
+| crowdstrike.event.PatternDispositionFlags.Rooting |  | boolean |
+| crowdstrike.event.PatternDispositionFlags.SensorOnly |  | boolean |
 | crowdstrike.event.PatternDispositionValue | Unique ID associated with action taken. | integer |
 | crowdstrike.event.PolicyID | CrowdStrike policy id. | keyword |
 | crowdstrike.event.PolicyName | CrowdStrike policy name. | keyword |


### PR DESCRIPTION

## What does this PR do?

Add a system test for CrowdStrike Falcon and fix the issues it detected.
These were the errors initially detected.

    crowdstrike/falcon :
    [0] field "crowdstrike.event.PatternDispositionFlags.Detect" is undefined
    [1] field "crowdstrike.event.PatternDispositionFlags.InddetMask" is undefined
    [2] field "crowdstrike.event.PatternDispositionFlags.Indicator" is undefined
    [3] field "crowdstrike.event.PatternDispositionFlags.KillParent" is undefined
    [4] field "crowdstrike.event.PatternDispositionFlags.KillProcess" is undefined
    [5] field "crowdstrike.event.PatternDispositionFlags.KillSubProcess" is undefined
    [6] field "crowdstrike.event.PatternDispositionFlags.OperationBlocked" is undefined
    [7] field "crowdstrike.event.PatternDispositionFlags.PolicyDisabled" is undefined
    [8] field "crowdstrike.event.PatternDispositionFlags.ProcessBlocked" is undefined
    [9] field "crowdstrike.event.PatternDispositionFlags.QuarantineFile" is undefined
    [10] field "crowdstrike.event.PatternDispositionFlags.QuarantineMachine" is undefined
    [11] field "crowdstrike.event.PatternDispositionFlags.Rooting" is undefined
    [12] field "crowdstrike.event.PatternDispositionFlags.SensorOnly" is undefined
    [13] parsing field value failed: field "crowdstrike.event.LocalPort"''s Go type, string, does not match the expected field type: long
    [14] parsing field value failed: field "crowdstrike.event.PID"''s Go type, string, does not match the expected field type: long
    [15] parsing field value failed: field "crowdstrike.event.ProcessEndTime"''s Go type, float64, does not match the expected field type: date
    [16] parsing field value failed: field "crowdstrike.event.RemotePort"''s Go type, string, does not match the expected field type: long
    [17] parsing field value failed: field "destination.port"''s Go type, string, does not match the expected field type: long
    [18] parsing field value failed: field "process.pid"''s Go type, string, does not match the expected field type: long
    [19] parsing field value failed: field "source.port"''s Go type, string, does not match the expected field type: long

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [ ] I have verified that all datasets collect metrics or logs.

## How to test this PR locally

```
elastic-package stack up -d
$(elastic-package stack shellinit)
cd crowdstrike/data_stream/falcon
elastic-package test system -v
```

## Related issues

- Relates #377 
