### PR TITLE
[aws package] change fileset.name to data_stream.dataset

### DIFF
--- a/packages/aws/kibana/map/aws-0edf0640-3e7e-11ea-bb0a-69c3ca1d410f.json
+++ b/packages/aws/kibana/map/aws-0edf0640-3e7e-11ea-bb0a-69c3ca1d410f.json
@@ -144,7 +144,7 @@
                         "key": "data_stream.dataset",
                         "negate": false,
                         "params": {
-                            "query": "aws.elb"
+                            "query": "aws.elb_logs"
                         },
                         "type": "phrase",
                         "value": "elb"
@@ -152,7 +152,7 @@
                     "query": {
                         "match": {
                             "data_stream.dataset": {
-                                "query": "aws.elb",
+                                "query": "aws.elb_logs",
                                 "type": "phrase"
                             }
                         }

--- a/packages/aws/kibana/map/aws-0edf0640-3e7e-11ea-bb0a-69c3ca1d410f.json
+++ b/packages/aws/kibana/map/aws-0edf0640-3e7e-11ea-bb0a-69c3ca1d410f.json
@@ -141,18 +141,18 @@
                         "alias": null,
                         "disabled": false,
                         "index": "logs-*",
-                        "key": "fileset.name",
+                        "key": "data_stream.dataset",
                         "negate": false,
                         "params": {
-                            "query": "elb"
+                            "query": "aws.elb"
                         },
                         "type": "phrase",
                         "value": "elb"
                     },
                     "query": {
                         "match": {
-                            "fileset.name": {
-                                "query": "elb",
+                            "data_stream.dataset": {
+                                "query": "aws.elb",
                                 "type": "phrase"
                             }
                         }

--- a/packages/aws/kibana/search/aws-5e5a3c90-bac0-11e9-9f70-1f7bda85a5eb.json
+++ b/packages/aws/kibana/search/aws-5e5a3c90-bac0-11e9-9f70-1f7bda85a5eb.json
@@ -44,18 +44,18 @@
                             "alias": null,
                             "disabled": false,
                             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[1].meta.index",
-                            "key": "fileset.name",
+                            "key": "data_stream.dataset",
                             "negate": false,
                             "params": {
-                                "query": "s3access"
+                                "query": "aws.s3access"
                             },
                             "type": "phrase",
                             "value": "s3access"
                         },
                         "query": {
                             "match": {
-                                "fileset.name": {
-                                    "query": "s3access",
+                                "data_stream.dataset": {
+                                    "query": "aws.s3access",
                                     "type": "phrase"
                                 }
                             }

--- a/packages/aws/kibana/search/aws-c1aee600-4487-11ea-ad63-791a5dc86f10.json
+++ b/packages/aws/kibana/search/aws-c1aee600-4487-11ea-ad63-791a5dc86f10.json
@@ -18,18 +18,18 @@
                             "alias": null,
                             "disabled": false,
                             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                            "key": "fileset.name",
+                            "key": "data_stream.dataset",
                             "negate": false,
                             "params": {
-                                "query": "vpcflow"
+                                "query": "aws.vpcflow"
                             },
                             "type": "phrase",
                             "value": "vpcflow"
                         },
                         "query": {
                             "match": {
-                                "fileset.name": {
-                                    "query": "vpcflow",
+                                "data_stream.dataset": {
+                                    "query": "aws.vpcflow",
                                     "type": "phrase"
                                 }
                             }

--- a/packages/aws/kibana/visualization/aws-219c1850-3e82-11ea-bb0a-69c3ca1d410f.json
+++ b/packages/aws/kibana/visualization/aws-219c1850-3e82-11ea-bb0a-69c3ca1d410f.json
@@ -35,7 +35,7 @@
                         "fill": 0.5,
                         "filter": {
                             "language": "kuery",
-                            "query": "data_stream.dataset : \"aws.elb\" and http.response.status_code \u003e= 200 and http.response.status_code\t\u003c 300"
+                            "query": "data_stream.dataset : \"aws.elb_logs\" and http.response.status_code \u003e= 200 and http.response.status_code\t\u003c 300"
                         },
                         "formatter": "number",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",

--- a/packages/aws/kibana/visualization/aws-219c1850-3e82-11ea-bb0a-69c3ca1d410f.json
+++ b/packages/aws/kibana/visualization/aws-219c1850-3e82-11ea-bb0a-69c3ca1d410f.json
@@ -35,7 +35,7 @@
                         "fill": 0.5,
                         "filter": {
                             "language": "kuery",
-                            "query": "fileset.name : \"elb\" and http.response.status_code \u003e= 200 and http.response.status_code\t\u003c 300"
+                            "query": "data_stream.dataset : \"aws.elb\" and http.response.status_code \u003e= 200 and http.response.status_code\t\u003c 300"
                         },
                         "formatter": "number",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",

--- a/packages/aws/kibana/visualization/aws-73970bc0-3e86-11ea-bb0a-69c3ca1d410f.json
+++ b/packages/aws/kibana/visualization/aws-73970bc0-3e86-11ea-bb0a-69c3ca1d410f.json
@@ -60,7 +60,7 @@
                         "fill": 0.5,
                         "filter": {
                             "language": "kuery",
-                            "query": "data_stream.dataset : \"aws.elb\" "
+                            "query": "data_stream.dataset : \"aws.elb_logs\" "
                         },
                         "formatter": "number",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",

--- a/packages/aws/kibana/visualization/aws-73970bc0-3e86-11ea-bb0a-69c3ca1d410f.json
+++ b/packages/aws/kibana/visualization/aws-73970bc0-3e86-11ea-bb0a-69c3ca1d410f.json
@@ -60,7 +60,7 @@
                         "fill": 0.5,
                         "filter": {
                             "language": "kuery",
-                            "query": "fileset.name : \"elb\" "
+                            "query": "data_stream.dataset : \"aws.elb\" "
                         },
                         "formatter": "number",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",

--- a/packages/aws/kibana/visualization/aws-75853f20-4484-11ea-ad63-791a5dc86f10.json
+++ b/packages/aws/kibana/visualization/aws-75853f20-4484-11ea-ad63-791a5dc86f10.json
@@ -60,7 +60,7 @@
                         "fill": 0.5,
                         "filter": {
                             "language": "kuery",
-                            "query": "fileset.name : \"vpcflow\" "
+                            "query": "data_stream.dataset : \"aws.vpcflow\" "
                         },
                         "formatter": "number",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",

--- a/packages/aws/kibana/visualization/aws-76af8140-3e84-11ea-bb0a-69c3ca1d410f.json
+++ b/packages/aws/kibana/visualization/aws-76af8140-3e84-11ea-bb0a-69c3ca1d410f.json
@@ -35,7 +35,7 @@
                         "fill": 0.5,
                         "filter": {
                             "language": "kuery",
-                            "query": "fileset.name : \"elb\""
+                            "query": "data_stream.dataset : \"aws.elb\""
                         },
                         "formatter": "bytes",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",

--- a/packages/aws/kibana/visualization/aws-76af8140-3e84-11ea-bb0a-69c3ca1d410f.json
+++ b/packages/aws/kibana/visualization/aws-76af8140-3e84-11ea-bb0a-69c3ca1d410f.json
@@ -35,7 +35,7 @@
                         "fill": 0.5,
                         "filter": {
                             "language": "kuery",
-                            "query": "data_stream.dataset : \"aws.elb\""
+                            "query": "data_stream.dataset : \"aws.elb_logs\""
                         },
                         "formatter": "bytes",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",

--- a/packages/aws/kibana/visualization/aws-b6a308f0-3e82-11ea-bb0a-69c3ca1d410f.json
+++ b/packages/aws/kibana/visualization/aws-b6a308f0-3e82-11ea-bb0a-69c3ca1d410f.json
@@ -35,7 +35,7 @@
                         "fill": 0.5,
                         "filter": {
                             "language": "kuery",
-                            "query": "data_stream.dataset : \"aws.elb\" and http.response.status_code \u003e= 400 and http.response.status_code \u003c 500"
+                            "query": "data_stream.dataset : \"aws.elb_logs\" and http.response.status_code \u003e= 400 and http.response.status_code \u003c 500"
                         },
                         "formatter": "number",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",

--- a/packages/aws/kibana/visualization/aws-b6a308f0-3e82-11ea-bb0a-69c3ca1d410f.json
+++ b/packages/aws/kibana/visualization/aws-b6a308f0-3e82-11ea-bb0a-69c3ca1d410f.json
@@ -35,7 +35,7 @@
                         "fill": 0.5,
                         "filter": {
                             "language": "kuery",
-                            "query": "fileset.name : \"elb\" and http.response.status_code \u003e= 400 and http.response.status_code \u003c 500"
+                            "query": "data_stream.dataset : \"aws.elb\" and http.response.status_code \u003e= 400 and http.response.status_code \u003c 500"
                         },
                         "formatter": "number",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",

--- a/packages/aws/kibana/visualization/aws-bad8c910-4485-11ea-ad63-791a5dc86f10.json
+++ b/packages/aws/kibana/visualization/aws-bad8c910-4485-11ea-ad63-791a5dc86f10.json
@@ -36,7 +36,7 @@
                         "fill": "0",
                         "filter": {
                             "language": "kuery",
-                            "query": "fileset.name : \"vpcflow\" and aws.vpcflow.action : \"REJECT\" "
+                            "query": "data_stream.dataset : \"aws.vpcflow\" and aws.vpcflow.action : \"REJECT\" "
                         },
                         "formatter": "number",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",
@@ -68,7 +68,7 @@
                         "fill": "0",
                         "filter": {
                             "language": "kuery",
-                            "query": "fileset.name : \"vpcflow\" and aws.vpcflow.action : \"ACCEPT\"  "
+                            "query": "data_stream.dataset : \"aws.vpcflow\" and aws.vpcflow.action : \"ACCEPT\"  "
                         },
                         "formatter": "number",
                         "id": "7ec99260-4485-11ea-9ee9-2d27e9149ae8",
@@ -100,7 +100,7 @@
                         "fill": "0",
                         "filter": {
                             "language": "kuery",
-                            "query": "fileset.name : \"vpcflow\" and aws.vpcflow.action : \"-\" "
+                            "query": "data_stream.dataset : \"aws.vpcflow\" and aws.vpcflow.action : \"-\" "
                         },
                         "formatter": "number",
                         "id": "8d550580-4485-11ea-9ee9-2d27e9149ae8",
@@ -132,7 +132,7 @@
                         "fill": "0.5",
                         "filter": {
                             "language": "kuery",
-                            "query": "fileset.name : \"vpcflow\""
+                            "query": "data_stream.dataset : \"aws.vpcflow\""
                         },
                         "formatter": "number",
                         "id": "c8c27df0-4485-11ea-9ee9-2d27e9149ae8",

--- a/packages/aws/kibana/visualization/aws-bd37d720-3e84-11ea-bb0a-69c3ca1d410f.json
+++ b/packages/aws/kibana/visualization/aws-bd37d720-3e84-11ea-bb0a-69c3ca1d410f.json
@@ -35,7 +35,7 @@
                         "fill": 0.5,
                         "filter": {
                             "language": "kuery",
-                            "query": "fileset.name : \"elb\""
+                            "query": "data_stream.dataset : \"aws.elb\""
                         },
                         "formatter": "bytes",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",

--- a/packages/aws/kibana/visualization/aws-bd37d720-3e84-11ea-bb0a-69c3ca1d410f.json
+++ b/packages/aws/kibana/visualization/aws-bd37d720-3e84-11ea-bb0a-69c3ca1d410f.json
@@ -35,7 +35,7 @@
                         "fill": 0.5,
                         "filter": {
                             "language": "kuery",
-                            "query": "data_stream.dataset : \"aws.elb\""
+                            "query": "data_stream.dataset : \"aws.elb_logs\""
                         },
                         "formatter": "bytes",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",

--- a/packages/aws/kibana/visualization/aws-ceb7c030-3e86-11ea-bb0a-69c3ca1d410f.json
+++ b/packages/aws/kibana/visualization/aws-ceb7c030-3e86-11ea-bb0a-69c3ca1d410f.json
@@ -60,7 +60,7 @@
                         "fill": 0.5,
                         "filter": {
                             "language": "kuery",
-                            "query": "data_stream.dataset : \"aws.elb\" "
+                            "query": "data_stream.dataset : \"aws.elb_logs\" "
                         },
                         "formatter": "number",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",

--- a/packages/aws/kibana/visualization/aws-ceb7c030-3e86-11ea-bb0a-69c3ca1d410f.json
+++ b/packages/aws/kibana/visualization/aws-ceb7c030-3e86-11ea-bb0a-69c3ca1d410f.json
@@ -60,7 +60,7 @@
                         "fill": 0.5,
                         "filter": {
                             "language": "kuery",
-                            "query": "fileset.name : \"elb\" "
+                            "query": "data_stream.dataset : \"aws.elb\" "
                         },
                         "formatter": "number",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",

--- a/packages/aws/kibana/visualization/aws-d8b1e830-3e82-11ea-bb0a-69c3ca1d410f.json
+++ b/packages/aws/kibana/visualization/aws-d8b1e830-3e82-11ea-bb0a-69c3ca1d410f.json
@@ -35,7 +35,7 @@
                         "fill": 0.5,
                         "filter": {
                             "language": "kuery",
-                            "query": "data_stream.dataset : \"aws.elb\" and http.response.status_code \u003e= 500 and http.response.status_code \u003c 600"
+                            "query": "data_stream.dataset : \"aws.elb_logs\" and http.response.status_code \u003e= 500 and http.response.status_code \u003c 600"
                         },
                         "formatter": "number",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",

--- a/packages/aws/kibana/visualization/aws-d8b1e830-3e82-11ea-bb0a-69c3ca1d410f.json
+++ b/packages/aws/kibana/visualization/aws-d8b1e830-3e82-11ea-bb0a-69c3ca1d410f.json
@@ -35,7 +35,7 @@
                         "fill": 0.5,
                         "filter": {
                             "language": "kuery",
-                            "query": "fileset.name : \"elb\" and http.response.status_code \u003e= 500 and http.response.status_code \u003c 600"
+                            "query": "data_stream.dataset : \"aws.elb\" and http.response.status_code \u003e= 500 and http.response.status_code \u003c 600"
                         },
                         "formatter": "number",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",

--- a/packages/aws/kibana/visualization/aws-e50c51e0-3e7f-11ea-bb0a-69c3ca1d410f.json
+++ b/packages/aws/kibana/visualization/aws-e50c51e0-3e7f-11ea-bb0a-69c3ca1d410f.json
@@ -35,7 +35,7 @@
                         "fill": 0.5,
                         "filter": {
                             "language": "kuery",
-                            "query": "data_stream.dataset : \"aws.elb\" "
+                            "query": "data_stream.dataset : \"aws.elb_logs\" "
                         },
                         "formatter": "number",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",

--- a/packages/aws/kibana/visualization/aws-e50c51e0-3e7f-11ea-bb0a-69c3ca1d410f.json
+++ b/packages/aws/kibana/visualization/aws-e50c51e0-3e7f-11ea-bb0a-69c3ca1d410f.json
@@ -35,7 +35,7 @@
                         "fill": 0.5,
                         "filter": {
                             "language": "kuery",
-                            "query": "fileset.name : \"elb\" "
+                            "query": "data_stream.dataset : \"aws.elb\" "
                         },
                         "formatter": "number",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",


### PR DESCRIPTION
## What does this PR do?

This PR is to fix `elb` and `vpcflow` dashboards by changing `fileset.name` to `data_stream.dataset`.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [ ] I have verified that all datasets collect metrics or logs.

## Related issues

- Closes https://github.com/elastic/integrations/issues/431