### PR TITLE
Nginx ingress contoller: fix wrong Kibana version

### DIFF
--- a/packages/nginx_ingress_controller/kibana/dashboard/nginx_ingress_controller-0b3dba40-f341-11ea-a3fd-1b45ec532bb3.json
+++ b/packages/nginx_ingress_controller/kibana/dashboard/nginx_ingress_controller-0b3dba40-f341-11ea-a3fd-1b45ec532bb3.json
@@ -30,7 +30,7 @@
                 },
                 "panelIndex": "36b94fba-26a2-4a63-9260-1e5bdf3a9dd8",
                 "panelRefName": "panel_0",
-                "version": "7.11.0-SNAPSHOT"
+                "version": "7.9.3"
             },
             {
                 "embeddableConfig": {
@@ -45,7 +45,7 @@
                 },
                 "panelIndex": "a7e7600a-703f-48a0-9a3a-3670294ee98b",
                 "panelRefName": "panel_1",
-                "version": "7.11.0-SNAPSHOT"
+                "version": "7.9.3"
             },
             {
                 "embeddableConfig": {
@@ -60,7 +60,7 @@
                 },
                 "panelIndex": "7e5729fd-aa67-4ee2-aaa3-8a67e529d4b1",
                 "panelRefName": "panel_2",
-                "version": "7.11.0-SNAPSHOT"
+                "version": "7.9.3"
             }
         ],
         "timeRestore": false,
@@ -69,7 +69,7 @@
     },
     "id": "nginx_ingress_controller-0b3dba40-f341-11ea-a3fd-1b45ec532bb3",
     "migrationVersion": {
-        "dashboard": "7.11.0"
+        "dashboard": "7.9.3"
     },
     "references": [
         {

--- a/packages/nginx_ingress_controller/kibana/dashboard/nginx_ingress_controller-dfbc0840-f340-11ea-a3fd-1b45ec532bb3.json
+++ b/packages/nginx_ingress_controller/kibana/dashboard/nginx_ingress_controller-dfbc0840-f340-11ea-a3fd-1b45ec532bb3.json
@@ -200,7 +200,7 @@
     },
     "id": "nginx_ingress_controller-dfbc0840-f340-11ea-a3fd-1b45ec532bb3",
     "migrationVersion": {
-        "dashboard": "7.11.0"
+        "dashboard": "7.9.3"
     },
     "references": [
         {

--- a/packages/nginx_ingress_controller/kibana/visualization/nginx_ingress_controller-1aa782a0-f345-11ea-a3fd-1b45ec532bb3.json
+++ b/packages/nginx_ingress_controller/kibana/visualization/nginx_ingress_controller-1aa782a0-f345-11ea-a3fd-1b45ec532bb3.json
@@ -71,7 +71,7 @@
     },
     "id": "nginx_ingress_controller-1aa782a0-f345-11ea-a3fd-1b45ec532bb3",
     "migrationVersion": {
-        "visualization": "7.10.0"
+        "visualization": "7.9.3"
     },
     "references": [],
     "type": "visualization"

--- a/packages/nginx_ingress_controller/kibana/visualization/nginx_ingress_controller-78738850-f342-11ea-a3fd-1b45ec532bb3.json
+++ b/packages/nginx_ingress_controller/kibana/visualization/nginx_ingress_controller-78738850-f342-11ea-a3fd-1b45ec532bb3.json
@@ -82,7 +82,7 @@
     },
     "id": "nginx_ingress_controller-78738850-f342-11ea-a3fd-1b45ec532bb3",
     "migrationVersion": {
-        "visualization": "7.10.0"
+        "visualization": "7.9.3"
     },
     "references": [],
     "type": "visualization"

--- a/packages/nginx_ingress_controller/kibana/visualization/nginx_ingress_controller-Access-Browsers.json
+++ b/packages/nginx_ingress_controller/kibana/visualization/nginx_ingress_controller-Access-Browsers.json
@@ -62,7 +62,7 @@
     },
     "id": "nginx_ingress_controller-Access-Browsers",
     "migrationVersion": {
-        "visualization": "7.10.0"
+        "visualization": "7.9.3"
     },
     "references": [
         {

--- a/packages/nginx_ingress_controller/kibana/visualization/nginx_ingress_controller-Access-Map.json
+++ b/packages/nginx_ingress_controller/kibana/visualization/nginx_ingress_controller-Access-Map.json
@@ -70,7 +70,7 @@
     },
     "id": "nginx_ingress_controller-Access-Map",
     "migrationVersion": {
-        "visualization": "7.10.0"
+        "visualization": "7.9.3"
     },
     "references": [
         {

--- a/packages/nginx_ingress_controller/kibana/visualization/nginx_ingress_controller-Access-OSes.json
+++ b/packages/nginx_ingress_controller/kibana/visualization/nginx_ingress_controller-Access-OSes.json
@@ -62,7 +62,7 @@
     },
     "id": "nginx_ingress_controller-Access-OSes",
     "migrationVersion": {
-        "visualization": "7.10.0"
+        "visualization": "7.9.3"
     },
     "references": [
         {

--- a/packages/nginx_ingress_controller/kibana/visualization/nginx_ingress_controller-a3bf1ce0-f347-11ea-a3fd-1b45ec532bb3.json
+++ b/packages/nginx_ingress_controller/kibana/visualization/nginx_ingress_controller-a3bf1ce0-f347-11ea-a3fd-1b45ec532bb3.json
@@ -72,7 +72,7 @@
     },
     "id": "nginx_ingress_controller-a3bf1ce0-f347-11ea-a3fd-1b45ec532bb3",
     "migrationVersion": {
-        "visualization": "7.10.0"
+        "visualization": "7.9.3"
     },
     "references": [],
     "type": "visualization"

--- a/packages/nginx_ingress_controller/kibana/visualization/nginx_ingress_controller-afd506b0-f348-11ea-a3fd-1b45ec532bb3.json
+++ b/packages/nginx_ingress_controller/kibana/visualization/nginx_ingress_controller-afd506b0-f348-11ea-a3fd-1b45ec532bb3.json
@@ -78,7 +78,7 @@
     },
     "id": "nginx_ingress_controller-afd506b0-f348-11ea-a3fd-1b45ec532bb3",
     "migrationVersion": {
-        "visualization": "7.10.0"
+        "visualization": "7.9.3"
     },
     "references": [],
     "type": "visualization"

--- a/packages/nginx_ingress_controller/kibana/visualization/nginx_ingress_controller-ba138ab0-f344-11ea-a3fd-1b45ec532bb3.json
+++ b/packages/nginx_ingress_controller/kibana/visualization/nginx_ingress_controller-ba138ab0-f344-11ea-a3fd-1b45ec532bb3.json
@@ -98,7 +98,7 @@
     },
     "id": "nginx_ingress_controller-ba138ab0-f344-11ea-a3fd-1b45ec532bb3",
     "migrationVersion": {
-        "visualization": "7.10.0"
+        "visualization": "7.9.3"
     },
     "references": [],
     "type": "visualization"

--- a/packages/nginx_ingress_controller/kibana/visualization/nginx_ingress_controller-c37e2770-f341-11ea-a3fd-1b45ec532bb3.json
+++ b/packages/nginx_ingress_controller/kibana/visualization/nginx_ingress_controller-c37e2770-f341-11ea-a3fd-1b45ec532bb3.json
@@ -26,7 +26,7 @@
     },
     "id": "nginx_ingress_controller-c37e2770-f341-11ea-a3fd-1b45ec532bb3",
     "migrationVersion": {
-        "visualization": "7.10.0"
+        "visualization": "7.9.3"
     },
     "references": [],
     "type": "visualization"

--- a/packages/nginx_ingress_controller/kibana/visualization/nginx_ingress_controller-ee250270-f344-11ea-a3fd-1b45ec532bb3.json
+++ b/packages/nginx_ingress_controller/kibana/visualization/nginx_ingress_controller-ee250270-f344-11ea-a3fd-1b45ec532bb3.json
@@ -64,7 +64,7 @@
     },
     "id": "nginx_ingress_controller-ee250270-f344-11ea-a3fd-1b45ec532bb3",
     "migrationVersion": {
-        "visualization": "7.10.0"
+        "visualization": "7.9.3"
     },
     "references": [],
     "type": "visualization"

--- a/packages/nginx_ingress_controller/kibana/visualization/nginx_ingress_controller-f137cb40-f345-11ea-a3fd-1b45ec532bb3.json
+++ b/packages/nginx_ingress_controller/kibana/visualization/nginx_ingress_controller-f137cb40-f345-11ea-a3fd-1b45ec532bb3.json
@@ -64,7 +64,7 @@
     },
     "id": "nginx_ingress_controller-f137cb40-f345-11ea-a3fd-1b45ec532bb3",
     "migrationVersion": {
-        "visualization": "7.10.0"
+        "visualization": "7.9.3"
     },
     "references": [],
     "type": "visualization"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR adjusts (corrects) Kibana versions after export to fix the issue spotted in https://github.com/elastic/package-storage/pull/704 .

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [x] I have verified that all datasets collect metrics or logs.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- https://github.com/elastic/package-storage/pull/704

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
