### PR TITLE
Fix credentials for metrics data streams in aws package

### DIFF
--- a/packages/aws/data_stream/billing/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/billing/agent/stream/stream.yml.hbs
@@ -1,13 +1,13 @@
 metricsets: ["billing"]
 period: {{period}}
-{{#if aws_access_key_id}}
-aws_access_key_id: {{aws_access_key_id}}
+{{#if access_key_id}}
+access_key_id: {{access_key_id}}
 {{/if}}
-{{#if aws_secret_access_key}}
-aws_secret_access_key: {{aws_secret_access_key}}
+{{#if secret_access_key}}
+secret_access_key: {{secret_access_key}}
 {{/if}}
-{{#if aws_session_token}}
-aws_session_token: {{aws_session_token}}
+{{#if session_token}}
+session_token: {{session_token}}
 {{/if}}
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}

--- a/packages/aws/data_stream/cloudwatch_metrics/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/cloudwatch_metrics/agent/stream/stream.yml.hbs
@@ -1,13 +1,13 @@
 metricsets: ["cloudwatch"]
 period: {{period}}
-{{#if aws_access_key_id}}
-aws_access_key_id: {{aws_access_key_id}}
+{{#if access_key_id}}
+access_key_id: {{access_key_id}}
 {{/if}}
-{{#if aws_secret_access_key}}
-aws_secret_access_key: {{aws_secret_access_key}}
+{{#if secret_access_key}}
+secret_access_key: {{secret_access_key}}
 {{/if}}
-{{#if aws_session_token}}
-aws_session_token: {{aws_session_token}}
+{{#if session_token}}
+session_token: {{session_token}}
 {{/if}}
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}

--- a/packages/aws/data_stream/dynamodb/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/dynamodb/agent/stream/stream.yml.hbs
@@ -1,13 +1,13 @@
 metricsets: ["dynamodb"]
 period: {{period}}
-{{#if aws_access_key_id}}
-aws_access_key_id: {{aws_access_key_id}}
+{{#if access_key_id}}
+access_key_id: {{access_key_id}}
 {{/if}}
-{{#if aws_secret_access_key}}
-aws_secret_access_key: {{aws_secret_access_key}}
+{{#if secret_access_key}}
+secret_access_key: {{secret_access_key}}
 {{/if}}
-{{#if aws_session_token}}
-aws_session_token: {{aws_session_token}}
+{{#if session_token}}
+session_token: {{session_token}}
 {{/if}}
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}

--- a/packages/aws/data_stream/ebs/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/ebs/agent/stream/stream.yml.hbs
@@ -1,13 +1,13 @@
 metricsets: ["ebs"]
 period: {{period}}
-{{#if aws_access_key_id}}
-aws_access_key_id: {{aws_access_key_id}}
+{{#if access_key_id}}
+access_key_id: {{access_key_id}}
 {{/if}}
-{{#if aws_secret_access_key}}
-aws_secret_access_key: {{aws_secret_access_key}}
+{{#if secret_access_key}}
+secret_access_key: {{secret_access_key}}
 {{/if}}
-{{#if aws_session_token}}
-aws_session_token: {{aws_session_token}}
+{{#if session_token}}
+session_token: {{session_token}}
 {{/if}}
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}

--- a/packages/aws/data_stream/ec2_metrics/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/ec2_metrics/agent/stream/stream.yml.hbs
@@ -1,13 +1,13 @@
 metricsets: ["ec2"]
 period: {{period}}
-{{#if aws_access_key_id}}
-aws_access_key_id: {{aws_access_key_id}}
+{{#if access_key_id}}
+access_key_id: {{access_key_id}}
 {{/if}}
-{{#if aws_secret_access_key}}
-aws_secret_access_key: {{aws_secret_access_key}}
+{{#if secret_access_key}}
+secret_access_key: {{secret_access_key}}
 {{/if}}
-{{#if aws_session_token}}
-aws_session_token: {{aws_session_token}}
+{{#if session_token}}
+session_token: {{session_token}}
 {{/if}}
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}

--- a/packages/aws/data_stream/elb_metrics/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/elb_metrics/agent/stream/stream.yml.hbs
@@ -1,13 +1,13 @@
 metricsets: ["elb"]
 period: {{period}}
-{{#if aws_access_key_id}}
-aws_access_key_id: {{aws_access_key_id}}
+{{#if access_key_id}}
+access_key_id: {{access_key_id}}
 {{/if}}
-{{#if aws_secret_access_key}}
-aws_secret_access_key: {{aws_secret_access_key}}
+{{#if secret_access_key}}
+secret_access_key: {{secret_access_key}}
 {{/if}}
-{{#if aws_session_token}}
-aws_session_token: {{aws_session_token}}
+{{#if session_token}}
+session_token: {{session_token}}
 {{/if}}
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}

--- a/packages/aws/data_stream/lambda/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/lambda/agent/stream/stream.yml.hbs
@@ -1,13 +1,13 @@
 metricsets: ["lambda"]
 period: {{period}}
-{{#if aws_access_key_id}}
-aws_access_key_id: {{aws_access_key_id}}
+{{#if access_key_id}}
+access_key_id: {{access_key_id}}
 {{/if}}
-{{#if aws_secret_access_key}}
-aws_secret_access_key: {{aws_secret_access_key}}
+{{#if secret_access_key}}
+secret_access_key: {{secret_access_key}}
 {{/if}}
-{{#if aws_session_token}}
-aws_session_token: {{aws_session_token}}
+{{#if session_token}}
+session_token: {{session_token}}
 {{/if}}
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}

--- a/packages/aws/data_stream/natgateway/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/natgateway/agent/stream/stream.yml.hbs
@@ -1,13 +1,13 @@
 metricsets: ["natgateway"]
 period: {{period}}
-{{#if aws_access_key_id}}
-aws_access_key_id: {{aws_access_key_id}}
+{{#if access_key_id}}
+access_key_id: {{access_key_id}}
 {{/if}}
-{{#if aws_secret_access_key}}
-aws_secret_access_key: {{aws_secret_access_key}}
+{{#if secret_access_key}}
+secret_access_key: {{secret_access_key}}
 {{/if}}
-{{#if aws_session_token}}
-aws_session_token: {{aws_session_token}}
+{{#if session_token}}
+session_token: {{session_token}}
 {{/if}}
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}

--- a/packages/aws/data_stream/rds/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/rds/agent/stream/stream.yml.hbs
@@ -1,13 +1,13 @@
 metricsets: ["rds"]
 period: {{period}}
-{{#if aws_access_key_id}}
-aws_access_key_id: {{aws_access_key_id}}
+{{#if access_key_id}}
+access_key_id: {{access_key_id}}
 {{/if}}
-{{#if aws_secret_access_key}}
-aws_secret_access_key: {{aws_secret_access_key}}
+{{#if secret_access_key}}
+secret_access_key: {{secret_access_key}}
 {{/if}}
-{{#if aws_session_token}}
-aws_session_token: {{aws_session_token}}
+{{#if session_token}}
+session_token: {{session_token}}
 {{/if}}
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}

--- a/packages/aws/data_stream/s3_daily_storage/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/s3_daily_storage/agent/stream/stream.yml.hbs
@@ -1,13 +1,13 @@
 metricsets: ["s3_daily_storage"]
 period: {{period}}
-{{#if aws_access_key_id}}
-aws_access_key_id: {{aws_access_key_id}}
+{{#if access_key_id}}
+access_key_id: {{access_key_id}}
 {{/if}}
-{{#if aws_secret_access_key}}
-aws_secret_access_key: {{aws_secret_access_key}}
+{{#if secret_access_key}}
+secret_access_key: {{secret_access_key}}
 {{/if}}
-{{#if aws_session_token}}
-aws_session_token: {{aws_session_token}}
+{{#if session_token}}
+session_token: {{session_token}}
 {{/if}}
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}

--- a/packages/aws/data_stream/s3_request/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/s3_request/agent/stream/stream.yml.hbs
@@ -1,13 +1,13 @@
 metricsets: ["s3_request"]
 period: {{period}}
-{{#if aws_access_key_id}}
-aws_access_key_id: {{aws_access_key_id}}
+{{#if access_key_id}}
+access_key_id: {{access_key_id}}
 {{/if}}
-{{#if aws_secret_access_key}}
-aws_secret_access_key: {{aws_secret_access_key}}
+{{#if secret_access_key}}
+secret_access_key: {{secret_access_key}}
 {{/if}}
-{{#if aws_session_token}}
-aws_session_token: {{aws_session_token}}
+{{#if session_token}}
+session_token: {{session_token}}
 {{/if}}
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}

--- a/packages/aws/data_stream/sns/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/sns/agent/stream/stream.yml.hbs
@@ -1,13 +1,13 @@
 metricsets: ["sns"]
 period: {{period}}
-{{#if aws_access_key_id}}
-aws_access_key_id: {{aws_access_key_id}}
+{{#if access_key_id}}
+access_key_id: {{access_key_id}}
 {{/if}}
-{{#if aws_secret_access_key}}
-aws_secret_access_key: {{aws_secret_access_key}}
+{{#if secret_access_key}}
+secret_access_key: {{secret_access_key}}
 {{/if}}
-{{#if aws_session_token}}
-aws_session_token: {{aws_session_token}}
+{{#if session_token}}
+session_token: {{session_token}}
 {{/if}}
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}

--- a/packages/aws/data_stream/sqs/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/sqs/agent/stream/stream.yml.hbs
@@ -1,13 +1,13 @@
 metricsets: ["sqs"]
 period: {{period}}
-{{#if aws_access_key_id}}
-aws_access_key_id: {{aws_access_key_id}}
+{{#if access_key_id}}
+access_key_id: {{access_key_id}}
 {{/if}}
-{{#if aws_secret_access_key}}
-aws_secret_access_key: {{aws_secret_access_key}}
+{{#if secret_access_key}}
+secret_access_key: {{secret_access_key}}
 {{/if}}
-{{#if aws_session_token}}
-aws_session_token: {{aws_session_token}}
+{{#if session_token}}
+session_token: {{session_token}}
 {{/if}}
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}

--- a/packages/aws/data_stream/transitgateway/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/transitgateway/agent/stream/stream.yml.hbs
@@ -1,13 +1,13 @@
 metricsets: ["transitgateway"]
 period: {{period}}
-{{#if aws_access_key_id}}
-aws_access_key_id: {{aws_access_key_id}}
+{{#if access_key_id}}
+access_key_id: {{access_key_id}}
 {{/if}}
-{{#if aws_secret_access_key}}
-aws_secret_access_key: {{aws_secret_access_key}}
+{{#if secret_access_key}}
+secret_access_key: {{secret_access_key}}
 {{/if}}
-{{#if aws_session_token}}
-aws_session_token: {{aws_session_token}}
+{{#if session_token}}
+session_token: {{session_token}}
 {{/if}}
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}

--- a/packages/aws/data_stream/usage/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/usage/agent/stream/stream.yml.hbs
@@ -1,13 +1,13 @@
 metricsets: ["usage"]
 period: {{period}}
-{{#if aws_access_key_id}}
-aws_access_key_id: {{aws_access_key_id}}
+{{#if access_key_id}}
+access_key_id: {{access_key_id}}
 {{/if}}
-{{#if aws_secret_access_key}}
-aws_secret_access_key: {{aws_secret_access_key}}
+{{#if secret_access_key}}
+secret_access_key: {{secret_access_key}}
 {{/if}}
-{{#if aws_session_token}}
-aws_session_token: {{aws_session_token}}
+{{#if session_token}}
+session_token: {{session_token}}
 {{/if}}
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}

--- a/packages/aws/data_stream/vpn/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/vpn/agent/stream/stream.yml.hbs
@@ -1,13 +1,13 @@
 metricsets: ["vpn"]
 period: {{period}}
-{{#if aws_access_key_id}}
-aws_access_key_id: {{aws_access_key_id}}
+{{#if access_key_id}}
+access_key_id: {{access_key_id}}
 {{/if}}
-{{#if aws_secret_access_key}}
-aws_secret_access_key: {{aws_secret_access_key}}
+{{#if secret_access_key}}
+secret_access_key: {{secret_access_key}}
 {{/if}}
-{{#if aws_session_token}}
-aws_session_token: {{aws_session_token}}
+{{#if session_token}}
+session_token: {{session_token}}
 {{/if}}
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 0.3.14
+version: 0.3.15
 license: basic
 description: AWS Integration
 type: integration
@@ -209,42 +209,36 @@ policy_templates:
             multi: false
             required: false
             show_user: false
-            default: ""
           - name: secret_access_key
             type: text
             title: Secret Access Key
             multi: false
             required: false
             show_user: false
-            default: ""
           - name: session_token
             type: text
             title: Session Token
             multi: false
             required: false
             show_user: false
-            default: ""
           - name: shared_credential_file
             type: text
             title: Shared Credential File
             multi: false
             required: false
             show_user: false
-            default: ""
           - name: credential_profile_name
             type: text
             title: Credential Profile Name
             multi: false
             required: false
             show_user: true
-            default: ""
           - name: role_arn
             type: text
             title: Role ARN
             multi: false
             required: false
             show_user: false
-            default: ""
           - name: endpoint
             type: text
             title: Endpoint


### PR DESCRIPTION
## What does this PR do?

This PR fixes passing credentials into aws package for metrics data streams. The bug is caused by mismatching variable names between `stream.yml.hbs` for elastic-agent template and `manifest.yml` for defining and passing credentials. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [x] I have verified that all datasets collect metrics or logs.

## Related issues

- Closes #https://github.com/elastic/integrations/issues/465


## Screenshots
```
id: 02716e40-4141-11eb-aecf-c93b3fa306f0
revision: 8
outputs:
  default:
    type: elasticsearch
    hosts:
      - 'http://elasticsearch:9200'
agent:
  monitoring:
    enabled: true
    use_output: default
    logs: true
    metrics: true
inputs:
  - id: ae0f6522-7da1-4ea5-bcd3-7d661d62a448
    name: aws-1
    revision: 1
    type: aws/metrics
    use_output: default
    meta:
      package:
        name: aws
        version: 0.3.15
    data_stream:
      namespace: default
    streams:
      - id: aws/metrics-aws.dynamodb-ae0f6522-7da1-4ea5-bcd3-7d661d62a448
        data_stream:
          dataset: aws.dynamodb
          type: metrics
        metricsets:
          - dynamodb
        period: 5m
        access_key_id: 123
        secret_access_key: 456
        session_token: 789
        tags_filter: null
        aws_partition: aws
fleet:
  kibana:
    protocol: http
    hosts:
      - 'kibana:5601'
```

