### PR TITLE
nginx_ingress_controller: use event.created in the ingest pipeline

### DIFF
--- a/packages/nginx_ingress_controller/data_stream/error/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nginx_ingress_controller/data_stream/error/elasticsearch/ingest_pipeline/default.yml
@@ -59,7 +59,7 @@ processors:
       lang: painless
       source: >-
         ZoneId zid = ZoneId.of(ctx.event.timezone);
-        ZonedDateTime zdt = ZonedDateTime.parse(ctx.event.ingested)
+        ZonedDateTime zdt = ZonedDateTime.parse(ctx.event.created)
                  .withMonth(ctx.timestamp_month)
                  .withDayOfMonth(ctx.timestamp_day)
                  .withHour(ctx.timestamp_hour)

--- a/packages/nginx_ingress_controller/manifest.yml
+++ b/packages/nginx_ingress_controller/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: nginx_ingress_controller
 title: Nginx Ingress Controller
-version: 0.0.2
+version: 0.0.3
 license: basic
 description: Nginx Ingress Controller Integration
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR fixes issue spotted in the Nginx Ingress Controller's pipeline tests (non-idempotent test runs).

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [x] I have verified that all datasets collect metrics or logs.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

The CI will verify it.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- https://github.com/elastic/integrations/issues/491
