### PR TITLE
Fix conditional in load dataset

### DIFF
--- a/packages/system/data_stream/load/agent/stream/stream.yml.hbs
+++ b/packages/system/data_stream/load/agent/stream/stream.yml.hbs
@@ -1,3 +1,3 @@
 metricsets: ["load"]
-condition: ${host.platform} == 'linux'
+condition: ${host.platform} != 'windows'
 period: {{period}}

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 0.10.4
+version: 0.10.5
 license: basic
 description: System Integration
 type: integration


### PR DESCRIPTION


## What does this PR do?

No idea how I missed this in testing, but the `load` metricset should only be skipped on Windows, as opposed to just running on Linux.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [X] I have verified that all datasets collect metrics or logs.

