### PR TITLE
add host inventory schema fields and process fields

### DIFF
--- a/packages/aws/data_stream/ec2_metrics/fields/agent.yml
+++ b/packages/aws/data_stream/ec2_metrics/fields/agent.yml
@@ -196,3 +196,29 @@
       description: >
         OS codename, if any.
 
+    - name: cpu.pct
+      type: scaled_float
+      format: percent
+      description: Percent CPU used. This value is normalized by the number of CPU cores and it ranges from 0 to 1.
+    - name: network.in.bytes
+      type: long
+      format: bytes
+      description: The number of bytes received on all network interfaces by the host in a given period of time.
+    - name: network.out.bytes
+      type: long
+      format: bytes
+      description: The number of bytes sent out on all network interfaces by the host in a given period of time.
+    - name: network.in.packets
+      type: long
+      description: The number of packets received on all network interfaces by the host in a given period of time.
+    - name: network.out.packets
+      type: long
+      description: The number of packets sent out on all network interfaces by the host in a given period of time.
+    - name: disk.read.bytes
+      type: long
+      format: bytes
+      description: The total number of bytes read successfully in a given period of time.
+    - name: disk.write.bytes
+      type: long
+      format: bytes
+      description: The total number of bytes write successfully in a given period of time.

--- a/packages/aws/data_stream/ec2_metrics/fields/agent.yml
+++ b/packages/aws/data_stream/ec2_metrics/fields/agent.yml
@@ -201,31 +201,38 @@
       format: percent
       description: >
         Percent CPU used. This value is normalized by the number of CPU cores and it ranges from 0 to 1.
+
     - name: disk.read.bytes
       type: long
       format: bytes
       description: >
         The total number of bytes read successfully in a given period of time.
+
     - name: disk.write.bytes
       type: long
       format: bytes
       description: >
         The total number of bytes write successfully in a given period of time.
+
     - name: network.in.bytes
       type: long
       format: bytes
       description: >
         The number of bytes received on all network interfaces by the host in a given period of time.
+
     - name: network.in.packets
       type: long
       description: >
         The number of packets received on all network interfaces by the host in a given period of time.
+
     - name: network.out.bytes
       type: long
       format: bytes
       description: >
         The number of bytes sent out on all network interfaces by the host in a given period of time.
+
     - name: network.out.packets
       type: long
       description: >
         The number of packets sent out on all network interfaces by the host in a given period of time.
+

--- a/packages/aws/data_stream/ec2_metrics/fields/agent.yml
+++ b/packages/aws/data_stream/ec2_metrics/fields/agent.yml
@@ -199,26 +199,33 @@
     - name: cpu.pct
       type: scaled_float
       format: percent
-      description: Percent CPU used. This value is normalized by the number of CPU cores and it ranges from 0 to 1.
-    - name: network.in.bytes
-      type: long
-      format: bytes
-      description: The number of bytes received on all network interfaces by the host in a given period of time.
-    - name: network.out.bytes
-      type: long
-      format: bytes
-      description: The number of bytes sent out on all network interfaces by the host in a given period of time.
-    - name: network.in.packets
-      type: long
-      description: The number of packets received on all network interfaces by the host in a given period of time.
-    - name: network.out.packets
-      type: long
-      description: The number of packets sent out on all network interfaces by the host in a given period of time.
+      description: >
+        Percent CPU used. This value is normalized by the number of CPU cores and it ranges from 0 to 1.
     - name: disk.read.bytes
       type: long
       format: bytes
-      description: The total number of bytes read successfully in a given period of time.
+      description: >
+        The total number of bytes read successfully in a given period of time.
     - name: disk.write.bytes
       type: long
       format: bytes
-      description: The total number of bytes write successfully in a given period of time.
+      description: >
+        The total number of bytes write successfully in a given period of time.
+    - name: network.in.bytes
+      type: long
+      format: bytes
+      description: >
+        The number of bytes received on all network interfaces by the host in a given period of time.
+    - name: network.in.packets
+      type: long
+      description: >
+        The number of packets received on all network interfaces by the host in a given period of time.
+    - name: network.out.bytes
+      type: long
+      format: bytes
+      description: >
+        The number of bytes sent out on all network interfaces by the host in a given period of time.
+    - name: network.out.packets
+      type: long
+      description: >
+        The number of packets sent out on all network interfaces by the host in a given period of time.

--- a/packages/aws/data_stream/ec2_metrics/fields/fields.yml
+++ b/packages/aws/data_stream/ec2_metrics/fields/fields.yml
@@ -159,34 +159,3 @@
           type: integer
           description: |
             The number of threads per CPU core.
-- name: host
-  type: group
-  fields:
-    - name: cpu.pct
-      type: scaled_float
-      description: |
-        Percent CPU used. This value is normalized by the number of CPU cores and it ranges from 0 to 1.
-    - name: disk.read.bytes
-      type: scaled_float
-      description: |
-        The total number of bytes read successfully in a given period of time.
-    - name: disk.write.bytes
-      type: scaled_float
-      description: |
-        The total number of bytes write successfully in a given period of time.
-    - name: network.in.bytes
-      type: scaled_float
-      description: |
-        The number of bytes received on all network interfaces by the host in a given period of time.
-    - name: network.out.bytes
-      type: scaled_float
-      description: |
-        The number of bytes sent out on all network interfaces by the host in a given period of time.
-    - name: network.in.packets
-      type: scaled_float
-      description: |
-        The number of packets received on all network interfaces by the host in a given period of time.
-    - name: network.out.packets
-      type: scaled_float
-      description: |
-        The number of packets sent out on all network interfaces by the host in a given period of time.

--- a/packages/aws/docs/README.md
+++ b/packages/aws/docs/README.md
@@ -1370,8 +1370,8 @@ An example event for `ec2` looks as following:
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
 | host.network.in.bytes | The number of bytes received on all network interfaces by the host in a given period of time. | scaled_float |
 | host.network.in.packets | The number of packets received on all network interfaces by the host in a given period of time. | scaled_float |
-| host.network.out.bytes | The number of bytes sent out on all network interfaces by the host in a given period of time. | scaled_float |
-| host.network.out.packets | The number of packets sent out on all network interfaces by the host in a given period of time. | scaled_float |
+| host.network.out.bytes | The number of bytes sent out on all network interfaces by the host in a given period of time. | long |
+| host.network.out.packets | The number of packets sent out on all network interfaces by the host in a given period of time. | long |
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |

--- a/packages/aws/docs/README.md
+++ b/packages/aws/docs/README.md
@@ -1360,7 +1360,7 @@ An example event for `ec2` looks as following:
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.cpu.pct | Percent CPU used. This value is normalized by the number of CPU cores and it ranges from 0 to 1. | scaled_float |
-| host.disk.read.bytes | The total number of bytes read successfully in a given period of time. | scaled_float |
+| host.disk.read.bytes | The total number of bytes read successfully in a given period of time. | long |
 | host.disk.write.bytes | The total number of bytes write successfully in a given period of time. | long |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
@@ -1370,7 +1370,7 @@ An example event for `ec2` looks as following:
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
 | host.network.in.bytes | The number of bytes received on all network interfaces by the host in a given period of time. | long |
 | host.network.in.packets | The number of packets received on all network interfaces by the host in a given period of time. | long |
-| host.network.out.bytes | The number of bytes sent out on all network interfaces by the host in a given period of time. | scaled_float |
+| host.network.out.bytes | The number of bytes sent out on all network interfaces by the host in a given period of time. | long |
 | host.network.out.packets | The number of packets sent out on all network interfaces by the host in a given period of time. | long |
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |

--- a/packages/aws/docs/README.md
+++ b/packages/aws/docs/README.md
@@ -1361,16 +1361,16 @@ An example event for `ec2` looks as following:
 | host.containerized | If the host is a container. | boolean |
 | host.cpu.pct | Percent CPU used. This value is normalized by the number of CPU cores and it ranges from 0 to 1. | scaled_float |
 | host.disk.read.bytes | The total number of bytes read successfully in a given period of time. | scaled_float |
-| host.disk.write.bytes | The total number of bytes write successfully in a given period of time. | scaled_float |
+| host.disk.write.bytes | The total number of bytes write successfully in a given period of time. | long |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.network.in.bytes | The number of bytes received on all network interfaces by the host in a given period of time. | scaled_float |
-| host.network.in.packets | The number of packets received on all network interfaces by the host in a given period of time. | scaled_float |
-| host.network.out.bytes | The number of bytes sent out on all network interfaces by the host in a given period of time. | long |
+| host.network.in.bytes | The number of bytes received on all network interfaces by the host in a given period of time. | long |
+| host.network.in.packets | The number of packets received on all network interfaces by the host in a given period of time. | long |
+| host.network.out.bytes | The number of bytes sent out on all network interfaces by the host in a given period of time. | scaled_float |
 | host.network.out.packets | The number of packets sent out on all network interfaces by the host in a given period of time. | long |
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 0.3.15
+version: 0.3.16
 license: basic
 description: AWS Integration
 type: integration

--- a/packages/system/data_stream/cpu/fields/agent.yml
+++ b/packages/system/data_stream/cpu/fields/agent.yml
@@ -201,3 +201,4 @@
       format: percent
       description: >
         Percent CPU used. This value is normalized by the number of CPU cores and it ranges from 0 to 1.
+

--- a/packages/system/data_stream/cpu/fields/agent.yml
+++ b/packages/system/data_stream/cpu/fields/agent.yml
@@ -199,4 +199,5 @@
     - name: cpu.pct
       type: scaled_float
       format: percent
-      description: Percent CPU used. This value is normalized by the number of CPU cores and it ranges from 0 to 1.
+      description: >
+        Percent CPU used. This value is normalized by the number of CPU cores and it ranges from 0 to 1.

--- a/packages/system/data_stream/cpu/fields/agent.yml
+++ b/packages/system/data_stream/cpu/fields/agent.yml
@@ -196,3 +196,7 @@
       description: >
         OS codename, if any.
 
+    - name: cpu.pct
+      type: scaled_float
+      format: percent
+      description: Percent CPU used. This value is normalized by the number of CPU cores and it ranges from 0 to 1.

--- a/packages/system/data_stream/diskio/fields/agent.yml
+++ b/packages/system/data_stream/diskio/fields/agent.yml
@@ -201,8 +201,9 @@
       format: bytes
       description: >
         The total number of bytes read successfully in a given period of time.
+
     - name: disk.write.bytes
       type: long
       format: bytes
-      description: >
+      description: >-
         The total number of bytes write successfully in a given period of time.

--- a/packages/system/data_stream/diskio/fields/agent.yml
+++ b/packages/system/data_stream/diskio/fields/agent.yml
@@ -199,8 +199,10 @@
     - name: disk.read.bytes
       type: long
       format: bytes
-      description: The total number of bytes read successfully in a given period of time.
+      description: >
+        The total number of bytes read successfully in a given period of time.
     - name: disk.write.bytes
       type: long
       format: bytes
-      description: The total number of bytes write successfully in a given period of time.
+      description: >
+        The total number of bytes write successfully in a given period of time.

--- a/packages/system/data_stream/diskio/fields/agent.yml
+++ b/packages/system/data_stream/diskio/fields/agent.yml
@@ -196,3 +196,11 @@
       description: >
         OS codename, if any.
 
+    - name: disk.read.bytes
+      type: long
+      format: bytes
+      description: The total number of bytes read successfully in a given period of time.
+    - name: disk.write.bytes
+      type: long
+      format: bytes
+      description: The total number of bytes write successfully in a given period of time.

--- a/packages/system/data_stream/network/fields/agent.yml
+++ b/packages/system/data_stream/network/fields/agent.yml
@@ -201,16 +201,20 @@
       format: bytes
       description: >
         The number of bytes received on all network interfaces by the host in a given period of time.
+
     - name: network.in.packets
       type: long
       description: >
         The number of packets received on all network interfaces by the host in a given period of time.
+
     - name: network.out.bytes
       type: long
       format: bytes
       description: >
         The number of bytes sent out on all network interfaces by the host in a given period of time.
+
     - name: network.out.packets
       type: long
       description: >
         The number of packets sent out on all network interfaces by the host in a given period of time.
+

--- a/packages/system/data_stream/network/fields/agent.yml
+++ b/packages/system/data_stream/network/fields/agent.yml
@@ -199,14 +199,18 @@
     - name: network.in.bytes
       type: long
       format: bytes
-      description: The number of bytes received on all network interfaces by the host in a given period of time.
+      description: >
+        The number of bytes received on all network interfaces by the host in a given period of time.
+    - name: network.in.packets
+      type: long
+      description: >
+        The number of packets received on all network interfaces by the host in a given period of time.
     - name: network.out.bytes
       type: long
       format: bytes
-      description: The number of bytes sent out on all network interfaces by the host in a given period of time.
-    - name: network.in.packets
-      type: long
-      description: The number of packets received on all network interfaces by the host in a given period of time.
+      description: >
+        The number of bytes sent out on all network interfaces by the host in a given period of time.
     - name: network.out.packets
       type: long
-      description: The number of packets sent out on all network interfaces by the host in a given period of time.
+      description: >
+        The number of packets sent out on all network interfaces by the host in a given period of time.

--- a/packages/system/data_stream/network/fields/agent.yml
+++ b/packages/system/data_stream/network/fields/agent.yml
@@ -196,3 +196,17 @@
       description: >
         OS codename, if any.
 
+    - name: network.in.bytes
+      type: long
+      format: bytes
+      description: The number of bytes received on all network interfaces by the host in a given period of time.
+    - name: network.out.bytes
+      type: long
+      format: bytes
+      description: The number of bytes sent out on all network interfaces by the host in a given period of time.
+    - name: network.in.packets
+      type: long
+      description: The number of packets received on all network interfaces by the host in a given period of time.
+    - name: network.out.packets
+      type: long
+      description: The number of packets sent out on all network interfaces by the host in a given period of time.

--- a/packages/system/data_stream/process/fields/agent.yml
+++ b/packages/system/data_stream/process/fields/agent.yml
@@ -195,6 +195,7 @@
       example: "stretch"
       description: >
         OS codename, if any.
+
 - name: process
   title: Process
   group: 2
@@ -205,19 +206,21 @@
       type: keyword
       description: >
         The process state. For example: "running".
+
     - name: cpu.pct
       type: scaled_float
       format: percent
       description: >
-        The percentage of CPU time spent by the process since the last event.
-        This value is normalized by the number of CPU cores and it ranges
-        from 0 to 1.
+        The percentage of CPU time spent by the process since the last event. This value is normalized by the number of CPU cores and it ranges from 0 to 1.
+
     - name: cpu.start_time
       type: date
       description: >
         The time when the process was started.
+
     - name: memory.pct
       type: scaled_float
       format: percent
       description: >
         The percentage of memory the process occupied in main memory (RAM).
+

--- a/packages/system/data_stream/process/fields/agent.yml
+++ b/packages/system/data_stream/process/fields/agent.yml
@@ -195,4 +195,29 @@
       example: "stretch"
       description: >
         OS codename, if any.
-
+- name: process
+  title: Process
+  group: 2
+  description: Process metrics.
+  type: group
+  fields:
+    - name: state
+      type: keyword
+      description: >
+        The process state. For example: "running".
+    - name: cpu.pct
+      type: scaled_float
+      format: percent
+      description: >
+        The percentage of CPU time spent by the process since the last event.
+        This value is normalized by the number of CPU cores and it ranges
+        from 0 to 1.
+    - name: cpu.start_time
+      type: date
+      description: >
+        The time when the process was started.
+    - name: memory.pct
+      type: scaled_float
+      format: percent
+      description: >
+        The percentage of memory the process occupied in main memory (RAM).

--- a/packages/system/docs/README.md
+++ b/packages/system/docs/README.md
@@ -127,7 +127,7 @@ This dataset is available on:
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
+| host.ip | Host ip address. | ip |
 | host.mac | Host mac addresses. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
 | host.os.build | OS build information. | keyword |
@@ -219,7 +219,7 @@ This dataset is available on:
 | host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. | keyword |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | system.diskio.io.time | The total number of of milliseconds spent doing I/Os. | long |
 | system.diskio.iostat.await | The average time spent for requests issued to the device to be served. | float |
 | system.diskio.iostat.busy | Percentage of CPU time during which I/O requests were issued to the device (bandwidth utilization for the device). Device saturation occurs when this value is close to 100%. | float |
@@ -548,9 +548,9 @@ This dataset is available on:
 | host.mac | Host mac addresses. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
 | host.network.in.bytes | The number of bytes received on all network interfaces by the host in a given period of time. | scaled_float |
-| host.network.in.packets | The number of packets received on all network interfaces by the host in a given period of time. | scaled_float |
+| host.network.in.packets | The number of packets received on all network interfaces by the host in a given period of time. | long |
 | host.network.out.bytes | The number of bytes sent out on all network interfaces by the host in a given period of time. | scaled_float |
-| host.network.out.packets | The number of packets sent out on all network interfaces by the host in a given period of time. | scaled_float |
+| host.network.out.packets | The number of packets sent out on all network interfaces by the host in a given period of time. | long |
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
@@ -621,8 +621,8 @@ This dataset is available on:
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
+| host.ip | Host ip address. | ip |
+| host.mac | Host mac address. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |
@@ -632,11 +632,15 @@ This dataset is available on:
 | host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. | keyword |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| process.cpu.pct | The percentage of CPU time spent by the process since the last event. This value is normalized by the number of CPU cores and it ranges from 0 to 1. | scaled_float |
+| process.cpu.start_time | The time when the process was started. | date |
+| process.memory.pct | The percentage of memory the process occupied in main memory (RAM). | scaled_float |
 | process.name | Process name. Sometimes called program name or similar. | keyword |
 | process.pgid | Identifier of the group of processes the process belongs to. | long |
 | process.pid | Process id. | long |
 | process.ppid | Parent process' pid. | long |
+| process.state | The process state. For example: "running". | keyword |
 | process.working_directory | The working directory of the process. | keyword |
 | system.process.cgroup.blkio.id | ID of the cgroup. | keyword |
 | system.process.cgroup.blkio.path | Path to the cgroup relative to the cgroup subsystems mountpoint. | keyword |

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 0.10.4
+version: 0.10.5
 license: basic
 description: System Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?

This PR is to add common [host inventory schema fields](https://github.com/elastic/beats/issues/19757) and [process inventory schema fields](https://github.com/elastic/beats/issues/22216) into integration packages. 

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [ ] I have verified that all datasets collect metrics or logs.