### PR TITLE
Update fortinet/firewall integration to ECS 1.7

### DIFF
--- a/packages/fortinet/data_stream/firewall/_dev/test/pipeline/test-fortinet.log-expected.json
+++ b/packages/fortinet/data_stream/firewall/_dev/test/pipeline/test-fortinet.log-expected.json
@@ -49,7 +49,7 @@
                 "protocol": "https",
                 "bytes": 2282,
                 "iana_number": "6",
-                "direction": "outgoing"
+                "direction": "outbound"
             },
             "observer": {
                 "ingress": {
@@ -94,7 +94,7 @@
                 }
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391149Z",
+                "ingested": "2021-01-12T02:31:22.248235600Z",
                 "code": "0316013056",
                 "timezone": "-0500",
                 "kind": "event",
@@ -194,7 +194,7 @@
             },
             "event": {
                 "duration": 0,
-                "ingested": "2020-12-03T04:21:52.391189500Z",
+                "ingested": "2021-01-12T02:31:22.248289800Z",
                 "code": "0000000013",
                 "kind": "event",
                 "module": "fortinet",
@@ -260,7 +260,7 @@
                 "protocol": "https",
                 "bytes": 10357,
                 "iana_number": "6",
-                "direction": "outgoing"
+                "direction": "outbound"
             },
             "observer": {
                 "ingress": {
@@ -305,7 +305,7 @@
                 }
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391220100Z",
+                "ingested": "2021-01-12T02:31:22.248297700Z",
                 "code": "0317013312",
                 "timezone": "-0500",
                 "kind": "event",
@@ -369,7 +369,7 @@
                 "protocol": "ssl",
                 "application": "HTTPS.BROWSER",
                 "iana_number": "6",
-                "direction": "outgoing"
+                "direction": "outbound"
             },
             "observer": {
                 "ingress": {
@@ -423,7 +423,7 @@
                 }
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391279200Z",
+                "ingested": "2021-01-12T02:31:22.248309500Z",
                 "code": "1059028704",
                 "timezone": "-0400",
                 "kind": "event",
@@ -487,7 +487,7 @@
                 "protocol": "ssl",
                 "application": "HTTPS.BROWSER",
                 "iana_number": "6",
-                "direction": "outgoing"
+                "direction": "outbound"
             },
             "observer": {
                 "ingress": {
@@ -541,7 +541,7 @@
                 }
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391293100Z",
+                "ingested": "2021-01-12T02:31:22.248324Z",
                 "code": "1059028704",
                 "timezone": "-0400",
                 "kind": "event",
@@ -643,7 +643,7 @@
                 }
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391303500Z",
+                "ingested": "2021-01-12T02:31:22.248338500Z",
                 "code": "1501054802",
                 "timezone": "-0500",
                 "kind": "event",
@@ -747,7 +747,7 @@
                 }
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391317500Z",
+                "ingested": "2021-01-12T02:31:22.248353Z",
                 "code": "1501054802",
                 "timezone": "-0500",
                 "kind": "event",
@@ -812,7 +812,7 @@
                 "protocol": "ssl",
                 "application": "HTTPS.BROWSER",
                 "iana_number": "6",
-                "direction": "outgoing"
+                "direction": "outbound"
             },
             "observer": {
                 "ingress": {
@@ -857,7 +857,7 @@
                 }
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391326Z",
+                "ingested": "2021-01-12T02:31:22.248367400Z",
                 "code": "1059028704",
                 "timezone": "-0500",
                 "kind": "event",
@@ -959,7 +959,7 @@
                 }
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391332600Z",
+                "ingested": "2021-01-12T02:31:22.248381700Z",
                 "code": "1501054802",
                 "timezone": "-0500",
                 "kind": "event",
@@ -1055,7 +1055,7 @@
                 }
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391368900Z",
+                "ingested": "2021-01-12T02:31:22.248422800Z",
                 "code": "1500054000",
                 "timezone": "-0500",
                 "kind": "event",
@@ -1153,7 +1153,7 @@
                 }
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391385300Z",
+                "ingested": "2021-01-12T02:31:22.248436400Z",
                 "code": "1700062001",
                 "timezone": "-0400",
                 "kind": "event",
@@ -1209,7 +1209,7 @@
                 "ip": "10.10.10.10"
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391396100Z",
+                "ingested": "2021-01-12T02:31:22.248444100Z",
                 "code": "0102043014",
                 "timezone": "-0500",
                 "kind": "event",
@@ -1304,7 +1304,7 @@
                 }
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391405700Z",
+                "ingested": "2021-01-12T02:31:22.248456Z",
                 "code": "0101037124",
                 "timezone": "-0500",
                 "kind": "event",
@@ -1403,7 +1403,7 @@
                 }
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391415500Z",
+                "ingested": "2021-01-12T02:31:22.248470800Z",
                 "code": "0101037127",
                 "timezone": "-0500",
                 "kind": "event",
@@ -1453,7 +1453,7 @@
                 "description": "System performance statistics"
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391426800Z",
+                "ingested": "2021-01-12T02:31:22.248485500Z",
                 "code": "0100040704",
                 "timezone": "-0300",
                 "kind": "event",
@@ -1509,7 +1509,7 @@
                 "ip": "10.10.10.10"
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391454900Z",
+                "ingested": "2021-01-12T02:31:22.248500800Z",
                 "code": "0102043039",
                 "timezone": "-0500",
                 "kind": "event",
@@ -1604,7 +1604,7 @@
                 }
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391465Z",
+                "ingested": "2021-01-12T02:31:22.248542600Z",
                 "code": "0101037127",
                 "timezone": "-0500",
                 "kind": "event",
@@ -1644,7 +1644,7 @@
                 "description": "FortiSandbox AV database updated"
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391474800Z",
+                "ingested": "2021-01-12T02:31:22.248549100Z",
                 "code": "0100041006",
                 "timezone": "-0300",
                 "kind": "event",
@@ -1696,7 +1696,7 @@
                 }
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391485600Z",
+                "ingested": "2021-01-12T02:31:22.248556300Z",
                 "code": "0107045057",
                 "timezone": "-0500",
                 "kind": "event",
@@ -1757,7 +1757,7 @@
                 "description": "SSL VPN new connection"
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391514800Z",
+                "ingested": "2021-01-12T02:31:22.248562800Z",
                 "code": "0101039943",
                 "timezone": "-0500",
                 "kind": "event",
@@ -1837,7 +1837,7 @@
                 }
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391529100Z",
+                "ingested": "2021-01-12T02:31:22.248570400Z",
                 "code": "0101039947",
                 "timezone": "-0500",
                 "kind": "event",
@@ -1891,7 +1891,7 @@
                 "ip": "192.168.1.1"
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391560500Z",
+                "ingested": "2021-01-12T02:31:22.248582400Z",
                 "code": "0102043015",
                 "timezone": "-0300",
                 "kind": "event",
@@ -1934,7 +1934,7 @@
                 "description": "FortiCloud server connected"
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391571600Z",
+                "ingested": "2021-01-12T02:31:22.248598200Z",
                 "code": "0100022915",
                 "timezone": "-0500",
                 "kind": "event",
@@ -1970,7 +1970,7 @@
                 "description": "FortiCloud server disconnected"
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391633400Z",
+                "ingested": "2021-01-12T02:31:22.248610Z",
                 "code": "0100022913",
                 "timezone": "-0500",
                 "kind": "event",
@@ -2059,7 +2059,7 @@
                 }
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391644600Z",
+                "ingested": "2021-01-12T02:31:22.248621800Z",
                 "code": "0000000011",
                 "timezone": "-0500",
                 "kind": "event",
@@ -2188,7 +2188,7 @@
             },
             "event": {
                 "duration": 5462000000000,
-                "ingested": "2020-12-03T04:21:52.391654600Z",
+                "ingested": "2021-01-12T02:31:22.248683400Z",
                 "code": "0000000020",
                 "timezone": "-0500",
                 "kind": "event",
@@ -2302,7 +2302,7 @@
             },
             "event": {
                 "duration": 42000000000,
-                "ingested": "2020-12-03T04:21:52.391665500Z",
+                "ingested": "2021-01-12T02:31:22.248714700Z",
                 "code": "0001000014",
                 "timezone": "-0500",
                 "kind": "event",
@@ -2413,7 +2413,7 @@
             },
             "event": {
                 "duration": 20000000000,
-                "ingested": "2020-12-03T04:21:52.391695800Z",
+                "ingested": "2021-01-12T02:31:22.248762400Z",
                 "code": "0001000014",
                 "timezone": "-0400",
                 "kind": "event",
@@ -2504,7 +2504,7 @@
                 }
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391699100Z",
+                "ingested": "2021-01-12T02:31:22.248836800Z",
                 "code": "0000000011",
                 "timezone": "-0500",
                 "kind": "event",
@@ -2656,7 +2656,7 @@
             },
             "event": {
                 "duration": 126000000000,
-                "ingested": "2020-12-03T04:21:52.391705600Z",
+                "ingested": "2021-01-12T02:31:22.248852200Z",
                 "code": "0000000013",
                 "timezone": "-0500",
                 "kind": "event",
@@ -2717,7 +2717,7 @@
                 "protocol": "https",
                 "application": "HTTPS.BROWSER",
                 "iana_number": "6",
-                "direction": "outgoing"
+                "direction": "outbound"
             },
             "observer": {
                 "ingress": {
@@ -2769,7 +2769,7 @@
                 }
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391716900Z",
+                "ingested": "2021-01-12T02:31:22.248861800Z",
                 "code": "1059028704",
                 "kind": "event",
                 "module": "fortinet",
@@ -2853,7 +2853,7 @@
                 }
             },
             "event": {
-                "ingested": "2020-12-03T04:21:52.391726300Z",
+                "ingested": "2021-01-12T02:31:22.248881400Z",
                 "code": "0101037127",
                 "kind": "event",
                 "module": "fortinet",

--- a/packages/fortinet/data_stream/firewall/agent/stream/log.yml.hbs
+++ b/packages/fortinet/data_stream/firewall/agent/stream/log.yml.hbs
@@ -9,7 +9,25 @@ tags:
 {{/each}}
 publisher_pipeline.disable_host: true
 processors:
+  {{#if internal_interfaces.length}}
+  - add_fields:
+      target: _temp
+      fields:
+        internal_interfaces:
+          {{#each internal_interfaces as |interface i|}}
+          - {{interface}}
+          {{/each}}
+  {{/if}}
+  {{#if external_interfaces.length}}
+  - add_fields:
+      target: _temp
+      fields:
+        external_interfaces:
+          {{#each external_interfaces as |interface i|}}
+          - {{interface}}
+          {{/each}}
+  {{/if}}
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.6.0
+        ecs.version: 1.7.0

--- a/packages/fortinet/data_stream/firewall/agent/stream/tcp.yml.hbs
+++ b/packages/fortinet/data_stream/firewall/agent/stream/tcp.yml.hbs
@@ -5,7 +5,25 @@ tags:
 {{/each}}
 publisher_pipeline.disable_host: true
 processors:
+  {{#if internal_interfaces.length}}
+  - add_fields:
+      target: _temp
+      fields:
+        internal_interfaces:
+          {{#each internal_interfaces as |interface i|}}
+          - {{interface}}
+          {{/each}}
+  {{/if}}
+  {{#if external_interfaces.length}}
+  - add_fields:
+      target: _temp
+      fields:
+        external_interfaces:
+          {{#each external_interfaces as |interface i|}}
+          - {{interface}}
+          {{/each}}
+  {{/if}}
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.6.0
+        ecs.version: 1.7.0

--- a/packages/fortinet/data_stream/firewall/agent/stream/udp.yml.hbs
+++ b/packages/fortinet/data_stream/firewall/agent/stream/udp.yml.hbs
@@ -5,7 +5,25 @@ tags:
 {{/each}}
 publisher_pipeline.disable_host: true
 processors:
+  {{#if internal_interfaces.length}}
+  - add_fields:
+      target: _temp
+      fields:
+        internal_interfaces:
+          {{#each internal_interfaces as |interface i|}}
+          - {{interface}}
+          {{/each}}
+  {{/if}}
+  {{#if external_interfaces.length}}
+  - add_fields:
+      target: _temp
+      fields:
+        external_interfaces:
+          {{#each external_interfaces as |interface i|}}
+          - {{interface}}
+          {{/each}}
+  {{/if}}
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.6.0
+        ecs.version: 1.7.0

--- a/packages/fortinet/data_stream/firewall/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fortinet/data_stream/firewall/elasticsearch/ingest_pipeline/default.yml
@@ -1,199 +1,257 @@
 ---
 description: Pipeline for parsing fortinet firewall logs
 processors:
-- set:
-    field: event.ingested
-    value: '{{_ingest.timestamp}}'
-- grok:
-    field: message
-    patterns:
-    - '%{SYSLOG5424PRI}%{GREEDYDATA:syslog5424_sd}$'
-- kv:
-    field: syslog5424_sd
-    field_split: " (?=[a-z\\_\\-]+=)"
-    value_split: "="
-    prefix: "fortinet.firewall."
-    ignore_missing: true
-    ignore_failure: false
-    trim_value: "\""
-- set:
-    field: observer.vendor
-    value: Fortinet
-- set:
-    field: observer.product
-    value: Fortigate
-- set:
-    field: observer.type
-    value: firewall
-- set:
-    field: event.module
-    value: fortinet
-- set:
-    field: event.dataset
-    value: fortinet.firewall
-- set:
-    field: event.timezone
-    value: "{{fortinet.firewall.tz}}"
-    ignore_empty_value: true
-- set:
-    field: _temp.time
-    value: "{{fortinet.firewall.date}} {{fortinet.firewall.time}} {{fortinet.firewall.tz}}"
-    if: "ctx.fortinet?.firewall?.tz != null"
-- set:
-    field: _temp.time
-    value: "{{fortinet.firewall.date}} {{fortinet.firewall.time}}"
-    if: "ctx.fortinet?.firewall?.tz == null"
-- date:
-    field: _temp.time
-    target_field: "@timestamp"
-    formats:
-    - yyyy-MM-dd HH:mm:ss
-    - yyyy-MM-dd HH:mm:ss Z
-    - yyyy-MM-dd HH:mm:ss z
-    - ISO8601
-    timezone: "{{fortinet.firewall.tz}}"
-    if: "ctx.fortinet?.firewall?.tz != null"
-- date:
-    field: _temp.time
-    target_field: "@timestamp"
-    formats:
-    - yyyy-MM-dd HH:mm:ss
-    - yyyy-MM-dd HH:mm:ss Z
-    - yyyy-MM-dd HH:mm:ss z
-    - ISO8601
-    if: "ctx.fortinet?.firewall?.tz == null"
-- gsub:
-    field: fortinet.firewall.eventtime
-    pattern: "\\d{6}$"
-    replacement: ""
-    if: "ctx.fortinet?.firewall?.eventtime != null && (ctx.fortinet?.firewall?.eventtime).length() > 18"
-- date:
-    field: fortinet.firewall.eventtime
-    target_field: event.start
-    formats:
-    - UNIX_MS
-    timezone: "{{fortinet.firewall.tz}}"
-    if: "ctx?.fortinet?.firewall?.eventtime != null && ctx.fortinet?.firewall?.tz != null && (ctx.fortinet?.firewall?.eventtime).length() > 11"
-- date:
-    field: fortinet.firewall.eventtime
-    target_field: event.start
-    formats:
-    - UNIX
-    timezone: "{{fortinet.firewall.tz}}"
-    if: "ctx?.fortinet?.firewall?.eventtime != null && ctx.fortinet?.firewall?.tz != null && (ctx.fortinet?.firewall?.eventtime).length() <= 11"
-- date:
-    field: fortinet.firewall.eventtime
-    target_field: event.start
-    formats:
-    - UNIX_MS
-    if: "ctx?.fortinet?.firewall?.eventtime != null && ctx.fortinet?.firewall?.tz == null && (ctx.fortinet?.firewall?.eventtime).length() > 11"
-- date:
-    field: fortinet.firewall.eventtime
-    target_field: event.start
-    formats:
-    - UNIX
-    if: "ctx?.fortinet?.firewall?.eventtime != null && ctx.fortinet?.firewall?.tz == null && (ctx.fortinet?.firewall?.eventtime).length() <= 11"
-- rename:
-    field: fortinet.firewall.devname
-    target_field: observer.name
-    ignore_missing: true
-- script:
-    lang: painless
-    source: "ctx.event.duration = Long.parseLong(ctx.fortinet.firewall.duration) * 1000000000"
-    if: "ctx.fortinet?.firewall?.duration != null"
-- rename:
-    field: fortinet.firewall.devid
-    target_field: observer.serial_number
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.dstintf
-    target_field: observer.egress.interface.name
-    ignore_missing: true
-    if: "ctx.observer?.egress?.interface?.name == null"
-- rename:
-    field: fortinet.firewall.srcintf
-    target_field: observer.ingress.interface.name
-    ignore_missing: true
-    if: "ctx.observer?.ingress?.interface?.name == null"
-- rename:
-    field: fortinet.firewall.dst_int
-    target_field: observer.egress.interface.name
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.src_int
-    target_field: observer.ingress.interface.name
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.level
-    target_field: log.level
-    ignore_missing: true
-- remove:
-    field: fortinet.firewall.assignip
-    if: "ctx.fortinet?.firewall?.assignip == 'N/A'"
-- remove:
-    field: fortinet.firewall.dstip
-    if: "ctx.fortinet?.firewall?.dstip == 'N/A'"
-- remove:
-    field: fortinet.firewall.srcip
-    if: "ctx.fortinet?.firewall?.srcip == 'N/A'"
-- remove:
-    field: fortinet.firewall.remip
-    if: "ctx.fortinet?.firewall?.remip == 'N/A'"
-- remove:
-    field: fortinet.firewall.locip
-    if: "ctx.fortinet?.firewall?.locip == 'N/A'"
-- remove:
-    field: fortinet.firewall.group
-    if: "ctx.fortinet?.firewall?.group == 'N/A'"
-- remove:
-    field: fortinet.firewall.user
-    if: "ctx.fortinet?.firewall?.user == 'N/A'"
-- remove:
-    field: fortinet.firewall.tranip
-    if: "ctx.fortinet?.firewall?.tranip == 'N/A'"
-- remove:
-    field: fortinet.firewall.transip
-    if: "ctx.fortinet?.firewall?.transip == 'N/A'"
-- remove:
-    field: fortinet.firewall.tunnelip
-    if: "ctx.fortinet?.firewall?.tunnelip == 'N/A'"
-- remove:
-    field:
-      - _temp.time
-      - _temp
-      - message
-      - syslog5424_sd
-      - syslog5424_pri
-      - fortinet.firewall.tz
-      - fortinet.firewall.date
-      - fortinet.firewall.devid
-      - fortinet.firewall.eventtime
-      - fortinet.firewall.time
-      - fortinet.firewall.duration
-      - host
-    ignore_missing: true
-- pipeline:
-    name: '{{ IngestPipeline "event" }}'
-    if: "ctx.fortinet?.firewall?.type == 'event'"
-- pipeline:
-    name: '{{ IngestPipeline "traffic" }}'
-    if: "ctx.fortinet?.firewall?.type == 'traffic'"
-- pipeline:
-    name: '{{ IngestPipeline "utm" }}'
-    if: "ctx.fortinet?.firewall?.type == 'utm' || ctx.fortinet?.firewall?.type == 'dns'"
-- convert:
-    field: fortinet.firewall.quotamax
-    type: long
-    ignore_missing: true
-- convert:
-    field: fortinet.firewall.quotaused
-    type: long
-    ignore_missing: true
-- convert:
-    field: fortinet.firewall.size
-    type: long
-    ignore_missing: true
+  - set:
+      field: event.ingested
+      value: "{{_ingest.timestamp}}"
+  - grok:
+      field: message
+      patterns:
+        - "%{SYSLOG5424PRI}%{GREEDYDATA:syslog5424_sd}$"
+  - kv:
+      field: syslog5424_sd
+      field_split: " (?=[a-z\\_\\-]+=)"
+      value_split: "="
+      prefix: "fortinet.firewall."
+      ignore_missing: true
+      ignore_failure: false
+      trim_value: '"'
+  - set:
+      field: observer.vendor
+      value: Fortinet
+  - set:
+      field: observer.product
+      value: Fortigate
+  - set:
+      field: observer.type
+      value: firewall
+  - set:
+      field: event.module
+      value: fortinet
+  - set:
+      field: event.dataset
+      value: fortinet.firewall
+  - set:
+      field: event.timezone
+      value: "{{fortinet.firewall.tz}}"
+      ignore_empty_value: true
+  - set:
+      field: _temp.time
+      value: "{{fortinet.firewall.date}} {{fortinet.firewall.time}} {{fortinet.firewall.tz}}"
+      if: "ctx.fortinet?.firewall?.tz != null"
+  - set:
+      field: _temp.time
+      value: "{{fortinet.firewall.date}} {{fortinet.firewall.time}}"
+      if: "ctx.fortinet?.firewall?.tz == null"
+  - date:
+      field: _temp.time
+      target_field: "@timestamp"
+      formats:
+        - yyyy-MM-dd HH:mm:ss
+        - yyyy-MM-dd HH:mm:ss Z
+        - yyyy-MM-dd HH:mm:ss z
+        - ISO8601
+      timezone: "{{fortinet.firewall.tz}}"
+      if: "ctx.fortinet?.firewall?.tz != null"
+  - date:
+      field: _temp.time
+      target_field: "@timestamp"
+      formats:
+        - yyyy-MM-dd HH:mm:ss
+        - yyyy-MM-dd HH:mm:ss Z
+        - yyyy-MM-dd HH:mm:ss z
+        - ISO8601
+      if: "ctx.fortinet?.firewall?.tz == null"
+  - gsub:
+      field: fortinet.firewall.eventtime
+      pattern: "\\d{6}$"
+      replacement: ""
+      if: "ctx.fortinet?.firewall?.eventtime != null && (ctx.fortinet?.firewall?.eventtime).length() > 18"
+  - date:
+      field: fortinet.firewall.eventtime
+      target_field: event.start
+      formats:
+        - UNIX_MS
+      timezone: "{{fortinet.firewall.tz}}"
+      if: "ctx?.fortinet?.firewall?.eventtime != null && ctx.fortinet?.firewall?.tz != null && (ctx.fortinet?.firewall?.eventtime).length() > 11"
+  - date:
+      field: fortinet.firewall.eventtime
+      target_field: event.start
+      formats:
+        - UNIX
+      timezone: "{{fortinet.firewall.tz}}"
+      if: "ctx?.fortinet?.firewall?.eventtime != null && ctx.fortinet?.firewall?.tz != null && (ctx.fortinet?.firewall?.eventtime).length() <= 11"
+  - date:
+      field: fortinet.firewall.eventtime
+      target_field: event.start
+      formats:
+        - UNIX_MS
+      if: "ctx?.fortinet?.firewall?.eventtime != null && ctx.fortinet?.firewall?.tz == null && (ctx.fortinet?.firewall?.eventtime).length() > 11"
+  - date:
+      field: fortinet.firewall.eventtime
+      target_field: event.start
+      formats:
+        - UNIX
+      if: "ctx?.fortinet?.firewall?.eventtime != null && ctx.fortinet?.firewall?.tz == null && (ctx.fortinet?.firewall?.eventtime).length() <= 11"
+  - rename:
+      field: fortinet.firewall.devname
+      target_field: observer.name
+      ignore_missing: true
+  - script:
+      lang: painless
+      source: "ctx.event.duration = Long.parseLong(ctx.fortinet.firewall.duration) * 1000000000"
+      if: "ctx.fortinet?.firewall?.duration != null"
+  - rename:
+      field: fortinet.firewall.devid
+      target_field: observer.serial_number
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.dstintf
+      target_field: observer.egress.interface.name
+      ignore_missing: true
+      if: "ctx.observer?.egress?.interface?.name == null"
+  - rename:
+      field: fortinet.firewall.srcintf
+      target_field: observer.ingress.interface.name
+      ignore_missing: true
+      if: "ctx.observer?.ingress?.interface?.name == null"
+  - rename:
+      field: fortinet.firewall.dst_int
+      target_field: observer.egress.interface.name
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.src_int
+      target_field: observer.ingress.interface.name
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.level
+      target_field: log.level
+      ignore_missing: true
+  - remove:
+      field: fortinet.firewall.assignip
+      if: "ctx.fortinet?.firewall?.assignip == 'N/A'"
+  - remove:
+      field: fortinet.firewall.dstip
+      if: "ctx.fortinet?.firewall?.dstip == 'N/A'"
+  - remove:
+      field: fortinet.firewall.srcip
+      if: "ctx.fortinet?.firewall?.srcip == 'N/A'"
+  - remove:
+      field: fortinet.firewall.remip
+      if: "ctx.fortinet?.firewall?.remip == 'N/A'"
+  - remove:
+      field: fortinet.firewall.locip
+      if: "ctx.fortinet?.firewall?.locip == 'N/A'"
+  - remove:
+      field: fortinet.firewall.group
+      if: "ctx.fortinet?.firewall?.group == 'N/A'"
+  - remove:
+      field: fortinet.firewall.user
+      if: "ctx.fortinet?.firewall?.user == 'N/A'"
+  - remove:
+      field: fortinet.firewall.tranip
+      if: "ctx.fortinet?.firewall?.tranip == 'N/A'"
+  - remove:
+      field: fortinet.firewall.transip
+      if: "ctx.fortinet?.firewall?.transip == 'N/A'"
+  - remove:
+      field: fortinet.firewall.tunnelip
+      if: "ctx.fortinet?.firewall?.tunnelip == 'N/A'"
+  # Handle interface-based network directionality
+  - set:
+      field: network.direction
+      value: inbound
+      if: >
+        ctx?._temp?.external_interfaces != null &&
+        ctx?._temp?.internal_interfaces != null &&
+        ctx?.observer?.ingress?.interface?.name != null &&
+        ctx?.observer?.egress?.interface?.name != null &&
+        ctx._temp.external_interfaces.contains(ctx.observer.ingress.interface.name) &&
+        ctx._temp.internal_interfaces.contains(ctx.observer.egress.interface.name)
+  - set:
+      field: network.direction
+      value: outbound
+      if: >
+        ctx?._temp?.external_interfaces != null &&
+        ctx?._temp?.internal_interfaces != null &&
+        ctx?.observer?.ingress?.interface?.name != null &&
+        ctx?.observer?.egress?.interface?.name != null &&
+        ctx._temp.external_interfaces.contains(ctx.observer.egress.interface.name) &&
+        ctx._temp.internal_interfaces.contains(ctx.observer.ingress.interface.name)
+  - set:
+      field: network.direction
+      value: internal
+      if: >
+        ctx?._temp?.external_interfaces != null &&
+        ctx?._temp?.internal_interfaces != null &&
+        ctx?.observer?.ingress?.interface?.name != null &&
+        ctx?.observer?.egress?.interface?.name != null &&
+        ctx._temp.internal_interfaces.contains(ctx.observer.egress.interface.name) &&
+        ctx._temp.internal_interfaces.contains(ctx.observer.ingress.interface.name)
+  - set:
+      field: network.direction
+      value: external
+      if: >
+        ctx?._temp?.external_interfaces != null &&
+        ctx?._temp?.internal_interfaces != null &&
+        ctx?.observer?.ingress?.interface?.name != null &&
+        ctx?.observer?.egress?.interface?.name != null &&
+        ctx._temp.external_interfaces.contains(ctx.observer.egress.interface.name) &&
+        ctx._temp.external_interfaces.contains(ctx.observer.ingress.interface.name)
+  - set:
+      field: network.direction
+      value: unknown
+      if: >
+        ctx?._temp?.external_interfaces != null &&
+        ctx?._temp?.internal_interfaces != null &&
+        ctx?.observer?.egress?.interface?.name != null &&
+        ctx?.observer?.ingress?.interface?.name != null &&
+        (
+          (
+            !ctx._temp.external_interfaces.contains(ctx.observer.egress.interface.name) &&
+            !ctx._temp.internal_interfaces.contains(ctx.observer.egress.interface.name)
+          ) ||
+          (
+            !ctx._temp.external_interfaces.contains(ctx.observer.ingress.interface.name) &&
+            !ctx._temp.internal_interfaces.contains(ctx.observer.ingress.interface.name)
+          )
+        )
+  - remove:
+      field:
+        - _temp
+        - message
+        - syslog5424_sd
+        - syslog5424_pri
+        - fortinet.firewall.tz
+        - fortinet.firewall.date
+        - fortinet.firewall.devid
+        - fortinet.firewall.eventtime
+        - fortinet.firewall.time
+        - fortinet.firewall.duration
+        - host
+      ignore_missing: true
+  - pipeline:
+      name: '{{ IngestPipeline "event" }}'
+      if: "ctx.fortinet?.firewall?.type == 'event'"
+  - pipeline:
+      name: '{{ IngestPipeline "traffic" }}'
+      if: "ctx.fortinet?.firewall?.type == 'traffic'"
+  - pipeline:
+      name: '{{ IngestPipeline "utm" }}'
+      if: "ctx.fortinet?.firewall?.type == 'utm' || ctx.fortinet?.firewall?.type == 'dns'"
+  - convert:
+      field: fortinet.firewall.quotamax
+      type: long
+      ignore_missing: true
+  - convert:
+      field: fortinet.firewall.quotaused
+      type: long
+      ignore_missing: true
+  - convert:
+      field: fortinet.firewall.size
+      type: long
+      ignore_missing: true
 on_failure:
-- set:
-    field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+  - set:
+      field: error.message
+      value: "{{ _ingest.on_failure_message }}"

--- a/packages/fortinet/data_stream/firewall/elasticsearch/ingest_pipeline/event.yml
+++ b/packages/fortinet/data_stream/firewall/elasticsearch/ingest_pipeline/event.yml
@@ -1,356 +1,377 @@
 ---
 description: Pipeline for parsing fortinet firewall logs (event pipeline)
 processors:
-- set:
-    field: event.kind
-    value: event
-- set:
-    field: event.outcome
-    value: failure
-    if: "ctx.fortinet?.firewall?.result == 'ERROR' || ctx.fortinet?.firewall?.status == 'negotiate_error'"
-- set:
-    field: event.outcome
-    value: success
-    if: "ctx.fortinet?.firewall?.result == 'OK' || ['FSSO-logon', 'auth-logon', 'FSSO-logoff', 'auth-logout'].contains(ctx.fortinet?.firewall?.action)"
-- append:
-    field: event.type
-    value:
-    - user
-    - start
-    if: "['FSSO-logon', 'auth-logon'].contains(ctx.fortinet?.firewall?.action)"
-- append:
-    field: event.type
-    value:
-    - user
-    - end
-    if: "['FSSO-logoff', 'auth-logout'].contains(ctx.fortinet?.firewall?.action)"
-- append:
-    field: event.type
-    value: connection
-    if: "ctx.fortinet?.firewall?.subtype == 'vpn'"
-- append:
-    field: event.category
-    value: network
-    if: "ctx.fortinet?.firewall?.subtype == 'vpn'"
-- append:
-    field: event.type
-    value: info
-    if: "ctx.fortinet?.firewall?.action == 'perf-stats'"
-- append:
-    field: event.category
-    value: host
-    if: "ctx.fortinet?.firewall?.action == 'perf-stats'"
-- append:
-    field: event.type
-    value: info
-    if: "ctx.fortinet?.firewall?.subtype == 'update'"
-- append:
-    field: event.category
-    value:
-    - host
-    - malware
-    if: "ctx.fortinet?.firewall?.subtype == 'update'"
-- append:
-    field: event.category
-    value: authentication
-    if: "ctx.fortinet?.firewall?.subtype == 'user'"
-- rename:
-    field: fortinet.firewall.dstip
-    target_field: destination.ip
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.remip
-    target_field: destination.ip
-    ignore_missing: true
-    if: "ctx.destination?.ip == null"  
-- convert:
-    field: fortinet.firewall.dstport
-    target_field: destination.port
-    type: long
-    ignore_failure: true
-    ignore_missing: true
-- convert:
-    field: fortinet.firewall.remport
-    target_field: destination.port
-    type: long
-    ignore_failure: true
-    ignore_missing: true
-    if: "ctx.destination?.port == null"
-- convert:
-    field: fortinet.firewall.rcvdbyte
-    target_field: destination.bytes
-    type: long
-    ignore_failure: true
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.daddr
-    target_field: destination.address
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.dst_host
-    target_field: destination.address
-    ignore_missing: true
-    if: "ctx.destination?.address == null"
-- rename:
-    field: fortinet.firewall.dst_host
-    target_field: destination.domain
-    ignore_missing: true
-    if: "ctx.destination?.address == null"
-- rename:
-    field: fortinet.firewall.group
-    target_field: source.user.group.name
-    ignore_missing: true
-- convert:
-    field: fortinet.firewall.sentbyte
-    target_field: source.bytes
-    type: long
-    ignore_failure: true
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.srcip
-    target_field: source.ip
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.locip
-    target_field: source.ip
-    ignore_missing: true
-    if: "ctx.source?.ip == null"
-- rename:
-    field: fortinet.firewall.srcmac
-    target_field: source.mac
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.source_mac
-    target_field: source.mac
-    ignore_missing: true
-    if: "ctx.source?.mac == null"
-- convert:
-    field: fortinet.firewall.srcport
-    target_field: source.port
-    type: long
-    ignore_failure: true
-    ignore_missing: true
-- convert:
-    field: fortinet.firewall.locport
-    target_field: source.port
-    type: long
-    ignore_failure: true
-    ignore_missing: true
-    if: "ctx.source?.port == null"
-- rename:
-    field: fortinet.firewall.user
-    target_field: source.user.name
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.saddr
-    target_field: source.address
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.agent
-    target_field: user_agent.original
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.file
-    target_field: file.name
-    ignore_missing: true
-- convert:
-    field: fortinet.firewall.filesize
-    target_field: file.size
-    type: long
-    ignore_failure: true
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.level
-    target_field: log.level
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.logid
-    target_field: event.code
-    ignore_missing: true
-    if: "ctx.event?.code == null"
-- rename:
-    field: fortinet.firewall.msg
-    target_field: message
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.policyid
-    target_field: rule.id
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.proto
-    target_field: network.iana_number
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.dir
-    target_field: network.direction
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.direction
-    target_field: network.direction
-    ignore_missing: true
-    if: "ctx.network?.direction == null"
-- rename:
-    field: fortinet.firewall.service
-    target_field: network.protocol
-    ignore_missing: true
-- lowercase:
-    field: network.protocol
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.error_num
-    target_field: error.code
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.hostname
-    target_field: url.domain
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.logdesc
-    target_field: rule.description
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.url
-    target_field: url.path
-    ignore_missing: true
-- convert:
-    field: fortinet.firewall.sess_duration
-    type: long
-    target_field: event.duration
-    ignore_failure: true
-    ignore_missing: true
-    if: "ctx.event?.duration == null"
-- convert:
-    field: fortinet.firewall.mem
-    type: integer
-    ignore_failure: true
-    ignore_missing: true
-- geoip:
-    field: source.ip
-    target_field: source.geo
-    ignore_missing: true
-    if: "ctx.source?.geo == null"
-- geoip:
-    field: destination.ip
-    target_field: destination.geo
-    ignore_missing: true
-    if: "ctx.destination?.geo == null"
-- geoip:
-    database_file: GeoLite2-ASN.mmdb
-    field: source.ip
-    target_field: source.as
-    properties:
-    - asn
-    - organization_name
-    ignore_missing: true
-- geoip:
-    database_file: GeoLite2-ASN.mmdb
-    field: destination.ip
-    target_field: destination.as
-    properties:
-    - asn
-    - organization_name
-    ignore_missing: true
-- geoip:
-    field: source.nat.ip
-    target_field: source.geo
-    ignore_missing: true
-    if: "ctx.source?.geo == null"
-- geoip:
-    field: destination.nat.ip
-    target_field: destination.geo
-    ignore_missing: true
-    if: "ctx.destination?.geo == null"
-- geoip:
-    database_file: GeoLite2-ASN.mmdb
-    field: source.nat.ip
-    target_field: source.as
-    properties:
-    - asn
-    - organization_name
-    ignore_missing: true
-    if: "ctx.source?.as == null"
-- geoip:
-    database_file: GeoLite2-ASN.mmdb
-    field: destination.nat.ip
-    target_field: destination.as
-    properties:
-    - asn
-    - organization_name
-    ignore_missing: true
-    if: "ctx.destination?.as == null"
-- rename:
-    field: source.as.asn
-    target_field: source.as.number
-    ignore_missing: true
-- rename:
-    field: source.as.organization_name
-    target_field: source.as.organization.name
-    ignore_missing: true
-- rename:
-    field: destination.as.asn
-    target_field: destination.as.number
-    ignore_missing: true
-- rename:
-    field: destination.as.organization_name
-    target_field: destination.as.organization.name
-    ignore_missing: true
-- script:
-    lang: painless
-    source: ctx.network.bytes = ctx.source.bytes + ctx.destination.bytes
-    if: "ctx?.source?.bytes != null && ctx?.destination?.bytes != null"
-    ignore_failure: true
-- append:
-    field: related.ip
-    value: "{{source.ip}}"
-    if: "ctx.source?.ip != null"
-- append:
-    field: related.ip
-    value: "{{destination.ip}}"
-    if: "ctx.destination?.ip != null"
-- append:
-    field: related.user
-    value: "{{source.user.name}}"
-    if: "ctx.source?.user?.name != null"
-- convert:
-    field: fortinet.firewall.disklograte
-    type: long
-    ignore_missing: true
-- convert:
-    field: fortinet.firewall.fazlograte
-    type: long
-    ignore_missing: true
-- convert:
-    field: fortinet.firewall.setuprate
-    type: long
-    ignore_missing: true
-- convert:
-    field: fortinet.firewall.auditid
-    type: long
-    ignore_missing: true
-- convert:
-    field: fortinet.firewall.audittime
-    type: long
-    ignore_missing: true
-- convert:
-    field: fortinet.firewall.scantime
-    type: long
-    ignore_missing: true
-- convert:
-    field: fortinet.firewall.setuprate
-    type: long
-    ignore_missing: true
-- remove:
-    field:
-    - fortinet.firewall.dstport
-    - fortinet.firewall.remport
-    - fortinet.firewall.rcvdbyte
-    - fortinet.firewall.sentbyte
-    - fortinet.firewall.srcport
-    - fortinet.firewall.locport
-    - fortinet.firewall.filesize
-    - fortinet.firewall.sess_duration
-    ignore_missing: true
+  - set:
+      field: event.kind
+      value: event
+  - set:
+      field: event.outcome
+      value: failure
+      if: "ctx.fortinet?.firewall?.result == 'ERROR' || ctx.fortinet?.firewall?.status == 'negotiate_error'"
+  - set:
+      field: event.outcome
+      value: success
+      if: "ctx.fortinet?.firewall?.result == 'OK' || ['FSSO-logon', 'auth-logon', 'FSSO-logoff', 'auth-logout'].contains(ctx.fortinet?.firewall?.action)"
+  - append:
+      field: event.type
+      value:
+        - user
+        - start
+      if: "['FSSO-logon', 'auth-logon'].contains(ctx.fortinet?.firewall?.action)"
+  - append:
+      field: event.type
+      value:
+        - user
+        - end
+      if: "['FSSO-logoff', 'auth-logout'].contains(ctx.fortinet?.firewall?.action)"
+  - append:
+      field: event.type
+      value: connection
+      if: "ctx.fortinet?.firewall?.subtype == 'vpn'"
+  - append:
+      field: event.category
+      value: network
+      if: "ctx.fortinet?.firewall?.subtype == 'vpn'"
+  - append:
+      field: event.type
+      value: info
+      if: "ctx.fortinet?.firewall?.action == 'perf-stats'"
+  - append:
+      field: event.category
+      value: host
+      if: "ctx.fortinet?.firewall?.action == 'perf-stats'"
+  - append:
+      field: event.type
+      value: info
+      if: "ctx.fortinet?.firewall?.subtype == 'update'"
+  - append:
+      field: event.category
+      value:
+        - host
+        - malware
+      if: "ctx.fortinet?.firewall?.subtype == 'update'"
+  - append:
+      field: event.category
+      value: authentication
+      if: "ctx.fortinet?.firewall?.subtype == 'user'"
+  - rename:
+      field: fortinet.firewall.dstip
+      target_field: destination.ip
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.remip
+      target_field: destination.ip
+      ignore_missing: true
+      if: "ctx.destination?.ip == null"
+  - convert:
+      field: fortinet.firewall.dstport
+      target_field: destination.port
+      type: long
+      ignore_failure: true
+      ignore_missing: true
+  - convert:
+      field: fortinet.firewall.remport
+      target_field: destination.port
+      type: long
+      ignore_failure: true
+      ignore_missing: true
+      if: "ctx.destination?.port == null"
+  - convert:
+      field: fortinet.firewall.rcvdbyte
+      target_field: destination.bytes
+      type: long
+      ignore_failure: true
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.daddr
+      target_field: destination.address
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.dst_host
+      target_field: destination.address
+      ignore_missing: true
+      if: "ctx.destination?.address == null"
+  - rename:
+      field: fortinet.firewall.dst_host
+      target_field: destination.domain
+      ignore_missing: true
+      if: "ctx.destination?.address == null"
+  - rename:
+      field: fortinet.firewall.group
+      target_field: source.user.group.name
+      ignore_missing: true
+  - convert:
+      field: fortinet.firewall.sentbyte
+      target_field: source.bytes
+      type: long
+      ignore_failure: true
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.srcip
+      target_field: source.ip
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.locip
+      target_field: source.ip
+      ignore_missing: true
+      if: "ctx.source?.ip == null"
+  - rename:
+      field: fortinet.firewall.srcmac
+      target_field: source.mac
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.source_mac
+      target_field: source.mac
+      ignore_missing: true
+      if: "ctx.source?.mac == null"
+  - convert:
+      field: fortinet.firewall.srcport
+      target_field: source.port
+      type: long
+      ignore_failure: true
+      ignore_missing: true
+  - convert:
+      field: fortinet.firewall.locport
+      target_field: source.port
+      type: long
+      ignore_failure: true
+      ignore_missing: true
+      if: "ctx.source?.port == null"
+  - rename:
+      field: fortinet.firewall.user
+      target_field: source.user.name
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.saddr
+      target_field: source.address
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.agent
+      target_field: user_agent.original
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.file
+      target_field: file.name
+      ignore_missing: true
+  - convert:
+      field: fortinet.firewall.filesize
+      target_field: file.size
+      type: long
+      ignore_failure: true
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.level
+      target_field: log.level
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.logid
+      target_field: event.code
+      ignore_missing: true
+      if: "ctx.event?.code == null"
+  - rename:
+      field: fortinet.firewall.msg
+      target_field: message
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.policyid
+      target_field: rule.id
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.proto
+      target_field: network.iana_number
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.dir
+      target_field: network.direction
+      ignore_missing: true
+      if: "ctx.network?.direction == null"
+  - rename:
+      field: fortinet.firewall.direction
+      target_field: network.direction
+      ignore_missing: true
+      if: "ctx.network?.direction == null"
+  # Normalize the network direction
+  - script:
+      lang: painless
+      ignore_failure: true
+      params:
+        outgoing: outbound
+        incoming: inbound
+      source: >-
+        if (ctx.network?.direction == null) {
+            return;
+        }
+        def k = ctx.network?.direction.toLowerCase();
+        def normalized = params.get(k);
+        if (normalized != null) {
+            ctx.network.direction = normalized;
+            return
+        }
+        ctx.network.direction = k;
+  - rename:
+      field: fortinet.firewall.service
+      target_field: network.protocol
+      ignore_missing: true
+  - lowercase:
+      field: network.protocol
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.error_num
+      target_field: error.code
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.hostname
+      target_field: url.domain
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.logdesc
+      target_field: rule.description
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.url
+      target_field: url.path
+      ignore_missing: true
+  - convert:
+      field: fortinet.firewall.sess_duration
+      type: long
+      target_field: event.duration
+      ignore_failure: true
+      ignore_missing: true
+      if: "ctx.event?.duration == null"
+  - convert:
+      field: fortinet.firewall.mem
+      type: integer
+      ignore_failure: true
+      ignore_missing: true
+  - geoip:
+      field: source.ip
+      target_field: source.geo
+      ignore_missing: true
+      if: "ctx.source?.geo == null"
+  - geoip:
+      field: destination.ip
+      target_field: destination.geo
+      ignore_missing: true
+      if: "ctx.destination?.geo == null"
+  - geoip:
+      database_file: GeoLite2-ASN.mmdb
+      field: source.ip
+      target_field: source.as
+      properties:
+        - asn
+        - organization_name
+      ignore_missing: true
+  - geoip:
+      database_file: GeoLite2-ASN.mmdb
+      field: destination.ip
+      target_field: destination.as
+      properties:
+        - asn
+        - organization_name
+      ignore_missing: true
+  - geoip:
+      field: source.nat.ip
+      target_field: source.geo
+      ignore_missing: true
+      if: "ctx.source?.geo == null"
+  - geoip:
+      field: destination.nat.ip
+      target_field: destination.geo
+      ignore_missing: true
+      if: "ctx.destination?.geo == null"
+  - geoip:
+      database_file: GeoLite2-ASN.mmdb
+      field: source.nat.ip
+      target_field: source.as
+      properties:
+        - asn
+        - organization_name
+      ignore_missing: true
+      if: "ctx.source?.as == null"
+  - geoip:
+      database_file: GeoLite2-ASN.mmdb
+      field: destination.nat.ip
+      target_field: destination.as
+      properties:
+        - asn
+        - organization_name
+      ignore_missing: true
+      if: "ctx.destination?.as == null"
+  - rename:
+      field: source.as.asn
+      target_field: source.as.number
+      ignore_missing: true
+  - rename:
+      field: source.as.organization_name
+      target_field: source.as.organization.name
+      ignore_missing: true
+  - rename:
+      field: destination.as.asn
+      target_field: destination.as.number
+      ignore_missing: true
+  - rename:
+      field: destination.as.organization_name
+      target_field: destination.as.organization.name
+      ignore_missing: true
+  - script:
+      lang: painless
+      source: ctx.network.bytes = ctx.source.bytes + ctx.destination.bytes
+      if: "ctx?.source?.bytes != null && ctx?.destination?.bytes != null"
+      ignore_failure: true
+  - append:
+      field: related.ip
+      value: "{{source.ip}}"
+      if: "ctx.source?.ip != null"
+  - append:
+      field: related.ip
+      value: "{{destination.ip}}"
+      if: "ctx.destination?.ip != null"
+  - append:
+      field: related.user
+      value: "{{source.user.name}}"
+      if: "ctx.source?.user?.name != null"
+  - convert:
+      field: fortinet.firewall.disklograte
+      type: long
+      ignore_missing: true
+  - convert:
+      field: fortinet.firewall.fazlograte
+      type: long
+      ignore_missing: true
+  - convert:
+      field: fortinet.firewall.setuprate
+      type: long
+      ignore_missing: true
+  - convert:
+      field: fortinet.firewall.auditid
+      type: long
+      ignore_missing: true
+  - convert:
+      field: fortinet.firewall.audittime
+      type: long
+      ignore_missing: true
+  - convert:
+      field: fortinet.firewall.scantime
+      type: long
+      ignore_missing: true
+  - convert:
+      field: fortinet.firewall.setuprate
+      type: long
+      ignore_missing: true
+  - remove:
+      field:
+        - fortinet.firewall.dstport
+        - fortinet.firewall.remport
+        - fortinet.firewall.rcvdbyte
+        - fortinet.firewall.sentbyte
+        - fortinet.firewall.srcport
+        - fortinet.firewall.locport
+        - fortinet.firewall.filesize
+        - fortinet.firewall.sess_duration
+        - fortinet.firewall.dir
+        - fortinet.firewall.direction
+      ignore_missing: true
 on_failure:
-- set:
-    field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+  - set:
+      field: error.message
+      value: "{{ _ingest.on_failure_message }}"

--- a/packages/fortinet/data_stream/firewall/elasticsearch/ingest_pipeline/utm.yml
+++ b/packages/fortinet/data_stream/firewall/elasticsearch/ingest_pipeline/utm.yml
@@ -166,22 +166,22 @@ processors:
       if: "ctx.network?.direction == null"
   # Normalize the network direction
   - script:
-    lang: painless
-    ignore_failure: true
-    params:
-      outgoing: outbound
-      incoming: inbound
-    source: >-
-      if (ctx.network?.direction == null) {
-        return;
-      }
-      def k = ctx.network?.direction.toLowerCase();
-      def normalized = params.get(k);
-      if (normalized != null) {
-        ctx.network.direction = normalized;
-        return
-      }
-      ctx.network.direction = k;
+      lang: painless
+      ignore_failure: true
+      params:
+        outgoing: outbound
+        incoming: inbound
+      source: >-
+        if (ctx.network?.direction == null) {
+            return;
+        }
+        def k = ctx.network?.direction.toLowerCase();
+        def normalized = params.get(k);
+        if (normalized != null) {
+            ctx.network.direction = normalized;
+            return
+        }
+        ctx.network.direction = k;
   - rename:
       field: fortinet.firewall.error
       target_field: event.message

--- a/packages/fortinet/data_stream/firewall/elasticsearch/ingest_pipeline/utm.yml
+++ b/packages/fortinet/data_stream/firewall/elasticsearch/ingest_pipeline/utm.yml
@@ -1,439 +1,460 @@
 ---
 description: Pipeline for parsing fortinet firewall logs (utm pipeline)
 processors:
-- set:
-    field: event.kind
-    value: event
-- append:
-    field: event.type
-    value: denied
-    if: "['block', 'blocked'].contains(ctx.fortinet?.firewall?.action)"
-- append:
-    field: event.type
-    value: info
-    if: "ctx.fortinet?.firewall?.subtype == 'dns'"
-- append:
-    field: event.type
-    value: allowed
-    if: "['pass', 'passthrough'].contains(ctx.fortinet?.firewall?.action)"
-- set:
-    field: event.outcome
-    value: success
-    if: "ctx.fortinet?.firewall?.action != null"
-- append:
-    field: event.category
-    value: network
-- rename:
-    field: fortinet.firewall.dstip
-    target_field: destination.ip
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.remip
-    target_field: destination.ip
-    ignore_missing: true
-    if: "ctx.destination?.ip == null"
-- convert:
-    field: fortinet.firewall.dst_port
-    target_field: destination.port
-    type: long
-    ignore_failure: true
-    ignore_missing: true
-- convert:
-    field: fortinet.firewall.remport
-    target_field: destination.port
-    type: long
-    ignore_failure: true
-    ignore_missing: true
-    if: "ctx.destination?.port == null"
-- convert:
-    field: fortinet.firewall.dstport
-    target_field: destination.port
-    type: long
-    ignore_failure: true
-    ignore_missing: true
-    if: "ctx.destination?.port == null"
-- convert:
-    field: fortinet.firewall.rcvdbyte
-    target_field: destination.bytes
-    type: long
-    ignore_failure: true
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.recipient
-    target_field: destination.user.email
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.group
-    target_field: source.user.group.name
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.locip
-    target_field: source.ip
-    ignore_missing: true
-- convert:
-    field: fortinet.firewall.locport
-    target_field: source.port
-    type: long
-    ignore_failure: true
-    ignore_missing: true
-- convert:
-    field: fortinet.firewall.src_port
-    target_field: source.port
-    type: long
-    ignore_failure: true
-    ignore_missing: true
-    if: "ctx.source?.port == null"
-- convert:
-    field: fortinet.firewall.srcport
-    target_field: source.port
-    type: long
-    ignore_failure: true
-    ignore_missing: true
-    if: "ctx.source?.port == null"
-- convert:
-    field: fortinet.firewall.sentbyte
-    target_field: source.bytes
-    type: long
-    ignore_failure: true
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.srcdomain
-    target_field: source.domain
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.srcip
-    target_field: source.ip
-    ignore_missing: true
-    if: "ctx.source?.ip == null"
-- rename:
-    field: fortinet.firewall.srcmac
-    target_field: source.mac
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.unauthuser
-    target_field: source.user.name
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.user
-    target_field: source.user.name
-    ignore_missing: true
-    if: "ctx.source?.user?.name == null"
-- rename:
-    field: fortinet.firewall.sender
-    target_field: source.user.email
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.from
-    target_field: source.user.email
-    ignore_missing: true
-    if: "ctx.source?.user?.email == null"
-- rename:
-    field: fortinet.firewall.agent
-    target_field: user_agent.original
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.app
-    target_field: network.application
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.appcat
-    target_field: rule.category
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.applist
-    target_field: rule.ruleset
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.catdesc
-    target_field: rule.category
-    ignore_missing: true
-    if: "ctx.rule?.category == null"
-- gsub:
-    field: rule.category
-    pattern: "\\."
-    replacement: "-"
-    ignore_missing: true
-    if: "ctx.rule?.category != null"
-- rename:
-    field: fortinet.firewall.dir
-    target_field: network.direction
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.direction
-    target_field: network.direction
-    ignore_missing: true
-    if: "ctx.network?.direction == null"
-- rename:
-    field: fortinet.firewall.error
-    target_field: event.message
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.errorcode
-    target_field: event.code
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.event_id
-    target_field: event.id
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.eventid
-    target_field: event.id
-    ignore_missing: true
-    if: "ctx.event?.id == null"
-- rename:
-    field: fortinet.firewall.eventtype
-    target_field: event.action
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.filename
-    target_field: file.name
-    ignore_missing: true
-- convert:
-    field: fortinet.firewall.filesize
-    target_field: file.size
-    type: long
-    ignore_failure: true
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.filetype
-    target_field: file.extension
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.infectedfilename
-    target_field: file.name
-    ignore_missing: true
-    if: "ctx.file?.name == null"
-- rename:
-    field: fortinet.firewall.infectedfilesize
-    target_field: file.size
-    ignore_missing: true
-    if: "ctx.file?.size == null"
-- rename:
-    field: fortinet.firewall.infectedfiletype
-    target_field: file.extension
-    ignore_missing: true
-    if: "ctx.file?.extension == null"
-- rename:
-    field: fortinet.firewall.matchedfilename
-    target_field: file.name
-    ignore_missing: true
-    if: "ctx.file?.name == null"
-- rename:
-    field: fortinet.firewall.matchedfiletype
-    target_field: file.extension
-    ignore_missing: true
-    if: "ctx.file?.extension == null"
-- rename:
-    field: fortinet.firewall.hostname
-    target_field: url.domain
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.ipaddr
-    target_field: dns.resolved_ip
-    ignore_missing: true
-- split:
-    field: dns.resolved_ip
-    separator: ', '
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.level
-    target_field: log.level
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.logid
-    target_field: event.code
-    ignore_missing: true
-    if: "ctx.event?.code == null"
-- rename:
-    field: fortinet.firewall.msg
-    target_field: message
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.policy_id
-    target_field: rule.id
-    ignore_missing: true
-    if: "ctx.rule?.id == null"
-- rename:
-    field: fortinet.firewall.policyid
-    target_field: rule.id
-    ignore_missing: true
-    if: "ctx.rule?.id == null"
-- rename:
-    field: fortinet.firewall.profile
-    target_field: rule.ruleset
-    ignore_missing: true
-    if: "ctx.rule?.ruleset == null"
-- rename:
-    field: fortinet.firewall.proto
-    target_field: network.iana_number
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.qclass
-    target_field: dns.question.class
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.qname
-    target_field: dns.question.name
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.qtype
-    target_field: dns.question.type
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.service
-    target_field: network.protocol
-    ignore_missing: true
-- lowercase:
-    field: network.protocol
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.url
-    target_field: url.path
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.xid
-    target_field: dns.id
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.scertcname
-    target_field: tls.server.x509.subject.common_name
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.scertissuer
-    target_field: tls.server.issuer
-    ignore_missing: true
-- set:
-    field: tls.server.x509.issuer.common_name
-    value: "{{tls.server.issuer}}"
-    ignore_empty_value: true
-- rename:
-    field: fortinet.firewall.ccertissuer
-    target_field: tls.client.issuer
-    ignore_missing: true
-- set:
-    field: tls.client.x509.issuer.common_name
-    value: "{{tls.client.issuer}}"
-    ignore_empty_value: true
-- rename:
-    field: fortinet.firewall.sender
-    target_field: tls.server.issuer
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.dtype
-    target_field: vulnerability.category
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.ref
-    target_field: event.reference
-    ignore_missing: true
-- rename:
-    field: fortinet.firewall.filehash
-    target_field: fortinet.file.hash.crc32
-    ignore_missing: true
-- geoip:
-    field: source.ip
-    target_field: source.geo
-    ignore_missing: true
-    if: "ctx.source?.geo == null"
-- geoip:
-    field: destination.ip
-    target_field: destination.geo
-    ignore_missing: true
-    if: "ctx.destination?.geo == null"
-- geoip:
-    database_file: GeoLite2-ASN.mmdb
-    field: source.ip
-    target_field: source.as
-    properties:
-    - asn
-    - organization_name
-    ignore_missing: true
-- geoip:
-    database_file: GeoLite2-ASN.mmdb
-    field: destination.ip
-    target_field: destination.as
-    properties:
-    - asn
-    - organization_name
-    ignore_missing: true
-- geoip:
-    field: source.nat.ip
-    target_field: source.geo
-    ignore_missing: true
-    if: "ctx.source?.geo == null"
-- geoip:
-    field: destination.nat.ip
-    target_field: destination.geo
-    ignore_missing: true
-    if: "ctx.destination?.geo == null"
-- geoip:
-    database_file: GeoLite2-ASN.mmdb
-    field: source.nat.ip
-    target_field: source.as
-    properties:
-    - asn
-    - organization_name
-    ignore_missing: true
-    if: "ctx.source?.as == null"
-- geoip:
-    database_file: GeoLite2-ASN.mmdb
-    field: destination.nat.ip
-    target_field: destination.as
-    properties:
-    - asn
-    - organization_name
-    ignore_missing: true
-    if: "ctx.destination?.as == null"
-- rename:
-    field: source.as.asn
-    target_field: source.as.number
-    ignore_missing: true
-- rename:
-    field: source.as.organization_name
-    target_field: source.as.organization.name
-    ignore_missing: true
-- rename:
-    field: destination.as.asn
-    target_field: destination.as.number
-    ignore_missing: true
-- rename:
-    field: destination.as.organization_name
-    target_field: destination.as.organization.name
-    ignore_missing: true
-- script:
+  - set:
+      field: event.kind
+      value: event
+  - append:
+      field: event.type
+      value: denied
+      if: "['block', 'blocked'].contains(ctx.fortinet?.firewall?.action)"
+  - append:
+      field: event.type
+      value: info
+      if: "ctx.fortinet?.firewall?.subtype == 'dns'"
+  - append:
+      field: event.type
+      value: allowed
+      if: "['pass', 'passthrough'].contains(ctx.fortinet?.firewall?.action)"
+  - set:
+      field: event.outcome
+      value: success
+      if: "ctx.fortinet?.firewall?.action != null"
+  - append:
+      field: event.category
+      value: network
+  - rename:
+      field: fortinet.firewall.dstip
+      target_field: destination.ip
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.remip
+      target_field: destination.ip
+      ignore_missing: true
+      if: "ctx.destination?.ip == null"
+  - convert:
+      field: fortinet.firewall.dst_port
+      target_field: destination.port
+      type: long
+      ignore_failure: true
+      ignore_missing: true
+  - convert:
+      field: fortinet.firewall.remport
+      target_field: destination.port
+      type: long
+      ignore_failure: true
+      ignore_missing: true
+      if: "ctx.destination?.port == null"
+  - convert:
+      field: fortinet.firewall.dstport
+      target_field: destination.port
+      type: long
+      ignore_failure: true
+      ignore_missing: true
+      if: "ctx.destination?.port == null"
+  - convert:
+      field: fortinet.firewall.rcvdbyte
+      target_field: destination.bytes
+      type: long
+      ignore_failure: true
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.recipient
+      target_field: destination.user.email
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.group
+      target_field: source.user.group.name
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.locip
+      target_field: source.ip
+      ignore_missing: true
+  - convert:
+      field: fortinet.firewall.locport
+      target_field: source.port
+      type: long
+      ignore_failure: true
+      ignore_missing: true
+  - convert:
+      field: fortinet.firewall.src_port
+      target_field: source.port
+      type: long
+      ignore_failure: true
+      ignore_missing: true
+      if: "ctx.source?.port == null"
+  - convert:
+      field: fortinet.firewall.srcport
+      target_field: source.port
+      type: long
+      ignore_failure: true
+      ignore_missing: true
+      if: "ctx.source?.port == null"
+  - convert:
+      field: fortinet.firewall.sentbyte
+      target_field: source.bytes
+      type: long
+      ignore_failure: true
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.srcdomain
+      target_field: source.domain
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.srcip
+      target_field: source.ip
+      ignore_missing: true
+      if: "ctx.source?.ip == null"
+  - rename:
+      field: fortinet.firewall.srcmac
+      target_field: source.mac
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.unauthuser
+      target_field: source.user.name
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.user
+      target_field: source.user.name
+      ignore_missing: true
+      if: "ctx.source?.user?.name == null"
+  - rename:
+      field: fortinet.firewall.sender
+      target_field: source.user.email
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.from
+      target_field: source.user.email
+      ignore_missing: true
+      if: "ctx.source?.user?.email == null"
+  - rename:
+      field: fortinet.firewall.agent
+      target_field: user_agent.original
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.app
+      target_field: network.application
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.appcat
+      target_field: rule.category
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.applist
+      target_field: rule.ruleset
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.catdesc
+      target_field: rule.category
+      ignore_missing: true
+      if: "ctx.rule?.category == null"
+  - gsub:
+      field: rule.category
+      pattern: "\\."
+      replacement: "-"
+      ignore_missing: true
+      if: "ctx.rule?.category != null"
+  - rename:
+      field: fortinet.firewall.dir
+      target_field: network.direction
+      ignore_missing: true
+      if: "ctx.network?.direction == null"
+  - rename:
+      field: fortinet.firewall.direction
+      target_field: network.direction
+      ignore_missing: true
+      if: "ctx.network?.direction == null"
+  # Normalize the network direction
+  - script:
     lang: painless
-    source: "ctx.network.bytes = ctx.source.bytes + ctx.destination.bytes"
-    if: "ctx?.source?.bytes != null && ctx?.destination?.bytes != null"
     ignore_failure: true
-- append:
-    field: related.ip
-    value: "{{source.ip}}"
-    if: "ctx.source?.ip != null"
-- append:
-    field: related.ip
-    value: "{{destination.ip}}"
-    if: "ctx.destination?.ip != null"
-- append:
-    field: related.user
-    value: "{{source.user.name}}"
-    if: "ctx.source?.user?.name != null"
-- append:
-    field: related.hash
-    value: "{{fortinet.file.hash.crc32}}"
-    if: "ctx.fortinet?.file?.hash?.crc32 != null"
-- remove:
-    field:
-    - fortinet.firewall.dst_port
-    - fortinet.firewall.remport
-    - fortinet.firewall.dstport
-    - fortinet.firewall.rcvdbyte
-    - fortinet.firewall.locport
-    - fortinet.firewall.src_port
-    - fortinet.firewall.srcport
-    - fortinet.firewall.sentbyte
-    - fortinet.firewall.filesize
-    ignore_missing: true
+    params:
+      outgoing: outbound
+      incoming: inbound
+    source: >-
+      if (ctx.network?.direction == null) {
+        return;
+      }
+      def k = ctx.network?.direction.toLowerCase();
+      def normalized = params.get(k);
+      if (normalized != null) {
+        ctx.network.direction = normalized;
+        return
+      }
+      ctx.network.direction = k;
+  - rename:
+      field: fortinet.firewall.error
+      target_field: event.message
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.errorcode
+      target_field: event.code
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.event_id
+      target_field: event.id
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.eventid
+      target_field: event.id
+      ignore_missing: true
+      if: "ctx.event?.id == null"
+  - rename:
+      field: fortinet.firewall.eventtype
+      target_field: event.action
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.filename
+      target_field: file.name
+      ignore_missing: true
+  - convert:
+      field: fortinet.firewall.filesize
+      target_field: file.size
+      type: long
+      ignore_failure: true
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.filetype
+      target_field: file.extension
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.infectedfilename
+      target_field: file.name
+      ignore_missing: true
+      if: "ctx.file?.name == null"
+  - rename:
+      field: fortinet.firewall.infectedfilesize
+      target_field: file.size
+      ignore_missing: true
+      if: "ctx.file?.size == null"
+  - rename:
+      field: fortinet.firewall.infectedfiletype
+      target_field: file.extension
+      ignore_missing: true
+      if: "ctx.file?.extension == null"
+  - rename:
+      field: fortinet.firewall.matchedfilename
+      target_field: file.name
+      ignore_missing: true
+      if: "ctx.file?.name == null"
+  - rename:
+      field: fortinet.firewall.matchedfiletype
+      target_field: file.extension
+      ignore_missing: true
+      if: "ctx.file?.extension == null"
+  - rename:
+      field: fortinet.firewall.hostname
+      target_field: url.domain
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.ipaddr
+      target_field: dns.resolved_ip
+      ignore_missing: true
+  - split:
+      field: dns.resolved_ip
+      separator: ", "
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.level
+      target_field: log.level
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.logid
+      target_field: event.code
+      ignore_missing: true
+      if: "ctx.event?.code == null"
+  - rename:
+      field: fortinet.firewall.msg
+      target_field: message
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.policy_id
+      target_field: rule.id
+      ignore_missing: true
+      if: "ctx.rule?.id == null"
+  - rename:
+      field: fortinet.firewall.policyid
+      target_field: rule.id
+      ignore_missing: true
+      if: "ctx.rule?.id == null"
+  - rename:
+      field: fortinet.firewall.profile
+      target_field: rule.ruleset
+      ignore_missing: true
+      if: "ctx.rule?.ruleset == null"
+  - rename:
+      field: fortinet.firewall.proto
+      target_field: network.iana_number
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.qclass
+      target_field: dns.question.class
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.qname
+      target_field: dns.question.name
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.qtype
+      target_field: dns.question.type
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.service
+      target_field: network.protocol
+      ignore_missing: true
+  - lowercase:
+      field: network.protocol
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.url
+      target_field: url.path
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.xid
+      target_field: dns.id
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.scertcname
+      target_field: tls.server.x509.subject.common_name
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.scertissuer
+      target_field: tls.server.issuer
+      ignore_missing: true
+  - set:
+      field: tls.server.x509.issuer.common_name
+      value: "{{tls.server.issuer}}"
+      ignore_empty_value: true
+  - rename:
+      field: fortinet.firewall.ccertissuer
+      target_field: tls.client.issuer
+      ignore_missing: true
+  - set:
+      field: tls.client.x509.issuer.common_name
+      value: "{{tls.client.issuer}}"
+      ignore_empty_value: true
+  - rename:
+      field: fortinet.firewall.sender
+      target_field: tls.server.issuer
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.dtype
+      target_field: vulnerability.category
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.ref
+      target_field: event.reference
+      ignore_missing: true
+  - rename:
+      field: fortinet.firewall.filehash
+      target_field: fortinet.file.hash.crc32
+      ignore_missing: true
+  - geoip:
+      field: source.ip
+      target_field: source.geo
+      ignore_missing: true
+      if: "ctx.source?.geo == null"
+  - geoip:
+      field: destination.ip
+      target_field: destination.geo
+      ignore_missing: true
+      if: "ctx.destination?.geo == null"
+  - geoip:
+      database_file: GeoLite2-ASN.mmdb
+      field: source.ip
+      target_field: source.as
+      properties:
+        - asn
+        - organization_name
+      ignore_missing: true
+  - geoip:
+      database_file: GeoLite2-ASN.mmdb
+      field: destination.ip
+      target_field: destination.as
+      properties:
+        - asn
+        - organization_name
+      ignore_missing: true
+  - geoip:
+      field: source.nat.ip
+      target_field: source.geo
+      ignore_missing: true
+      if: "ctx.source?.geo == null"
+  - geoip:
+      field: destination.nat.ip
+      target_field: destination.geo
+      ignore_missing: true
+      if: "ctx.destination?.geo == null"
+  - geoip:
+      database_file: GeoLite2-ASN.mmdb
+      field: source.nat.ip
+      target_field: source.as
+      properties:
+        - asn
+        - organization_name
+      ignore_missing: true
+      if: "ctx.source?.as == null"
+  - geoip:
+      database_file: GeoLite2-ASN.mmdb
+      field: destination.nat.ip
+      target_field: destination.as
+      properties:
+        - asn
+        - organization_name
+      ignore_missing: true
+      if: "ctx.destination?.as == null"
+  - rename:
+      field: source.as.asn
+      target_field: source.as.number
+      ignore_missing: true
+  - rename:
+      field: source.as.organization_name
+      target_field: source.as.organization.name
+      ignore_missing: true
+  - rename:
+      field: destination.as.asn
+      target_field: destination.as.number
+      ignore_missing: true
+  - rename:
+      field: destination.as.organization_name
+      target_field: destination.as.organization.name
+      ignore_missing: true
+  - script:
+      lang: painless
+      source: "ctx.network.bytes = ctx.source.bytes + ctx.destination.bytes"
+      if: "ctx?.source?.bytes != null && ctx?.destination?.bytes != null"
+      ignore_failure: true
+  - append:
+      field: related.ip
+      value: "{{source.ip}}"
+      if: "ctx.source?.ip != null"
+  - append:
+      field: related.ip
+      value: "{{destination.ip}}"
+      if: "ctx.destination?.ip != null"
+  - append:
+      field: related.user
+      value: "{{source.user.name}}"
+      if: "ctx.source?.user?.name != null"
+  - append:
+      field: related.hash
+      value: "{{fortinet.file.hash.crc32}}"
+      if: "ctx.fortinet?.file?.hash?.crc32 != null"
+  - remove:
+      field:
+        - fortinet.firewall.dst_port
+        - fortinet.firewall.remport
+        - fortinet.firewall.dstport
+        - fortinet.firewall.rcvdbyte
+        - fortinet.firewall.locport
+        - fortinet.firewall.src_port
+        - fortinet.firewall.srcport
+        - fortinet.firewall.sentbyte
+        - fortinet.firewall.filesize
+        - fortinet.firewall.dir
+        - fortinet.firewall.direction
+      ignore_missing: true
 on_failure:
-- set:
-    field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+  - set:
+      field: error.message
+      value: "{{ _ingest.on_failure_message }}"

--- a/packages/fortinet/data_stream/firewall/fields/agent.yml
+++ b/packages/fortinet/data_stream/firewall/fields/agent.yml
@@ -107,7 +107,7 @@
       default_field: false
     - name: hostname
       level: core
-      type: keyword
+      type: wildcard
       ignore_above: 1024
       description: 'Hostname of the host.
 
@@ -151,7 +151,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: keyword
+      type: wildcard
       ignore_above: 1024
       multi_fields:
         - name: text

--- a/packages/fortinet/data_stream/firewall/fields/beats.yml
+++ b/packages/fortinet/data_stream/firewall/fields/beats.yml
@@ -1,15 +1,15 @@
-- name: input.type
+- description: Type of Filebeat input.
+  name: input.type
   type: keyword
-  description: Type of Filebeat input.
-- name: log.flags
+- description: Flags for the log file.
+  name: log.flags
   type: keyword
-  description: Flags for the log file.
-- name: log.offset
+- description: Offset of the entry in the log file.
+  name: log.offset
   type: long
-  description: Offset of the entry in the log file.
-- name: log.file.path
-  type: keyword
-  description: Path to the log file.
-- name: event.message # this isn't actually ECS
+- description: Path to the log file.
+  name: log.file.path
+  type: wildcard
+- description: Log message optimized for viewing in a log viewer.
+  name: event.message
   type: text
-  description: Log message optimized for viewing in a log viewer.

--- a/packages/fortinet/data_stream/firewall/fields/ecs.yml
+++ b/packages/fortinet/data_stream/firewall/fields/ecs.yml
@@ -9,13 +9,13 @@
   type: long
 - description: Organization name.
   name: destination.as.organization.name
-  type: keyword
+  type: wildcard
 - description: Bytes sent from the destination to the source.
   name: destination.bytes
   type: long
 - description: Destination domain.
   name: destination.domain
-  type: keyword
+  type: wildcard
 - description: City name.
   name: destination.geo.city_name
   type: keyword
@@ -33,7 +33,7 @@
   type: geo_point
 - description: User-defined description of a location.
   name: destination.geo.name
-  type: keyword
+  type: wildcard
 - description: Region ISO code.
   name: destination.geo.region_iso_code
   type: keyword
@@ -57,10 +57,10 @@
   type: long
 - description: User email address.
   name: destination.user.email
-  type: keyword
+  type: wildcard
 - description: Short name or login of the user.
   name: destination.user.name
-  type: keyword
+  type: wildcard
 - description: DNS packet identifier.
   name: dns.id
   type: keyword
@@ -69,7 +69,7 @@
   type: keyword
 - description: The name being queried.
   name: dns.question.name
-  type: keyword
+  type: wildcard
 - description: The type of record being queried.
   name: dns.question.type
   type: keyword
@@ -207,7 +207,7 @@
   type: long
 - description: Organization name.
   name: source.as.organization.name
-  type: keyword
+  type: wildcard
 - description: Bytes sent from the source to the destination.
   name: source.bytes
   type: long
@@ -228,7 +228,7 @@
   type: geo_point
 - description: User-defined description of a location.
   name: source.geo.name
-  type: keyword
+  type: wildcard
 - description: Region ISO code.
   name: source.geo.region_iso_code
   type: keyword
@@ -255,43 +255,43 @@
   type: long
 - description: User email address.
   name: source.user.email
-  type: keyword
+  type: wildcard
 - description: Name of the group.
   name: source.user.group.name
   type: keyword
 - description: Short name or login of the user.
   name: source.user.name
-  type: keyword
+  type: wildcard
 - description: List of keywords used to tag each event.
   name: tags
   type: keyword
 - description: Distinguished name of subject of the issuer.
   name: tls.client.issuer
-  type: keyword
+  type: wildcard
 - description: Hostname the client is trying to connect to. Also called the SNI.
   name: tls.client.server_name
   type: keyword
 - description: Subject of the issuer of the x.509 certificate presented by the server.
   name: tls.server.issuer
-  type: keyword
+  type: wildcard
 - description: Domain of the url.
   name: url.domain
-  type: keyword
+  type: wildcard
 - description: Path of the request, such as "/search".
   name: url.path
-  type: keyword
+  type: wildcard
 - description: Unparsed user_agent string.
   name: user_agent.original
-  type: keyword
+  type: wildcard
 - description: Category of a vulnerability.
   name: vulnerability.category
   type: keyword
-- name: tls.server.x509.subject.common_name
+- description: List of common names (CN) of subject.
+  name: tls.server.x509.subject.common_name
   type: keyword
-  description: List of common names (CN) of subject.
-- name: tls.server.x509.issuer.common_name
+- description: List of common name (CN) of issuing certificate authority.
+  name: tls.server.x509.issuer.common_name
   type: keyword
-  description: List of common name (CN) of issuing certificate authority.
-- name: tls.client.x509.issuer.common_name
+- description: List of common name (CN) of issuing certificate authority.
+  name: tls.client.x509.issuer.common_name
   type: keyword
-  description: List of common name (CN) of issuing certificate authority.

--- a/packages/fortinet/data_stream/firewall/manifest.yml
+++ b/packages/fortinet/data_stream/firewall/manifest.yml
@@ -78,6 +78,18 @@ streams:
         default:
           - fortinet-firewall
           - forwarded
+      - name: internal_interfaces
+        type: text
+        title: Internal Interfaces
+        multi: true
+        required: false
+        show_user: false
+      - name: external_interfaces
+        type: text
+        title: External Interfaces
+        multi: true
+        required: false
+        show_user: false
     template_path: log.yml.hbs
     title: Fortinet firewall logs (log)
     description: Collect Fortinet firewall logs using log input

--- a/packages/fortinet/docs/README.md
+++ b/packages/fortinet/docs/README.md
@@ -40,15 +40,15 @@ Contains log entries from Fortinet FortiGate applicances.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | keyword |
+| destination.as.organization.name | Organization name. | wildcard |
 | destination.bytes | Bytes sent from the destination to the source. | long |
-| destination.domain | Destination domain. | keyword |
+| destination.domain | Destination domain. | wildcard |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | keyword |
+| destination.geo.name | User-defined description of a location. | wildcard |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -56,11 +56,11 @@ Contains log entries from Fortinet FortiGate applicances.
 | destination.nat.port | Destination NAT Port | long |
 | destination.packets | Packets sent from the destination to the source. | long |
 | destination.port | Port of the destination. | long |
-| destination.user.email | User email address. | keyword |
-| destination.user.name | Short name or login of the user. | keyword |
+| destination.user.email | User email address. | wildcard |
+| destination.user.name | Short name or login of the user. | wildcard |
 | dns.id | DNS packet identifier. | keyword |
 | dns.question.class | The class of records being queried. | keyword |
-| dns.question.name | The name being queried. | keyword |
+| dns.question.name | The name being queried. | wildcard |
 | dns.question.type | The type of record being queried. | keyword |
 | dns.resolved_ip | Array containing all IPs seen in answers.data | ip |
 | error.code | Error code describing the error. | keyword |
@@ -514,7 +514,7 @@ Contains log entries from Fortinet FortiGate applicances.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -523,12 +523,12 @@ Contains log entries from Fortinet FortiGate applicances.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
+| host.os.name | Operating system name, without the version. | wildcard |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | input.type | Type of Filebeat input. | keyword |
-| log.file.path | Path to the log file. | keyword |
+| log.file.path | Path to the log file. | wildcard |
 | log.flags | Flags for the log file. | keyword |
 | log.level | Log level of the log event. | keyword |
 | log.offset | Offset of the entry in the log file. | long |
@@ -557,14 +557,14 @@ Contains log entries from Fortinet FortiGate applicances.
 | rule.uuid | Rule UUID | keyword |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | keyword |
+| source.as.organization.name | Organization name. | wildcard |
 | source.bytes | Bytes sent from the source to the destination. | long |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | keyword |
+| source.geo.name | User-defined description of a location. | wildcard |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -573,19 +573,19 @@ Contains log entries from Fortinet FortiGate applicances.
 | source.nat.port | Source NAT port | long |
 | source.packets | Packets sent from the source to the destination. | long |
 | source.port | Port of the source. | long |
-| source.user.email | User email address. | keyword |
+| source.user.email | User email address. | wildcard |
 | source.user.group.name | Name of the group. | keyword |
-| source.user.name | Short name or login of the user. | keyword |
+| source.user.name | Short name or login of the user. | wildcard |
 | tags | List of keywords used to tag each event. | keyword |
-| tls.client.issuer | Distinguished name of subject of the issuer. | keyword |
+| tls.client.issuer | Distinguished name of subject of the issuer. | wildcard |
 | tls.client.server_name | Hostname the client is trying to connect to. Also called the SNI. | keyword |
 | tls.client.x509.issuer.common_name | List of common name (CN) of issuing certificate authority. | keyword |
-| tls.server.issuer | Subject of the issuer of the x.509 certificate presented by the server. | keyword |
+| tls.server.issuer | Subject of the issuer of the x.509 certificate presented by the server. | wildcard |
 | tls.server.x509.issuer.common_name | List of common name (CN) of issuing certificate authority. | keyword |
 | tls.server.x509.subject.common_name | List of common names (CN) of subject. | keyword |
-| url.domain | Domain of the url. | keyword |
-| url.path | Path of the request, such as "/search". | keyword |
-| user_agent.original | Unparsed user_agent string. | keyword |
+| url.domain | Domain of the url. | wildcard |
+| url.path | Path of the request, such as "/search". | wildcard |
+| user_agent.original | Unparsed user_agent string. | wildcard |
 | vulnerability.category | Category of a vulnerability. | keyword |
 
 

--- a/packages/fortinet/manifest.yml
+++ b/packages/fortinet/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet
 title: Fortinet
-version: 0.5.4
+version: 0.6.0
 release: experimental
 description: Fortinet Integration
 type: integration
@@ -8,7 +8,7 @@ format_version: 1.0.0
 license: basic
 categories: ["security"]
 conditions:
-  kibana.version: "^7.10.0"
+  kibana.version: "^7.11.0"
 icons:
   - src: /img/fortinet-logo.svg
     title: Fortinet


### PR DESCRIPTION
## What does this PR do?

This updates the fortinet package's firewall data_stream to use ECS 1.7, including the network direction changes recently introduced in beats.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
~~[ ] I have verified that all datasets collect metrics or logs.~~