### PR TITLE
Ensure all composed services are up for nats cluster testing

### DIFF
--- a/packages/nats/_dev/deploy/docker/docker-compose.yml
+++ b/packages/nats/_dev/deploy/docker/docker-compose.yml
@@ -9,8 +9,14 @@ services:
       - 8222
     volumes:
       - ${SERVICE_LOGS_DIR}:/var/log/nats
+    depends_on:
+      - "nats-routes"
   nats-routes:
-    extends:
-      service: nats
+    # Commented out `image:` below until we have a process to refresh the hosted images from
+    # Dockerfiles in this repo. Until then, we build the image locally using `build:` below.
+    # image: docker.elastic.co/integrations-ci/beats-apache:${SERVICE_VERSION:-2.4.20}-1
+    build: .
+    ports:
+      - 8222
     environment:
       - ROUTES=1

--- a/packages/nats/data_stream/route/_dev/test/system/test-default-config.yml
+++ b/packages/nats/data_stream/route/_dev/test/system/test-default-config.yml
@@ -1,0 +1,5 @@
+vars:
+  hosts:
+    - http://{{Hostname}}:{{Port}}
+data_stream:
+  vars: ~

--- a/packages/nats/data_stream/routes/_dev/test/system/test-default-config.yml
+++ b/packages/nats/data_stream/routes/_dev/test/system/test-default-config.yml
@@ -1,0 +1,5 @@
+vars:
+  hosts:
+    - http://{{Hostname}}:{{Port}}
+data_stream:
+  vars: ~


### PR DESCRIPTION
## What does this PR do?
This PR fixes the flakiness reported at https://github.com/elastic/integrations/issues/520 after the changes happened at https://github.com/elastic/elastic-package/pull/209 and more specifically the one at https://github.com/elastic/elastic-package/blob/master/internal/testrunner/runners/system/servicedeployer/compose.go#L64.

`route` and `routes` data_streams require a clustered nats so as to find the required metrics, in this we need to make sure that a clustered nats is running (2 services) instead of a single nats service.
