### PR TITLE
Add agent manifest as refrence in k8s package

### DIFF
--- a/packages/kubernetes/_dev/build/docs/README.md
+++ b/packages/kubernetes/_dev/build/docs/README.md
@@ -17,7 +17,7 @@ a single cluster-wide endpoint. This is important to determine the optimal confi
 for the different datasets included in the integration.
 
 For a complete reference on how to configure and run this package on Kubernetes as part of a `DaemonSet` and a `Deployment`,
-there's a complete [example manifest](https://github.com/elastic/beats/blob/v7.10.0/deploy/kubernetes/elastic-agent-kubernetes.yaml)
+there's a complete [example manifest](https://github.com/elastic/beats/blob/master/deploy/kubernetes/elastic-agent-kubernetes.yaml)
 available.
 
 #### Kubernetes endpoints and metricsets

--- a/packages/kubernetes/_dev/build/docs/README.md
+++ b/packages/kubernetes/_dev/build/docs/README.md
@@ -17,7 +17,8 @@ a single cluster-wide endpoint. This is important to determine the optimal confi
 for the different datasets included in the integration.
 
 For a complete reference on how to configure and run this package on Kubernetes as part of a `DaemonSet` and a `Deployment`,
-there's a complete example manifest available in <<TODO: link to the proper page here>> document.
+there's a complete [example manifest](https://github.com/elastic/beats/blob/v7.10.0/deploy/kubernetes/elastic-agent-kubernetes.yaml)
+available.
 
 #### Kubernetes endpoints and metricsets
 

--- a/packages/kubernetes/docs/README.md
+++ b/packages/kubernetes/docs/README.md
@@ -17,7 +17,7 @@ a single cluster-wide endpoint. This is important to determine the optimal confi
 for the different datasets included in the integration.
 
 For a complete reference on how to configure and run this package on Kubernetes as part of a `DaemonSet` and a `Deployment`,
-there's a complete [example manifest](https://github.com/elastic/beats/blob/v7.10.0/deploy/kubernetes/elastic-agent-kubernetes.yaml)
+there's a complete [example manifest](https://github.com/elastic/beats/blob/master/deploy/kubernetes/elastic-agent-kubernetes.yaml)
 available.
 
 #### Kubernetes endpoints and metricsets

--- a/packages/kubernetes/docs/README.md
+++ b/packages/kubernetes/docs/README.md
@@ -17,7 +17,8 @@ a single cluster-wide endpoint. This is important to determine the optimal confi
 for the different datasets included in the integration.
 
 For a complete reference on how to configure and run this package on Kubernetes as part of a `DaemonSet` and a `Deployment`,
-there's a complete example manifest available in <<TODO: link to the proper page here>> document.
+there's a complete [example manifest](https://github.com/elastic/beats/blob/v7.10.0/deploy/kubernetes/elastic-agent-kubernetes.yaml)
+available.
 
 #### Kubernetes endpoints and metricsets
 

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 0.2.8
+version: 0.2.9
 license: basic
 description: Kubernetes Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?
This PR fixes a leftover TODO in the docs of kubernetes package so as to point to the current agent manifests for k8s.
