### PR TITLE
CI: Collect Elastic stack logs

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -75,8 +75,8 @@ pipeline {
                         dir("${BASE_DIR}") {
                           archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/test-results/*.xml')
                           junit(allowEmptyResults: true, keepLongStdio: true, testResults: "build/test-results/*.xml")
-                          sh(label: "Collect Elastic stack details", script: 'build/elastic-package stack dump -v --output build/elastic-stack-dump')
-                          archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/elastic-stack-dump/*.log')
+                          sh(label: "Collect Elastic stack logs", script: 'build/elastic-package stack dump -v --output build/elastic-stack-dump')
+                          archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/elastic-stack-dump/logs/*.log')
                           sh(label: "Take down the Elastic stack", script: 'build/elastic-package stack down -v')
                         }
                       }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
                           archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/test-results/*.xml')
                           junit(allowEmptyResults: true, keepLongStdio: true, testResults: "build/test-results/*.xml")
                           sh(label: "Collect Elastic stack logs", script: "build/elastic-package stack dump -v --output build/elastic-stack-dump/${it}")
-                          archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/elastic-stack-dump/${it}/logs/*.log')
+                          archiveArtifacts(allowEmptyArchive: true, artifacts: "build/elastic-stack-dump/${it}/logs/*.log")
                           sh(label: "Take down the Elastic stack", script: 'build/elastic-package stack down -v')
                         }
                       }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -75,6 +75,8 @@ pipeline {
                         dir("${BASE_DIR}") {
                           archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/test-results/*.xml')
                           junit(allowEmptyResults: true, keepLongStdio: true, testResults: "build/test-results/*.xml")
+                          sh(label: "Collect Elastic stack details", script: 'build/elastic-package stack dump -v --output build/elastic-stack-dump')
+                          archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/elastic-stack-dump/*.log')
                           sh(label: "Take down the Elastic stack", script: 'build/elastic-package stack down -v')
                         }
                       }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -75,8 +75,8 @@ pipeline {
                         dir("${BASE_DIR}") {
                           archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/test-results/*.xml')
                           junit(allowEmptyResults: true, keepLongStdio: true, testResults: "build/test-results/*.xml")
-                          sh(label: "Collect Elastic stack logs", script: 'build/elastic-package stack dump -v --output build/elastic-stack-dump')
-                          archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/elastic-stack-dump/logs/*.log')
+                          sh(label: "Collect Elastic stack logs", script: "build/elastic-package stack dump -v --output build/elastic-stack-dump/${it}")
+                          archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/elastic-stack-dump/${it}/logs/*.log')
                           sh(label: "Take down the Elastic stack", script: 'build/elastic-package stack down -v')
                         }
                       }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/elastic/elastic-package v0.0.0-20210114095213-7142d596d6d9
+	github.com/elastic/elastic-package v0.0.0-20210114174512-e4b08c480f1f
 	github.com/elastic/package-registry v0.13.0
 	github.com/magefile/mage v1.10.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/elastic/elastic-package v0.0.0-20210114095213-7142d596d6d9 h1:xwBKRhurqIkF1Q3u9WM5IXVvgv++mO1CGq7M+7JYPkg=
-github.com/elastic/elastic-package v0.0.0-20210114095213-7142d596d6d9/go.mod h1:lphRg8ZgCi63Nd3vpKy29oqx2N/mme2VdTSHpN1ZNnk=
+github.com/elastic/elastic-package v0.0.0-20210114174512-e4b08c480f1f h1:nSZjPaTsPTUoOCM2aGxgTLrZb0mf56gxuWAlECI/cRk=
+github.com/elastic/elastic-package v0.0.0-20210114174512-e4b08c480f1f/go.mod h1:lphRg8ZgCi63Nd3vpKy29oqx2N/mme2VdTSHpN1ZNnk=
 github.com/elastic/go-elasticsearch/v7 v7.9.0 h1:UEau+a1MiiE/F+UrDj60kqIHFWdzU1M2y/YtBU2NC2M=
 github.com/elastic/go-elasticsearch/v7 v7.9.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/go-ucfg v0.8.3/go.mod h1:iaiY0NBIYeasNgycLyTvhJftQlQEUO2hpF+FX0JKxzo=


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR enables docker logging for containers running in the CI.

Artifacts collected here: https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fintegrations/detail/PR-535/4/artifacts

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- https://github.com/elastic/integrations/issues/380
