### PR TITLE
Add missing datastream filters

### DIFF
--- a/packages/stan/kibana/visualization/stan-0e412fe0-4371-11ea-b0c6-cb14c0977bd1.json
+++ b/packages/stan/kibana/visualization/stan-0e412fe0-4371-11ea-b0c6-cb14c0977bd1.json
@@ -2,7 +2,14 @@
     "attributes": {
         "description": "Queue depth of STAN channels, summed per channel",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {}
+            "searchSourceJSON": {
+                "filter": [],
+                "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+                "query": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset: stan.channels"
+                }
+            }
         },
         "title": "Channel Queue Depth [Metrics Stan]",
         "uiStateJSON": {},

--- a/packages/stan/kibana/visualization/stan-46a07ac0-436d-11ea-b0c6-cb14c0977bd1.json
+++ b/packages/stan/kibana/visualization/stan-46a07ac0-436d-11ea-b0c6-cb14c0977bd1.json
@@ -2,7 +2,14 @@
     "attributes": {
         "description": "Number of messages in each channel / subject",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {}
+            "searchSourceJSON": {
+                "filter": [],
+                "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+                "query": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset: stan.channels"
+                }
+            }
         },
         "title": "Channel Messages [Metrics Stan]",
         "uiStateJSON": {},

--- a/packages/stan/manifest.yml
+++ b/packages/stan/manifest.yml
@@ -1,6 +1,6 @@
 name: stan
 title: STAN
-version: 0.1.0
+version: 0.1.1
 release: beta
 description: STAN Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?
Follow up of https://github.com/elastic/integrations/pull/532 to add missing datastream filters to kibana visualisations.
Part of https://github.com/elastic/integrations/issues/363/
