### PR TITLE
Fix linux documentation and config names

### DIFF
--- a/packages/linux/_dev/build/docs/README.md
+++ b/packages/linux/_dev/build/docs/README.md
@@ -1,4 +1,4 @@
-# System Integration
+# Linux Integration
 
 The Linux integration allows you to monitor low-level metrics on linux servers. Because the System integration
 always applies to the local server, the `hosts` config option is not needed.
@@ -11,6 +11,38 @@ permissions can be blocked by
 
 ## Metrics
 
+### Conntrack
+
+The conntrack module reports on performance counters for the linux connection tracking component of netfilter. 
+Conntrack uses a http://people.netfilter.org/pablo/docs/login.pdf[hash table] to track the state of network connections.
+
+### Iostat
+
+The iostat module reports per-disk IO statistics that emulate `iostat -x` on linux.
+
+### KSM
+
+The KSM module reports data from https://www.kernel.org/doc/html/latest/admin-guide/mm/ksm.html[Kernel Samepage Merging]. 
+In order to take advantage of KSM, applications must use the `madvise` system call to mark memory regions for merging. KSM is not enabled on all distros, and KSM status is set with the `CONFIG_KSM` kernel flag.
+
+
+### Memory
+
+The memory metricset extends system/memory and adds linux-specific memory metrics, including Huge Pages and overall paging statistics.
+
+### Pageinfo
+
+The pageinfo metricset reports on paging statistics as found in /proc/pagetypeinfo
+
+
+Reported metrics are broken down by page type: DMA, DMA32, Normal, and Highmem. These types are further broken down by order, which represents zones of 2^ORDER*PAGE_SIZE.
+These metrics are divided into two reporting types: `buddyinfo`, which is summarized by page type, as in `/proc/buddyinfo`. `nodes` reports info broken down by memory migration type.
+
+
+This information can be used to determine memory fragmentation. 
+The kernel https://www.kernel.org/doc/gorman/html/understand/understand009.html[buddy algorithim] will always search for the smallest page order to allocate, and if none is available, a larger page order will be split into two "buddies." When memory is freed, the kernel will attempt to merge the "buddies." If the only available pages are at lower orders, this indicates fragmentation, as buddy pages cannot be merged.
+
+
 ### Entropy
 
 This is the entropy dataset of the module system. 
@@ -21,7 +53,7 @@ entropy will be out of a total pool size of 4096.
 
 ### Network summary
 
-The System `network_summary` dataset provides network IO metrics collected from the
+The linux `network_summary` dataset provides network IO metrics collected from the
 operating system. These events are global and sorted by protocol.
 
 {{fields "network_summary"}}
@@ -50,7 +82,7 @@ This dataset is available on:
 
 This dataset requires kernel 2.6.14 or newer.
 
-The system `socket` dataset reports an event for each new TCP socket that it
+The linux `socket` dataset reports an event for each new TCP socket that it
 sees. It does this by polling the kernel periodically to get a dump of all
 sockets. You set the polling interval by configuring the `period` option.
 Specifying a short polling interval with this dataset is important to avoid
@@ -60,6 +92,6 @@ missing short-lived connections.
 
 ### Users
 
-The system/users dataset reports logged in users and associated sessions via dbus and logind, which is a systemd component. By default, the dataset will look in `/var/run/dbus/` for a system socket, although a new path can be selected with `DBUS_SYSTEM_BUS_ADDRESS`.
+The linux/users dataset reports logged in users and associated sessions via dbus and logind, which is a systemd component. By default, the dataset will look in `/var/run/dbus/` for a system socket, although a new path can be selected with `DBUS_SYSTEM_BUS_ADDRESS`.
 
 {{fields "users"}}

--- a/packages/linux/_dev/build/docs/README.md
+++ b/packages/linux/_dev/build/docs/README.md
@@ -3,7 +3,7 @@
 The Linux integration allows you to monitor low-level metrics on linux servers. Because the System integration
 always applies to the local server, the `hosts` config option is not needed.
 
-Note that certain datasets may access `/proc` to gather process information,
+Note that certain data streams may access `/proc` to gather process information,
 and the resulting `ptrace_may_access()` call by the kernel to check for
 permissions can be blocked by
 [AppArmor and other LSM software](https://gitlab.com/apparmor/apparmor/wikis/TechnicalDoc_Proc_and_ptrace), even though the System module doesn't use `ptrace` directly.
@@ -14,7 +14,7 @@ permissions can be blocked by
 ### Conntrack
 
 The conntrack module reports on performance counters for the linux connection tracking component of netfilter. 
-Conntrack uses a http://people.netfilter.org/pablo/docs/login.pdf[hash table] to track the state of network connections.
+Conntrack uses a [hash table](http://people.netfilter.org/pablo/docs/login.pdf) to track the state of network connections.
 
 ### Iostat
 
@@ -22,17 +22,17 @@ The iostat module reports per-disk IO statistics that emulate `iostat -x` on lin
 
 ### KSM
 
-The KSM module reports data from https://www.kernel.org/doc/html/latest/admin-guide/mm/ksm.html[Kernel Samepage Merging]. 
+The KSM module reports data from [Kernel Samepage Merging](https://www.kernel.org/doc/html/latest/admin-guide/mm/ksm.html). 
 In order to take advantage of KSM, applications must use the `madvise` system call to mark memory regions for merging. KSM is not enabled on all distros, and KSM status is set with the `CONFIG_KSM` kernel flag.
 
 
 ### Memory
 
-The memory metricset extends system/memory and adds linux-specific memory metrics, including Huge Pages and overall paging statistics.
+The memory data stream extends system/memory and adds linux-specific memory metrics, including Huge Pages and overall paging statistics.
 
 ### Pageinfo
 
-The pageinfo metricset reports on paging statistics as found in /proc/pagetypeinfo
+The pageinfo data stream reports on paging statistics as found in `/proc/pagetypeinfo`.
 
 
 Reported metrics are broken down by page type: DMA, DMA32, Normal, and Highmem. These types are further broken down by order, which represents zones of 2^ORDER*PAGE_SIZE.
@@ -40,12 +40,12 @@ These metrics are divided into two reporting types: `buddyinfo`, which is summar
 
 
 This information can be used to determine memory fragmentation. 
-The kernel https://www.kernel.org/doc/gorman/html/understand/understand009.html[buddy algorithim] will always search for the smallest page order to allocate, and if none is available, a larger page order will be split into two "buddies." When memory is freed, the kernel will attempt to merge the "buddies." If the only available pages are at lower orders, this indicates fragmentation, as buddy pages cannot be merged.
+The kernel [buddy algorithim](https://www.kernel.org/doc/gorman/html/understand/understand009.html) will always search for the smallest page order to allocate, and if none is available, a larger page order will be split into two "buddies." When memory is freed, the kernel will attempt to merge the "buddies." If the only available pages are at lower orders, this indicates fragmentation, as buddy pages cannot be merged.
 
 
 ### Entropy
 
-This is the entropy dataset of the module system. 
+This is the entropy data stream of the module system. 
 It collects the amount of available entropy in bits. On kernel versions greater than 2.6, 
 entropy will be out of a total pool size of 4096.
 
@@ -53,16 +53,16 @@ entropy will be out of a total pool size of 4096.
 
 ### Network summary
 
-The linux `network_summary` dataset provides network IO metrics collected from the
+The linux `network_summary` data stream provides network IO metrics collected from the
 operating system. These events are global and sorted by protocol.
 
 {{fields "network_summary"}}
 
 ### RAID
 
-This is the raid dataset of the module system. It collects stats about the raid.
+This is the raid data stream of the module system. It collects stats about the raid.
 
-This dataset is available on:
+This data stream is available on:
 
 - Linux
 
@@ -70,9 +70,9 @@ This dataset is available on:
 
 ### Service
 
-The `service` dataset reports on the status of systemd services.
+The `service` data stream reports on the status of systemd services.
 
-This dataset is available on:
+This data stream is available on:
 
 - Linux
 
@@ -80,18 +80,18 @@ This dataset is available on:
 
 ### Socket
 
-This dataset requires kernel 2.6.14 or newer.
+This data stream requires kernel 2.6.14 or newer.
 
-The linux `socket` dataset reports an event for each new TCP socket that it
+The Linux `socket` data stream reports an event for each new TCP socket that it
 sees. It does this by polling the kernel periodically to get a dump of all
 sockets. You set the polling interval by configuring the `period` option.
-Specifying a short polling interval with this dataset is important to avoid
+Specifying a short polling interval with this data stream is important to avoid
 missing short-lived connections.
 
 {{fields "socket"}}
 
 ### Users
 
-The linux/users dataset reports logged in users and associated sessions via dbus and logind, which is a systemd component. By default, the dataset will look in `/var/run/dbus/` for a system socket, although a new path can be selected with `DBUS_SYSTEM_BUS_ADDRESS`.
+The linux/users data stream reports logged in users and associated sessions via dbus and logind, which is a systemd component. By default, the data stream will look in `/var/run/dbus/` for a system socket, although a new path can be selected with `DBUS_SYSTEM_BUS_ADDRESS`.
 
 {{fields "users"}}

--- a/packages/linux/data_stream/entropy/manifest.yml
+++ b/packages/linux/data_stream/entropy/manifest.yml
@@ -13,4 +13,4 @@ streams:
         default: 10s
     enabled: false
     title: System entropy metrics
-    description: Collect System entropy metrics
+    description: Collect Linux entropy metrics

--- a/packages/linux/data_stream/network_summary/manifest.yml
+++ b/packages/linux/data_stream/network_summary/manifest.yml
@@ -13,4 +13,4 @@ streams:
         default: 10s
     enabled: false
     title: System network summary metrics
-    description: Collect System network_summary metrics
+    description: Collect Linux network_summary metrics

--- a/packages/linux/data_stream/raid/manifest.yml
+++ b/packages/linux/data_stream/raid/manifest.yml
@@ -22,4 +22,4 @@ streams:
 
     enabled: false
     title: System raid metrics
-    description: Collect System raid metrics
+    description: Collect Linux raid metrics

--- a/packages/linux/data_stream/service/manifest.yml
+++ b/packages/linux/data_stream/service/manifest.yml
@@ -33,4 +33,4 @@ streams:
           Filter systemd services based on a name pattern
 
     title: System service metrics
-    description: Collect System service metrics
+    description: Collect Linux service metrics

--- a/packages/linux/data_stream/socket/manifest.yml
+++ b/packages/linux/data_stream/socket/manifest.yml
@@ -35,4 +35,4 @@ streams:
         show_user: true
         description: "Failure TTL for reverse DNS lookup on remote IP addresses in the socket dataset (sample: 10s)"
     title: System socket metrics
-    description: Collect System socket metrics
+    description: Collect Linux socket metrics

--- a/packages/linux/data_stream/users/manifest.yml
+++ b/packages/linux/data_stream/users/manifest.yml
@@ -13,4 +13,4 @@ streams:
         default: 10s
     enabled: false
     title: System users metrics
-    description: Collect System users metrics
+    description: Collect Linux users metrics

--- a/packages/linux/docs/README.md
+++ b/packages/linux/docs/README.md
@@ -3,7 +3,7 @@
 The Linux integration allows you to monitor low-level metrics on linux servers. Because the System integration
 always applies to the local server, the `hosts` config option is not needed.
 
-Note that certain datasets may access `/proc` to gather process information,
+Note that certain data streams may access `/proc` to gather process information,
 and the resulting `ptrace_may_access()` call by the kernel to check for
 permissions can be blocked by
 [AppArmor and other LSM software](https://gitlab.com/apparmor/apparmor/wikis/TechnicalDoc_Proc_and_ptrace), even though the System module doesn't use `ptrace` directly.
@@ -14,7 +14,7 @@ permissions can be blocked by
 ### Conntrack
 
 The conntrack module reports on performance counters for the linux connection tracking component of netfilter. 
-Conntrack uses a http://people.netfilter.org/pablo/docs/login.pdf[hash table] to track the state of network connections.
+Conntrack uses a [hash table](http://people.netfilter.org/pablo/docs/login.pdf) to track the state of network connections.
 
 ### Iostat
 
@@ -22,17 +22,17 @@ The iostat module reports per-disk IO statistics that emulate `iostat -x` on lin
 
 ### KSM
 
-The KSM module reports data from https://www.kernel.org/doc/html/latest/admin-guide/mm/ksm.html[Kernel Samepage Merging]. 
+The KSM module reports data from [Kernel Samepage Merging](https://www.kernel.org/doc/html/latest/admin-guide/mm/ksm.html). 
 In order to take advantage of KSM, applications must use the `madvise` system call to mark memory regions for merging. KSM is not enabled on all distros, and KSM status is set with the `CONFIG_KSM` kernel flag.
 
 
 ### Memory
 
-The memory metricset extends system/memory and adds linux-specific memory metrics, including Huge Pages and overall paging statistics.
+The memory data stream extends system/memory and adds linux-specific memory metrics, including Huge Pages and overall paging statistics.
 
 ### Pageinfo
 
-The pageinfo metricset reports on paging statistics as found in /proc/pagetypeinfo
+The pageinfo data stream reports on paging statistics as found in `/proc/pagetypeinfo`.
 
 
 Reported metrics are broken down by page type: DMA, DMA32, Normal, and Highmem. These types are further broken down by order, which represents zones of 2^ORDER*PAGE_SIZE.
@@ -40,12 +40,12 @@ These metrics are divided into two reporting types: `buddyinfo`, which is summar
 
 
 This information can be used to determine memory fragmentation. 
-The kernel https://www.kernel.org/doc/gorman/html/understand/understand009.html[buddy algorithim] will always search for the smallest page order to allocate, and if none is available, a larger page order will be split into two "buddies." When memory is freed, the kernel will attempt to merge the "buddies." If the only available pages are at lower orders, this indicates fragmentation, as buddy pages cannot be merged.
+The kernel [buddy algorithim](https://www.kernel.org/doc/gorman/html/understand/understand009.html) will always search for the smallest page order to allocate, and if none is available, a larger page order will be split into two "buddies." When memory is freed, the kernel will attempt to merge the "buddies." If the only available pages are at lower orders, this indicates fragmentation, as buddy pages cannot be merged.
 
 
 ### Entropy
 
-This is the entropy dataset of the module system. 
+This is the entropy data stream of the module system. 
 It collects the amount of available entropy in bits. On kernel versions greater than 2.6, 
 entropy will be out of a total pool size of 4096.
 
@@ -92,7 +92,7 @@ entropy will be out of a total pool size of 4096.
 
 ### Network summary
 
-The linux `network_summary` dataset provides network IO metrics collected from the
+The linux `network_summary` data stream provides network IO metrics collected from the
 operating system. These events are global and sorted by protocol.
 
 **Exported fields**
@@ -141,9 +141,9 @@ operating system. These events are global and sorted by protocol.
 
 ### RAID
 
-This is the raid dataset of the module system. It collects stats about the raid.
+This is the raid data stream of the module system. It collects stats about the raid.
 
-This dataset is available on:
+This data stream is available on:
 
 - Linux
 
@@ -199,9 +199,9 @@ This dataset is available on:
 
 ### Service
 
-The `service` dataset reports on the status of systemd services.
+The `service` data stream reports on the status of systemd services.
 
-This dataset is available on:
+This data stream is available on:
 
 - Linux
 
@@ -269,12 +269,12 @@ This dataset is available on:
 
 ### Socket
 
-This dataset requires kernel 2.6.14 or newer.
+This data stream requires kernel 2.6.14 or newer.
 
-The linux `socket` dataset reports an event for each new TCP socket that it
+The Linux `socket` data stream reports an event for each new TCP socket that it
 sees. It does this by polling the kernel periodically to get a dump of all
 sockets. You set the polling interval by configuring the `period` option.
-Specifying a short polling interval with this dataset is important to avoid
+Specifying a short polling interval with this data stream is important to avoid
 missing short-lived connections.
 
 **Exported fields**
@@ -333,7 +333,7 @@ missing short-lived connections.
 
 ### Users
 
-The linux/users dataset reports logged in users and associated sessions via dbus and logind, which is a systemd component. By default, the dataset will look in `/var/run/dbus/` for a system socket, although a new path can be selected with `DBUS_SYSTEM_BUS_ADDRESS`.
+The linux/users data stream reports logged in users and associated sessions via dbus and logind, which is a systemd component. By default, the data stream will look in `/var/run/dbus/` for a system socket, although a new path can be selected with `DBUS_SYSTEM_BUS_ADDRESS`.
 
 **Exported fields**
 

--- a/packages/linux/docs/README.md
+++ b/packages/linux/docs/README.md
@@ -1,4 +1,4 @@
-# System Integration
+# Linux Integration
 
 The Linux integration allows you to monitor low-level metrics on linux servers. Because the System integration
 always applies to the local server, the `hosts` config option is not needed.
@@ -10,6 +10,38 @@ permissions can be blocked by
 
 
 ## Metrics
+
+### Conntrack
+
+The conntrack module reports on performance counters for the linux connection tracking component of netfilter. 
+Conntrack uses a http://people.netfilter.org/pablo/docs/login.pdf[hash table] to track the state of network connections.
+
+### Iostat
+
+The iostat module reports per-disk IO statistics that emulate `iostat -x` on linux.
+
+### KSM
+
+The KSM module reports data from https://www.kernel.org/doc/html/latest/admin-guide/mm/ksm.html[Kernel Samepage Merging]. 
+In order to take advantage of KSM, applications must use the `madvise` system call to mark memory regions for merging. KSM is not enabled on all distros, and KSM status is set with the `CONFIG_KSM` kernel flag.
+
+
+### Memory
+
+The memory metricset extends system/memory and adds linux-specific memory metrics, including Huge Pages and overall paging statistics.
+
+### Pageinfo
+
+The pageinfo metricset reports on paging statistics as found in /proc/pagetypeinfo
+
+
+Reported metrics are broken down by page type: DMA, DMA32, Normal, and Highmem. These types are further broken down by order, which represents zones of 2^ORDER*PAGE_SIZE.
+These metrics are divided into two reporting types: `buddyinfo`, which is summarized by page type, as in `/proc/buddyinfo`. `nodes` reports info broken down by memory migration type.
+
+
+This information can be used to determine memory fragmentation. 
+The kernel https://www.kernel.org/doc/gorman/html/understand/understand009.html[buddy algorithim] will always search for the smallest page order to allocate, and if none is available, a larger page order will be split into two "buddies." When memory is freed, the kernel will attempt to merge the "buddies." If the only available pages are at lower orders, this indicates fragmentation, as buddy pages cannot be merged.
+
 
 ### Entropy
 
@@ -60,7 +92,7 @@ entropy will be out of a total pool size of 4096.
 
 ### Network summary
 
-The System `network_summary` dataset provides network IO metrics collected from the
+The linux `network_summary` dataset provides network IO metrics collected from the
 operating system. These events are global and sorted by protocol.
 
 **Exported fields**
@@ -239,7 +271,7 @@ This dataset is available on:
 
 This dataset requires kernel 2.6.14 or newer.
 
-The system `socket` dataset reports an event for each new TCP socket that it
+The linux `socket` dataset reports an event for each new TCP socket that it
 sees. It does this by polling the kernel periodically to get a dump of all
 sockets. You set the polling interval by configuring the `period` option.
 Specifying a short polling interval with this dataset is important to avoid
@@ -301,7 +333,7 @@ missing short-lived connections.
 
 ### Users
 
-The system/users dataset reports logged in users and associated sessions via dbus and logind, which is a systemd component. By default, the dataset will look in `/var/run/dbus/` for a system socket, although a new path can be selected with `DBUS_SYSTEM_BUS_ADDRESS`.
+The linux/users dataset reports logged in users and associated sessions via dbus and logind, which is a systemd component. By default, the dataset will look in `/var/run/dbus/` for a system socket, although a new path can be selected with `DBUS_SYSTEM_BUS_ADDRESS`.
 
 **Exported fields**
 

--- a/packages/linux/manifest.yml
+++ b/packages/linux/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: linux
 title: Linux
-version: 0.3.3
+version: 0.3.4
 license: basic
 description: Linux Integration
 type: integration
@@ -22,7 +22,7 @@ policy_templates:
     inputs:
       - type: system/metrics
         title: Collect system metrics from Linux instances
-        description: Collecting System entropy, Network Summary, RAID, service, socket, and users metrics
+        description: Collecting Linux entropy, Network Summary, RAID, service, socket, and users metrics
       - type: linux/metrics
         title: Collect low-level system metrics from Linux instances
         description: Collecting Linux conntrack, ksm, pageinfo metrics.


### PR DESCRIPTION
## What does this PR do?

- This fixes a handful of documentation issues in the linux module relating to config labels and the readme.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [X] I have verified that all datasets collect metrics or logs.

## Related issues

- https://github.com/elastic/integrations/issues/546
- https://github.com/elastic/integrations/issues/547
- https://github.com/elastic/integrations/issues/548