### PR TITLE
Add missing field definitions into AWS data streams

### DIFF
--- a/packages/aws/data_stream/billing/fields/ecs.yml
+++ b/packages/aws/data_stream/billing/fields/ecs.yml
@@ -43,3 +43,11 @@
       type: keyword
       description: Region in which this host is running.
       ignore_above: 1024
+- name: ecs.version
+  type: keyword
+  description: ECS version this event conforms to.
+  example: 1.0.0
+  ignore_above: 1024
+- name: service.type
+  type: keyword
+  description: Service type

--- a/packages/aws/data_stream/cloudwatch_metrics/fields/ecs.yml
+++ b/packages/aws/data_stream/cloudwatch_metrics/fields/ecs.yml
@@ -43,3 +43,11 @@
       type: keyword
       description: Region in which this host is running.
       ignore_above: 1024
+- name: ecs.version
+  type: keyword
+  description: ECS version this event conforms to.
+  example: 1.0.0
+  ignore_above: 1024
+- name: service.type
+  type: keyword
+  description: Service type

--- a/packages/aws/data_stream/dynamodb/fields/ecs.yml
+++ b/packages/aws/data_stream/dynamodb/fields/ecs.yml
@@ -43,3 +43,11 @@
       type: keyword
       description: Region in which this host is running.
       ignore_above: 1024
+- name: ecs.version
+  type: keyword
+  description: ECS version this event conforms to.
+  example: 1.0.0
+  ignore_above: 1024
+- name: service.type
+  type: keyword
+  description: Service type

--- a/packages/aws/data_stream/ebs/fields/ecs.yml
+++ b/packages/aws/data_stream/ebs/fields/ecs.yml
@@ -43,3 +43,11 @@
       type: keyword
       description: Region in which this host is running.
       ignore_above: 1024
+- name: ecs.version
+  type: keyword
+  description: ECS version this event conforms to.
+  example: 1.0.0
+  ignore_above: 1024
+- name: service.type
+  type: keyword
+  description: Service type

--- a/packages/aws/data_stream/ec2_metrics/fields/ecs.yml
+++ b/packages/aws/data_stream/ec2_metrics/fields/ecs.yml
@@ -43,3 +43,11 @@
       type: keyword
       description: Region in which this host is running.
       ignore_above: 1024
+- name: ecs.version
+  type: keyword
+  description: ECS version this event conforms to.
+  example: 1.0.0
+  ignore_above: 1024
+- name: service.type
+  type: keyword
+  description: Service type

--- a/packages/aws/data_stream/ec2_metrics/fields/fields.yml
+++ b/packages/aws/data_stream/ec2_metrics/fields/fields.yml
@@ -91,19 +91,19 @@
           type: long
           description: |
             Bytes written per second to all instance store volumes available to the instance.
-        - name: diskio.read.ops
+        - name: diskio.read.count
           type: long
           description: |
             Completed read operations from all instance store volumes available to the instance in a specified period of time.
-        - name: diskio.read.ops_per_sec
+        - name: diskio.read.count_per_sec
           type: long
           description: |
             Completed read operations per second from all instance store volumes available to the instance in a specified period of time.
-        - name: diskio.write.ops
+        - name: diskio.write.count
           type: long
           description: |
             Completed write operations to all instance store volumes available to the instance in a specified period of time.
-        - name: diskio.write.ops_per_sec
+        - name: diskio.write.count_per_sec
           type: long
           description: |
             Completed write operations per second to all instance store volumes available to the instance in a specified period of time.

--- a/packages/aws/data_stream/elb_metrics/fields/ecs.yml
+++ b/packages/aws/data_stream/elb_metrics/fields/ecs.yml
@@ -43,3 +43,11 @@
       type: keyword
       description: Region in which this host is running.
       ignore_above: 1024
+- name: ecs.version
+  type: keyword
+  description: ECS version this event conforms to.
+  example: 1.0.0
+  ignore_above: 1024
+- name: service.type
+  type: keyword
+  description: Service type

--- a/packages/aws/data_stream/lambda/fields/ecs.yml
+++ b/packages/aws/data_stream/lambda/fields/ecs.yml
@@ -43,3 +43,11 @@
       type: keyword
       description: Region in which this host is running.
       ignore_above: 1024
+- name: ecs.version
+  type: keyword
+  description: ECS version this event conforms to.
+  example: 1.0.0
+  ignore_above: 1024
+- name: service.type
+  type: keyword
+  description: Service type

--- a/packages/aws/data_stream/natgateway/fields/ecs.yml
+++ b/packages/aws/data_stream/natgateway/fields/ecs.yml
@@ -43,3 +43,11 @@
       type: keyword
       description: Region in which this host is running.
       ignore_above: 1024
+- name: ecs.version
+  type: keyword
+  description: ECS version this event conforms to.
+  example: 1.0.0
+  ignore_above: 1024
+- name: service.type
+  type: keyword
+  description: Service type

--- a/packages/aws/data_stream/rds/fields/ecs.yml
+++ b/packages/aws/data_stream/rds/fields/ecs.yml
@@ -43,3 +43,11 @@
       type: keyword
       description: Region in which this host is running.
       ignore_above: 1024
+- name: ecs.version
+  type: keyword
+  description: ECS version this event conforms to.
+  example: 1.0.0
+  ignore_above: 1024
+- name: service.type
+  type: keyword
+  description: Service type

--- a/packages/aws/data_stream/s3_daily_storage/fields/ecs.yml
+++ b/packages/aws/data_stream/s3_daily_storage/fields/ecs.yml
@@ -43,3 +43,11 @@
       type: keyword
       description: Region in which this host is running.
       ignore_above: 1024
+- name: ecs.version
+  type: keyword
+  description: ECS version this event conforms to.
+  example: 1.0.0
+  ignore_above: 1024
+- name: service.type
+  type: keyword
+  description: Service type

--- a/packages/aws/data_stream/s3_request/fields/ecs.yml
+++ b/packages/aws/data_stream/s3_request/fields/ecs.yml
@@ -43,3 +43,11 @@
       type: keyword
       description: Region in which this host is running.
       ignore_above: 1024
+- name: ecs.version
+  type: keyword
+  description: ECS version this event conforms to.
+  example: 1.0.0
+  ignore_above: 1024
+- name: service.type
+  type: keyword
+  description: Service type

--- a/packages/aws/data_stream/sns/fields/ecs.yml
+++ b/packages/aws/data_stream/sns/fields/ecs.yml
@@ -43,3 +43,11 @@
       type: keyword
       description: Region in which this host is running.
       ignore_above: 1024
+- name: ecs.version
+  type: keyword
+  description: ECS version this event conforms to.
+  example: 1.0.0
+  ignore_above: 1024
+- name: service.type
+  type: keyword
+  description: Service type

--- a/packages/aws/data_stream/sqs/fields/ecs.yml
+++ b/packages/aws/data_stream/sqs/fields/ecs.yml
@@ -43,3 +43,11 @@
       type: keyword
       description: Region in which this host is running.
       ignore_above: 1024
+- name: ecs.version
+  type: keyword
+  description: ECS version this event conforms to.
+  example: 1.0.0
+  ignore_above: 1024
+- name: service.type
+  type: keyword
+  description: Service type

--- a/packages/aws/data_stream/transitgateway/fields/ecs.yml
+++ b/packages/aws/data_stream/transitgateway/fields/ecs.yml
@@ -43,3 +43,11 @@
       type: keyword
       description: Region in which this host is running.
       ignore_above: 1024
+- name: ecs.version
+  type: keyword
+  description: ECS version this event conforms to.
+  example: 1.0.0
+  ignore_above: 1024
+- name: service.type
+  type: keyword
+  description: Service type

--- a/packages/aws/data_stream/usage/fields/ecs.yml
+++ b/packages/aws/data_stream/usage/fields/ecs.yml
@@ -43,3 +43,11 @@
       type: keyword
       description: Region in which this host is running.
       ignore_above: 1024
+- name: ecs.version
+  type: keyword
+  description: ECS version this event conforms to.
+  example: 1.0.0
+  ignore_above: 1024
+- name: service.type
+  type: keyword
+  description: Service type

--- a/packages/aws/data_stream/vpn/fields/ecs.yml
+++ b/packages/aws/data_stream/vpn/fields/ecs.yml
@@ -43,3 +43,11 @@
       type: keyword
       description: Region in which this host is running.
       ignore_above: 1024
+- name: ecs.version
+  type: keyword
+  description: ECS version this event conforms to.
+  example: 1.0.0
+  ignore_above: 1024
+- name: service.type
+  type: keyword
+  description: Service type

--- a/packages/aws/docs/README.md
+++ b/packages/aws/docs/README.md
@@ -701,6 +701,7 @@ An example event for `billing` looks as following:
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| ecs.version | ECS version this event conforms to. | keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -717,6 +718,7 @@ An example event for `billing` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| service.type | Service type | keyword |
 
 
 ### cloudwatch
@@ -825,6 +827,7 @@ An example event for `cloudwatch` looks as following:
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| ecs.version | ECS version this event conforms to. | keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -841,6 +844,7 @@ An example event for `cloudwatch` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| service.type | Service type | keyword |
 
 
 ### dynamodb
@@ -981,6 +985,7 @@ An example event for `dynamodb` looks as following:
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| ecs.version | ECS version this event conforms to. | keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -997,6 +1002,7 @@ An example event for `dynamodb` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| service.type | Service type | keyword |
 
 
 ### ebs
@@ -1134,6 +1140,7 @@ An example event for `ebs` looks as following:
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| ecs.version | ECS version this event conforms to. | keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -1150,6 +1157,7 @@ An example event for `ebs` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| service.type | Service type | keyword |
 
 
 ### ec2
@@ -1311,12 +1319,12 @@ An example event for `ec2` looks as following:
 | aws.ec2.cpu.total.pct | The percentage of allocated EC2 compute units that are currently in use on the instance. | scaled_float |
 | aws.ec2.diskio.read.bytes | Bytes read from all instance store volumes available to the instance. | long |
 | aws.ec2.diskio.read.bytes_per_sec | Bytes read per second from all instance store volumes available to the instance. | long |
-| aws.ec2.diskio.read.ops | Completed read operations from all instance store volumes available to the instance in a specified period of time. | long |
-| aws.ec2.diskio.read.ops_per_sec | Completed read operations per second from all instance store volumes available to the instance in a specified period of time. | long |
+| aws.ec2.diskio.read.count | Completed read operations from all instance store volumes available to the instance in a specified period of time. | long |
+| aws.ec2.diskio.read.count_per_sec | Completed read operations per second from all instance store volumes available to the instance in a specified period of time. | long |
 | aws.ec2.diskio.write.bytes | Bytes written to all instance store volumes available to the instance. | long |
 | aws.ec2.diskio.write.bytes_per_sec | Bytes written per second to all instance store volumes available to the instance. | long |
-| aws.ec2.diskio.write.ops | Completed write operations to all instance store volumes available to the instance in a specified period of time. | long |
-| aws.ec2.diskio.write.ops_per_sec | Completed write operations per second to all instance store volumes available to the instance in a specified period of time. | long |
+| aws.ec2.diskio.write.count | Completed write operations to all instance store volumes available to the instance in a specified period of time. | long |
+| aws.ec2.diskio.write.count_per_sec | Completed write operations per second to all instance store volumes available to the instance in a specified period of time. | long |
 | aws.ec2.instance.core.count | The number of CPU cores for the instance. | integer |
 | aws.ec2.instance.image.id | The ID of the image used to launch the instance. | keyword |
 | aws.ec2.instance.monitoring.state | Indicates whether detailed monitoring is enabled. | keyword |
@@ -1357,6 +1365,7 @@ An example event for `ec2` looks as following:
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| ecs.version | ECS version this event conforms to. | keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.cpu.pct | Percent CPU used. This value is normalized by the number of CPU cores and it ranges from 0 to 1. | scaled_float |
@@ -1380,6 +1389,7 @@ An example event for `ec2` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| service.type | Service type | keyword |
 
 
 ### elb
@@ -1559,6 +1569,7 @@ An example event for `elb` looks as following:
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| ecs.version | ECS version this event conforms to. | keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -1575,6 +1586,7 @@ An example event for `elb` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| service.type | Service type | keyword |
 
 
 ### lambda
@@ -1703,6 +1715,7 @@ An example event for `lambda` looks as following:
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| ecs.version | ECS version this event conforms to. | keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -1719,6 +1732,7 @@ An example event for `lambda` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| service.type | Service type | keyword |
 
 
 ### natgateway
@@ -1877,6 +1891,7 @@ An example event for `natgateway` looks as following:
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| ecs.version | ECS version this event conforms to. | keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -1893,6 +1908,7 @@ An example event for `natgateway` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| service.type | Service type | keyword |
 
 
 ### rds
@@ -2122,6 +2138,7 @@ An example event for `rds` looks as following:
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| ecs.version | ECS version this event conforms to. | keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -2138,6 +2155,7 @@ An example event for `rds` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| service.type | Service type | keyword |
 
 
 ### s3_daily_storage
@@ -2250,6 +2268,7 @@ An example event for `s3_daily_storage` looks as following:
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| ecs.version | ECS version this event conforms to. | keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -2266,6 +2285,7 @@ An example event for `s3_daily_storage` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| service.type | Service type | keyword |
 
 
 ### s3_request
@@ -2405,6 +2425,7 @@ An example event for `s3_request` looks as following:
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| ecs.version | ECS version this event conforms to. | keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -2421,6 +2442,7 @@ An example event for `s3_request` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| service.type | Service type | keyword |
 
 
 ### sns
@@ -2554,6 +2576,7 @@ An example event for `sns` looks as following:
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| ecs.version | ECS version this event conforms to. | keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -2570,6 +2593,7 @@ An example event for `sns` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| service.type | Service type | keyword |
 
 
 ### sqs
@@ -2693,6 +2717,7 @@ An example event for `sqs` looks as following:
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| ecs.version | ECS version this event conforms to. | keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -2709,6 +2734,7 @@ An example event for `sqs` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| service.type | Service type | keyword |
 
 
 ### transitgateway
@@ -2839,6 +2865,7 @@ An example event for `transitgateway` looks as following:
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| ecs.version | ECS version this event conforms to. | keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -2855,6 +2882,7 @@ An example event for `transitgateway` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| service.type | Service type | keyword |
 
 
 ### usage
@@ -2971,6 +2999,7 @@ An example event for `usage` looks as following:
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| ecs.version | ECS version this event conforms to. | keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -2987,6 +3016,7 @@ An example event for `usage` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| service.type | Service type | keyword |
 
 
 ### vpn
@@ -3102,6 +3132,7 @@ An example event for `vpn` looks as following:
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| ecs.version | ECS version this event conforms to. | keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -3118,4 +3149,5 @@ An example event for `vpn` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| service.type | Service type | keyword |
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR is to fix missing field definitions in AWS package.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md#tips-for-building-integrations) and this pull request is aligned with them.
- [x] I have verified that all datasets collect metrics or logs.


