### PR TITLE
Rename action input_id to input_type

### DIFF
--- a/packages/fleet_server/elasticsearch/index_template/.fleet-actions.json
+++ b/packages/fleet_server/elasticsearch/index_template/.fleet-actions.json
@@ -20,7 +20,7 @@
                 "expiration": {
                     "type": "date"
                 },
-                "input_id": {
+                "input_type": {
                     "type": "keyword"
                 },
                 "@timestamp": {

--- a/packages/fleet_server/manifest.yml
+++ b/packages/fleet_server/manifest.yml
@@ -1,6 +1,6 @@
 name: fleet_server
 title: Fleet Server
-version: 0.1.1
+version: 0.1.2
 release: experimental
 description: Fleet Server Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?

Rename action input_id to input_type. Instead of integration input id that is generated every time by kibana, rely on more stable integration input type.

This integration was not released and still under development, should be safe to break.

## Related changes

- Relates to Fleet Server change https://github.com/elastic/fleet-server/pull/73

## Screenshots

<img width="704" alt="Screen Shot 2021-01-27 at 4 43 18 PM" src="https://user-images.githubusercontent.com/872351/106058508-5110af00-60bf-11eb-91c9-71e2769f2818.png">
