### PR TITLE
Fix Osquery naming, to make consistent with the official product naming

### DIFF
--- a/packages/osquery_elastic_managed/data_stream/osquery/manifest.yml
+++ b/packages/osquery_elastic_managed/data_stream/osquery/manifest.yml
@@ -1,10 +1,10 @@
-title: OSquery Elastic Managed queries
+title: Osquery Elastic Managed queries
 type: logs
 release: experimental
 streams:
   - input: osquery
-    title: OSquery Elastic Managed queries configuration
-    description: OSquery Elastic Managed queries configuration
+    title: Osquery Elastic Managed queries configuration
+    description: Osquery Elastic Managed queries configuration
     vars:
       - name: query
         type: text

--- a/packages/osquery_elastic_managed/docs/README.md
+++ b/packages/osquery_elastic_managed/docs/README.md
@@ -1,4 +1,4 @@
-# OSQuery Elastic Managed Integration
+# Osquery Elastic Managed Integration
 
 This integration executes the [osquery](https://osquery.io/) binary on all the
 hosts where elastic-agent in running and it allows you to query the host data

--- a/packages/osquery_elastic_managed/manifest.yml
+++ b/packages/osquery_elastic_managed/manifest.yml
@@ -1,9 +1,9 @@
 format_version: 1.0.0
 name: osquery_elastic_managed
-title: OSquery Elastic Managed
-version: 0.1.0
+title: Osquery Elastic Managed
+version: 0.1.1
 license: basic
-description: OSquery Elastic Managed Integration
+description: Osquery Elastic Managed Integration
 type: integration
 release: experimental
 conditions:
@@ -15,7 +15,7 @@ icons:
     type: image/svg+xml
 policy_templates:
   - name: osquery_elastic_managed
-    title: OSquery Elastic Managed
+    title: Osquery Elastic Managed
     description: Send interactive or scheduled queries to the osquery instances executed by the elastic-agent.
     inputs:
       - type: osquery


### PR DESCRIPTION
I noticed the naming inconsistencies with the official product https://osquery.io/
Fixed em.