### PR TITLE
Revert wildcards

### DIFF
--- a/packages/checkpoint/data_stream/firewall/fields/agent.yml
+++ b/packages/checkpoint/data_stream/firewall/fields/agent.yml
@@ -99,7 +99,7 @@
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
@@ -135,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text

--- a/packages/checkpoint/data_stream/firewall/fields/beats.yml
+++ b/packages/checkpoint/data_stream/firewall/fields/beats.yml
@@ -9,7 +9,7 @@
   type: long
 - description: Path to the log file.
   name: log.file.path
-  type: wildcard
+  type: keyword
 - description: Name of the service data is collected from.
   name: destination.service.name
   type: keyword

--- a/packages/checkpoint/data_stream/firewall/fields/ecs.yml
+++ b/packages/checkpoint/data_stream/firewall/fields/ecs.yml
@@ -6,13 +6,13 @@
   type: long
 - description: Organization name.
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: Bytes sent from the destination to the source.
   name: destination.bytes
   type: long
 - description: Destination domain.
   name: destination.domain
-  type: wildcard
+  type: keyword
 - description: City name.
   name: destination.geo.city_name
   type: keyword
@@ -30,7 +30,7 @@
   type: geo_point
 - description: User-defined description of a location.
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   name: destination.geo.region_iso_code
   type: keyword
@@ -57,19 +57,19 @@
   type: long
 - description: User email address.
   name: destination.user.email
-  type: wildcard
+  type: keyword
 - description: Unique identifier of the user.
   name: destination.user.id
   type: keyword
 - description: Short name or login of the user.
   name: destination.user.name
-  type: wildcard
+  type: keyword
 - description: The DNS packet identifier.
   name: dns.id
   type: keyword
 - description: The name being queried.
   name: dns.question.name
-  type: wildcard
+  type: keyword
 - description: The type of record being queried.
   name: dns.question.type
   type: keyword
@@ -159,7 +159,7 @@
   type: keyword
 - description: Operating system name, without the version.
   name: host.os.name
-  type: wildcard
+  type: keyword
 - description: Operating system version as a raw string.
   name: host.os.version
   type: keyword
@@ -168,7 +168,7 @@
   type: keyword
 - description: Referrer for this HTTP request.
   name: http.request.referrer
-  type: wildcard
+  type: keyword
 - description: Log message optimized for viewing in a log viewer.
   name: message
   type: text
@@ -225,13 +225,13 @@
   type: keyword
 - description: Process name.
   name: process.name
-  type: wildcard
+  type: keyword
 - description: MD5 hash.
   name: process.parent.hash.md5
   type: keyword
 - description: Process name.
   name: process.parent.name
-  type: wildcard
+  type: keyword
 - description: All the hashes seen on your event.
   name: related.hash
   type: keyword
@@ -264,13 +264,13 @@
   type: long
 - description: Organization name.
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: Bytes sent from the source to the destination.
   name: source.bytes
   type: long
 - description: Source domain.
   name: source.domain
-  type: wildcard
+  type: keyword
 - description: City name.
   name: source.geo.city_name
   type: keyword
@@ -288,7 +288,7 @@
   type: geo_point
 - description: User-defined description of a location.
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   name: source.geo.region_iso_code
   type: keyword
@@ -315,7 +315,7 @@
   type: long
 - description: User email address.
   name: source.user.email
-  type: wildcard
+  type: keyword
 - description: Name of the group.
   name: source.user.group.name
   type: keyword
@@ -324,22 +324,22 @@
   type: keyword
 - description: Short name or login of the user.
   name: source.user.name
-  type: wildcard
+  type: keyword
 - description: List of keywords used to tag each event.
   name: tags
   type: keyword
 - description: Domain of the url.
   name: url.domain
-  type: wildcard
+  type: keyword
 - description: Unmodified original url as seen in the event source.
   name: url.original
-  type: wildcard
+  type: keyword
 - description: Name of the user agent.
   name: user_agent.name
   type: keyword
 - description: Unparsed user_agent string.
   name: user_agent.original
-  type: wildcard
+  type: keyword
 - description: ID of the vulnerability.
   name: vulnerability.id
   type: keyword

--- a/packages/checkpoint/docs/README.md
+++ b/packages/checkpoint/docs/README.md
@@ -443,15 +443,15 @@ Consists of log entries from the Log Exporter in the Syslog format.
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.bytes | Bytes sent from the destination to the source. | long |
-| destination.domain | Destination domain. | wildcard |
+| destination.domain | Destination domain. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -461,11 +461,11 @@ Consists of log entries from the Log Exporter in the Syslog format.
 | destination.packets | Packets sent from the destination to the source. | long |
 | destination.port | Port of the destination. | long |
 | destination.service.name | Name of the service data is collected from. | keyword |
-| destination.user.email | User email address. | wildcard |
+| destination.user.email | User email address. | keyword |
 | destination.user.id | Unique identifier of the user. | keyword |
-| destination.user.name | Short name or login of the user. | wildcard |
+| destination.user.name | Short name or login of the user. | keyword |
 | dns.id | The DNS packet identifier. | keyword |
-| dns.question.name | The name being queried. | wildcard |
+| dns.question.name | The name being queried. | keyword |
 | dns.question.type | The type of record being queried. | keyword |
 | dns.type | The type of DNS event captured, query or answer. | keyword |
 | ecs.version | ECS version this event conforms to. | keyword |
@@ -497,7 +497,7 @@ Consists of log entries from the Log Exporter in the Syslog format.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -506,14 +506,14 @@ Consists of log entries from the Log Exporter in the Syslog format.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | http.request.method | HTTP request method. | keyword |
-| http.request.referrer | Referrer for this HTTP request. | wildcard |
+| http.request.referrer | Referrer for this HTTP request. | keyword |
 | input.type | Type of Filebeat input. | keyword |
-| log.file.path | Path to the log file. | wildcard |
+| log.file.path | Path to the log file. | keyword |
 | log.flags | Flags for the log file. | keyword |
 | log.offset | Offset of the entry in the log file. | long |
 | log.source.address | Source address of logs received over the network. | keyword |
@@ -535,9 +535,9 @@ Consists of log entries from the Log Exporter in the Syslog format.
 | observer.vendor | Vendor name of the observer. | keyword |
 | observer.version | Observer version. | keyword |
 | process.hash.md5 | MD5 hash. | keyword |
-| process.name | Process name. | wildcard |
+| process.name | Process name. | keyword |
 | process.parent.hash.md5 | MD5 hash. | keyword |
-| process.parent.name | Process name. | wildcard |
+| process.parent.name | Process name. | keyword |
 | related.hash | All the hashes seen on your event. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | related.user | All the user names seen on your event. | keyword |
@@ -548,15 +548,15 @@ Consists of log entries from the Log Exporter in the Syslog format.
 | rule.ruleset | Rule ruleset | keyword |
 | rule.uuid | Rule UUID | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.bytes | Bytes sent from the source to the destination. | long |
-| source.domain | Source domain. | wildcard |
+| source.domain | Source domain. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -565,14 +565,14 @@ Consists of log entries from the Log Exporter in the Syslog format.
 | source.nat.port | Source NAT port | long |
 | source.packets | Packets sent from the source to the destination. | long |
 | source.port | Port of the source. | long |
-| source.user.email | User email address. | wildcard |
+| source.user.email | User email address. | keyword |
 | source.user.group.name | Name of the group. | keyword |
 | source.user.id | Unique identifier of the user. | keyword |
-| source.user.name | Short name or login of the user. | wildcard |
+| source.user.name | Short name or login of the user. | keyword |
 | tags | List of keywords used to tag each event. | keyword |
-| url.domain | Domain of the url. | wildcard |
-| url.original | Unmodified original url as seen in the event source. | wildcard |
+| url.domain | Domain of the url. | keyword |
+| url.original | Unmodified original url as seen in the event source. | keyword |
 | user_agent.name | Name of the user agent. | keyword |
-| user_agent.original | Unparsed user_agent string. | wildcard |
+| user_agent.original | Unparsed user_agent string. | keyword |
 | vulnerability.id | ID of the vulnerability. | keyword |
 

--- a/packages/checkpoint/manifest.yml
+++ b/packages/checkpoint/manifest.yml
@@ -1,6 +1,6 @@
 name: checkpoint
 title: Check Point
-version: 0.4.0
+version: 0.5.0
 release: experimental
 description: Check Point Integration
 type: integration

--- a/packages/fortinet/data_stream/firewall/fields/agent.yml
+++ b/packages/fortinet/data_stream/firewall/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/fortinet/data_stream/firewall/fields/beats.yml
+++ b/packages/fortinet/data_stream/firewall/fields/beats.yml
@@ -9,7 +9,7 @@
   type: long
 - description: Path to the log file.
   name: log.file.path
-  type: wildcard
+  type: keyword
 - description: Log message optimized for viewing in a log viewer.
   name: event.message
   type: text

--- a/packages/fortinet/data_stream/firewall/fields/ecs.yml
+++ b/packages/fortinet/data_stream/firewall/fields/ecs.yml
@@ -9,13 +9,13 @@
   type: long
 - description: Organization name.
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: Bytes sent from the destination to the source.
   name: destination.bytes
   type: long
 - description: Destination domain.
   name: destination.domain
-  type: wildcard
+  type: keyword
 - description: City name.
   name: destination.geo.city_name
   type: keyword
@@ -33,7 +33,7 @@
   type: geo_point
 - description: User-defined description of a location.
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   name: destination.geo.region_iso_code
   type: keyword
@@ -57,10 +57,10 @@
   type: long
 - description: User email address.
   name: destination.user.email
-  type: wildcard
+  type: keyword
 - description: Short name or login of the user.
   name: destination.user.name
-  type: wildcard
+  type: keyword
 - description: DNS packet identifier.
   name: dns.id
   type: keyword
@@ -69,7 +69,7 @@
   type: keyword
 - description: The name being queried.
   name: dns.question.name
-  type: wildcard
+  type: keyword
 - description: The type of record being queried.
   name: dns.question.type
   type: keyword
@@ -207,7 +207,7 @@
   type: long
 - description: Organization name.
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: Bytes sent from the source to the destination.
   name: source.bytes
   type: long
@@ -228,7 +228,7 @@
   type: geo_point
 - description: User-defined description of a location.
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   name: source.geo.region_iso_code
   type: keyword
@@ -255,34 +255,34 @@
   type: long
 - description: User email address.
   name: source.user.email
-  type: wildcard
+  type: keyword
 - description: Name of the group.
   name: source.user.group.name
   type: keyword
 - description: Short name or login of the user.
   name: source.user.name
-  type: wildcard
+  type: keyword
 - description: List of keywords used to tag each event.
   name: tags
   type: keyword
 - description: Distinguished name of subject of the issuer.
   name: tls.client.issuer
-  type: wildcard
+  type: keyword
 - description: Hostname the client is trying to connect to. Also called the SNI.
   name: tls.client.server_name
   type: keyword
 - description: Subject of the issuer of the x.509 certificate presented by the server.
   name: tls.server.issuer
-  type: wildcard
+  type: keyword
 - description: Domain of the url.
   name: url.domain
-  type: wildcard
+  type: keyword
 - description: Path of the request, such as "/search".
   name: url.path
-  type: wildcard
+  type: keyword
 - description: Unparsed user_agent string.
   name: user_agent.original
-  type: wildcard
+  type: keyword
 - description: Category of a vulnerability.
   name: vulnerability.category
   type: keyword

--- a/packages/fortinet/docs/README.md
+++ b/packages/fortinet/docs/README.md
@@ -40,15 +40,15 @@ Contains log entries from Fortinet FortiGate applicances.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.bytes | Bytes sent from the destination to the source. | long |
-| destination.domain | Destination domain. | wildcard |
+| destination.domain | Destination domain. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -56,11 +56,11 @@ Contains log entries from Fortinet FortiGate applicances.
 | destination.nat.port | Destination NAT Port | long |
 | destination.packets | Packets sent from the destination to the source. | long |
 | destination.port | Port of the destination. | long |
-| destination.user.email | User email address. | wildcard |
-| destination.user.name | Short name or login of the user. | wildcard |
+| destination.user.email | User email address. | keyword |
+| destination.user.name | Short name or login of the user. | keyword |
 | dns.id | DNS packet identifier. | keyword |
 | dns.question.class | The class of records being queried. | keyword |
-| dns.question.name | The name being queried. | wildcard |
+| dns.question.name | The name being queried. | keyword |
 | dns.question.type | The type of record being queried. | keyword |
 | dns.resolved_ip | Array containing all IPs seen in answers.data | ip |
 | ecs.version | ECS version this event conforms to. | keyword |
@@ -515,7 +515,7 @@ Contains log entries from Fortinet FortiGate applicances.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -524,12 +524,12 @@ Contains log entries from Fortinet FortiGate applicances.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | input.type | Type of Filebeat input. | keyword |
-| log.file.path | Path to the log file. | wildcard |
+| log.file.path | Path to the log file. | keyword |
 | log.flags | Flags for the log file. | keyword |
 | log.level | Log level of the log event. | keyword |
 | log.offset | Offset of the entry in the log file. | long |
@@ -559,14 +559,14 @@ Contains log entries from Fortinet FortiGate applicances.
 | rule.uuid | Rule UUID | keyword |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.bytes | Bytes sent from the source to the destination. | long |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -575,19 +575,19 @@ Contains log entries from Fortinet FortiGate applicances.
 | source.nat.port | Source NAT port | long |
 | source.packets | Packets sent from the source to the destination. | long |
 | source.port | Port of the source. | long |
-| source.user.email | User email address. | wildcard |
+| source.user.email | User email address. | keyword |
 | source.user.group.name | Name of the group. | keyword |
-| source.user.name | Short name or login of the user. | wildcard |
+| source.user.name | Short name or login of the user. | keyword |
 | tags | List of keywords used to tag each event. | keyword |
-| tls.client.issuer | Distinguished name of subject of the issuer. | wildcard |
+| tls.client.issuer | Distinguished name of subject of the issuer. | keyword |
 | tls.client.server_name | Hostname the client is trying to connect to. Also called the SNI. | keyword |
 | tls.client.x509.issuer.common_name | List of common name (CN) of issuing certificate authority. | keyword |
-| tls.server.issuer | Subject of the issuer of the x.509 certificate presented by the server. | wildcard |
+| tls.server.issuer | Subject of the issuer of the x.509 certificate presented by the server. | keyword |
 | tls.server.x509.issuer.common_name | List of common name (CN) of issuing certificate authority. | keyword |
 | tls.server.x509.subject.common_name | List of common names (CN) of subject. | keyword |
-| url.domain | Domain of the url. | wildcard |
-| url.path | Path of the request, such as "/search". | wildcard |
-| user_agent.original | Unparsed user_agent string. | wildcard |
+| url.domain | Domain of the url. | keyword |
+| url.path | Path of the request, such as "/search". | keyword |
+| user_agent.original | Unparsed user_agent string. | keyword |
 | vulnerability.category | Category of a vulnerability. | keyword |
 
 

--- a/packages/fortinet/manifest.yml
+++ b/packages/fortinet/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet
 title: Fortinet
-version: 0.6.0
+version: 0.7.0
 release: experimental
 description: Fortinet Integration
 type: integration

--- a/packages/google_workspace/data_stream/admin/fields/ecs.yml
+++ b/packages/google_workspace/data_stream/admin/fields/ecs.yml
@@ -27,13 +27,13 @@
   fields:
     - name: domain
       level: extended
-      type: wildcard
+      type: keyword
       description: 'Domain of the url, such as "www.elastic.co".'
     - name: extension
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The field contains the file extension from the original request url, excluding the leading dot.'
+      description: "The field contains the file extension from the original request url, excluding the leading dot."
     - name: fragment
       level: extended
       type: keyword
@@ -43,7 +43,7 @@
         The `#` is not part of the fragment.'
     - name: full
       level: extended
-      type: wildcard
+      type: keyword
       multi_fields:
         - name: text
           type: text
@@ -52,13 +52,13 @@
       description: If full URLs are important to your use case, they should be stored in `url.full`, whether this field is reconstructed or present in the event source.
     - name: original
       level: extended
-      type: wildcard
+      type: keyword
       multi_fields:
         - name: text
           type: text
           norms: false
           default_field: false
-      description: 'Unmodified original url as seen in the event source.'
+      description: "Unmodified original url as seen in the event source."
     - name: password
       level: extended
       type: keyword
@@ -66,7 +66,7 @@
       description: Password of the request.
     - name: path
       level: extended
-      type: wildcard
+      type: keyword
       description: Path of the request, such as "/search".
     - name: port
       level: extended
@@ -80,8 +80,8 @@
       description: 'The query field describes the query string of the request, such as "q=elasticsearch".'
     - name: registered_domain
       level: extended
-      type: wildcard
-      description: 'The highest registered url domain, stripped of the subdomain.'
+      type: keyword
+      description: "The highest registered url domain, stripped of the subdomain."
     - name: scheme
       level: extended
       type: keyword
@@ -91,7 +91,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.'
+      description: "The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain."
       default_field: false
     - name: top_level_domain
       level: extended
@@ -125,17 +125,17 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'The action captured by the event.'
+      description: "The action captured by the event."
     - name: category
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy.'
+      description: "This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy."
     - name: dataset
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the dataset.'
+      description: "Name of the dataset."
     - name: duration
       level: core
       type: long
@@ -143,7 +143,7 @@
       input_format: nanoseconds
       output_format: asMilliseconds
       output_precision: 1
-      description: 'Duration of the event in nanoseconds.'
+      description: "Duration of the event in nanoseconds."
     - name: end
       level: extended
       type: date
@@ -156,24 +156,24 @@
     - name: ingested
       level: core
       type: date
-      description: 'Timestamp when an event arrived in the central data store.'
+      description: "Timestamp when an event arrived in the central data store."
       default_field: false
     - name: original
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Raw text message of entire event. Used to demonstrate log integrity.'
+      description: "Raw text message of entire event. Used to demonstrate log integrity."
       index: false
     - name: outcome
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy.'
+      description: "This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy."
     - name: provider
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Source of the event.'
+      description: "Source of the event."
     - name: start
       level: extended
       type: date
@@ -182,7 +182,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy.'
+      description: "This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy."
 - name: input.type
   type: keyword
   description: Input type
@@ -292,12 +292,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the directory the user is a member of.
-
-        For example, an LDAP or Active Directory domain name.'
+      description: "Name of the directory the user is a member of.\nFor example, an LDAP or Active Directory domain name."
     - name: user.email
       level: extended
-      type: wildcard
+      type: keyword
       description: User email address.
     - name: user.id
       level: core
@@ -306,7 +304,7 @@
       description: Unique identifier of the user.
     - name: user.name
       level: core
-      type: wildcard
+      type: keyword
       multi_fields:
         - name: text
           type: text
@@ -332,9 +330,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the directory the group is a member of.
-
-        For example, an LDAP or Active Directory domain name.'
+      description: "Name of the directory the group is a member of.\nFor example, an LDAP or Active Directory domain name."
     - name: id
       level: extended
       type: keyword

--- a/packages/google_workspace/data_stream/drive/fields/ecs.yml
+++ b/packages/google_workspace/data_stream/drive/fields/ecs.yml
@@ -32,17 +32,17 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'The action captured by the event.'
+      description: "The action captured by the event."
     - name: category
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy.'
+      description: "This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy."
     - name: dataset
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the dataset.'
+      description: "Name of the dataset."
     - name: duration
       level: core
       type: long
@@ -50,7 +50,7 @@
       input_format: nanoseconds
       output_format: asMilliseconds
       output_precision: 1
-      description: 'Duration of the event in nanoseconds.'
+      description: "Duration of the event in nanoseconds."
     - name: end
       level: extended
       type: date
@@ -63,24 +63,24 @@
     - name: ingested
       level: core
       type: date
-      description: 'Timestamp when an event arrived in the central data store.'
+      description: "Timestamp when an event arrived in the central data store."
       default_field: false
     - name: original
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Raw text message of entire event. Used to demonstrate log integrity.'
+      description: "Raw text message of entire event. Used to demonstrate log integrity."
       index: false
     - name: outcome
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy.'
+      description: "This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy."
     - name: provider
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Source of the event.'
+      description: "Source of the event."
     - name: start
       level: extended
       type: date
@@ -89,7 +89,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy.'
+      description: "This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy."
 - name: input.type
   type: keyword
   description: Input type
@@ -199,12 +199,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the directory the user is a member of.
-
-        For example, an LDAP or Active Directory domain name.'
+      description: "Name of the directory the user is a member of.\nFor example, an LDAP or Active Directory domain name."
     - name: user.email
       level: extended
-      type: wildcard
+      type: keyword
       description: User email address.
     - name: user.id
       level: core
@@ -213,7 +211,7 @@
       description: Unique identifier of the user.
     - name: user.name
       level: core
-      type: wildcard
+      type: keyword
       multi_fields:
         - name: text
           type: text
@@ -239,9 +237,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the directory the group is a member of.
-
-        For example, an LDAP or Active Directory domain name.'
+      description: "Name of the directory the group is a member of.\nFor example, an LDAP or Active Directory domain name."
     - name: id
       level: extended
       type: keyword
@@ -261,7 +257,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'File extension, excluding the leading dot.'
+      description: "File extension, excluding the leading dot."
     - name: name
       level: extended
       type: keyword
@@ -274,7 +270,7 @@
       description: File owner's username.
     - name: path
       level: extended
-      type: wildcard
+      type: keyword
       multi_fields:
         - name: text
           type: text

--- a/packages/google_workspace/data_stream/groups/fields/ecs.yml
+++ b/packages/google_workspace/data_stream/groups/fields/ecs.yml
@@ -32,17 +32,17 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'The action captured by the event.'
+      description: "The action captured by the event."
     - name: category
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy.'
+      description: "This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy."
     - name: dataset
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the dataset.'
+      description: "Name of the dataset."
     - name: duration
       level: core
       type: long
@@ -50,7 +50,7 @@
       input_format: nanoseconds
       output_format: asMilliseconds
       output_precision: 1
-      description: 'Duration of the event in nanoseconds.'
+      description: "Duration of the event in nanoseconds."
     - name: end
       level: extended
       type: date
@@ -63,24 +63,24 @@
     - name: ingested
       level: core
       type: date
-      description: 'Timestamp when an event arrived in the central data store.'
+      description: "Timestamp when an event arrived in the central data store."
       default_field: false
     - name: original
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Raw text message of entire event. Used to demonstrate log integrity.'
+      description: "Raw text message of entire event. Used to demonstrate log integrity."
       index: false
     - name: outcome
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy.'
+      description: "This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy."
     - name: provider
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Source of the event.'
+      description: "Source of the event."
     - name: start
       level: extended
       type: date
@@ -89,7 +89,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy.'
+      description: "This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy."
 - name: input.type
   type: keyword
   description: Input type
@@ -199,12 +199,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the directory the user is a member of.
-
-        For example, an LDAP or Active Directory domain name.'
+      description: "Name of the directory the user is a member of.\nFor example, an LDAP or Active Directory domain name."
     - name: user.email
       level: extended
-      type: wildcard
+      type: keyword
       description: User email address.
     - name: user.id
       level: core
@@ -213,7 +211,7 @@
       description: Unique identifier of the user.
     - name: user.name
       level: core
-      type: wildcard
+      type: keyword
       multi_fields:
         - name: text
           type: text
@@ -239,9 +237,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the directory the group is a member of.
-
-        For example, an LDAP or Active Directory domain name.'
+      description: "Name of the directory the group is a member of.\nFor example, an LDAP or Active Directory domain name."
     - name: id
       level: extended
       type: keyword

--- a/packages/google_workspace/data_stream/login/fields/ecs.yml
+++ b/packages/google_workspace/data_stream/login/fields/ecs.yml
@@ -32,17 +32,17 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'The action captured by the event.'
+      description: "The action captured by the event."
     - name: category
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy.'
+      description: "This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy."
     - name: dataset
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the dataset.'
+      description: "Name of the dataset."
     - name: duration
       level: core
       type: long
@@ -50,7 +50,7 @@
       input_format: nanoseconds
       output_format: asMilliseconds
       output_precision: 1
-      description: 'Duration of the event in nanoseconds.'
+      description: "Duration of the event in nanoseconds."
     - name: end
       level: extended
       type: date
@@ -63,24 +63,24 @@
     - name: ingested
       level: core
       type: date
-      description: 'Timestamp when an event arrived in the central data store.'
+      description: "Timestamp when an event arrived in the central data store."
       default_field: false
     - name: original
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Raw text message of entire event. Used to demonstrate log integrity.'
+      description: "Raw text message of entire event. Used to demonstrate log integrity."
       index: false
     - name: outcome
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy.'
+      description: "This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy."
     - name: provider
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Source of the event.'
+      description: "Source of the event."
     - name: start
       level: extended
       type: date
@@ -89,7 +89,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy.'
+      description: "This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy."
 - name: input.type
   type: keyword
   description: Input type
@@ -199,12 +199,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the directory the user is a member of.
-
-        For example, an LDAP or Active Directory domain name.'
+      description: "Name of the directory the user is a member of.\nFor example, an LDAP or Active Directory domain name."
     - name: user.email
       level: extended
-      type: wildcard
+      type: keyword
       description: User email address.
     - name: user.id
       level: core
@@ -213,7 +211,7 @@
       description: Unique identifier of the user.
     - name: user.name
       level: core
-      type: wildcard
+      type: keyword
       multi_fields:
         - name: text
           type: text
@@ -239,9 +237,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the directory the group is a member of.
-
-        For example, an LDAP or Active Directory domain name.'
+      description: "Name of the directory the group is a member of.\nFor example, an LDAP or Active Directory domain name."
     - name: id
       level: extended
       type: keyword

--- a/packages/google_workspace/data_stream/saml/fields/ecs.yml
+++ b/packages/google_workspace/data_stream/saml/fields/ecs.yml
@@ -32,17 +32,17 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'The action captured by the event.'
+      description: "The action captured by the event."
     - name: category
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy.'
+      description: "This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy."
     - name: dataset
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the dataset.'
+      description: "Name of the dataset."
     - name: duration
       level: core
       type: long
@@ -50,7 +50,7 @@
       input_format: nanoseconds
       output_format: asMilliseconds
       output_precision: 1
-      description: 'Duration of the event in nanoseconds.'
+      description: "Duration of the event in nanoseconds."
     - name: end
       level: extended
       type: date
@@ -63,24 +63,24 @@
     - name: ingested
       level: core
       type: date
-      description: 'Timestamp when an event arrived in the central data store.'
+      description: "Timestamp when an event arrived in the central data store."
       default_field: false
     - name: original
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Raw text message of entire event. Used to demonstrate log integrity.'
+      description: "Raw text message of entire event. Used to demonstrate log integrity."
       index: false
     - name: outcome
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy.'
+      description: "This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy."
     - name: provider
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Source of the event.'
+      description: "Source of the event."
     - name: start
       level: extended
       type: date
@@ -89,7 +89,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy.'
+      description: "This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy."
 - name: input.type
   type: keyword
   description: Input type
@@ -199,12 +199,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the directory the user is a member of.
-
-        For example, an LDAP or Active Directory domain name.'
+      description: "Name of the directory the user is a member of.\nFor example, an LDAP or Active Directory domain name."
     - name: user.email
       level: extended
-      type: wildcard
+      type: keyword
       description: User email address.
     - name: user.id
       level: core
@@ -213,7 +211,7 @@
       description: Unique identifier of the user.
     - name: user.name
       level: core
-      type: wildcard
+      type: keyword
       multi_fields:
         - name: text
           type: text
@@ -239,9 +237,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the directory the group is a member of.
-
-        For example, an LDAP or Active Directory domain name.'
+      description: "Name of the directory the group is a member of.\nFor example, an LDAP or Active Directory domain name."
     - name: id
       level: extended
       type: keyword

--- a/packages/google_workspace/data_stream/user_accounts/fields/ecs.yml
+++ b/packages/google_workspace/data_stream/user_accounts/fields/ecs.yml
@@ -32,17 +32,17 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'The action captured by the event.'
+      description: "The action captured by the event."
     - name: category
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy.'
+      description: "This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy."
     - name: dataset
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the dataset.'
+      description: "Name of the dataset."
     - name: duration
       level: core
       type: long
@@ -50,7 +50,7 @@
       input_format: nanoseconds
       output_format: asMilliseconds
       output_precision: 1
-      description: 'Duration of the event in nanoseconds.'
+      description: "Duration of the event in nanoseconds."
     - name: end
       level: extended
       type: date
@@ -63,24 +63,24 @@
     - name: ingested
       level: core
       type: date
-      description: 'Timestamp when an event arrived in the central data store.'
+      description: "Timestamp when an event arrived in the central data store."
       default_field: false
     - name: original
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Raw text message of entire event. Used to demonstrate log integrity.'
+      description: "Raw text message of entire event. Used to demonstrate log integrity."
       index: false
     - name: outcome
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy.'
+      description: "This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy."
     - name: provider
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Source of the event.'
+      description: "Source of the event."
     - name: start
       level: extended
       type: date
@@ -89,7 +89,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy.'
+      description: "This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy."
 - name: input.type
   type: keyword
   description: Input type
@@ -199,12 +199,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the directory the user is a member of.
-
-        For example, an LDAP or Active Directory domain name.'
+      description: "Name of the directory the user is a member of.\nFor example, an LDAP or Active Directory domain name."
     - name: user.email
       level: extended
-      type: wildcard
+      type: keyword
       description: User email address.
     - name: user.id
       level: core
@@ -213,7 +211,7 @@
       description: Unique identifier of the user.
     - name: user.name
       level: core
-      type: wildcard
+      type: keyword
       multi_fields:
         - name: text
           type: text
@@ -239,9 +237,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the directory the group is a member of.
-
-        For example, an LDAP or Active Directory domain name.'
+      description: "Name of the directory the group is a member of.\nFor example, an LDAP or Active Directory domain name."
     - name: id
       level: extended
       type: keyword

--- a/packages/google_workspace/docs/README.md
+++ b/packages/google_workspace/docs/README.md
@@ -252,9 +252,9 @@ An example event for `saml` looks as following:
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source (IPv4 or IPv6). | ip |
 | source.user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
-| source.user.email | User email address. | wildcard |
+| source.user.email | User email address. | keyword |
 | source.user.id | Unique identifier of the user. | keyword |
-| source.user.name | Short name or login of the user. | wildcard |
+| source.user.name | Short name or login of the user. | keyword |
 | tags | List of keywords used to tag each event. | keyword |
 
 
@@ -451,9 +451,9 @@ An example event for `user_accounts` looks as following:
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source (IPv4 or IPv6). | ip |
 | source.user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
-| source.user.email | User email address. | wildcard |
+| source.user.email | User email address. | keyword |
 | source.user.id | Unique identifier of the user. | keyword |
-| source.user.name | Short name or login of the user. | wildcard |
+| source.user.name | Short name or login of the user. | keyword |
 | tags | List of keywords used to tag each event. | keyword |
 
 
@@ -659,9 +659,9 @@ An example event for `login` looks as following:
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source (IPv4 or IPv6). | ip |
 | source.user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
-| source.user.email | User email address. | wildcard |
+| source.user.email | User email address. | keyword |
 | source.user.id | Unique identifier of the user. | keyword |
-| source.user.name | Short name or login of the user. | wildcard |
+| source.user.name | Short name or login of the user. | keyword |
 | tags | List of keywords used to tag each event. | keyword |
 
 
@@ -962,20 +962,20 @@ An example event for `admin` looks as following:
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source (IPv4 or IPv6). | ip |
 | source.user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
-| source.user.email | User email address. | wildcard |
+| source.user.email | User email address. | keyword |
 | source.user.id | Unique identifier of the user. | keyword |
-| source.user.name | Short name or login of the user. | wildcard |
+| source.user.name | Short name or login of the user. | keyword |
 | tags | List of keywords used to tag each event. | keyword |
-| url.domain | Domain of the url, such as "www.elastic.co". | wildcard |
+| url.domain | Domain of the url, such as "www.elastic.co". | keyword |
 | url.extension | The field contains the file extension from the original request url, excluding the leading dot. | keyword |
 | url.fragment | Portion of the url after the `#`, such as "top". The `#` is not part of the fragment. | keyword |
-| url.full | If full URLs are important to your use case, they should be stored in `url.full`, whether this field is reconstructed or present in the event source. | wildcard |
-| url.original | Unmodified original url as seen in the event source. | wildcard |
+| url.full | If full URLs are important to your use case, they should be stored in `url.full`, whether this field is reconstructed or present in the event source. | keyword |
+| url.original | Unmodified original url as seen in the event source. | keyword |
 | url.password | Password of the request. | keyword |
-| url.path | Path of the request, such as "/search". | wildcard |
+| url.path | Path of the request, such as "/search". | keyword |
 | url.port | Port of the request, such as 443. | long |
 | url.query | The query field describes the query string of the request, such as "q=elasticsearch". | keyword |
-| url.registered_domain | The highest registered url domain, stripped of the subdomain. | wildcard |
+| url.registered_domain | The highest registered url domain, stripped of the subdomain. | keyword |
 | url.scheme | Scheme of the request, such as "https". | keyword |
 | url.subdomain | The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain. | keyword |
 | url.top_level_domain | The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com". | keyword |
@@ -1154,7 +1154,7 @@ An example event for `drive` looks as following:
 | file.extension | File extension, excluding the leading dot. | keyword |
 | file.name | Name of the file including the extension, without the directory. | keyword |
 | file.owner | File owner's username. | keyword |
-| file.path | Full path to the file, including the file name. It should include the drive letter, when appropriate. | wildcard |
+| file.path | Full path to the file, including the file name. It should include the drive letter, when appropriate. | keyword |
 | file.type | File type (file, dir, or symlink). | keyword |
 | google_workspace.actor.key | Only present when `actor.type` is `KEY`. Can be the `consumer_key` of the requestor for OAuth 2LO API requests or an identifier for robot accounts. | keyword |
 | google_workspace.actor.type | The type of actor. Values can be:   *USER*: Another user in the same domain.   *EXTERNAL_USER*: A user outside the domain.   *KEY*: A non-human actor. | keyword |
@@ -1225,9 +1225,9 @@ An example event for `drive` looks as following:
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source (IPv4 or IPv6). | ip |
 | source.user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
-| source.user.email | User email address. | wildcard |
+| source.user.email | User email address. | keyword |
 | source.user.id | Unique identifier of the user. | keyword |
-| source.user.name | Short name or login of the user. | wildcard |
+| source.user.name | Short name or login of the user. | keyword |
 | tags | List of keywords used to tag each event. | keyword |
 
 
@@ -1450,8 +1450,8 @@ An example event for `groups` looks as following:
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source (IPv4 or IPv6). | ip |
 | source.user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
-| source.user.email | User email address. | wildcard |
+| source.user.email | User email address. | keyword |
 | source.user.id | Unique identifier of the user. | keyword |
-| source.user.name | Short name or login of the user. | wildcard |
+| source.user.name | Short name or login of the user. | keyword |
 | tags | List of keywords used to tag each event. | keyword |
 

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: 0.0.1
+version: 0.1.0
 release: experimental
 description: Google Workspace Integration
 type: integration
@@ -75,10 +75,10 @@ policy_templates:
             show_user: true
             default:
               - forwarded
-        title: 'Collect admin, drive, groups, login, saml and user accounts logs (input: httpjson)'
-        description: 'Collecting admin, drive, groups, login, saml and user accounts logs (input: httpjson)'
+        title: "Collect admin, drive, groups, login, saml and user accounts logs (input: httpjson)"
+        description: "Collecting admin, drive, groups, login, saml and user accounts logs (input: httpjson)"
       - type: logfile
-        title: 'Collect admin, drive, groups, login, saml and user accounts logs (input: logfile)'
-        description: 'Collecting admin, drive, groups, login, saml and user accounts logs (input: logfile)'
+        title: "Collect admin, drive, groups, login, saml and user accounts logs (input: logfile)"
+        description: "Collecting admin, drive, groups, login, saml and user accounts logs (input: logfile)"
 owner:
   github: elastic/security-external-integrations

--- a/packages/iis/data_stream/access/fields/ecs.yml
+++ b/packages/iis/data_stream/access/fields/ecs.yml
@@ -17,7 +17,7 @@
       description: Port of the destination.
     - name: domain
       level: core
-      type: wildcard
+      type: keyword
       description: Destination domain.
     - name: ip
       level: core

--- a/packages/iis/data_stream/error/fields/ecs.yml
+++ b/packages/iis/data_stream/error/fields/ecs.yml
@@ -17,7 +17,7 @@
       description: Port of the destination.
     - name: domain
       level: core
-      type: wildcard
+      type: keyword
       description: Destination domain.
     - name: ip
       level: core

--- a/packages/iis/docs/README.md
+++ b/packages/iis/docs/README.md
@@ -547,7 +547,7 @@ The fields reported are:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
-| destination.domain | Destination domain. | wildcard |
+| destination.domain | Destination domain. | keyword |
 | destination.ip |  | ip |
 | destination.port | Port of the destination. | long |
 | error.message | Error message. | text |
@@ -697,7 +697,7 @@ The fields reported are:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
-| destination.domain | Destination domain. | wildcard |
+| destination.domain | Destination domain. | keyword |
 | destination.ip |  | ip |
 | destination.port | Port of the destination. | long |
 | error.message | Error message | text |

--- a/packages/iis/manifest.yml
+++ b/packages/iis/manifest.yml
@@ -1,6 +1,6 @@
 name: iis
 title: IIS
-version: 0.2.7
+version: 0.3.0
 description: IIS Integration
 type: integration
 icons:
@@ -14,7 +14,7 @@ categories:
   - web
 release: beta
 conditions:
-  kibana.version: '^7.9.0'
+  kibana.version: "^7.9.0"
 screenshots:
   - src: /img/kibana-iis.png
     title: kibana iis

--- a/packages/osquery/data_stream/result/fields/ecs.yml
+++ b/packages/osquery/data_stream/result/fields/ecs.yml
@@ -8,7 +8,7 @@
       required: true
       type: keyword
       ignore_above: 1024
-      description: 'ECS version this event conforms to.'
+      description: "ECS version this event conforms to."
 - name: event
   title: Event
   group: 2
@@ -18,11 +18,11 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the dataset.'
+      description: "Name of the dataset."
     - name: ingested
       level: core
       type: date
-      description: 'Timestamp when an event arrived in the central data store.'
+      description: "Timestamp when an event arrived in the central data store."
       default_field: false
 - name: log
   title: Log
@@ -33,13 +33,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Full path to the log file this event came from, including the file name. It should include the drive letter, when appropriate.'
+      description: "Full path to the log file this event came from, including the file name. It should include the drive letter, when appropriate."
       default_field: false
     - name: level
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Original log level of the log event.'
+      description: "Original log level of the log event."
     - name: offset
       type: long
       description: Log offset
@@ -47,27 +47,25 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'This is the original log message and contains the full log message before splitting it up in multiple parts.'
+      description: "This is the original log message and contains the full log message before splitting it up in multiple parts."
       index: false
 - name: file
   title: File
   group: 2
-  description: 'A file is defined as a set of information that has been created on, or has existed on a filesystem.
-
-    File objects can be associated with host events, network events, and/or file events (e.g., those produced by File Integrity Monitoring [FIM] products or services). File fields provide details about the affected file associated with the event or metric.'
+  description: "A file is defined as a set of information that has been created on, or has existed on a filesystem.\nFile objects can be associated with host events, network events, and/or file events (e.g., those produced by File Integrity Monitoring [FIM] products or services). File fields provide details about the affected file associated with the event or metric."
   type: group
   fields:
     - name: accessed
       level: extended
       type: date
-      description: 'Last time the file was accessed.'
+      description: "Last time the file was accessed."
     - name: created
       level: extended
       type: date
-      description: 'File creation time.'
+      description: "File creation time."
     - name: directory
       level: extended
-      type: wildcard
+      type: keyword
       description: Directory where the file is located. It should include the drive letter, when appropriate.
     - name: gid
       level: extended
@@ -84,7 +82,7 @@
       type: keyword
       ignore_above: 1024
       description: Mode of the file in octal representation.
-      example: '0640'
+      example: "0640"
     - name: mtime
       level: extended
       type: date
@@ -96,7 +94,7 @@
       description: Name of the file including the extension, without the directory.
     - name: path
       level: extended
-      type: wildcard
+      type: keyword
       multi_fields:
         - name: text
           type: text
@@ -106,7 +104,7 @@
     - name: size
       level: extended
       type: long
-      description: 'File size in bytes.'
+      description: "File size in bytes."
     - name: type
       level: extended
       type: keyword
@@ -123,20 +121,18 @@
 - name: process
   title: Process
   group: 2
-  description: 'These fields contain information about a process.
-
-    These fields can help you correlate metrics information with a process id/name from a log message.  The `process.pid` often stays in the metric itself and is copied to the global field for correlation.'
+  description: "These fields contain information about a process.\nThese fields can help you correlate metrics information with a process id/name from a log message.  The `process.pid` often stays in the metric itself and is copied to the global field for correlation."
   type: group
   fields:
     - name: name
       level: extended
-      type: wildcard
+      type: keyword
       multi_fields:
         - name: text
           type: text
           norms: false
           default_field: false
-      description: 'Process name.'
+      description: "Process name."
 - name: related
   title: Related
   type: group
@@ -169,7 +165,7 @@
   fields:
     - name: full
       level: extended
-      type: wildcard
+      type: keyword
       multi_fields:
         - name: text
           type: text
@@ -182,7 +178,7 @@
   fields:
     - name: name
       level: core
-      type: wildcard
+      type: keyword
       multi_fields:
         - name: text
           type: text

--- a/packages/osquery/docs/README.md
+++ b/packages/osquery/docs/README.md
@@ -114,13 +114,13 @@ An example event for `result` looks as following:
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | file.accessed | Last time the file was accessed. | date |
 | file.created | File creation time. | date |
-| file.directory | Directory where the file is located. It should include the drive letter, when appropriate. | wildcard |
+| file.directory | Directory where the file is located. It should include the drive letter, when appropriate. | keyword |
 | file.gid | Primary group ID (GID) of the file. | keyword |
 | file.inode | Inode representing the file in the filesystem. | keyword |
 | file.mode | Mode of the file in octal representation. | keyword |
 | file.mtime | Last time the file content was modified. | date |
 | file.name | Name of the file including the extension, without the directory. | keyword |
-| file.path | Full path to the file, including the file name. It should include the drive letter, when appropriate. | wildcard |
+| file.path | Full path to the file, including the file name. It should include the drive letter, when appropriate. | keyword |
 | file.size | File size in bytes. | long |
 | file.type | File type (file, dir, or symlink). | keyword |
 | file.uid | The user ID (UID) or security identifier (SID) of the file owner. | keyword |
@@ -318,10 +318,10 @@ An example event for `result` looks as following:
 | osquery.result.host_identifier | The identifier for the host on which the osquery agent is running. Normally the hostname. | keyword |
 | osquery.result.name | The name of the query that generated this event. | keyword |
 | osquery.result.unix_time | Unix timestamp of the event, in seconds since the epoch. Used for computing the `@timestamp` column. | keyword |
-| process.name | Process name. | wildcard |
+| process.name | Process name. | keyword |
 | related.hosts |  | keyword |
 | related.user |  | keyword |
 | rule.name | The name of the rule or signature generating the event. | keyword |
-| url.full |  | wildcard |
-| user.name | Short name or login of the user. | wildcard |
+| url.full |  | keyword |
+| user.name | Short name or login of the user. | keyword |
 

--- a/packages/osquery/manifest.yml
+++ b/packages/osquery/manifest.yml
@@ -1,6 +1,6 @@
 name: osquery
 title: Osquery
-version: 0.0.1
+version: 0.1.0
 release: experimental
 description: Osquery Integration
 type: integration
@@ -27,7 +27,7 @@ policy_templates:
     description: Collect logs from Osquery instances
     inputs:
       - type: logfile
-        title: 'Collect Osquery result logs (input: logfile)'
-        description: 'Collecting result logs from Osquery instances (input: logfile)'
+        title: "Collect Osquery result logs (input: logfile)"
+        description: "Collecting result logs from Osquery instances (input: logfile)"
 owner:
   github: elastic/security-external-integrations

--- a/packages/panw/data_stream/panos/fields/agent.yml
+++ b/packages/panw/data_stream/panos/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/panw/data_stream/panos/fields/beats.yml
+++ b/packages/panw/data_stream/panos/fields/beats.yml
@@ -9,7 +9,7 @@
   type: long
 - description: Path to the log file.
   name: log.file.path
-  type: wildcard
+  type: keyword
 - description: Source address from which the log event was read / sent from.
   name: log.source.address
   type: keyword

--- a/packages/panw/data_stream/panos/fields/ecs.yml
+++ b/packages/panw/data_stream/panos/fields/ecs.yml
@@ -18,7 +18,7 @@
   type: long
 - description: Short name or login of the user.
   name: client.user.name
-  type: wildcard
+  type: keyword
 - description: Unique container id.
   name: container.id
   type: keyword
@@ -30,7 +30,7 @@
   type: long
 - description: Organization name.
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: Bytes sent from the destination to the source.
   name: destination.bytes
   type: long
@@ -51,7 +51,7 @@
   type: geo_point
 - description: User-defined description of a location.
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   name: destination.geo.region_iso_code
   type: keyword
@@ -75,10 +75,10 @@
   type: long
 - description: User email address.
   name: destination.user.email
-  type: wildcard
+  type: keyword
 - description: Short name or login of the user.
   name: destination.user.name
-  type: wildcard
+  type: keyword
 - description: ECS version this event conforms to.
   name: ecs.version
   type: keyword
@@ -219,7 +219,7 @@
   type: long
 - description: Short name or login of the user.
   name: server.user.name
-  type: wildcard
+  type: keyword
 - description: Source network address.
   name: source.address
   type: keyword
@@ -228,7 +228,7 @@
   type: long
 - description: Organization name.
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: Bytes sent from the source to the destination.
   name: source.bytes
   type: long
@@ -249,7 +249,7 @@
   type: geo_point
 - description: User-defined description of a location.
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   name: source.geo.region_iso_code
   type: keyword
@@ -273,16 +273,16 @@
   type: long
 - description: User email address.
   name: source.user.email
-  type: wildcard
+  type: keyword
 - description: Short name or login of the user.
   name: source.user.name
-  type: wildcard
+  type: keyword
 - description: Unmodified original url as seen in the event source.
   name: url.original
-  type: wildcard
+  type: keyword
 - description: Unparsed user_agent string.
   name: user_agent.original
-  type: wildcard
+  type: keyword
 - description: All the host identifiers seen on your event.
   name: related.hosts
   type: keyword

--- a/packages/panw/docs/README.md
+++ b/packages/panw/docs/README.md
@@ -23,7 +23,7 @@ The ingest-geoip Elasticsearch plugin is required to run this module.
 | client.nat.port | Client NAT port | long |
 | client.packets | Packets sent from the client to the server. | long |
 | client.port | Port of the client. | long |
-| client.user.name | Short name or login of the user. | wildcard |
+| client.user.name | Short name or login of the user. | keyword |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
 | cloud.availability_zone | Availability zone in which this host is running. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
@@ -42,14 +42,14 @@ The ingest-geoip Elasticsearch plugin is required to run this module.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.bytes | Bytes sent from the destination to the source. | long |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -57,8 +57,8 @@ The ingest-geoip Elasticsearch plugin is required to run this module.
 | destination.nat.port | Destination NAT Port | long |
 | destination.packets | Packets sent from the destination to the source. | long |
 | destination.port | Port of the destination. | long |
-| destination.user.email | User email address. | wildcard |
-| destination.user.name | Short name or login of the user. | wildcard |
+| destination.user.email | User email address. | keyword |
+| destination.user.name | Short name or login of the user. | keyword |
 | ecs.version | ECS version this event conforms to. | keyword |
 | error.message | Error message. | text |
 | event.action | The action captured by the event. | keyword |
@@ -77,7 +77,7 @@ The ingest-geoip Elasticsearch plugin is required to run this module.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -86,7 +86,7 @@ The ingest-geoip Elasticsearch plugin is required to run this module.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -105,7 +105,7 @@ The ingest-geoip Elasticsearch plugin is required to run this module.
 | labels.temporary_match |  | boolean |
 | labels.url_filter_denied |  | boolean |
 | labels.x_forwarded_for |  | boolean |
-| log.file.path | Path to the log file. | wildcard |
+| log.file.path | Path to the log file. | keyword |
 | log.flags | Flags for the log file. | keyword |
 | log.level | Log level of the log event. | keyword |
 | log.offset | Offset of the entry in the log file. | long |
@@ -162,17 +162,17 @@ The ingest-geoip Elasticsearch plugin is required to run this module.
 | server.nat.port | Server NAT port | long |
 | server.packets | Packets sent from the server to the client. | long |
 | server.port | Port of the server. | long |
-| server.user.name | Short name or login of the user. | wildcard |
+| server.user.name | Short name or login of the user. | keyword |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.bytes | Bytes sent from the source to the destination. | long |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -180,13 +180,13 @@ The ingest-geoip Elasticsearch plugin is required to run this module.
 | source.nat.port | Source NAT port | long |
 | source.packets | Packets sent from the source to the destination. | long |
 | source.port | Port of the source. | long |
-| source.user.email | User email address. | wildcard |
-| source.user.name | Short name or login of the user. | wildcard |
+| source.user.email | User email address. | keyword |
+| source.user.name | Short name or login of the user. | keyword |
 | syslog.facility | Syslog numeric facility of the event. | long |
 | syslog.facility_label | Syslog text-based facility of the event. | keyword |
 | syslog.priority | Syslog priority of the event. | long |
 | syslog.severity_label | Syslog text-based severity of the event. | keyword |
 | tags | List of keywords used to tag each event. | keyword |
-| url.original | Unmodified original url as seen in the event source. | wildcard |
-| user_agent.original | Unparsed user_agent string. | wildcard |
+| url.original | Unmodified original url as seen in the event source. | keyword |
+| user_agent.original | Unparsed user_agent string. | keyword |
 

--- a/packages/panw/manifest.yml
+++ b/packages/panw/manifest.yml
@@ -1,6 +1,6 @@
 name: panw
 title: Palo Alto Networks
-version: 0.4.0
+version: 0.5.0
 release: experimental
 description: Palo Alto Networks Integration
 type: integration

--- a/packages/suricata/data_stream/eve/fields/agent.yml
+++ b/packages/suricata/data_stream/eve/fields/agent.yml
@@ -99,7 +99,7 @@
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
@@ -135,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text

--- a/packages/suricata/data_stream/eve/fields/fields-epr.yml
+++ b/packages/suricata/data_stream/eve/fields/fields-epr.yml
@@ -39,7 +39,7 @@
       example: IN
     - name: answers.data
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       description: "The data describing the resource.\nThe meaning of this data depends on the type and class of the resource record."
       example: 10.10.10.10
@@ -88,7 +88,7 @@
       example: IN
     - name: question.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       description: 'The name being queried.
 
@@ -159,7 +159,7 @@
   type: keyword
   description: Filebeat input type used to collect the log.
 - name: log.file.path
-  type: wildcard
+  type: keyword
   description: >
     The file from which the line was read. This field contains the absolute path to the file. For example: `/var/log/system.log`.
 

--- a/packages/suricata/docs/README.md
+++ b/packages/suricata/docs/README.md
@@ -49,7 +49,7 @@ with other versions of Suricata.
 | destination.port | Port of the destination. | long |
 | dns.answers | An array containing an object for each answer section returned by the server. The main keys that should be present in these objects are defined by ECS. Records that have more information may contain more keys than what ECS defines. Not all DNS data sources give all details about DNS answers. At minimum, answer objects must contain the `data` key. If more information is available, map as much of it to ECS as possible, and add any additional fields to the answer objects as custom fields. | object |
 | dns.answers.class | The class of DNS data contained in this resource record. | keyword |
-| dns.answers.data | The data describing the resource. The meaning of this data depends on the type and class of the resource record. | wildcard |
+| dns.answers.data | The data describing the resource. The meaning of this data depends on the type and class of the resource record. | keyword |
 | dns.answers.name | The domain name to which this resource record pertains. If a chain of CNAME is being resolved, each answer's `name` should be the one that corresponds with the answer's `data`. It should not simply be the original `question.name` repeated. | keyword |
 | dns.answers.ttl | The time interval in seconds that this resource record may be cached before it should be discarded. Zero values mean that the data should not be cached. | long |
 | dns.answers.type | The type of data contained in this resource record. | keyword |
@@ -57,7 +57,7 @@ with other versions of Suricata.
 | dns.id | The DNS packet identifier assigned by the program that generated the query. The identifier is copied to the response. | keyword |
 | dns.op_code | The DNS operation code that specifies the kind of query in the message. This value is set by the originator of a query and copied into the response. | keyword |
 | dns.question.class | The class of records being queried. | keyword |
-| dns.question.name | The name being queried. If the name field contains non-printable characters (below 32 or above 126), those characters should be represented as escaped base 10 integers (\DDD). Back slashes and quotes should be escaped. Tabs, carriage returns, and line feeds should be converted to \t, \r, and \n respectively. | wildcard |
+| dns.question.name | The name being queried. If the name field contains non-printable characters (below 32 or above 126), those characters should be represented as escaped base 10 integers (\DDD). Back slashes and quotes should be escaped. Tabs, carriage returns, and line feeds should be converted to \t, \r, and \n respectively. | keyword |
 | dns.question.registered_domain | The highest registered domain, stripped of the subdomain. For example, the registered domain for "foo.google.com" is "google.com". This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk". | keyword |
 | dns.question.subdomain | The subdomain is all of the labels under the registered_domain. If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period. | keyword |
 | dns.question.top_level_domain | The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for google.com is "com". This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk". | keyword |
@@ -79,7 +79,7 @@ with other versions of Suricata.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -88,7 +88,7 @@ with other versions of Suricata.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -97,7 +97,7 @@ with other versions of Suricata.
 | http.response.body.bytes | Size in bytes of the response body. | long |
 | http.response.status_code | HTTP response status code. | long |
 | input.type | Filebeat input type used to collect the log. | keyword |
-| log.file.path | The file from which the line was read. This field contains the absolute path to the file. For example: `/var/log/system.log`. | wildcard |
+| log.file.path | The file from which the line was read. This field contains the absolute path to the file. For example: `/var/log/system.log`. | keyword |
 | log.offset | The file offset the reported line starts at. | long |
 | message | Log message optimized for viewing in a log viewer. | text |
 | network.bytes | Total bytes transferred in both directions. | long |

--- a/packages/suricata/manifest.yml
+++ b/packages/suricata/manifest.yml
@@ -1,6 +1,6 @@
 name: suricata
 title: Suricata
-version: 0.4.0
+version: 0.5.0
 release: experimental
 description: Suricata Integration
 type: integration

--- a/packages/zeek/data_stream/capture_loss/fields/agent.yml
+++ b/packages/zeek/data_stream/capture_loss/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/capture_loss/fields/beats.yml
+++ b/packages/zeek/data_stream/capture_loss/fields/beats.yml
@@ -9,7 +9,7 @@
   example: /var/log/fun-times.log
   ignore_above: 1024
   name: log.file.path
-  type: wildcard
+  type: keyword
 - description: Flags for the log file.
   name: log.flags
   type: keyword

--- a/packages/zeek/data_stream/connection/fields/agent.yml
+++ b/packages/zeek/data_stream/connection/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/connection/fields/beats.yml
+++ b/packages/zeek/data_stream/connection/fields/beats.yml
@@ -9,7 +9,7 @@
   example: /var/log/fun-times.log
   ignore_above: 1024
   name: log.file.path
-  type: wildcard
+  type: keyword
 - description: Flags for the log file.
   name: log.flags
   type: keyword

--- a/packages/zeek/data_stream/connection/fields/ecs.yml
+++ b/packages/zeek/data_stream/connection/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: Bytes sent from the destination to the source.
   example: 184
   name: destination.bytes
@@ -48,7 +48,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -87,7 +87,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Duration of the event in nanoseconds.
@@ -99,7 +99,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -162,7 +162,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: Bytes sent from the source to the destination.
   example: 184
   name: source.bytes
@@ -195,7 +195,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024

--- a/packages/zeek/data_stream/dce_rpc/fields/agent.yml
+++ b/packages/zeek/data_stream/dce_rpc/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/dce_rpc/fields/ecs.yml
+++ b/packages/zeek/data_stream/dce_rpc/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: Bytes sent from the destination to the source.
   example: 184
   name: destination.bytes
@@ -48,7 +48,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -84,7 +84,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -93,7 +93,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -143,7 +143,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: Bytes sent from the source to the destination.
   example: 184
   name: source.bytes
@@ -176,7 +176,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024

--- a/packages/zeek/data_stream/dhcp/fields/agent.yml
+++ b/packages/zeek/data_stream/dhcp/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/dnp3/fields/agent.yml
+++ b/packages/zeek/data_stream/dnp3/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/dnp3/fields/ecs.yml
+++ b/packages/zeek/data_stream/dnp3/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: Bytes sent from the destination to the source.
   example: 184
   name: destination.bytes
@@ -48,7 +48,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -84,7 +84,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -93,7 +93,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -143,7 +143,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: Bytes sent from the source to the destination.
   example: 184
   name: source.bytes
@@ -176,7 +176,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024

--- a/packages/zeek/data_stream/dns/fields/agent.yml
+++ b/packages/zeek/data_stream/dns/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/dns/fields/ecs.yml
+++ b/packages/zeek/data_stream/dns/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -73,7 +73,7 @@
   example: 10.10.10.10
   ignore_above: 1024
   name: dns.answers.data
-  type: wildcard
+  type: keyword
 - description: The domain name to which this resource record pertains.
   example: www.example.com
   ignore_above: 1024
@@ -109,7 +109,7 @@
   example: www.google.com
   ignore_above: 1024
   name: dns.question.name
-  type: wildcard
+  type: keyword
 - description: The highest registered domain, stripped of the subdomain.
   example: google.com
   ignore_above: 1024
@@ -160,7 +160,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Duration of the event in nanoseconds.
@@ -172,7 +172,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -227,7 +227,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -256,7 +256,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024

--- a/packages/zeek/data_stream/dpd/fields/agent.yml
+++ b/packages/zeek/data_stream/dpd/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/dpd/fields/ecs.yml
+++ b/packages/zeek/data_stream/dpd/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -75,7 +75,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -84,7 +84,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -129,7 +129,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -158,7 +158,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024

--- a/packages/zeek/data_stream/files/fields/agent.yml
+++ b/packages/zeek/data_stream/files/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/ftp/fields/agent.yml
+++ b/packages/zeek/data_stream/ftp/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/ftp/fields/ecs.yml
+++ b/packages/zeek/data_stream/ftp/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -80,7 +80,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -89,7 +89,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -141,7 +141,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -170,7 +170,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -196,4 +196,4 @@
       norms: false
       type: text
   name: user.name
-  type: wildcard
+  type: keyword

--- a/packages/zeek/data_stream/http/fields/agent.yml
+++ b/packages/zeek/data_stream/http/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/http/fields/ecs.yml
+++ b/packages/zeek/data_stream/http/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -80,7 +80,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -89,7 +89,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -119,7 +119,7 @@
   example: https://blog.example.com/
   ignore_above: 1024
   name: http.request.referrer
-  type: wildcard
+  type: keyword
 - description: Size in bytes of the response body.
   example: 887
   name: http.response.body.bytes
@@ -170,7 +170,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -199,7 +199,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -220,7 +220,7 @@
   example: www.elastic.co
   ignore_above: 1024
   name: url.domain
-  type: wildcard
+  type: keyword
 - description: Unmodified original url as seen in the event source.
   example: https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch
   ignore_above: 1024
@@ -230,7 +230,7 @@
       norms: false
       type: text
   name: url.original
-  type: wildcard
+  type: keyword
 - description: Password of the request.
   ignore_above: 1024
   name: url.password
@@ -262,7 +262,7 @@
       norms: false
       type: text
   name: user_agent.original
-  type: wildcard
+  type: keyword
 - description: OS family (such as redhat, debian, freebsd, windows).
   example: debian
   ignore_above: 1024
@@ -277,7 +277,7 @@
       norms: false
       type: text
   name: user_agent.os.full
-  type: wildcard
+  type: keyword
 - description: Operating system kernel version as a raw string.
   example: 4.4.0-112-generic
   ignore_above: 1024
@@ -292,7 +292,7 @@
       norms: false
       type: text
   name: user_agent.os.name
-  type: wildcard
+  type: keyword
 - description: Operating system platform (such centos, ubuntu, windows).
   example: darwin
   ignore_above: 1024

--- a/packages/zeek/data_stream/intel/fields/agent.yml
+++ b/packages/zeek/data_stream/intel/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/intel/fields/ecs.yml
+++ b/packages/zeek/data_stream/intel/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -70,11 +70,11 @@
   name: error.message
   type: text
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -119,7 +119,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -148,7 +148,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024

--- a/packages/zeek/data_stream/irc/fields/agent.yml
+++ b/packages/zeek/data_stream/irc/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/irc/fields/ecs.yml
+++ b/packages/zeek/data_stream/irc/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -80,7 +80,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -89,7 +89,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -156,7 +156,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -185,7 +185,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -211,4 +211,4 @@
       norms: false
       type: text
   name: user.name
-  type: wildcard
+  type: keyword

--- a/packages/zeek/data_stream/kerberos/fields/agent.yml
+++ b/packages/zeek/data_stream/kerberos/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/kerberos/fields/ecs.yml
+++ b/packages/zeek/data_stream/kerberos/fields/ecs.yml
@@ -19,7 +19,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -48,7 +48,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -84,7 +84,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -93,7 +93,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -156,7 +156,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -185,7 +185,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -273,4 +273,4 @@
       norms: false
       type: text
   name: user.name
-  type: wildcard
+  type: keyword

--- a/packages/zeek/data_stream/modbus/fields/agent.yml
+++ b/packages/zeek/data_stream/modbus/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/modbus/fields/ecs.yml
+++ b/packages/zeek/data_stream/modbus/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -80,7 +80,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -89,7 +89,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -144,7 +144,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -173,7 +173,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024

--- a/packages/zeek/data_stream/mysql/fields/agent.yml
+++ b/packages/zeek/data_stream/mysql/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/mysql/fields/ecs.yml
+++ b/packages/zeek/data_stream/mysql/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -88,7 +88,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -143,7 +143,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -172,7 +172,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024

--- a/packages/zeek/data_stream/notice/fields/agent.yml
+++ b/packages/zeek/data_stream/notice/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/notice/fields/ecs.yml
+++ b/packages/zeek/data_stream/notice/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -75,7 +75,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -84,7 +84,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -147,7 +147,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -176,7 +176,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024

--- a/packages/zeek/data_stream/ntlm/fields/agent.yml
+++ b/packages/zeek/data_stream/ntlm/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/ntlm/fields/ecs.yml
+++ b/packages/zeek/data_stream/ntlm/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -75,7 +75,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -84,7 +84,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -143,7 +143,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -172,7 +172,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -202,4 +202,4 @@
       norms: false
       type: text
   name: user.name
-  type: wildcard
+  type: keyword

--- a/packages/zeek/data_stream/ocsp/fields/agent.yml
+++ b/packages/zeek/data_stream/ocsp/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/pe/fields/agent.yml
+++ b/packages/zeek/data_stream/pe/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/radius/fields/agent.yml
+++ b/packages/zeek/data_stream/radius/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/radius/fields/ecs.yml
+++ b/packages/zeek/data_stream/radius/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -75,7 +75,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -84,7 +84,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -143,7 +143,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -172,7 +172,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -198,4 +198,4 @@
       norms: false
       type: text
   name: user.name
-  type: wildcard
+  type: keyword

--- a/packages/zeek/data_stream/rdp/fields/agent.yml
+++ b/packages/zeek/data_stream/rdp/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/rdp/fields/ecs.yml
+++ b/packages/zeek/data_stream/rdp/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -75,7 +75,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -84,7 +84,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -134,7 +134,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -163,7 +163,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024

--- a/packages/zeek/data_stream/rfb/fields/agent.yml
+++ b/packages/zeek/data_stream/rfb/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/rfb/fields/ecs.yml
+++ b/packages/zeek/data_stream/rfb/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -75,7 +75,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -84,7 +84,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -134,7 +134,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -163,7 +163,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024

--- a/packages/zeek/data_stream/sip/fields/agent.yml
+++ b/packages/zeek/data_stream/sip/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/sip/fields/ecs.yml
+++ b/packages/zeek/data_stream/sip/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -80,7 +80,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -89,7 +89,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -144,7 +144,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -173,7 +173,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -199,4 +199,4 @@
       norms: false
       type: text
   name: url.full
-  type: wildcard
+  type: keyword

--- a/packages/zeek/data_stream/smb_cmd/fields/agent.yml
+++ b/packages/zeek/data_stream/smb_cmd/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/smb_cmd/fields/ecs.yml
+++ b/packages/zeek/data_stream/smb_cmd/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -80,7 +80,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -89,7 +89,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -148,7 +148,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -177,7 +177,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -203,4 +203,4 @@
       norms: false
       type: text
   name: user.name
-  type: wildcard
+  type: keyword

--- a/packages/zeek/data_stream/smb_files/fields/agent.yml
+++ b/packages/zeek/data_stream/smb_files/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/smb_files/fields/ecs.yml
+++ b/packages/zeek/data_stream/smb_files/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -80,7 +80,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -89,7 +89,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -127,7 +127,7 @@
       norms: false
       type: text
   name: file.path
-  type: wildcard
+  type: keyword
 - description: File size in bytes.
   example: 16384
   name: file.size
@@ -174,7 +174,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -203,7 +203,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024

--- a/packages/zeek/data_stream/smb_mapping/fields/agent.yml
+++ b/packages/zeek/data_stream/smb_mapping/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/smb_mapping/fields/ecs.yml
+++ b/packages/zeek/data_stream/smb_mapping/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -75,7 +75,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -84,7 +84,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -134,7 +134,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -163,7 +163,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024

--- a/packages/zeek/data_stream/smtp/fields/agent.yml
+++ b/packages/zeek/data_stream/smtp/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/smtp/fields/ecs.yml
+++ b/packages/zeek/data_stream/smtp/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -75,7 +75,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -84,7 +84,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -134,7 +134,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -163,7 +163,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024

--- a/packages/zeek/data_stream/snmp/fields/agent.yml
+++ b/packages/zeek/data_stream/snmp/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/snmp/fields/ecs.yml
+++ b/packages/zeek/data_stream/snmp/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -75,7 +75,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -84,7 +84,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -134,7 +134,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -163,7 +163,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024

--- a/packages/zeek/data_stream/socks/fields/agent.yml
+++ b/packages/zeek/data_stream/socks/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/socks/fields/ecs.yml
+++ b/packages/zeek/data_stream/socks/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -72,7 +72,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -81,7 +81,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -140,7 +140,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -169,7 +169,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -195,4 +195,4 @@
       norms: false
       type: text
   name: user.name
-  type: wildcard
+  type: keyword

--- a/packages/zeek/data_stream/ssh/fields/agent.yml
+++ b/packages/zeek/data_stream/ssh/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/ssh/fields/ecs.yml
+++ b/packages/zeek/data_stream/ssh/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -75,7 +75,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -84,7 +84,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -139,7 +139,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -168,7 +168,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024

--- a/packages/zeek/data_stream/ssl/fields/agent.yml
+++ b/packages/zeek/data_stream/ssl/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/ssl/fields/ecs.yml
+++ b/packages/zeek/data_stream/ssl/fields/ecs.yml
@@ -19,7 +19,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -48,7 +48,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -79,7 +79,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -88,7 +88,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -137,7 +137,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -166,7 +166,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -192,7 +192,7 @@
   example: CN=MyDomain Root CA, OU=Infrastructure Team, DC=mydomain, DC=com
   ignore_above: 1024
   name: tls.client.issuer
-  type: wildcard
+  type: keyword
 - description: List of country (C) code
   example: US
   ignore_above: 1024
@@ -237,12 +237,12 @@
   example: CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com
   ignore_above: 1024
   name: tls.server.issuer
-  type: wildcard
+  type: keyword
 - description: Subject of the x.509 certificate presented by the server.
   example: CN=www.example.com, OU=Infrastructure Team, DC=example, DC=com
   ignore_above: 1024
   name: tls.server.subject
-  type: wildcard
+  type: keyword
 - description: List of common name (CN) of issuing certificate authority.
   example: Example SHA2 High Assurance Server CA
   ignore_above: 1024
@@ -257,7 +257,7 @@
   example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance Server CA
   ignore_above: 1024
   name: tls.server.x509.issuer.distinguished_name
-  type: wildcard
+  type: keyword
 - description: List of locality names (L)
   example: Mountain View
   ignore_above: 1024
@@ -308,7 +308,7 @@
   name: tls.server.x509.subject.state_or_province
   type: keyword
 - description: Numeric part of the version parsed from the original string.
-  example: '1.2'
+  example: "1.2"
   ignore_above: 1024
   name: tls.version
   type: keyword

--- a/packages/zeek/data_stream/stats/fields/agent.yml
+++ b/packages/zeek/data_stream/stats/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/syslog/fields/agent.yml
+++ b/packages/zeek/data_stream/syslog/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/syslog/fields/ecs.yml
+++ b/packages/zeek/data_stream/syslog/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -70,7 +70,7 @@
   name: error.message
   type: text
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -79,7 +79,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -135,7 +135,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -164,7 +164,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024

--- a/packages/zeek/data_stream/traceroute/fields/agent.yml
+++ b/packages/zeek/data_stream/traceroute/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/traceroute/fields/ecs.yml
+++ b/packages/zeek/data_stream/traceroute/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -72,11 +72,11 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -116,7 +116,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -145,7 +145,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024

--- a/packages/zeek/data_stream/tunnel/fields/agent.yml
+++ b/packages/zeek/data_stream/tunnel/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/tunnel/fields/ecs.yml
+++ b/packages/zeek/data_stream/tunnel/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -80,7 +80,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -89,7 +89,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -124,7 +124,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -153,7 +153,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024

--- a/packages/zeek/data_stream/weird/fields/agent.yml
+++ b/packages/zeek/data_stream/weird/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/weird/fields/ecs.yml
+++ b/packages/zeek/data_stream/weird/fields/ecs.yml
@@ -15,7 +15,7 @@
       norms: false
       type: text
   name: destination.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -44,7 +44,7 @@
   example: boston-dc
   ignore_above: 1024
   name: destination.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024
@@ -72,7 +72,7 @@
   name: event.category
   type: keyword
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -81,7 +81,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -121,7 +121,7 @@
       norms: false
       type: text
   name: source.as.organization.name
-  type: wildcard
+  type: keyword
 - description: City name.
   example: Montreal
   ignore_above: 1024
@@ -150,7 +150,7 @@
   example: boston-dc
   ignore_above: 1024
   name: source.geo.name
-  type: wildcard
+  type: keyword
 - description: Region ISO code.
   example: CA-QC
   ignore_above: 1024

--- a/packages/zeek/data_stream/x509/fields/agent.yml
+++ b/packages/zeek/data_stream/x509/fields/agent.yml
@@ -2,16 +2,14 @@
   title: Cloud
   group: 2
   description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
@@ -57,9 +55,7 @@
 - name: container
   title: Container
   group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -85,9 +81,7 @@
 - name: host
   title: Host
   group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture
@@ -100,27 +94,19 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       default_field: false
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
     - name: ip
       level: core
       type: ip
@@ -134,9 +120,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -151,7 +135,7 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
@@ -176,9 +160,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
     - name: containerized
       type: boolean
       description: >

--- a/packages/zeek/data_stream/x509/fields/ecs.yml
+++ b/packages/zeek/data_stream/x509/fields/ecs.yml
@@ -7,7 +7,7 @@
   name: error.message
   type: text
 - description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
+  example: "2016-05-23T08:05:34.857Z"
   name: event.created
   type: date
 - description: Unique ID to describe the event.
@@ -16,7 +16,7 @@
   name: event.id
   type: keyword
 - description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
+  example: "2016-05-23T08:05:35.101Z"
   name: event.ingested
   type: date
 - description: The kind of the event. The highest categorization field in the hierarchy.
@@ -29,7 +29,7 @@
   name: event.type
   type: keyword
 - description: List of subject alternative names (SAN).
-  example: '*.elastic.co'
+  example: "*.elastic.co"
   ignore_above: 1024
   name: file.x509.alternative_names
   type: keyword
@@ -47,7 +47,7 @@
   example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance Server CA
   ignore_above: 1024
   name: file.x509.issuer.distinguished_name
-  type: wildcard
+  type: keyword
 - description: List of locality names (L)
   example: Mountain View
   ignore_above: 1024
@@ -118,7 +118,7 @@
   example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
   ignore_above: 1024
   name: file.x509.subject.distinguished_name
-  type: wildcard
+  type: keyword
 - description: List of locality names (L)
   example: San Francisco
   ignore_above: 1024

--- a/packages/zeek/docs/README.md
+++ b/packages/zeek/docs/README.md
@@ -48,7 +48,7 @@ which contains packet loss rate data.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -57,12 +57,12 @@ which contains packet loss rate data.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | input.type | Type of Filebeat input. | keyword |
-| log.file.path | Full path to the log file this event came from. | wildcard |
+| log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
 | log.offset | Offset of the entry in the log file. | long |
 | tags | List of keywords used to tag each event. | keyword |
@@ -102,14 +102,14 @@ contains TCP/UDP/ICMP connection data.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.bytes | Bytes sent from the destination to the source. | long |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -128,7 +128,7 @@ contains TCP/UDP/ICMP connection data.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -137,12 +137,12 @@ contains TCP/UDP/ICMP connection data.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | input.type | Type of Filebeat input. | keyword |
-| log.file.path | Full path to the log file this event came from. | wildcard |
+| log.file.path | Full path to the log file this event came from. | keyword |
 | log.flags | Flags for the log file. | keyword |
 | log.offset | Offset of the entry in the log file. | long |
 | network.bytes | Total bytes transferred in both directions. | long |
@@ -154,14 +154,14 @@ contains TCP/UDP/ICMP connection data.
 | related.ip | All of the IPs seen on your event. | ip |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.bytes | Bytes sent from the source to the destination. | long |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -210,14 +210,14 @@ contains Distributed Computing Environment/RPC data.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.bytes | Bytes sent from the destination to the source. | long |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -234,7 +234,7 @@ contains Distributed Computing Environment/RPC data.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -243,7 +243,7 @@ contains Distributed Computing Environment/RPC data.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -257,14 +257,14 @@ contains Distributed Computing Environment/RPC data.
 | related.ip | All of the IPs seen on your event. | ip |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.bytes | Bytes sent from the source to the destination. | long |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -318,7 +318,7 @@ DHCP lease data.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -327,7 +327,7 @@ DHCP lease data.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -395,14 +395,14 @@ requests and replies.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.bytes | Bytes sent from the destination to the source. | long |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -419,7 +419,7 @@ requests and replies.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -428,7 +428,7 @@ requests and replies.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -442,14 +442,14 @@ requests and replies.
 | related.ip | All of the IPs seen on your event. | ip |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.bytes | Bytes sent from the source to the destination. | long |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -489,27 +489,27 @@ activity.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
 | destination.port | Port of the destination. | long |
 | dns.answers | Array of DNS answers. | object |
 | dns.answers.class | The class of DNS data contained in this resource record. | keyword |
-| dns.answers.data | The data describing the resource. | wildcard |
+| dns.answers.data | The data describing the resource. | keyword |
 | dns.answers.name | The domain name to which this resource record pertains. | keyword |
 | dns.answers.ttl | The time interval in seconds that this resource record may be cached before it should be discarded. | long |
 | dns.answers.type | The type of data contained in this resource record. | keyword |
 | dns.header_flags | Array of DNS header flags. | keyword |
 | dns.id | The DNS packet identifier assigned by the program that generated the query. The identifier is copied to the response. | keyword |
 | dns.question.class | The class of records being queried. | keyword |
-| dns.question.name | The name being queried. | wildcard |
+| dns.question.name | The name being queried. | keyword |
 | dns.question.registered_domain | The highest registered domain, stripped of the subdomain. | keyword |
 | dns.question.subdomain | The subdomain of the domain. | keyword |
 | dns.question.top_level_domain | The effective top level domain (com, org, net, co.uk). | keyword |
@@ -531,7 +531,7 @@ activity.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -540,7 +540,7 @@ activity.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -553,13 +553,13 @@ activity.
 | related.ip | All of the IPs seen on your event. | ip |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -616,13 +616,13 @@ protocol detection failures.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -638,7 +638,7 @@ protocol detection failures.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -647,7 +647,7 @@ protocol detection failures.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -660,13 +660,13 @@ protocol detection failures.
 | related.ip | All of the IPs seen on your event. | ip |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -722,7 +722,7 @@ file analysis results.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -731,7 +731,7 @@ file analysis results.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -799,13 +799,13 @@ activity.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -824,7 +824,7 @@ activity.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -833,7 +833,7 @@ activity.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -846,19 +846,19 @@ activity.
 | related.user | All the user names seen on your event. | keyword |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
 | source.port | Port of the source. | long |
 | tags | List of keywords used to tag each event. | keyword |
-| user.name | Short name or login of the user. | wildcard |
+| user.name | Short name or login of the user. | keyword |
 | zeek.ftp.arg | Argument for the command if one is given. | keyword |
 | zeek.ftp.capture_password | Determines if the password will be captured for this request. | boolean |
 | zeek.ftp.cmdarg.arg | Argument for the command if one was given. | keyword |
@@ -911,13 +911,13 @@ HTTP requests and replies.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -935,7 +935,7 @@ HTTP requests and replies.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -944,13 +944,13 @@ HTTP requests and replies.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | http.request.body.bytes | Size in bytes of the request body. | long |
 | http.request.method | HTTP request method. | keyword |
-| http.request.referrer | Referrer for this HTTP request. | wildcard |
+| http.request.referrer | Referrer for this HTTP request. | keyword |
 | http.response.body.bytes | Size in bytes of the response body. | long |
 | http.response.status_code | HTTP response status code. | long |
 | http.version | HTTP version. | keyword |
@@ -964,30 +964,30 @@ HTTP requests and replies.
 | related.user | All the user names seen on your event. | keyword |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
 | source.port | Port of the source. | long |
 | tags | List of keywords used to tag each event. | keyword |
-| url.domain | Domain of the url. | wildcard |
-| url.original | Unmodified original url as seen in the event source. | wildcard |
+| url.domain | Domain of the url. | keyword |
+| url.original | Unmodified original url as seen in the event source. | keyword |
 | url.password | Password of the request. | keyword |
 | url.port | Port of the request, such as 443. | long |
 | url.username | Username of the request. | keyword |
 | user_agent.device.name | Name of the device. | keyword |
 | user_agent.name | Name of the user agent. | keyword |
-| user_agent.original | Unparsed user_agent string. | wildcard |
+| user_agent.original | Unparsed user_agent string. | keyword |
 | user_agent.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| user_agent.os.full | Operating system name, including the version or code name. | wildcard |
+| user_agent.os.full | Operating system name, including the version or code name. | keyword |
 | user_agent.os.kernel | Operating system kernel version as a raw string. | keyword |
-| user_agent.os.name | Operating system name, without the version. | wildcard |
+| user_agent.os.name | Operating system name, without the version. | keyword |
 | user_agent.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | user_agent.os.version | Operating system version as a raw string. | keyword |
 | user_agent.version | Version of the user agent. | keyword |
@@ -1041,13 +1041,13 @@ intelligence data matches.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -1062,7 +1062,7 @@ intelligence data matches.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -1071,7 +1071,7 @@ intelligence data matches.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -1083,13 +1083,13 @@ intelligence data matches.
 | related.ip | All of the IPs seen on your event. | ip |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -1140,13 +1140,13 @@ commands and responses.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -1166,7 +1166,7 @@ commands and responses.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -1175,7 +1175,7 @@ commands and responses.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -1190,19 +1190,19 @@ commands and responses.
 | related.user | All the user names seen on your event. | keyword |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
 | source.port | Port of the source. | long |
 | tags | List of keywords used to tag each event. | keyword |
-| user.name | Short name or login of the user. | wildcard |
+| user.name | Short name or login of the user. | keyword |
 | zeek.irc.addl | Any additional data for the command. | keyword |
 | zeek.irc.command | Command given by the client. | keyword |
 | zeek.irc.dcc.file.name | Present if base/protocols/irc/dcc-send.bro is loaded. DCC filename requested. | keyword |
@@ -1244,13 +1244,13 @@ contains kerberos data.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -1268,7 +1268,7 @@ contains kerberos data.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -1277,7 +1277,7 @@ contains kerberos data.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -1293,13 +1293,13 @@ contains kerberos data.
 | server.address | Server network address. | keyword |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -1318,7 +1318,7 @@ contains kerberos data.
 | tls.server.x509.subject.organizational_unit | List of organizational units (OU) of subject. | keyword |
 | tls.server.x509.subject.state_or_province | List of state or province names (ST, S, or P) | keyword |
 | user.domain | Name of the directory the user is a member of. | keyword |
-| user.name | Short name or login of the user. | wildcard |
+| user.name | Short name or login of the user. | keyword |
 | zeek.kerberos.cert.client.fuid | File unique ID of client cert. | keyword |
 | zeek.kerberos.cert.client.subject | Subject of client certificate. | keyword |
 | zeek.kerberos.cert.client.value | Client certificate. | keyword |
@@ -1370,13 +1370,13 @@ modbus commands and responses.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -1394,7 +1394,7 @@ modbus commands and responses.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -1403,7 +1403,7 @@ modbus commands and responses.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -1417,13 +1417,13 @@ modbus commands and responses.
 | related.ip | All of the IPs seen on your event. | ip |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -1463,13 +1463,13 @@ MySQL data.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -1487,7 +1487,7 @@ MySQL data.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -1496,7 +1496,7 @@ MySQL data.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -1510,13 +1510,13 @@ MySQL data.
 | related.ip | All of the IPs seen on your event. | ip |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -1558,13 +1558,13 @@ Zeek notices.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -1582,7 +1582,7 @@ Zeek notices.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -1591,7 +1591,7 @@ Zeek notices.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -1606,13 +1606,13 @@ Zeek notices.
 | rule.name | Rule name | keyword |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -1673,13 +1673,13 @@ LAN Manager(NTLM) data.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -1696,7 +1696,7 @@ LAN Manager(NTLM) data.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -1705,7 +1705,7 @@ LAN Manager(NTLM) data.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -1720,20 +1720,20 @@ LAN Manager(NTLM) data.
 | related.user | All the user names seen on your event. | keyword |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
 | source.port | Port of the source. | long |
 | tags | List of keywords used to tag each event. | keyword |
 | user.domain | Name of the directory the user is a member of. | keyword |
-| user.name | Short name or login of the user. | wildcard |
+| user.name | Short name or login of the user. | keyword |
 | zeek.ntlm.domain | Domain name given by the client. | keyword |
 | zeek.ntlm.hostname | Hostname given by the client. | keyword |
 | zeek.ntlm.server.name.dns | DNS name given by the server in a CHALLENGE. | keyword |
@@ -1778,7 +1778,7 @@ Online Certificate Status Protocol (OCSP) data.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -1787,7 +1787,7 @@ Online Certificate Status Protocol (OCSP) data.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -1847,7 +1847,7 @@ portable executable data.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -1856,7 +1856,7 @@ portable executable data.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -1913,13 +1913,13 @@ RADIUS authentication attempts.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -1936,7 +1936,7 @@ RADIUS authentication attempts.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -1945,7 +1945,7 @@ RADIUS authentication attempts.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -1960,19 +1960,19 @@ RADIUS authentication attempts.
 | related.user | All the user names seen on your event. | keyword |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
 | source.port | Port of the source. | long |
 | tags | List of keywords used to tag each event. | keyword |
-| user.name | Short name or login of the user. | wildcard |
+| user.name | Short name or login of the user. | keyword |
 | zeek.radius.connect_info | Connect info, if present. | keyword |
 | zeek.radius.framed_addr | The address given to the network access server, if present. This is only a hint from the RADIUS server and the network access server is not required to honor the address. | ip |
 | zeek.radius.logged | Whether this has already been logged and can be ignored. | boolean |
@@ -2013,13 +2013,13 @@ data.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -2035,7 +2035,7 @@ data.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -2044,7 +2044,7 @@ data.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -2058,13 +2058,13 @@ data.
 | related.ip | All of the IPs seen on your event. | ip |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -2119,13 +2119,13 @@ Remote Framebuffer (RFB) data.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -2141,7 +2141,7 @@ Remote Framebuffer (RFB) data.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -2150,7 +2150,7 @@ Remote Framebuffer (RFB) data.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -2164,13 +2164,13 @@ Remote Framebuffer (RFB) data.
 | related.ip | All of the IPs seen on your event. | ip |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -2217,13 +2217,13 @@ data.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -2241,7 +2241,7 @@ data.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -2250,7 +2250,7 @@ data.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -2264,19 +2264,19 @@ data.
 | related.ip | All of the IPs seen on your event. | ip |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
 | source.port | Port of the source. | long |
 | tags | List of keywords used to tag each event. | keyword |
-| url.full | Full unparsed URL. | wildcard |
+| url.full | Full unparsed URL. | keyword |
 | zeek.session_id | A unique identifier of the session | keyword |
 | zeek.sip.call_id | Contents of the Call-ID: header from the client. | keyword |
 | zeek.sip.content_type | Contents of the Content-Type: header from the server. | keyword |
@@ -2329,13 +2329,13 @@ contains SMB commands.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -2353,7 +2353,7 @@ contains SMB commands.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -2362,7 +2362,7 @@ contains SMB commands.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -2377,19 +2377,19 @@ contains SMB commands.
 | related.user | All the user names seen on your event. | keyword |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
 | source.port | Port of the source. | long |
 | tags | List of keywords used to tag each event. | keyword |
-| user.name | Short name or login of the user. | wildcard |
+| user.name | Short name or login of the user. | keyword |
 | zeek.session_id | A unique identifier of the session | keyword |
 | zeek.smb_cmd.argument | Command argument sent by the client, if any. | keyword |
 | zeek.smb_cmd.command | The command sent by the client. | keyword |
@@ -2437,13 +2437,13 @@ contains SMB file data.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -2462,12 +2462,12 @@ contains SMB file data.
 | file.ctime | Last time the file attributes or metadata changed. | date |
 | file.mtime | Last time the file content was modified. | date |
 | file.name | Name of the file including the extension, without the directory. | keyword |
-| file.path | Full path to the file, including the file name. | wildcard |
+| file.path | Full path to the file, including the file name. | keyword |
 | file.size | File size in bytes. | long |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -2476,7 +2476,7 @@ contains SMB file data.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -2491,13 +2491,13 @@ contains SMB file data.
 | related.user | All the user names seen on your event. | keyword |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -2545,13 +2545,13 @@ which contains SMB trees.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -2567,7 +2567,7 @@ which contains SMB trees.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -2576,7 +2576,7 @@ which contains SMB trees.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -2590,13 +2590,13 @@ which contains SMB trees.
 | related.ip | All of the IPs seen on your event. | ip |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -2637,13 +2637,13 @@ SMTP transactions..
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -2659,7 +2659,7 @@ SMTP transactions..
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -2668,7 +2668,7 @@ SMTP transactions..
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -2682,13 +2682,13 @@ SMTP transactions..
 | related.ip | All of the IPs seen on your event. | ip |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -2749,13 +2749,13 @@ SNMP messages.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -2771,7 +2771,7 @@ SNMP messages.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -2780,7 +2780,7 @@ SNMP messages.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -2794,13 +2794,13 @@ SNMP messages.
 | related.ip | All of the IPs seen on your event. | ip |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -2846,13 +2846,13 @@ SOCKS proxy requests.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -2868,7 +2868,7 @@ SOCKS proxy requests.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -2877,7 +2877,7 @@ SOCKS proxy requests.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -2892,19 +2892,19 @@ SOCKS proxy requests.
 | related.user | All the user names seen on your event. | keyword |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
 | source.port | Port of the source. | long |
 | tags | List of keywords used to tag each event. | keyword |
-| user.name | Short name or login of the user. | wildcard |
+| user.name | Short name or login of the user. | keyword |
 | zeek.session_id | A unique identifier of the session | keyword |
 | zeek.socks.bound.host | Server bound address. Could be an address, a name or both. | keyword |
 | zeek.socks.bound.port | Server bound port. | integer |
@@ -2945,13 +2945,13 @@ connection data.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -2968,7 +2968,7 @@ connection data.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -2977,7 +2977,7 @@ connection data.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -2991,13 +2991,13 @@ connection data.
 | related.ip | All of the IPs seen on your event. | ip |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -3047,13 +3047,13 @@ SSL/TLS handshake info.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -3069,7 +3069,7 @@ SSL/TLS handshake info.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -3078,7 +3078,7 @@ SSL/TLS handshake info.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -3092,20 +3092,20 @@ SSL/TLS handshake info.
 | server.address | Server network address. | keyword |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
 | source.port | Port of the source. | long |
 | tags | List of keywords used to tag each event. | keyword |
 | tls.cipher | String indicating the cipher used during the current connection. | keyword |
-| tls.client.issuer | Distinguished name of subject of the issuer of the x.509 certificate presented by the client. | wildcard |
+| tls.client.issuer | Distinguished name of subject of the issuer of the x.509 certificate presented by the client. | keyword |
 | tls.client.x509.subject.common_name | List of common names (CN) of subject. | keyword |
 | tls.client.x509.subject.country | List of country (C) code | keyword |
 | tls.client.x509.subject.locality | List of locality names (L) | keyword |
@@ -3115,11 +3115,11 @@ SSL/TLS handshake info.
 | tls.curve | String indicating the curve used for the given cipher, when applicable. | keyword |
 | tls.established | Boolean flag indicating if the TLS negotiation was successful and transitioned to an encrypted tunnel. | boolean |
 | tls.resumed | Boolean flag indicating if this TLS connection was resumed from an existing TLS negotiation. | boolean |
-| tls.server.issuer | Subject of the issuer of the x.509 certificate presented by the server. | wildcard |
-| tls.server.subject | Subject of the x.509 certificate presented by the server. | wildcard |
+| tls.server.issuer | Subject of the issuer of the x.509 certificate presented by the server. | keyword |
+| tls.server.subject | Subject of the x.509 certificate presented by the server. | keyword |
 | tls.server.x509.issuer.common_name | List of common name (CN) of issuing certificate authority. | keyword |
 | tls.server.x509.issuer.country | List of country (C) codes | keyword |
-| tls.server.x509.issuer.distinguished_name | Distinguished name (DN) of issuing certificate authority. | wildcard |
+| tls.server.x509.issuer.distinguished_name | Distinguished name (DN) of issuing certificate authority. | keyword |
 | tls.server.x509.issuer.locality | List of locality names (L) | keyword |
 | tls.server.x509.issuer.organization | List of organizations (O) of issuing certificate authority. | keyword |
 | tls.server.x509.issuer.organizational_unit | List of organizational units (OU) of issuing certificate authority. | keyword |
@@ -3207,7 +3207,7 @@ memory/event/packet/lag statistics.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -3216,7 +3216,7 @@ memory/event/packet/lag statistics.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -3281,13 +3281,13 @@ syslog messages.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -3301,7 +3301,7 @@ syslog messages.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -3310,7 +3310,7 @@ syslog messages.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -3326,13 +3326,13 @@ syslog messages.
 | related.ip | All of the IPs seen on your event. | ip |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -3372,13 +3372,13 @@ contains traceroute detections.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -3392,7 +3392,7 @@ contains traceroute detections.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -3401,7 +3401,7 @@ contains traceroute detections.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -3413,13 +3413,13 @@ contains traceroute detections.
 | related.ip | All of the IPs seen on your event. | ip |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -3455,13 +3455,13 @@ tunneling protocol events.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -3478,7 +3478,7 @@ tunneling protocol events.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -3487,7 +3487,7 @@ tunneling protocol events.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -3498,13 +3498,13 @@ tunneling protocol events.
 | related.ip | All of the IPs seen on your event. | ip |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -3543,13 +3543,13 @@ unexpected network-level activity.
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
-| destination.as.organization.name | Organization name. | wildcard |
+| destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | wildcard |
+| destination.geo.name | User-defined description of a location. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination. | ip |
@@ -3564,7 +3564,7 @@ unexpected network-level activity.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -3573,7 +3573,7 @@ unexpected network-level activity.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -3585,13 +3585,13 @@ unexpected network-level activity.
 | rule.name | Rule name | keyword |
 | source.address | Source network address. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | wildcard |
+| source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | wildcard |
+| source.geo.name | User-defined description of a location. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source. | ip |
@@ -3641,7 +3641,7 @@ X.509 certificate info.
 | file.x509.alternative_names | List of subject alternative names (SAN). | keyword |
 | file.x509.issuer.common_name | List of common name (CN) of issuing certificate authority. | keyword |
 | file.x509.issuer.country | List of country (C) codes | keyword |
-| file.x509.issuer.distinguished_name | Distinguished name (DN) of issuing certificate authority. | wildcard |
+| file.x509.issuer.distinguished_name | Distinguished name (DN) of issuing certificate authority. | keyword |
 | file.x509.issuer.locality | List of locality names (L) | keyword |
 | file.x509.issuer.organization | List of organizations (O) of issuing certificate authority. | keyword |
 | file.x509.issuer.organizational_unit | List of organizational units (OU) of issuing certificate authority. | keyword |
@@ -3656,7 +3656,7 @@ X.509 certificate info.
 | file.x509.signature_algorithm | Identifier for certificate signature algorithm. | keyword |
 | file.x509.subject.common_name | List of common names (CN) of subject. | keyword |
 | file.x509.subject.country | List of country (C) code | keyword |
-| file.x509.subject.distinguished_name | Distinguished name (DN) of the certificate subject entity. | wildcard |
+| file.x509.subject.distinguished_name | Distinguished name (DN) of the certificate subject entity. | keyword |
 | file.x509.subject.locality | List of locality names (L) | keyword |
 | file.x509.subject.organization | List of organizations (O) of subject. | keyword |
 | file.x509.subject.organizational_unit | List of organizational units (OU) of subject. | keyword |
@@ -3665,7 +3665,7 @@ X.509 certificate info.
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | wildcard |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
@@ -3674,7 +3674,7 @@ X.509 certificate info.
 | host.os.codename | OS codename, if any. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | wildcard |
+| host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |

--- a/packages/zeek/manifest.yml
+++ b/packages/zeek/manifest.yml
@@ -1,6 +1,6 @@
 name: zeek
 title: Zeek
-version: 0.4.0
+version: 0.5.0
 release: beta
 description: Zeek Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?

This reverts all of the `keyword`-->`wildcard` changes and revs all package versions that previously had `wildcard` in them. Besides some of the packages I changed, it looks like additional packages were migrated in the interim prior to the beats wildcard revert, so this also modifies those to use `keyword`s again.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
~~- [ ] I have verified that all data streams collect metrics or logs.~~
