### PR TITLE
Clean up linux config value names

### DIFF
--- a/packages/linux/data_stream/conntrack/manifest.yml
+++ b/packages/linux/data_stream/conntrack/manifest.yml
@@ -12,5 +12,5 @@ streams:
         show_user: true
         default: 10s
     enabled: false
-    title: System conntrack metrics
+    title: Linux host conntrack metrics
     description: Collect network metrics from /proc/net/nf_conntrack

--- a/packages/linux/data_stream/entropy/manifest.yml
+++ b/packages/linux/data_stream/entropy/manifest.yml
@@ -12,5 +12,5 @@ streams:
         show_user: true
         default: 10s
     enabled: false
-    title: System entropy metrics
+    title: Linux host entropy metrics
     description: Collect Linux entropy metrics

--- a/packages/linux/data_stream/ksm/manifest.yml
+++ b/packages/linux/data_stream/ksm/manifest.yml
@@ -12,5 +12,5 @@ streams:
         show_user: true
         default: 10s
     enabled: false
-    title: System KSM metrics
+    title: Linux host KSM metrics
     description: Collect kernel samepage merging metrics

--- a/packages/linux/data_stream/network_summary/manifest.yml
+++ b/packages/linux/data_stream/network_summary/manifest.yml
@@ -12,5 +12,5 @@ streams:
         show_user: true
         default: 10s
     enabled: false
-    title: System network summary metrics
+    title: Linux host network summary metrics
     description: Collect Linux network_summary metrics

--- a/packages/linux/data_stream/pageinfo/manifest.yml
+++ b/packages/linux/data_stream/pageinfo/manifest.yml
@@ -12,5 +12,5 @@ streams:
         show_user: true
         default: 10s
     enabled: false
-    title: System pageinfo metrics
+    title: Linux host pageinfo metrics
     description: Collect paging statistics as found in /proc/pagetypeinfo

--- a/packages/linux/data_stream/raid/manifest.yml
+++ b/packages/linux/data_stream/raid/manifest.yml
@@ -21,5 +21,5 @@ streams:
           Specifty a RAID mount location. By default, Any available RAID mounts will be selected.
 
     enabled: false
-    title: System raid metrics
+    title: Linux host raid metrics
     description: Collect Linux raid metrics

--- a/packages/linux/data_stream/service/manifest.yml
+++ b/packages/linux/data_stream/service/manifest.yml
@@ -32,5 +32,5 @@ streams:
         description: >
           Filter systemd services based on a name pattern
 
-    title: System service metrics
+    title: Linux host service metrics
     description: Collect Linux service metrics

--- a/packages/linux/data_stream/socket/manifest.yml
+++ b/packages/linux/data_stream/socket/manifest.yml
@@ -34,5 +34,5 @@ streams:
         required: false
         show_user: true
         description: "Failure TTL for reverse DNS lookup on remote IP addresses in the socket dataset (sample: 10s)"
-    title: System socket metrics
+    title: Linux host socket metrics
     description: Collect Linux socket metrics

--- a/packages/linux/data_stream/users/manifest.yml
+++ b/packages/linux/data_stream/users/manifest.yml
@@ -12,5 +12,5 @@ streams:
         show_user: true
         default: 10s
     enabled: false
-    title: System users metrics
+    title: Linux host user metrics
     description: Collect Linux users metrics

--- a/packages/linux/manifest.yml
+++ b/packages/linux/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: linux
 title: Linux
-version: 0.3.4
+version: 0.3.5
 license: basic
 description: Linux Integration
 type: integration


### PR DESCRIPTION


## What does this PR do?

Addresses https://github.com/elastic/integrations/issues/548 and cleans up some of the config values in the Linux integration.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.

## How to test this PR locally

- Pull down and build
- Start up the elastic stack
- Go into the Linux integration, make sure the config fields in the Integration say `Linux host...`.
