### PR TITLE
Restore deleted system tests and properly mark them as skipped

### DIFF
--- a/packages/cef/data_stream/log/_dev/test/system/test-default-config.yml
+++ b/packages/cef/data_stream/log/_dev/test/system/test-default-config.yml
@@ -1,5 +1,5 @@
-vars: ~	
-data_stream:	
-  vars:	
-    paths:	
+vars: ~
+data_stream:
+  vars:
+    paths:
       - "{{SERVICE_LOGS_DIR}}/cef.log"

--- a/packages/cef/data_stream/log/_dev/test/system/test-default-config.yml
+++ b/packages/cef/data_stream/log/_dev/test/system/test-default-config.yml
@@ -1,0 +1,5 @@
+vars: ~	
+data_stream:	
+  vars:	
+    paths:	
+      - "{{SERVICE_LOGS_DIR}}/cef.log"

--- a/packages/crowdstrike/data_stream/falcon/_dev/test/system/test-default-config.yml
+++ b/packages/crowdstrike/data_stream/falcon/_dev/test/system/test-default-config.yml
@@ -1,6 +1,6 @@
-input: logfile	
-vars: ~	
-data_stream:	
-  vars:	
-    paths:	
+input: logfile
+vars: ~
+data_stream:
+  vars:
+    paths:
       - "{{SERVICE_LOGS_DIR}}/*.log"

--- a/packages/crowdstrike/data_stream/falcon/_dev/test/system/test-default-config.yml
+++ b/packages/crowdstrike/data_stream/falcon/_dev/test/system/test-default-config.yml
@@ -1,0 +1,6 @@
+input: logfile	
+vars: ~	
+data_stream:	
+  vars:	
+    paths:	
+      - "{{SERVICE_LOGS_DIR}}/*.log"


### PR DESCRIPTION
## What does this PR do?

As part of #514, default system tests for two datasets, `cef.log` and `crowdstrike.falcon` were removed. The intent was to **skip** these tests but there was no mechanism in place to do so at the time. So they were simply removed to allow the PR to go forward.

This PR restores those two system tests while marking them as skipped, now that we have the mechanism to do so: https://github.com/elastic/elastic-package/issues/218.

## Related issues
- https://github.com/elastic/elastic-package/issues/218
