### PR TITLE
Update .fleet-actions-results mapping

### DIFF
--- a/packages/fleet_server/elasticsearch/index_template/.fleet-actions-results.json
+++ b/packages/fleet_server/elasticsearch/index_template/.fleet-actions-results.json
@@ -16,14 +16,30 @@
                 "agent_id": {
                     "type": "keyword"
                 },
+                "action_data": {
+                    "enabled": false,
+                    "type": "object"
+                },
                 "data": {
                     "enabled": false,
                     "type": "object"
                 },
                 "error": {
-                    "type": "keyword"
+                    "type": "text",
+                    "fields": {
+                        "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                        }
+                    }
                 },
                 "@timestamp": {
+                    "type": "date"
+                },
+                "started_at": {
+                    "type": "date"
+                },
+                "completed_at": {
                     "type": "date"
                 }
             }

--- a/packages/fleet_server/manifest.yml
+++ b/packages/fleet_server/manifest.yml
@@ -1,6 +1,6 @@
 name: fleet_server
 title: Fleet Server
-version: 0.1.3
+version: 0.1.4
 release: experimental
 description: Fleet Server Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?

This change flattens the .fleet-actions-results schema moving to the action top level the additional properties ```started_at```, ```completed_at```, ```action_data```
