### PR TITLE
Add system.hostfs setting

### DIFF
--- a/packages/linux/_dev/build/docs/README.md
+++ b/packages/linux/_dev/build/docs/README.md
@@ -8,6 +8,8 @@ and the resulting `ptrace_may_access()` call by the kernel to check for
 permissions can be blocked by
 [AppArmor and other LSM software](https://gitlab.com/apparmor/apparmor/wikis/TechnicalDoc_Proc_and_ptrace), even though the System module doesn't use `ptrace` directly.
 
+In addition, when running inside a container the proc filesystem directory of the host
+should be set using `system.hostfs` setting to `/hostfs`. 
 
 ## Metrics
 

--- a/packages/linux/data_stream/entropy/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/entropy/agent/stream/stream.yml.hbs
@@ -1,2 +1,5 @@
 metricsets: ["entropy"]
 period: {{period}}
+{{#if system.hostfs}}
+system.hostfs: {{system.hostfs}}
+{{/if}}

--- a/packages/linux/data_stream/raid/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/raid/agent/stream/stream.yml.hbs
@@ -3,3 +3,6 @@ metricsets: ["raid"]
 raid.mount_point: {{raid.mount_point}}
 {{/if}}
 period: {{period}}
+{{#if system.hostfs}}
+system.hostfs: {{system.hostfs}}
+{{/if}}

--- a/packages/linux/data_stream/socket/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/socket/agent/stream/stream.yml.hbs
@@ -9,3 +9,6 @@ socket.reverse_lookup.success_ttl: {{socket.reverse_lookup.success_ttl}}
 socket.reverse_lookup.failure_ttl: {{socket.reverse_lookup.failure_ttl}}
 {{/if}}
 period: {{period}}
+{{#if system.hostfs}}
+system.hostfs: {{system.hostfs}}
+{{/if}}

--- a/packages/linux/docs/README.md
+++ b/packages/linux/docs/README.md
@@ -8,6 +8,8 @@ and the resulting `ptrace_may_access()` call by the kernel to check for
 permissions can be blocked by
 [AppArmor and other LSM software](https://gitlab.com/apparmor/apparmor/wikis/TechnicalDoc_Proc_and_ptrace), even though the System module doesn't use `ptrace` directly.
 
+In addition, when running inside a container the proc filesystem directory of the host
+should be set using `system.hostfs` setting to `/hostfs`. 
 
 ## Metrics
 

--- a/packages/linux/manifest.yml
+++ b/packages/linux/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: linux
 title: Linux
-version: 0.3.5
+version: 0.3.6
 license: basic
 description: Linux Integration
 type: integration
@@ -23,6 +23,14 @@ policy_templates:
       - type: system/metrics
         title: Collect system metrics from Linux instances
         description: Collecting Linux entropy, Network Summary, RAID, service, socket, and users metrics
+        vars:
+          - name: system.hostfs
+            type: text
+            title: Proc Filesystem Directory
+            multi: false
+            required: false
+            show_user: true
+            description: The proc filesystem base directory.
       - type: linux/metrics
         title: Collect low-level system metrics from Linux instances
         description: Collecting Linux conntrack, ksm, pageinfo metrics.

--- a/packages/system/_dev/build/docs/README.md
+++ b/packages/system/_dev/build/docs/README.md
@@ -12,6 +12,9 @@ and the resulting `ptrace_may_access()` call by the kernel to check for
 permissions can be blocked by
 [AppArmor and other LSM software](https://gitlab.com/apparmor/apparmor/wikis/TechnicalDoc_Proc_and_ptrace), even though the System module doesn't use `ptrace` directly.
 
+In addition, when running inside a container the proc filesystem directory of the host
+should be set using `system.hostfs` setting to `/hostfs`.  
+
 ## Compatibility
 
 The System datasets collect different kinds of metric data, which may require dedicated permissions

--- a/packages/system/data_stream/process/agent/stream/stream.yml.hbs
+++ b/packages/system/data_stream/process/agent/stream/stream.yml.hbs
@@ -14,3 +14,6 @@ processes:
 {{#each processes}}
   - {{this}}
 {{/each}}
+{{#if system.hostfs}}
+system.hostfs: {{system.hostfs}}
+{{/if}}

--- a/packages/system/data_stream/process_summary/agent/stream/stream.yml.hbs
+++ b/packages/system/data_stream/process_summary/agent/stream/stream.yml.hbs
@@ -1,2 +1,5 @@
 metricsets: ["process_summary"]
 period: {{period}}
+{{#if system.hostfs}}
+system.hostfs: {{system.hostfs}}
+{{/if}}

--- a/packages/system/data_stream/socket_summary/agent/stream/stream.yml.hbs
+++ b/packages/system/data_stream/socket_summary/agent/stream/stream.yml.hbs
@@ -1,2 +1,5 @@
 metricsets: ["socket_summary"]
 period: {{period}}
+{{#if system.hostfs}}
+system.hostfs: {{system.hostfs}}
+{{/if}}

--- a/packages/system/docs/README.md
+++ b/packages/system/docs/README.md
@@ -12,6 +12,9 @@ and the resulting `ptrace_may_access()` call by the kernel to check for
 permissions can be blocked by
 [AppArmor and other LSM software](https://gitlab.com/apparmor/apparmor/wikis/TechnicalDoc_Proc_and_ptrace), even though the System module doesn't use `ptrace` directly.
 
+In addition, when running inside a container the proc filesystem directory of the host
+should be set using `system.hostfs` setting to `/hostfs`.  
+
 ## Compatibility
 
 The System datasets collect different kinds of metric data, which may require dedicated permissions

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 0.10.8
+version: 0.10.9
 license: basic
 description: System Integration
 type: integration
@@ -39,5 +39,13 @@ policy_templates:
       - type: system/metrics
         title: Collect metrics from System instances
         description: Collecting System core, CPU, diskio, entropy, filesystem, fsstat, load, memory, network, Network Summary, process, Process Summary, raid, service, socket, Socket Summary, uptime and users metrics
+        vars:
+          - name: system.hostfs
+            type: text
+            title: Proc Filesystem Directory
+            multi: false
+            required: false
+            show_user: true
+            description: The proc filesystem base directory.
 owner:
   github: elastic/integrations-services


### PR DESCRIPTION
## What does this PR do?
This PR adds `system.hostfs` options for `system` and `linux` package. This setting was introduced in https://github.com/elastic/beats/pull/23831 in oder to resolve https://github.com/elastic/beats/issues/22915.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.


## How to test this PR locally
0. Update properly the stack manifest file so as to mount the proper directories inside the docker container:
```
# /home/linux_test_user/.elastic-package/stack/snapshot.yml
      - "0.0.0.0:5601:5601"
  kibana_is_ready:
    image: tianon/true
    depends_on:
      kibana:
        condition: service_healthy
  package-registry:
    build:
      context: .
      dockerfile: Dockerfile.package-registry
    healthcheck:
      test: ["CMD", "curl", "-f", "http://127.0.0.1:8080"]
      retries: 300
      interval: 1s
    ports:
      - "0.0.0.0:8080:8080"
  package-registry_is_ready:
    image: tianon/true
    depends_on:
      package-registry:
        condition: service_healthy
  elastic-agent:
    image: docker.elastic.co/beats/elastic-agent:${STACK_VERSION}
    depends_on:
      elasticsearch:
        condition: service_healthy
      kibana:
        condition: service_healthy
    healthcheck:
      test: "sh -c 'grep \"Agent is starting\" /usr/share/elastic-agent/elastic-agent.log*'"
      retries: 30
      interval: 1s
    environment:
    - "FLEET_ENROLL=1"
    - "FLEET_ENROLL_INSECURE=1"
    - "FLEET_SETUP=1"
    - "KIBANA_HOST=http://kibana:5601"
    volumes:
    - /proc:/hostfs/proc
    - /sys/fs/cgroup:/hostfs/sys/fs/cgroup
    - type: bind
      source: ../tmp/service_logs/
      target: /tmp/service_logs/
  elastic-agent_is_ready:
    image: tianon/true
    depends_on:
      elastic-agent:
        condition: service_healthy
```
1. Launch Elastic stack on a linux machine:  `elastic-package stack up --version 7.12.0-SNAPSHOT -v -d` (make sure that the updated package is served by the registry) 
2. From Fleet UI enable `System` integration and set `system.hostfs` to `/hostfs`.
3. Verify that data-streams work properly for instance `data_stream.dataset: system.process` filter shows events in Discover page of Kibana.

Relevant Resources:
1. https://www.elastic.co/guide/en/beats/metricbeat/current/running-on-docker.html#monitoring-host
2. https://github.com/elastic/beats/blob/master/deploy/kubernetes/metricbeat-kubernetes.yaml#L192-L197

## Related issues

- Relates https://github.com/elastic/beats/issues/22915 https://github.com/elastic/beats/pull/23831

## Screenshots
![Screenshot 2021-02-08 at 4 19 45 PM](https://user-images.githubusercontent.com/11754898/107231966-91f6b500-6a29-11eb-95f8-c661103896f3.png)
![Screenshot 2021-02-08 at 4 20 09 PM](https://user-images.githubusercontent.com/11754898/107231977-93c07880-6a29-11eb-9252-06ba75a9d748.png)



@fearful-symmetry could you have a look and share your feedback please?
