### PR TITLE
Adding package changelogs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,7 @@ Explain here the changes you made on the PR.
 
 - [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
 - [ ] I have verified that all data streams collect metrics or logs.
+- [ ] I have added an entry to my package's `changelog.yml` file.
 
 ## Author's Checklist
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/elastic/elastic-package v0.0.0-20210209113653-f951769cba10
+	github.com/elastic/elastic-package v0.0.0-20210217003032-2b2a137a0b02
 	github.com/elastic/package-registry v0.17.0
 	github.com/magefile/mage v1.11.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/elastic/elastic-package v0.0.0-20210209113653-f951769cba10 h1:NxwbbpPIPwodq2M3af7ND7p5HKDi3ef7BjZrNRSO2A0=
-github.com/elastic/elastic-package v0.0.0-20210209113653-f951769cba10/go.mod h1:LQxKk+Igq5fhrGKstTX29rdAliLrtu+NQCstJYuCuNs=
+github.com/elastic/elastic-package v0.0.0-20210217003032-2b2a137a0b02 h1:P2K1ztSRBCY2IdnmcvYkgqL3FoBNQVtFru67+ra9ZKA=
+github.com/elastic/elastic-package v0.0.0-20210217003032-2b2a137a0b02/go.mod h1:hzJTWwSTpP3mLK9NcjnoLifXmOjitGbVwgI/RPmsEGE=
 github.com/elastic/go-elasticsearch/v7 v7.9.0 h1:UEau+a1MiiE/F+UrDj60kqIHFWdzU1M2y/YtBU2NC2M=
 github.com/elastic/go-elasticsearch/v7 v7.9.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/go-licenser v0.3.1/go.mod h1:D8eNQk70FOCVBl3smCGQt/lv7meBeQno2eI1S5apiHQ=
@@ -95,8 +95,8 @@ github.com/elastic/go-ucfg v0.8.4-0.20200415140258-1232bd4774a6 h1:Ehbr7du4rSSEy
 github.com/elastic/go-ucfg v0.8.4-0.20200415140258-1232bd4774a6/go.mod h1:iaiY0NBIYeasNgycLyTvhJftQlQEUO2hpF+FX0JKxzo=
 github.com/elastic/package-registry v0.17.0 h1:Gh7u3TlHA3GJh+C/OZ8Pf4EUrFxcCXMAe2kUCjAiYgQ=
 github.com/elastic/package-registry v0.17.0/go.mod h1:fMVt9ozLSPAIgYTDgV23IZrSoDKZma7VKpA4uSkfPts=
-github.com/elastic/package-spec/code/go v0.0.0-20210204181807-877461fbcf74 h1:bEccXQs1baxo7DEf3eWQZ0UT47ZYWlTqijaY5aGpWyM=
-github.com/elastic/package-spec/code/go v0.0.0-20210204181807-877461fbcf74/go.mod h1:dog1l3e8NoRYxuB8yIbbOWglE6GSQuU6ZL75wT9pKL8=
+github.com/elastic/package-spec/code/go v0.0.0-20210210152225-3f48d5aaa17e h1:kL1ypDLbxsEyPxkjmvccMau5Ap5s3yMk4qDO3xlbEos=
+github.com/elastic/package-spec/code/go v0.0.0-20210210152225-3f48d5aaa17e/go.mod h1:dog1l3e8NoRYxuB8yIbbOWglE6GSQuU6ZL75wT9pKL8=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/98

--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/98

--- a/packages/auditd/changelog.yml
+++ b/packages/auditd/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.0.1"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/396

--- a/packages/auditd/changelog.yml
+++ b/packages/auditd/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.0.1"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/396

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.0.3"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/21

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.0.3"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/package-registry/pull/437

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,4 +3,4 @@
   changes:
     - description: initial release
       type: enhancement                # can be one of: enhancement, bugfix, breaking-change
-      link: https://github.com/elastic/package-registry/pull/437
+      link: https://github.com/elastic/integrations/pull/21

--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.0.1"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/272

--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.0.1"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/272

--- a/packages/barracuda/changelog.yml
+++ b/packages/barracuda/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/package-storage/pull/152

--- a/packages/bluecoat/changelog.yml
+++ b/packages/bluecoat/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/package-storage/pull/181

--- a/packages/cef/changelog.yml
+++ b/packages/cef/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.0.1"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/418

--- a/packages/cef/changelog.yml
+++ b/packages/cef/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.0.1"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/418

--- a/packages/checkpoint/changelog.yml
+++ b/packages/checkpoint/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/220

--- a/packages/checkpoint/changelog.yml
+++ b/packages/checkpoint/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/220

--- a/packages/cisco/changelog.yml
+++ b/packages/cisco/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: TODO
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: TODO

--- a/packages/cisco/changelog.yml
+++ b/packages/cisco/changelog.yml
@@ -3,4 +3,4 @@
   changes:
     - description: initial release
       type: enhancement                # can be one of: enhancement, bugfix, breaking-change
-      link: https://github.com/elastic/package-storage/pull/22
+      link: https://github.com/elastic/integrations/pull/23

--- a/packages/cisco/changelog.yml
+++ b/packages/cisco/changelog.yml
@@ -1,6 +1,6 @@
 # newer versions go on top
-- version: TODO
+- version: "0.1.0"
   changes:
     - description: initial release
       type: enhancement                # can be one of: enhancement, bugfix, breaking-change
-      link: TODO
+      link: https://github.com/elastic/package-storage/pull/22

--- a/packages/cisco/changelog.yml
+++ b/packages/cisco/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/23

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/182

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/182

--- a/packages/cyberark/changelog.yml
+++ b/packages/cyberark/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/package-storage/pull/400

--- a/packages/cylance/changelog.yml
+++ b/packages/cylance/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/package-storage/pull/181

--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.0.5"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/462

--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.0.5"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/462

--- a/packages/f5/changelog.yml
+++ b/packages/f5/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/package-storage/pull/181

--- a/packages/fleet_server/changelog.yml
+++ b/packages/fleet_server/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/544

--- a/packages/fleet_server/changelog.yml
+++ b/packages/fleet_server/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/544

--- a/packages/fortinet/changelog.yml
+++ b/packages/fortinet/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/228

--- a/packages/fortinet/changelog.yml
+++ b/packages/fortinet/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/228

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.0.1"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/466

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.0.1"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/466

--- a/packages/haproxy/changelog.yml
+++ b/packages/haproxy/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/148

--- a/packages/haproxy/changelog.yml
+++ b/packages/haproxy/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/148

--- a/packages/iis/changelog.yml
+++ b/packages/iis/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/138

--- a/packages/iis/changelog.yml
+++ b/packages/iis/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/138

--- a/packages/imperva/changelog.yml
+++ b/packages/imperva/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/package-storage/pull/181

--- a/packages/infoblox/changelog.yml
+++ b/packages/infoblox/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/package-storage/pull/181

--- a/packages/iptables/changelog.yml
+++ b/packages/iptables/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.0.1"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/446

--- a/packages/iptables/changelog.yml
+++ b/packages/iptables/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.0.1"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/446

--- a/packages/juniper/changelog.yml
+++ b/packages/juniper/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/package-storage/pull/181

--- a/packages/juniper/changelog.yml
+++ b/packages/juniper/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/package-storage/pull/181

--- a/packages/kafka/changelog.yml
+++ b/packages/kafka/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/package-storage/pull/21

--- a/packages/kafka/changelog.yml
+++ b/packages/kafka/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/package-storage/pull/21

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/70

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/70

--- a/packages/kubernetes/data_stream/volume/fields/fields.yml
+++ b/packages/kubernetes/data_stream/volume/fields/fields.yml
@@ -32,6 +32,10 @@
               format: bytes
               description: |
                 Filesystem total used in bytes
+            - name: pct
+              type: long
+              description: |
+                Percentage of filesystem total used
         - name: inodes
           type: group
           fields:

--- a/packages/kubernetes/docs/README.md
+++ b/packages/kubernetes/docs/README.md
@@ -4413,6 +4413,7 @@ An example event for `volume` looks as following:
 | kubernetes.volume.fs.inodes.free | Free inodes | long |
 | kubernetes.volume.fs.inodes.used | Used inodes | long |
 | kubernetes.volume.fs.used.bytes | Filesystem total used in bytes | long |
+| kubernetes.volume.fs.used.pct | Percentage of filesystem total used | long |
 | kubernetes.volume.name | Volume name | keyword |
 | service.address | Service address | keyword |
 | service.type | Service type | keyword |

--- a/packages/linux/changelog.yml
+++ b/packages/linux/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/278

--- a/packages/linux/changelog.yml
+++ b/packages/linux/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/278

--- a/packages/log/changelog.yml
+++ b/packages/log/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/package-storage/pull/30

--- a/packages/log/changelog.yml
+++ b/packages/log/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/package-storage/pull/30

--- a/packages/microsoft/changelog.yml
+++ b/packages/microsoft/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/231

--- a/packages/microsoft/changelog.yml
+++ b/packages/microsoft/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/231

--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/110

--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/110

--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: TODO
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: TODO

--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -1,6 +1,6 @@
 # newer versions go on top
-- version: TODO
+- version: "0.1.0"
   changes:
     - description: initial release
       type: enhancement                # can be one of: enhancement, bugfix, breaking-change
-      link: TODO
+      link: https://github.com/elastic/integrations/pull/21

--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/21

--- a/packages/nats/changelog.yml
+++ b/packages/nats/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/413

--- a/packages/nats/changelog.yml
+++ b/packages/nats/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/413

--- a/packages/netflow/changelog.yml
+++ b/packages/netflow/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/package-storage/pull/22

--- a/packages/netflow/changelog.yml
+++ b/packages/netflow/changelog.yml
@@ -3,4 +3,4 @@
   changes:
     - description: initial release
       type: enhancement                # can be one of: enhancement, bugfix, breaking-change
-      link: https://github.com/elastic/package-storage/pull/22
+      link: https://github.com/elastic/integrations/pull/23

--- a/packages/netflow/changelog.yml
+++ b/packages/netflow/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/23

--- a/packages/netscout/changelog.yml
+++ b/packages/netscout/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/package-storage/pull/181

--- a/packages/nginx/changelog.yml
+++ b/packages/nginx/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: TODO
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: TODO

--- a/packages/nginx/changelog.yml
+++ b/packages/nginx/changelog.yml
@@ -1,6 +1,6 @@
 # newer versions go on top
-- version: TODO
+- version: "0.1.0"
   changes:
     - description: initial release
       type: enhancement                # can be one of: enhancement, bugfix, breaking-change
-      link: TODO
+      link: https://github.com/elastic/integrations/pull/21

--- a/packages/nginx/changelog.yml
+++ b/packages/nginx/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/21

--- a/packages/nginx_ingress_controller/changelog.yml
+++ b/packages/nginx_ingress_controller/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.0.1"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/451

--- a/packages/nginx_ingress_controller/changelog.yml
+++ b/packages/nginx_ingress_controller/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.0.1"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/451

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/230

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/230

--- a/packages/okta/changelog.yml
+++ b/packages/okta/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/232

--- a/packages/okta/changelog.yml
+++ b/packages/okta/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/232

--- a/packages/osquery/changelog.yml
+++ b/packages/osquery/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.0.1"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/450

--- a/packages/osquery/changelog.yml
+++ b/packages/osquery/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.0.1"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/450

--- a/packages/osquery_elastic_managed/changelog.yml
+++ b/packages/osquery_elastic_managed/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/273

--- a/packages/osquery_elastic_managed/changelog.yml
+++ b/packages/osquery_elastic_managed/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/273

--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/233

--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/233

--- a/packages/postgresql/changelog.yml
+++ b/packages/postgresql/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/83

--- a/packages/postgresql/changelog.yml
+++ b/packages/postgresql/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/83

--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/114

--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/114

--- a/packages/proofpoint/changelog.yml
+++ b/packages/proofpoint/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/package-storage/pull/400

--- a/packages/rabbitmq/changelog.yml
+++ b/packages/rabbitmq/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/99

--- a/packages/rabbitmq/changelog.yml
+++ b/packages/rabbitmq/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/99

--- a/packages/radware/changelog.yml
+++ b/packages/radware/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/package-storage/pull/181

--- a/packages/redis/changelog.yml
+++ b/packages/redis/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: TODO
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: TODO

--- a/packages/redis/changelog.yml
+++ b/packages/redis/changelog.yml
@@ -1,6 +1,6 @@
 # newer versions go on top
-- version: TODO
+- version: "0.1.0"
   changes:
     - description: initial release
       type: enhancement                # can be one of: enhancement, bugfix, breaking-change
-      link: TODO
+      link: https://github.com/elastic/integrations/pull/21

--- a/packages/redis/changelog.yml
+++ b/packages/redis/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/21

--- a/packages/santa/changelog.yml
+++ b/packages/santa/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.0.1"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/440

--- a/packages/santa/changelog.yml
+++ b/packages/santa/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.0.1"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/440

--- a/packages/sonicwall/changelog.yml
+++ b/packages/sonicwall/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/package-storage/pull/181

--- a/packages/sophos/changelog.yml
+++ b/packages/sophos/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/package-storage/pull/400

--- a/packages/squid/changelog.yml
+++ b/packages/squid/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/package-storage/pull/181

--- a/packages/stan/changelog.yml
+++ b/packages/stan/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/532

--- a/packages/stan/changelog.yml
+++ b/packages/stan/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/532

--- a/packages/suricata/changelog.yml
+++ b/packages/suricata/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.0.1"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/186

--- a/packages/suricata/changelog.yml
+++ b/packages/suricata/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.0.1"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/186

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.0.3"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/8

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.0.3"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/8

--- a/packages/tomcat/changelog.yml
+++ b/packages/tomcat/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/package-storage/pull/181

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/91

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/91

--- a/packages/zeek/changelog.yml
+++ b/packages/zeek/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/245

--- a/packages/zeek/changelog.yml
+++ b/packages/zeek/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/245

--- a/packages/zookeeper/changelog.yml
+++ b/packages/zookeeper/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/162

--- a/packages/zookeeper/changelog.yml
+++ b/packages/zookeeper/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/162

--- a/packages/zoom/changelog.yml
+++ b/packages/zoom/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/284

--- a/packages/zoom/changelog.yml
+++ b/packages/zoom/changelog.yml
@@ -2,5 +2,5 @@
 - version: "0.1.0"
   changes:
     - description: initial release
-      type: enhancement                # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/284

--- a/packages/zoom/data_stream/webhook/_dev/test/system/test-webhook-https-config.yml
+++ b/packages/zoom/data_stream/webhook/_dev/test/system/test-webhook-https-config.yml
@@ -57,3 +57,4 @@ data_stream:
         DSiM9duWTttlzzUhUQMHCua2z/LXjz1XMb0LoSEOVdk00TDgRMSFhBLhr3ZXmoLb
         Iqi7is4z2mP8pbcIIlmloogE
         -----END PRIVATE KEY-----
+      verification_mode: none

--- a/packages/zoom/data_stream/webhook/_dev/test/system/test-webhook-https-config.yml
+++ b/packages/zoom/data_stream/webhook/_dev/test/system/test-webhook-https-config.yml
@@ -7,7 +7,7 @@ data_stream:
     listen_port: 7443
     url: /zoom
     secret_value: abc123
-    ssl: |
+    ssl: |-
       certificate: |
         -----BEGIN CERTIFICATE-----
         MIIDJjCCAg6gAwIBAgIRAO76bP2QhJVqbLjcsWD6gkUwDQYJKoZIhvcNAQELBQAw

--- a/packages/zscaler/changelog.yml
+++ b/packages/zscaler/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/package-storage/pull/181


### PR DESCRIPTION
## What does this PR do?

This PR does the following:
* [x] Create initial skeleton `changelog.yml` files for every package.
* [x] Adds an item to the PR checklist that reminds package authors to add entries to their package's `changelog.yml`.

## Related issues
- https://github.com/elastic/package-spec/issues/17