### PR TITLE
Updates the dependency on elastic-package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/elastic/elastic-package v0.0.0-20210202205615-7e1e3b1cd40f
+	github.com/elastic/elastic-package v0.0.0-20210209113653-f951769cba10
 	github.com/elastic/package-registry v0.17.0
 	github.com/magefile/mage v1.11.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/elastic/elastic-package v0.0.0-20210202205615-7e1e3b1cd40f h1:1ov1GhUZ2EhodAq1IPzRFq/0++rKjqsLBZoefDlQJqM=
-github.com/elastic/elastic-package v0.0.0-20210202205615-7e1e3b1cd40f/go.mod h1:vED3BFD5+mEEdkmcY/aAZs4zgbAUisKE5fisVD1MUZg=
+github.com/elastic/elastic-package v0.0.0-20210209113653-f951769cba10 h1:NxwbbpPIPwodq2M3af7ND7p5HKDi3ef7BjZrNRSO2A0=
+github.com/elastic/elastic-package v0.0.0-20210209113653-f951769cba10/go.mod h1:LQxKk+Igq5fhrGKstTX29rdAliLrtu+NQCstJYuCuNs=
 github.com/elastic/go-elasticsearch/v7 v7.9.0 h1:UEau+a1MiiE/F+UrDj60kqIHFWdzU1M2y/YtBU2NC2M=
 github.com/elastic/go-elasticsearch/v7 v7.9.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/go-licenser v0.3.1/go.mod h1:D8eNQk70FOCVBl3smCGQt/lv7meBeQno2eI1S5apiHQ=
@@ -95,8 +95,8 @@ github.com/elastic/go-ucfg v0.8.4-0.20200415140258-1232bd4774a6 h1:Ehbr7du4rSSEy
 github.com/elastic/go-ucfg v0.8.4-0.20200415140258-1232bd4774a6/go.mod h1:iaiY0NBIYeasNgycLyTvhJftQlQEUO2hpF+FX0JKxzo=
 github.com/elastic/package-registry v0.17.0 h1:Gh7u3TlHA3GJh+C/OZ8Pf4EUrFxcCXMAe2kUCjAiYgQ=
 github.com/elastic/package-registry v0.17.0/go.mod h1:fMVt9ozLSPAIgYTDgV23IZrSoDKZma7VKpA4uSkfPts=
-github.com/elastic/package-spec/code/go v0.0.0-20210202180611-1c4504debe7f h1:pX9JXVjOLTb1wGd3zGffW91othWiK86PR6XS6X5rYm8=
-github.com/elastic/package-spec/code/go v0.0.0-20210202180611-1c4504debe7f/go.mod h1:dog1l3e8NoRYxuB8yIbbOWglE6GSQuU6ZL75wT9pKL8=
+github.com/elastic/package-spec/code/go v0.0.0-20210204181807-877461fbcf74 h1:bEccXQs1baxo7DEf3eWQZ0UT47ZYWlTqijaY5aGpWyM=
+github.com/elastic/package-spec/code/go v0.0.0-20210204181807-877461fbcf74/go.mod h1:dog1l3e8NoRYxuB8yIbbOWglE6GSQuU6ZL75wT9pKL8=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=


### PR DESCRIPTION
## What does this PR do?

Updates the dependency on `elastic-package` to bring in https://github.com/elastic/elastic-package/pull/247.

## Related issues
- Will benefit https://github.com/elastic/integrations/pull/674