### PR TITLE
Enable only default datastreams of k8s package

### DIFF
--- a/packages/kubernetes/_dev/build/docs/README.md
+++ b/packages/kubernetes/_dev/build/docs/README.md
@@ -50,6 +50,8 @@ deployment are available [here](https://github.com/kubernetes/kube-state-metrics
 Generally `kube-state-metrics` runs a `Deployment` and is accessible via a service called `kube-state-metrics` on
 `kube-system` namespace, which will be the service to use in our configuration.
 
+state_* datasets are not enabled by default.
+
 #### apiserver
 
 The apiserver dataset requires access to the Kubernetes API, which should be easily available in all Kubernetes
@@ -71,6 +73,7 @@ available for its configuration:
  the datasets to point to these services as part of an `Agent Deployment`.
 - Run these datasets as part an `Agent Daemonset` (with HostNetwork setting) with a `nodeSelector` to only run on Master nodes.
 
+These datasets are not enabled by default.
 
 Note: In some "As a Service" Kubernetes implementations, like `GKE`, the master nodes or even the pods running on
 the masters won't be visible. In these cases it won't be possible to use `scheduler` and `controllermanager` metricsets.

--- a/packages/kubernetes/data_stream/apiserver/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/apiserver/agent/stream/stream.yml.hbs
@@ -6,9 +6,9 @@ hosts:
 period: {{period}}
 
 {{#if bearer_token_file}}
-    bearer_token_file: {{bearer_token_file}}
-    ssl.certificate_authorities:
-    {{#each ssl.certificate_authorities}}
-      - {{this}}
-    {{/each}}
+bearer_token_file: {{bearer_token_file}}
+ssl.certificate_authorities:
+{{#each ssl.certificate_authorities}}
+  - {{this}}
+{{/each}}
 {{/if}}

--- a/packages/kubernetes/data_stream/controllermanager/manifest.yml
+++ b/packages/kubernetes/data_stream/controllermanager/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
   - input: kubernetes/metrics
+    enabled: false
     vars:
       - name: hosts
         type: text

--- a/packages/kubernetes/data_stream/scheduler/manifest.yml
+++ b/packages/kubernetes/data_stream/scheduler/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
   - input: kubernetes/metrics
+    enabled: false
     vars:
       - name: hosts
         type: text

--- a/packages/kubernetes/data_stream/state_container/manifest.yml
+++ b/packages/kubernetes/data_stream/state_container/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
   - input: kubernetes/metrics
+    enabled: false
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_cronjob/manifest.yml
+++ b/packages/kubernetes/data_stream/state_cronjob/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
   - input: kubernetes/metrics
+    enabled: false
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_daemonset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_daemonset/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
   - input: kubernetes/metrics
+    enabled: false
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_deployment/manifest.yml
+++ b/packages/kubernetes/data_stream/state_deployment/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
   - input: kubernetes/metrics
+    enabled: false
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_node/manifest.yml
+++ b/packages/kubernetes/data_stream/state_node/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
   - input: kubernetes/metrics
+    enabled: false
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_persistentvolume/manifest.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolume/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
   - input: kubernetes/metrics
+    enabled: false
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_persistentvolumeclaim/manifest.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolumeclaim/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
   - input: kubernetes/metrics
+    enabled: false
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_pod/manifest.yml
+++ b/packages/kubernetes/data_stream/state_pod/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
   - input: kubernetes/metrics
+    enabled: false
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_replicaset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_replicaset/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
   - input: kubernetes/metrics
+    enabled: false
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_resourcequota/manifest.yml
+++ b/packages/kubernetes/data_stream/state_resourcequota/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
   - input: kubernetes/metrics
+    enabled: false
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_service/manifest.yml
+++ b/packages/kubernetes/data_stream/state_service/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
   - input: kubernetes/metrics
+    enabled: false
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_statefulset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_statefulset/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
   - input: kubernetes/metrics
+    enabled: false
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_storageclass/manifest.yml
+++ b/packages/kubernetes/data_stream/state_storageclass/manifest.yml
@@ -3,6 +3,7 @@ release: experimental
 type: metrics
 streams:
   - input: kubernetes/metrics
+    enabled: false
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/docs/README.md
+++ b/packages/kubernetes/docs/README.md
@@ -50,6 +50,8 @@ deployment are available [here](https://github.com/kubernetes/kube-state-metrics
 Generally `kube-state-metrics` runs a `Deployment` and is accessible via a service called `kube-state-metrics` on
 `kube-system` namespace, which will be the service to use in our configuration.
 
+state_* datasets are not enabled by default.
+
 #### apiserver
 
 The apiserver dataset requires access to the Kubernetes API, which should be easily available in all Kubernetes
@@ -71,6 +73,7 @@ available for its configuration:
  the datasets to point to these services as part of an `Agent Deployment`.
 - Run these datasets as part an `Agent Daemonset` (with HostNetwork setting) with a `nodeSelector` to only run on Master nodes.
 
+These datasets are not enabled by default.
 
 Note: In some "As a Service" Kubernetes implementations, like `GKE`, the master nodes or even the pods running on
 the masters won't be visible. In these cases it won't be possible to use `scheduler` and `controllermanager` metricsets.

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 0.3.0
+version: 0.4.0
 license: basic
 description: Kubernetes Integration
 type: integration
@@ -10,7 +10,7 @@ categories:
   - kubernetes
 release: experimental
 conditions:
-  kibana.version: '^7.9.0'
+  kibana.version: ">=7.11.0"
 screenshots:
   - src: /img/metricbeat_kubernetes_overview.png
     title: Metricbeat Kubernetes Overview


### PR DESCRIPTION
## What does this PR do?
This PR is the final part of https://github.com/elastic/integrations/issues/511. Based on the specs defined at [migration assessment](https://github.com/elastic/obs-dc-team/blob/master/migration/packages/kubernetes.md), only specific datastreams should be 
enabled by default. This PR makes the appropriate changes so as to enable by default only the datastreams that were defined as default in the [migration assessment](https://github.com/elastic/obs-dc-team/blob/master/migration/packages/kubernetes.md).

Also setting the kibana version to `kibana.version: ">=7.11.0"`.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.


## Screenshots
<img width="841" alt="Screenshot 2021-02-09 at 2 36 54 PM" src="https://user-images.githubusercontent.com/11754898/107364621-5a990e80-6ae4-11eb-9ad0-6a502b3b02b3.png">


Note: Manual test of Dashboards performed using data shipped from [Elastic-Agent-Standalone](https://github.com/elastic/beats/pull/23679)