### PR TITLE
Add guards to OS-specific data streams

### DIFF
--- a/packages/linux/data_stream/conntrack/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/conntrack/agent/stream/stream.yml.hbs
@@ -1,2 +1,3 @@
 metricsets: ["conntrack"]
+condition: ${host.platform} == 'linux'
 period: {{period}}

--- a/packages/linux/data_stream/iostat/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/iostat/agent/stream/stream.yml.hbs
@@ -1,2 +1,3 @@
 metricsets: ["iostat"]
+condition: ${host.platform} == 'linux'
 period: {{period}}

--- a/packages/linux/data_stream/ksm/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/ksm/agent/stream/stream.yml.hbs
@@ -1,2 +1,3 @@
 metricsets: ["ksm"]
+condition: ${host.platform} == 'linux'
 period: {{period}}

--- a/packages/linux/data_stream/memory/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/memory/agent/stream/stream.yml.hbs
@@ -1,2 +1,3 @@
 metricsets: ["memory"]
+condition: ${host.platform} == 'linux'
 period: {{period}}

--- a/packages/linux/data_stream/pageinfo/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/pageinfo/agent/stream/stream.yml.hbs
@@ -1,2 +1,3 @@
 metricsets: ["pageinfo"]
+condition: ${host.platform} == 'linux'
 period: {{period}}

--- a/packages/linux/manifest.yml
+++ b/packages/linux/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: linux
 title: Linux
-version: 0.3.6
+version: 0.3.7
 license: basic
 description: Linux Integration
 type: integration

--- a/packages/windows/data_stream/forwarded/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/forwarded/agent/stream/winlog.yml.hbs
@@ -1,4 +1,5 @@
 name: ForwardedEvents
+condition: ${host.platform} == 'windows'
 tags: [forwarded]
 processors:
   - add_fields:

--- a/packages/windows/data_stream/perfmon/agent/stream/stream.yml.hbs
+++ b/packages/windows/data_stream/perfmon/agent/stream/stream.yml.hbs
@@ -1,4 +1,5 @@
 metricsets: ["perfmon"]
+condition: ${host.platform} == 'windows'
 perfmon.group_measurements_by_instance: {{perfmon.group_measurements_by_instance}}
 perfmon.ignore_non_existent_counters: {{perfmon.ignore_non_existent_counters}}
 perfmon.queries: {{perfmon.queries}}

--- a/packages/windows/data_stream/powershell/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/powershell/agent/stream/winlog.yml.hbs
@@ -1,4 +1,5 @@
 name: Windows PowerShell
+condition: ${host.platform} == 'windows'
 event_id: 400, 403, 600, 800
 processors:
   - add_fields:

--- a/packages/windows/data_stream/powershell_operational/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/powershell_operational/agent/stream/winlog.yml.hbs
@@ -1,4 +1,5 @@
 name: Microsoft-Windows-PowerShell/Operational
+condition: ${host.platform} == 'windows'
 event_id: 4103, 4104, 4105, 4106
 processors:
   - add_fields:

--- a/packages/windows/data_stream/service/agent/stream/stream.yml.hbs
+++ b/packages/windows/data_stream/service/agent/stream/stream.yml.hbs
@@ -1,2 +1,3 @@
 metricsets: ["service"]
+condition: ${host.platform} == 'windows'
 period: {{period}}

--- a/packages/windows/data_stream/sysmon_operational/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/sysmon_operational/agent/stream/winlog.yml.hbs
@@ -1,4 +1,5 @@
 name: Microsoft-Windows-Sysmon/Operational
+condition: ${host.platform} == 'windows'
 processors:
   - add_fields:
       target: ''

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 0.3.0
+version: 0.3.1
 description: Windows Integration
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

This PR adds conditional guards to the windows and Linux modules to prevent them from running on non-compatible OSes. I'm still testing this on non-linux OSes.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.

## How to test this PR locally

- pull down PR, build and setup kibana with the integration
- Create a policy with the `system`, `linux` and `windows` integrations
- Apply the policy to an agent
- Make sure the agent is showing a healthy status, and that non-compatible data streams aren't trying to run on the agent.

## Related issues

- https://github.com/elastic/beats/issues/23996
