### PR TITLE
[Fleet Server] Change default bind port from 8000 to 8220

### DIFF
--- a/packages/fleet_server/manifest.yml
+++ b/packages/fleet_server/manifest.yml
@@ -1,6 +1,6 @@
 name: fleet_server
 title: Fleet Server
-version: 0.1.4
+version: 0.1.5
 release: experimental
 description: Fleet Server Integration
 type: integration
@@ -37,7 +37,7 @@ policy_templates:
             required: true
             show_user: true
             default:
-              - 8000
+              - 8220
         title: "Fleet Server"
         description: "Fleet Server Configuration"
 


### PR DESCRIPTION
## What does this PR do?

Change default bind port from 8000 to 8220 for Fleet Server integration configuration.
Follow up on: https://github.com/elastic/fleet-server/pull/92#pullrequestreview-591730588

