### PR TITLE
Add additional guards for Linux/Windows

### DIFF
--- a/packages/linux/changelog.yml
+++ b/packages/linux/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.8"
+  changes:
+    - description: Add Guards
+      type: bugfix # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/724
 - version: "0.1.0"
   changes:
     - description: initial release

--- a/packages/linux/data_stream/entropy/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/entropy/agent/stream/stream.yml.hbs
@@ -1,4 +1,5 @@
 metricsets: ["entropy"]
+condition: ${host.platform} == 'linux'
 period: {{period}}
 {{#if system.hostfs}}
 system.hostfs: {{system.hostfs}}

--- a/packages/linux/data_stream/network_summary/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/network_summary/agent/stream/stream.yml.hbs
@@ -1,2 +1,3 @@
 metricsets: ["network_summary"]
+condition: ${host.platform} == 'linux'
 period: {{period}}

--- a/packages/linux/data_stream/raid/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/raid/agent/stream/stream.yml.hbs
@@ -1,4 +1,5 @@
 metricsets: ["raid"]
+condition: ${host.platform} == 'linux'
 {{#if raid.mount_point}}
 raid.mount_point: {{raid.mount_point}}
 {{/if}}

--- a/packages/linux/data_stream/service/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/service/agent/stream/stream.yml.hbs
@@ -1,4 +1,5 @@
 metricsets: ["service"]
+condition: ${host.platform} == 'linux'
 {{#if service.state_filter}}
 service.state_filter: {{service.state_filter}}
 {{/if}}

--- a/packages/linux/data_stream/socket/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/socket/agent/stream/stream.yml.hbs
@@ -1,4 +1,5 @@
 metricsets: ["socket"]
+condition: ${host.platform} == 'linux'
 {{#if socket.reverse_lookup.enabled}}
 socket.reverse_lookup.enabled: {{socket.reverse_lookup.enabled}}
 {{/if}}

--- a/packages/linux/data_stream/users/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/users/agent/stream/stream.yml.hbs
@@ -1,2 +1,3 @@
 metricsets: ["users"]
+condition: ${host.platform} == 'linux'
 period: {{period}}

--- a/packages/linux/manifest.yml
+++ b/packages/linux/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: linux
 title: Linux
-version: 0.3.7
+version: 0.3.8
 license: basic
 description: Linux Integration
 type: integration

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,10 @@
 # newer versions go on top
+# newer versions go on top
+- version: "0.4.1"
+  changes:
+    - description: Fix Guards
+      type: bugfix # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/724
 - version: "0.1.0"
   changes:
     - description: initial release

--- a/packages/windows/data_stream/security/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/security/agent/stream/winlog.yml.hbs
@@ -1,4 +1,5 @@
 name: Security
+condition: ${host.platform} == 'windows'
 processors:
   - add_fields:
       target: ''

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 0.4.0
+version: 0.4.1
 description: Windows Integration
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/elastic/beats/issues/23996

I keep on forgetting this isn't metricbeat, and more metricsets are enabled now. We'll need OS guards across most things that aren't broadly cross-compatible. 

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.

## How to test this PR locally

- Pull down, build with `elastic-package`
- run on MacOS or windows, enabled `linux` package and make sure there's no errors and the agent is healthy.

## Related issues

- https://github.com/elastic/beats/issues/23996

