### PR TITLE
Define healthchecks for Kubernetes integration

### DIFF
--- a/packages/kubernetes/_dev/deploy/docker/docker-compose.yml
+++ b/packages/kubernetes/_dev/deploy/docker/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     depends_on:
       kubernetes:
         condition: service_healthy
-
   kubernetes:
     image: nginx:alpine
     ports:
@@ -25,14 +24,13 @@ services:
       interval: 1s
       retries: 120
       timeout: 120s
-      test: >
+      test: |-
         curl -f -s http://localhost:8080/metrics -o /dev/null &&
         curl -f -s http://localhost:10249/metrics -o /dev/null &&
         curl -f -s http://localhost:10250/stats/summary -o /dev/null &&
         curl -f -s http://localhost:10251/metrics -o /dev/null &&
         curl -f -s http://localhost:10252/metrics -o /dev/null &&
         curl -f -s http://localhost:25000/metrics -o /dev/null
-
   kube-state-metrics:
     image: chanjarster/prometheus-mock-data:latest
     ports:

--- a/packages/kubernetes/_dev/deploy/docker/docker-compose.yml
+++ b/packages/kubernetes/_dev/deploy/docker/docker-compose.yml
@@ -1,4 +1,5 @@
 version: '2.3'
+
 services:
   kubernetes:
     image: nginx:alpine

--- a/packages/kubernetes/_dev/deploy/docker/docker-compose.yml
+++ b/packages/kubernetes/_dev/deploy/docker/docker-compose.yml
@@ -1,14 +1,20 @@
 version: '2.3'
 services:
+  kubernetes_is_ready:
+    image: tianon/true
+    depends_on:
+      kubernetes:
+        condition: service_healthy
+
   kubernetes:
     image: nginx:alpine
     ports:
-      - 8080:8080
-      - 10249:10249
-      - 10250:10250
-      - 10251:10251
-      - 10252:10252
-      - 25000:25000
+      - 8080
+      - 10249
+      - 10250
+      - 10251
+      - 10252
+      - 25000
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf
     depends_on:
@@ -18,6 +24,18 @@ services:
       - scheduler
       - proxy
       - kubelet
+    healthcheck:
+      interval: 1s
+      retries: 120
+      timeout: 120s
+      test: >
+        curl -f -s http://localhost:8080/metrics -o /dev/null &&
+        curl -f -s http://localhost:10249/metrics -o /dev/null &&
+        curl -f -s http://localhost:10250/stats/summary -o /dev/null &&
+        curl -f -s http://localhost:10251/metrics -o /dev/null &&
+        curl -f -s http://localhost:10252/metrics -o /dev/null &&
+        curl -f -s http://localhost:25000/metrics -o /dev/null
+
   kube-state-metrics:
     image: chanjarster/prometheus-mock-data:latest
     ports:

--- a/packages/kubernetes/_dev/deploy/docker/docker-compose.yml
+++ b/packages/kubernetes/_dev/deploy/docker/docker-compose.yml
@@ -1,15 +1,14 @@
 version: '2.3'
-
 services:
   kubernetes:
     image: nginx:alpine
     ports:
-      - 8080
-      - 25000
-      - 10252
-      - 10251
-      - 10249
-      - 10250
+      - 8080:8080
+      - 10249:10249
+      - 10250:10250
+      - 10251:10251
+      - 10252:10252
+      - 25000:25000
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf
     depends_on:

--- a/packages/kubernetes/_dev/deploy/docker/docker-compose.yml
+++ b/packages/kubernetes/_dev/deploy/docker/docker-compose.yml
@@ -10,10 +10,7 @@ services:
     image: nginx:alpine
     ports:
       - 8080
-      - 10249
-      - 10250
-      - 10251
-      - 10252
+      - 10249-10252
       - 25000
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf


### PR DESCRIPTION
This PR defines healthchecks for the Docker service used by the Kubernetes integration. The lack of healthchecks caused problems for the master branch (HTTP 502 errors).