### PR TITLE
Drop cloud field in Defender ATP to set it with provided values

### DIFF
--- a/packages/microsoft/changelog.yml
+++ b/packages/microsoft/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.1"
+  changes:
+    - description: Drop cloud field in Defender ATP to set it with provided values
+      type: bugfix # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/732
 - version: "0.4.0"
   changes:
     - description: Add Defender ATP data stream

--- a/packages/microsoft/data_stream/defender_atp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft/data_stream/defender_atp/elasticsearch/ingest_pipeline/default.yml
@@ -15,6 +15,7 @@ processors:
       - message
       - json.comments
       - host
+      - cloud
     ignore_missing: true
 
 #########################

--- a/packages/microsoft/manifest.yml
+++ b/packages/microsoft/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft
 title: Microsoft
-version: 0.4.0
+version: 0.4.1
 description: Microsoft Integration
 categories:
   - "network"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Drops any present `cloud` field to be able to set it with event provided values.

Related failures: https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fintegrations/detail/master/107/tests

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
