### PR TITLE
Temporarily use hardcoded agent image reference

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/elastic/elastic-package v0.0.0-20210217003032-2b2a137a0b02
+	github.com/elastic/elastic-package v0.0.0-20210224151129-fb7942fe4b4c
 	github.com/elastic/package-registry v0.17.0
 	github.com/magefile/mage v1.11.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/elastic/elastic-package v0.0.0-20210217003032-2b2a137a0b02 h1:P2K1ztSRBCY2IdnmcvYkgqL3FoBNQVtFru67+ra9ZKA=
-github.com/elastic/elastic-package v0.0.0-20210217003032-2b2a137a0b02/go.mod h1:hzJTWwSTpP3mLK9NcjnoLifXmOjitGbVwgI/RPmsEGE=
+github.com/elastic/elastic-package v0.0.0-20210224151129-fb7942fe4b4c h1:bxiDMfAi1Yx3IbIXPgKm69i3Ps8QKopaF3Xh6X9/gpg=
+github.com/elastic/elastic-package v0.0.0-20210224151129-fb7942fe4b4c/go.mod h1:hzJTWwSTpP3mLK9NcjnoLifXmOjitGbVwgI/RPmsEGE=
 github.com/elastic/go-elasticsearch/v7 v7.9.0 h1:UEau+a1MiiE/F+UrDj60kqIHFWdzU1M2y/YtBU2NC2M=
 github.com/elastic/go-elasticsearch/v7 v7.9.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/go-licenser v0.3.1/go.mod h1:D8eNQk70FOCVBl3smCGQt/lv7meBeQno2eI1S5apiHQ=


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR updates the elastic-package to temporarily switch the Agent's image to hardcoded stable one.

## Checklist

~- [ ] I have reviewed [tips for building integrations]~(https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
~- [ ] I have verified that all data streams collect metrics or logs.~
~- [ ] I have added an entry to my package's `changelog.yml` file.~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- https://github.com/elastic/beats/issues/24198