### PR TITLE
Use kibana.version ^ instead of >=

### DIFF
--- a/packages/checkpoint/changelog.yml
+++ b/packages/checkpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.1"
+  changes:
+    - description: Change kibana.version constraint to be more conservative.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/749
 - version: "0.1.0"
   changes:
     - description: initial release

--- a/packages/checkpoint/manifest.yml
+++ b/packages/checkpoint/manifest.yml
@@ -1,6 +1,6 @@
 name: checkpoint
 title: Check Point
-version: 0.5.0
+version: 0.5.1
 release: experimental
 description: Check Point Integration
 type: integration
@@ -8,7 +8,7 @@ format_version: 1.0.0
 license: basic
 categories: [security]
 conditions:
-  kibana.version: ">=7.11.0"
+  kibana.version: "^7.11.0"
 icons:
   - src: /img/checkpoint-logo.svg
     title: Check Point

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Change kibana.version constraint to be more conservative.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/749
 - version: "0.1.0"
   changes:
     - description: initial release

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: 0.3.0
+version: 0.3.1
 description: CrowdStrike Integration
 type: integration
 format_version: 1.0.0
@@ -8,7 +8,7 @@ license: basic
 categories: [security]
 release: experimental
 conditions:
-  kibana.version: ">=7.10.0"
+  kibana.version: "^7.10.0"
 icons:
   - src: /img/logo-integrations-crowdstrike.svg
     title: CrowdStrike

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.2"
+  changes:
+    - description: Change kibana.version constraint to be more conservative.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/749
 - version: "0.4.1"
   changes:
     - description: Add missing fields

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 0.4.1
+version: 0.4.2
 license: basic
 description: Kubernetes Integration
 type: integration
@@ -10,7 +10,7 @@ categories:
   - kubernetes
 release: experimental
 conditions:
-  kibana.version: ">=7.11.0"
+  kibana.version: "^7.11.0"
 screenshots:
   - src: /img/metricbeat_kubernetes_overview.png
     title: Metricbeat Kubernetes Overview

--- a/packages/nats/changelog.yml
+++ b/packages/nats/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Change kibana.version constraint to be more conservative.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/749
 - version: "0.1.0"
   changes:
     - description: initial release

--- a/packages/nats/manifest.yml
+++ b/packages/nats/manifest.yml
@@ -1,6 +1,6 @@
 name: nats
 title: NATS
-version: 0.1.0
+version: 0.1.1
 release: experimental
 description: NATS Integration
 type: integration
@@ -14,7 +14,7 @@ license: basic
 categories:
   - message_queue
 conditions:
-  kibana.version: ">=7.11.0"
+  kibana.version: "^7.11.0"
 screenshots:
   - src: /img/filebeat_nats_dashboard.png
     title: Filebeat NATS Dashboard

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Change kibana.version constraint to be more conservative.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/749
 - version: "0.3.0"
   changes:
     - description: Add changes to use ECS 1.8 fields.

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Office 365
-version: 0.3.0
+version: 0.3.1
 release: experimental
 description: Office 365 Integration
 type: integration
@@ -8,7 +8,7 @@ format_version: 1.0.0
 license: basic
 categories: [security]
 conditions:
-  kibana.version: ">=7.10.0"
+  kibana.version: "^7.10.0"
 icons:
   - src: /img/logo-integrations-microsoft-365.svg
     title: Microsoft Office 365

--- a/packages/okta/changelog.yml
+++ b/packages/okta/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Change kibana.version constraint to be more conservative.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/749
 - version: "0.1.0"
   changes:
     - description: initial release

--- a/packages/okta/manifest.yml
+++ b/packages/okta/manifest.yml
@@ -1,6 +1,6 @@
 name: okta
 title: Okta
-version: 0.3.0
+version: 0.3.1
 release: experimental
 description: Okta Integration
 type: integration
@@ -8,7 +8,7 @@ format_version: 1.0.0
 license: basic
 categories: [security]
 conditions:
-  kibana.version: ">=7.10"
+  kibana.version: "^7.10"
 icons:
   - src: /img/okta-logo.svg
     title: Okta

--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.1"
+  changes:
+    - description: Change kibana.version constraint to be more conservative.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/749
 - version: "0.1.0"
   changes:
     - description: initial release

--- a/packages/panw/manifest.yml
+++ b/packages/panw/manifest.yml
@@ -1,6 +1,6 @@
 name: panw
 title: Palo Alto Networks
-version: 0.6.0
+version: 0.6.1
 release: experimental
 description: Palo Alto Networks Integration
 type: integration
@@ -8,7 +8,7 @@ format_version: 1.0.0
 license: basic
 categories: [security]
 conditions:
-  kibana.version: ">=7.11.0"
+  kibana.version: "^7.11.0"
 icons:
   - src: /img/logo-integrations-paloalto-networks.svg
     title: Palo Alto Networks

--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.3"
+  changes:
+    - description: Change kibana.version constraint to be more conservative.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/749
 - version: "0.1.0"
   changes:
     - description: initial release

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: prometheus
 title: Prometheus
-version: 0.3.2
+version: 0.3.3
 license: basic
 description: Prometheus Integration
 type: integration
@@ -10,7 +10,7 @@ categories:
   - datastore
 release: experimental
 conditions:
-  kibana.version: ">=7.10.0"
+  kibana.version: "^7.10.0"
 screenshots:
   - src: /img/metricbeat-prometheus-overview.png
     title: Metricbeat Prometheus Overview

--- a/packages/stan/changelog.yml
+++ b/packages/stan/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.2"
+  changes:
+    - description: Change kibana.version constraint to be more conservative.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/749
 - version: "0.1.0"
   changes:
     - description: initial release

--- a/packages/stan/manifest.yml
+++ b/packages/stan/manifest.yml
@@ -1,6 +1,6 @@
 name: stan
 title: STAN
-version: 0.1.1
+version: 0.1.2
 release: beta
 description: NATS Streaming Integration
 type: integration
@@ -15,7 +15,7 @@ categories:
   - message_queue
   - kubernetes
 conditions:
-  kibana.version: ">=7.11.0"
+  kibana.version: "^7.11.0"
 screenshots:
   - src: /img/metrics-stan-overview.png
     title: Metrics STAN Dashboard

--- a/packages/suricata/changelog.yml
+++ b/packages/suricata/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.1"
+  changes:
+    - description: Change kibana.version constraint to be more conservative.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/749
 - version: "0.0.1"
   changes:
     - description: initial release

--- a/packages/suricata/manifest.yml
+++ b/packages/suricata/manifest.yml
@@ -1,6 +1,6 @@
 name: suricata
 title: Suricata
-version: 0.5.0
+version: 0.5.1
 release: experimental
 description: Suricata Integration
 type: integration
@@ -13,7 +13,7 @@ format_version: 1.0.0
 license: basic
 categories: [network, security]
 conditions:
-  kibana.version: ">=7.10.0"
+  kibana.version: "^7.10.0"
 screenshots:
   - src: /img/filebeat-suricata-events.png
     title: filebeat suricata events


### PR DESCRIPTION
## What does this PR do?

Packages must contain kibana.version: '^7.12.0' and NOT '>7.12.0', for example.

Otherwise these packages will automatically be compatible with 8.0 which we are not sure yet.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.