### PR TITLE
Fix: correctly filter AWS instance type

### DIFF
--- a/packages/aws/data_stream/ec2_metrics/_dev/deploy/tf/main.tf
+++ b/packages/aws/data_stream/ec2_metrics/_dev/deploy/tf/main.tf
@@ -18,6 +18,6 @@ data "aws_ami" "latest-amzn" {
   owners = [ "amazon" ] # AWS
   filter {
     name   = "name"
-    values = ["amzn2-ami-hvm-*"]
+    values = ["amzn2-ami-minimal-hvm-*-ebs"]
   }
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR modifies TF definition for AWS EC2 metrics system test to correctly select the instance type. Otherwise the TF runner fails like https://github.com/elastic/elastic-package/pull/265 .

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
~- [ ] I have added an entry to my package's `changelog.yml` file.~
