### PR TITLE
Temporary switch to stable image of Elastic Agent

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -87,8 +87,9 @@ pipeline {
                       }
 
                       // Check compatibility with previous stacks
-                      checkPackageCompatibility(it, ELASTIC_STACK_VERSION_PREV)
-                      checkPackageCompatibility(it, ELASTIC_STACK_VERSION_PREV_PREV)
+                      // FIXME Disable compatibility checks due to https://github.com/elastic/beats/issues/24310
+                      //checkPackageCompatibility(it, ELASTIC_STACK_VERSION_PREV)
+                      //checkPackageCompatibility(it, ELASTIC_STACK_VERSION_PREV_PREV)
                     }
                   }
                 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/elastic/elastic-package v0.0.0-20210302155343-7a8f99157a71
+	github.com/elastic/elastic-package v0.0.0-20210304090610-3b20737c0a81
 	github.com/elastic/package-registry v0.17.0
 	github.com/magefile/mage v1.11.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/elastic/elastic-package v0.0.0-20210302155343-7a8f99157a71 h1:uVs37M0pMJBtRZuiRbRsGxZvNjGdQc4anbyI1VFahuc=
-github.com/elastic/elastic-package v0.0.0-20210302155343-7a8f99157a71/go.mod h1:NjAFCbU9bzFpHIq8bGmcM7ejGNuqJ2KgN8gFb3qcvsU=
+github.com/elastic/elastic-package v0.0.0-20210304090610-3b20737c0a81 h1:4AOOr2RHTeEYeNYKxMXQPaOB8lmJJTILNjIXKntE66M=
+github.com/elastic/elastic-package v0.0.0-20210304090610-3b20737c0a81/go.mod h1:NjAFCbU9bzFpHIq8bGmcM7ejGNuqJ2KgN8gFb3qcvsU=
 github.com/elastic/go-elasticsearch/v7 v7.9.0 h1:UEau+a1MiiE/F+UrDj60kqIHFWdzU1M2y/YtBU2NC2M=
 github.com/elastic/go-elasticsearch/v7 v7.9.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/go-licenser v0.3.1/go.mod h1:D8eNQk70FOCVBl3smCGQt/lv7meBeQno2eI1S5apiHQ=


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR temporarily switches to the stable revision of Elastic Agent until https://github.com/elastic/beats/issues/24310 is fixed.

The PR also disables compatibility checks with older stack versions (as the tool doesn't support them currently, due to the mentioned issue).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- https://github.com/elastic/beats/issues/24310

