### PR TITLE
[CI] enable one shoot workers

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -57,8 +57,7 @@ pipeline {
             findFiles()?.findAll{ !it.name.endsWith('@tmp') }?.collect{ it.name }?.sort()?.each {
               if (isPrAffected(it)) {
                 integrations[it] = {
-                  sleep(randomNumber(min: 1, max: 5))
-                  node('ubuntu-20 && immutable') {
+                  withNode('ubuntu-20 && immutable') {
                     stage("${it}: check") {
                       deleteDir()
                       gitCheckout(basedir: "${BASE_DIR}")
@@ -139,6 +138,30 @@ pipeline {
     cleanup {
       notifyBuildResult(prComment: true)
     }
+  }
+}
+
+/**
+* If a static worker given the labels.
+* TODO: as soon as ARM and MacOS are ephemerals then we need to change this method
+*/
+def isStaticWorker(label) {
+  return (label?.contains('arm') || label?.contains('macosx') || label?.contains('metal'))
+}
+
+/**
+* This method wraps the node call for two reasons:
+*  1. with some latency to avoid the known issue with the scalabitity in gobld.
+*  2. enforce one shoot ephemeral workers with the extra/uuid label that gobld provides.
+*/
+def withNode(String label, Closure body) {
+  sleep randomNumber(min: 10, max: 100)
+  // this should workaround the existing issue with reusing workers with the Gobld
+  def uuid = UUID.randomUUID().toString()
+  def labels = isStaticWorker(label) ? label : (label?.trim() ? "${label} && extra/${uuid}" : "extra/${uuid}")
+  log(level: 'INFO', text: "Allocating a worker with the labels '${labels}'.")
+  node("${labels}") {
+    body()
   }
 }
 

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -142,23 +142,15 @@ pipeline {
 }
 
 /**
-* If a static worker given the labels.
-* TODO: as soon as ARM and MacOS are ephemerals then we need to change this method
-*/
-def isStaticWorker(label) {
-  return (label?.contains('arm') || label?.contains('macosx') || label?.contains('metal'))
-}
-
-/**
 * This method wraps the node call for two reasons:
-*  1. with some latency to avoid the known issue with the scalabitity in gobld.
+*  1. with some latency to avoid the known issue with the scalability in gobld.
 *  2. enforce one shoot ephemeral workers with the extra/uuid label that gobld provides.
 */
 def withNode(String label, Closure body) {
   sleep randomNumber(min: 10, max: 100)
   // this should workaround the existing issue with reusing workers with the Gobld
   def uuid = UUID.randomUUID().toString()
-  def labels = isStaticWorker(label) ? label : (label?.trim() ? "${label} && extra/${uuid}" : "extra/${uuid}")
+  def labels = isStaticWorker(labels: label) ? label : (label?.trim() ? "${label} && extra/${uuid}" : "extra/${uuid}")
   log(level: 'INFO', text: "Allocating a worker with the labels '${labels}'.")
   node("${labels}") {
     body()

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
             findFiles()?.findAll{ !it.name.endsWith('@tmp') }?.collect{ it.name }?.sort()?.each {
               if (isPrAffected(it)) {
                 integrations[it] = {
-                  withNode('ubuntu-20 && immutable') {
+                  withNode(labels: 'ubuntu-20 && immutable', sleepMin: 10, sleepMax: 100) {
                     stage("${it}: check") {
                       deleteDir()
                       gitCheckout(basedir: "${BASE_DIR}")
@@ -138,22 +138,6 @@ pipeline {
     cleanup {
       notifyBuildResult(prComment: true)
     }
-  }
-}
-
-/**
-* This method wraps the node call for two reasons:
-*  1. with some latency to avoid the known issue with the scalability in gobld.
-*  2. enforce one shoot ephemeral workers with the extra/uuid label that gobld provides.
-*/
-def withNode(String label, Closure body) {
-  sleep randomNumber(min: 10, max: 100)
-  // this should workaround the existing issue with reusing workers with the Gobld
-  def uuid = UUID.randomUUID().toString()
-  def labels = isStaticWorker(labels: label) ? label : (label?.trim() ? "${label} && extra/${uuid}" : "extra/${uuid}")
-  log(level: 'INFO', text: "Allocating a worker with the labels '${labels}'.")
-  node("${labels}") {
-    body()
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

Mitigate the failures due to aborted build by ensuring the Workers are one shoot based and there is a sleep to have a smooth ram up when requesting several workers at the same time.

