### PR TITLE
prevent 7.12 Fleet-Server package usage to avoid future / upgrade bugs

### DIFF
--- a/packages/fleet_server/changelog.yml
+++ b/packages/fleet_server/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.1.1"
+- version: "0.1.7"
   changes:
     - description: increment package version and manifest link to 7.13
       type: enhancement # can be one of: enhancement, bugfix, breaking-change

--- a/packages/fleet_server/changelog.yml
+++ b/packages/fleet_server/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: increment package version and manifest link to 7.13
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/788
 - version: "0.1.0"
   changes:
     - description: initial release

--- a/packages/fleet_server/manifest.yml
+++ b/packages/fleet_server/manifest.yml
@@ -8,7 +8,7 @@ format_version: 1.0.0
 license: basic
 categories: ["elastic_stack"]
 conditions:
-  kibana.version: "^7.12.0"
+  kibana.version: "^7.13.0"
 owner:
   github: elastic/ingest-management
 #icons:

--- a/packages/fleet_server/manifest.yml
+++ b/packages/fleet_server/manifest.yml
@@ -1,6 +1,6 @@
 name: fleet_server
 title: Fleet Server
-version: 0.1.6
+version: 0.1.7
 release: experimental
 description: Fleet Server Integration
 type: integration


### PR DESCRIPTION
This is that gray area of both:
- Feature work
- Bug

came out of discussion in https://github.com/elastic/integrations/issues/787

## What does this PR do?
It sets the manifest to be ^7.13 so we don't end up with accidental 7.12 usage and have to deal with SDH / upgrade bugs when folks go from 7.12 to 7.13 and DO want to use Fleet Server

## Checklist

~~- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.~~
~~- [ ] I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.

## Author's Checklist

Anyone disagree or see that it would be a problem to better avoid this usage?  

## How to test this PR locally

after it is promoted / merged, make sure it does not appear for 7.12 BC / or shipped stacks
