### PR TITLE
[CI] use the stash/unstash approach

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -13,7 +13,8 @@ pipeline {
     HOME = "${env.WORKSPACE}"
     KIND_VERSION = "v0.10.0"
     K8S_VERSION = "v1.20.2"
-
+    JOB_GCS_BUCKET = 'beats-ci-temp'
+    JOB_GCS_CREDENTIALS = 'beats-ci-gcs-plugin'
     ELASTIC_STACK_VERSION_PREV = "7.12.0-SNAPSHOT"
     ELASTIC_STACK_VERSION_PREV_PREV = "7.11.2-SNAPSHOT"
   }
@@ -35,6 +36,7 @@ pipeline {
       steps {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
+        stashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
       }
     }
     stage('Check Go sources') {
@@ -60,7 +62,7 @@ pipeline {
                   withNode(labels: 'ubuntu-20 && immutable', sleepMin: 10, sleepMax: 100) {
                     stage("${it}: check") {
                       deleteDir()
-                      gitCheckout(basedir: "${BASE_DIR}")
+                      unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
                       useElasticPackage()
                       try {
                         dir("${BASE_DIR}/packages/${it}") {


### PR DESCRIPTION
## What does this PR do?

Use the stash/unstash instead the `gitCheckout` in each parallel stage

## Why

Avoid issues with GitHub when it's down.
Avoid several entries for each gitcheckout in the jenkins ui

![image](https://user-images.githubusercontent.com/2871786/111185517-f61d1380-85a9-11eb-8642-afea2256d318.png)
