### PR TITLE
Generate initial package changelog when importing from Beats modules

### DIFF
--- a/dev/import-beats/changelog.go
+++ b/dev/import-beats/changelog.go
@@ -16,7 +16,7 @@ type entry struct {
 type change struct {
 	Description string
 	Type        string
-	Link        string
+	Link        string `yaml:",omitempty"`
 }
 
 func newChangelog(initVersion string) *changelog {
@@ -28,7 +28,7 @@ func newChangelog(initVersion string) *changelog {
 					{
 						"initial release",
 						"enhancement",
-						"",
+						"", // deliberately empty so user has to specify a real link
 					},
 				},
 			},

--- a/dev/import-beats/changelog.go
+++ b/dev/import-beats/changelog.go
@@ -1,18 +1,18 @@
 package main
 
 type changelog struct {
-	entries []entry
+	Entries []entry
 }
 
 type entry struct {
-	version string
-	changes []change
+	Version string
+	Changes []change
 }
 
 type change struct {
-	description string
-	typ string `yaml:"type"`
-	link string
+	Description string
+	Type string
+	Link string
 }
 
 func newChangelog(initVersion string) *changelog {

--- a/dev/import-beats/changelog.go
+++ b/dev/import-beats/changelog.go
@@ -11,8 +11,8 @@ type entry struct {
 
 type change struct {
 	Description string
-	Type string
-	Link string
+	Type        string
+	Link        string
 }
 
 func newChangelog(initVersion string) *changelog {

--- a/dev/import-beats/changelog.go
+++ b/dev/import-beats/changelog.go
@@ -1,0 +1,33 @@
+package main
+
+type changelog struct {
+	entries []entry
+}
+
+type entry struct {
+	version string
+	changes []change
+}
+
+type change struct {
+	description string
+	typ string `yaml:"type"`
+	link string
+}
+
+func newChangelog(initVersion string) *changelog {
+	return &changelog{
+		[]entry{
+			{
+				initVersion,
+				[]change{
+					{
+						"initial release",
+						"enhancement",
+						"",
+					},
+				},
+			},
+		},
+	}
+}

--- a/dev/import-beats/changelog.go
+++ b/dev/import-beats/changelog.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package main
 
 type changelog struct {

--- a/dev/import-beats/main.go
+++ b/dev/import-beats/main.go
@@ -136,6 +136,5 @@ func build(options importerOptions) error {
 			return errors.Wrap(err, "creating from metrics source failed")
 		}
 	}
-
 	return repository.save(options.outputDir)
 }

--- a/dev/import-beats/main.go
+++ b/dev/import-beats/main.go
@@ -136,5 +136,6 @@ func build(options importerOptions) error {
 			return errors.Wrap(err, "creating from metrics source failed")
 		}
 	}
+
 	return repository.save(options.outputDir)
 }

--- a/dev/import-beats/packages.go
+++ b/dev/import-beats/packages.go
@@ -412,19 +412,18 @@ func (r *packageRepository) save(outputDir string) error {
 
 		// changelog
 		changelog := newChangelog(manifest.Version)
-		log.Println("changelog:", changelog)
 
-		contents, err := yaml.Marshal(changelog)
+		c, err := yaml.Marshal(changelog)
 		if err != nil {
 			return errors.Wrap(err, "marshalling changelog failed")
 		}
 
-		header := []byte("# newer versions go on top\n")
-		contents = append(header, contents...)
-		log.Println("contents:", string(contents))
+		header := "# newer versions go on top"
+		contents := strings.Replace(string(c),"entries:", header, 1) // HACK: cannot marshal sequence at root level!
+		c = []byte(contents)
 
 		changelogPath := filepath.Join(packagePath, "changelog.yml")
-		if err := ioutil.WriteFile(changelogPath, contents, 0644); err != nil {
+		if err := ioutil.WriteFile(changelogPath, c, 0644); err != nil {
 			return errors.Wrap(err, "writing changelog file failed")
 		}
 	}

--- a/dev/import-beats/packages.go
+++ b/dev/import-beats/packages.go
@@ -409,6 +409,24 @@ func (r *packageRepository) save(outputDir string) error {
 				}
 			}
 		}
+
+		// changelog
+		changelog := newChangelog(manifest.Version)
+		log.Println("changelog:", changelog)
+
+		contents, err := yaml.Marshal(changelog)
+		if err != nil {
+			return errors.Wrap(err, "marshalling changelog failed")
+		}
+
+		header := []byte("# newer versions go on top\n")
+		contents = append(header, contents...)
+		log.Println("contents:", string(contents))
+
+		changelogPath := filepath.Join(packagePath, "changelog.yml")
+		if err := ioutil.WriteFile(changelogPath, contents, 0644); err != nil {
+			return errors.Wrap(err, "writing changelog file failed")
+		}
 	}
 	return nil
 }

--- a/dev/import-beats/packages.go
+++ b/dev/import-beats/packages.go
@@ -419,7 +419,7 @@ func (r *packageRepository) save(outputDir string) error {
 		}
 
 		header := "# newer versions go on top"
-		contents := strings.Replace(string(c),"entries:", header, 1) // HACK: cannot marshal sequence at root level!
+		contents := strings.Replace(string(c), "entries:", header, 1) // HACK: cannot marshal sequence at root level!
 		c = []byte(contents)
 
 		changelogPath := filepath.Join(packagePath, "changelog.yml")


### PR DESCRIPTION
## What does this PR do?

This PR enhances the `mage ImportBeats` script to generate a `changelog.yml` file for every imported package.

## How to test this PR locally

1. Import a package. Example:
   ```
   PACKAGES=traefik mage ImportBeats
   ```
2.  Check that there is a `changelog.yml` file in the package's root folder with these contents:
   ```
   # newer versions go on top
   - version: "<package version>"
     changes:
       - description: initial release
         type: enhancement # can be one of: enhancement, bugfix, breaking-change
         link: 
   ```

## Related issues
- Resolves partially #765
