### PR TITLE
Update zeek to ecs 1.9.0

### DIFF
--- a/packages/zeek/changelog.yml
+++ b/packages/zeek/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.1"
+  changes:
+    - description: update to ECS 1.9.0
+      type: enhancement
+      link: https://github.com/elastic/package-storage/pull/xxx
 - version: "0.1.0"
   changes:
     - description: initial release

--- a/packages/zeek/data_stream/capture_loss/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/capture_loss/agent/stream/httpjson.yml.hbs
@@ -71,7 +71,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
   - drop_fields:
       fields: ["json","message"]
       ignore_missing: true

--- a/packages/zeek/data_stream/capture_loss/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/capture_loss/agent/stream/log.yml.hbs
@@ -24,4 +24,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/connection/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/connection/agent/stream/httpjson.yml.hbs
@@ -136,7 +136,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
   - drop_fields:
       fields: ["zeek.connection.orig_bytes","zeek.connection.resp_bytes","zeek.connection.tunnel_parents","json","message"]
       ignore_missing: true

--- a/packages/zeek/data_stream/connection/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/connection/agent/stream/log.yml.hbs
@@ -87,4 +87,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/dce_rpc/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/dce_rpc/agent/stream/httpjson.yml.hbs
@@ -103,7 +103,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
         network.transport: tcp
         network.protocol: dce_rpc
   - drop_fields:

--- a/packages/zeek/data_stream/dce_rpc/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/dce_rpc/agent/stream/log.yml.hbs
@@ -55,4 +55,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/dhcp/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/dhcp/agent/stream/httpjson.yml.hbs
@@ -149,7 +149,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
         network.transport: udp
         network.protocol: dhcp
   - drop_fields:

--- a/packages/zeek/data_stream/dhcp/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/dhcp/agent/stream/log.yml.hbs
@@ -101,4 +101,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/dnp3/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/dnp3/agent/stream/httpjson.yml.hbs
@@ -109,7 +109,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
         network.transport: tcp
         network.protocol: dnp3
   - drop_fields:

--- a/packages/zeek/data_stream/dnp3/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/dnp3/agent/stream/log.yml.hbs
@@ -61,4 +61,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/dns/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/dns/agent/stream/httpjson.yml.hbs
@@ -254,7 +254,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
   - drop_fields:
       fields: ["json","message"]
       ignore_missing: true

--- a/packages/zeek/data_stream/dns/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/dns/agent/stream/log.yml.hbs
@@ -205,4 +205,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/dpd/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/dpd/agent/stream/httpjson.yml.hbs
@@ -104,7 +104,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
   - drop_fields:
       fields: ["json","message"]
       ignore_missing: true

--- a/packages/zeek/data_stream/dpd/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/dpd/agent/stream/log.yml.hbs
@@ -53,4 +53,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/files/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/files/agent/stream/httpjson.yml.hbs
@@ -95,7 +95,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
   - drop_fields:
       fields: ["json","message"]
       ignore_missing: true

--- a/packages/zeek/data_stream/files/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/files/agent/stream/log.yml.hbs
@@ -46,4 +46,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/ftp/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/ftp/agent/stream/httpjson.yml.hbs
@@ -123,7 +123,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
         network.transport: tcp
         network.protocol: ftp
   - drop_fields:

--- a/packages/zeek/data_stream/ftp/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/ftp/agent/stream/log.yml.hbs
@@ -75,4 +75,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/http/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/http/agent/stream/httpjson.yml.hbs
@@ -128,6 +128,6 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
         network.transport: tcp
 

--- a/packages/zeek/data_stream/http/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/http/agent/stream/log.yml.hbs
@@ -80,4 +80,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/intel/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/intel/agent/stream/httpjson.yml.hbs
@@ -120,7 +120,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
   - drop_fields:
       fields: ["json","message"]
       ignore_missing: true

--- a/packages/zeek/data_stream/intel/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/intel/agent/stream/log.yml.hbs
@@ -71,4 +71,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/irc/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/irc/agent/stream/httpjson.yml.hbs
@@ -114,7 +114,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
         network.transport: tcp
         network.protocol: irc
   - drop_fields:

--- a/packages/zeek/data_stream/irc/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/irc/agent/stream/log.yml.hbs
@@ -66,4 +66,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/kerberos/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/kerberos/agent/stream/httpjson.yml.hbs
@@ -137,7 +137,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
         network.transport: tcp
         network.protocol: kerberos
   - drop_fields:

--- a/packages/zeek/data_stream/kerberos/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/kerberos/agent/stream/log.yml.hbs
@@ -89,4 +89,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/modbus/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/modbus/agent/stream/httpjson.yml.hbs
@@ -117,7 +117,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
         network.transport: tcp
         network.protocol: modbus
   - drop_fields:

--- a/packages/zeek/data_stream/modbus/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/modbus/agent/stream/log.yml.hbs
@@ -69,4 +69,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/mysql/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/mysql/agent/stream/httpjson.yml.hbs
@@ -117,7 +117,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
         network.transport: tcp
         network.protocol: mysql
   - drop_fields:

--- a/packages/zeek/data_stream/mysql/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/mysql/agent/stream/log.yml.hbs
@@ -69,4 +69,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/notice/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/notice/agent/stream/httpjson.yml.hbs
@@ -136,7 +136,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
   - drop_fields:
       fields: ["json","message"]
       ignore_missing: true

--- a/packages/zeek/data_stream/notice/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/notice/agent/stream/log.yml.hbs
@@ -87,4 +87,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/ntlm/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/ntlm/agent/stream/httpjson.yml.hbs
@@ -127,7 +127,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
         network.transport: tcp
         network.protocol: ntlm
   - drop_fields:

--- a/packages/zeek/data_stream/ntlm/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/ntlm/agent/stream/log.yml.hbs
@@ -79,4 +79,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/ocsp/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/ocsp/agent/stream/httpjson.yml.hbs
@@ -103,7 +103,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
         network.transport: tcp
   - drop_fields:
       fields: ["json","message"]

--- a/packages/zeek/data_stream/ocsp/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/ocsp/agent/stream/log.yml.hbs
@@ -54,4 +54,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/pe/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/pe/agent/stream/httpjson.yml.hbs
@@ -85,7 +85,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
   - drop_fields:
       fields: ["json","message"]
       ignore_missing: true

--- a/packages/zeek/data_stream/pe/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/pe/agent/stream/log.yml.hbs
@@ -34,4 +34,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/radius/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/radius/agent/stream/httpjson.yml.hbs
@@ -103,7 +103,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
         network.transport: udp
         netwokr.protocol: radius
   - drop_fields:

--- a/packages/zeek/data_stream/radius/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/radius/agent/stream/log.yml.hbs
@@ -55,4 +55,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/rdp/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/rdp/agent/stream/httpjson.yml.hbs
@@ -122,7 +122,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
         network.transport: tcp
         network.protocol: rdp
   - drop_fields:

--- a/packages/zeek/data_stream/rdp/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/rdp/agent/stream/log.yml.hbs
@@ -74,4 +74,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/rfb/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/rfb/agent/stream/httpjson.yml.hbs
@@ -112,7 +112,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
         network.transport: tcp
         network.protocol: rfb
   - drop_fields:

--- a/packages/zeek/data_stream/rfb/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/rfb/agent/stream/log.yml.hbs
@@ -64,4 +64,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/sip/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/sip/agent/stream/httpjson.yml.hbs
@@ -128,7 +128,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
         network.transport: udp
         network.protocol: sip
   - drop_fields:

--- a/packages/zeek/data_stream/sip/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/sip/agent/stream/log.yml.hbs
@@ -80,4 +80,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/smb_cmd/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/smb_cmd/agent/stream/httpjson.yml.hbs
@@ -136,7 +136,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
         network.transport: tcp
         network.protocol: smb
   - drop_fields:

--- a/packages/zeek/data_stream/smb_cmd/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/smb_cmd/agent/stream/log.yml.hbs
@@ -90,4 +90,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/smb_files/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/smb_files/agent/stream/httpjson.yml.hbs
@@ -106,7 +106,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
         network.transport: tcp
         network.protocol: smb
   - drop_fields:

--- a/packages/zeek/data_stream/smb_files/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/smb_files/agent/stream/log.yml.hbs
@@ -58,4 +58,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/smb_mapping/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/smb_mapping/agent/stream/httpjson.yml.hbs
@@ -102,7 +102,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
         network.transport: tcp
         network.protocol: smb
   - drop_fields:

--- a/packages/zeek/data_stream/smb_mapping/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/smb_mapping/agent/stream/log.yml.hbs
@@ -54,4 +54,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/smtp/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/smtp/agent/stream/httpjson.yml.hbs
@@ -109,7 +109,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
         network.transport: tcp
         network.protocol: smtp
   - drop_fields:

--- a/packages/zeek/data_stream/smtp/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/smtp/agent/stream/log.yml.hbs
@@ -61,4 +61,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/snmp/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/snmp/agent/stream/httpjson.yml.hbs
@@ -110,7 +110,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
         network.transport: udp
         network.protocol: snmp
   - drop_fields:

--- a/packages/zeek/data_stream/snmp/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/snmp/agent/stream/log.yml.hbs
@@ -62,4 +62,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/socks/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/socks/agent/stream/httpjson.yml.hbs
@@ -109,7 +109,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
         network.transport: tcp
         network.protocol: socks
   - drop_fields:

--- a/packages/zeek/data_stream/socks/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/socks/agent/stream/log.yml.hbs
@@ -61,4 +61,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/ssh/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/ssh/agent/stream/httpjson.yml.hbs
@@ -114,7 +114,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
         network.transport: tcp
         network.protocol: ssh
   - drop_fields:

--- a/packages/zeek/data_stream/ssh/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/ssh/agent/stream/log.yml.hbs
@@ -66,4 +66,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/ssl/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/ssl/agent/stream/httpjson.yml.hbs
@@ -118,7 +118,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
         network.transport: tcp
   - drop_fields:
       fields: ["json","message"]

--- a/packages/zeek/data_stream/ssl/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/ssl/agent/stream/log.yml.hbs
@@ -69,4 +69,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/stats/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/stats/agent/stream/httpjson.yml.hbs
@@ -125,7 +125,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
   - drop_fields:
       fields: ["json","message"]
       ignore_missing: true

--- a/packages/zeek/data_stream/stats/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/stats/agent/stream/log.yml.hbs
@@ -74,4 +74,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/syslog/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/syslog/agent/stream/httpjson.yml.hbs
@@ -101,7 +101,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
         network.protocol: syslog
   - drop_fields:
       fields: ["json","message"]

--- a/packages/zeek/data_stream/syslog/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/syslog/agent/stream/log.yml.hbs
@@ -52,4 +52,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/traceroute/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/traceroute/agent/stream/httpjson.yml.hbs
@@ -95,7 +95,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
   - drop_fields:
       fields: ["json","message"]
       ignore_missing: true

--- a/packages/zeek/data_stream/traceroute/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/traceroute/agent/stream/log.yml.hbs
@@ -44,4 +44,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/tunnel/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/tunnel/agent/stream/httpjson.yml.hbs
@@ -103,7 +103,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
   - drop_fields:
       fields: ["json","message"]
       ignore_missing: true

--- a/packages/zeek/data_stream/tunnel/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/tunnel/agent/stream/log.yml.hbs
@@ -52,4 +52,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/weird/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/weird/agent/stream/httpjson.yml.hbs
@@ -103,7 +103,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
   - drop_fields:
       fields: ["json","message"]
       ignore_missing: true

--- a/packages/zeek/data_stream/weird/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/weird/agent/stream/log.yml.hbs
@@ -52,4 +52,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/zeek/data_stream/x509/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/x509/agent/stream/httpjson.yml.hbs
@@ -107,7 +107,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
   - drop_fields:
       fields: ["json","message"]
       ignore_missing: true

--- a/packages/zeek/data_stream/x509/agent/stream/log.yml.hbs
+++ b/packages/zeek/data_stream/x509/agent/stream/log.yml.hbs
@@ -56,4 +56,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0


### PR DESCRIPTION
## What does this PR do?

This PR updates the zeek package to use ecs 1.9.0.

## Checklist

- [x] I have added an entry to my package's `changelog.yml` file.