### PR TITLE
Update google_workspace to ecs 1.9.0

### DIFF
--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: update to ECS 1.9.0
       type: enhancement
-      link: https://github.com/elastic/package-storage/pull/xxx
+      link: https://github.com/elastic/integrations/pull/847
 - version: "0.2.2"
   changes:
     - description: fix status code parsing for saml datastream

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.3"
+  changes:
+    - description: update to ECS 1.9.0
+      type: enhancement
+      link: https://github.com/elastic/package-storage/pull/xxx
 - version: "0.2.2"
   changes:
     - description: fix status code parsing for saml datastream

--- a/packages/google_workspace/data_stream/admin/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/admin/agent/stream/httpjson.yml.hbs
@@ -37,7 +37,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0
   - script:
       lang: javascript
       id: gworkspace-common

--- a/packages/google_workspace/data_stream/admin/agent/stream/log.yml.hbs
+++ b/packages/google_workspace/data_stream/admin/agent/stream/log.yml.hbs
@@ -14,7 +14,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0
   - script:
       lang: javascript
       id: gworkspace-common

--- a/packages/google_workspace/data_stream/drive/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/drive/agent/stream/httpjson.yml.hbs
@@ -37,7 +37,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0
   - script:
       lang: javascript
       id: gworkspace-common

--- a/packages/google_workspace/data_stream/drive/agent/stream/log.yml.hbs
+++ b/packages/google_workspace/data_stream/drive/agent/stream/log.yml.hbs
@@ -14,7 +14,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0
   - script:
       lang: javascript
       id: gworkspace-common

--- a/packages/google_workspace/data_stream/groups/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/groups/agent/stream/httpjson.yml.hbs
@@ -37,7 +37,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0
   - script:
       lang: javascript
       id: gworkspace-common

--- a/packages/google_workspace/data_stream/groups/agent/stream/log.yml.hbs
+++ b/packages/google_workspace/data_stream/groups/agent/stream/log.yml.hbs
@@ -14,7 +14,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0
   - script:
       lang: javascript
       id: gworkspace-common

--- a/packages/google_workspace/data_stream/login/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/login/agent/stream/httpjson.yml.hbs
@@ -37,7 +37,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0
   - script:
       lang: javascript
       id: gworkspace-common

--- a/packages/google_workspace/data_stream/login/agent/stream/log.yml.hbs
+++ b/packages/google_workspace/data_stream/login/agent/stream/log.yml.hbs
@@ -14,7 +14,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.9.0
   - script:
       lang: javascript
       id: gworkspace-common

--- a/packages/google_workspace/data_stream/saml/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/saml/agent/stream/httpjson.yml.hbs
@@ -37,7 +37,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0
   - script:
       lang: javascript
       id: gworkspace-common

--- a/packages/google_workspace/data_stream/saml/agent/stream/log.yml.hbs
+++ b/packages/google_workspace/data_stream/saml/agent/stream/log.yml.hbs
@@ -14,7 +14,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0
   - script:
       lang: javascript
       id: gworkspace-common

--- a/packages/google_workspace/data_stream/user_accounts/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/user_accounts/agent/stream/httpjson.yml.hbs
@@ -37,7 +37,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0
   - script:
       lang: javascript
       id: gworkspace-common

--- a/packages/google_workspace/data_stream/user_accounts/agent/stream/log.yml.hbs
+++ b/packages/google_workspace/data_stream/user_accounts/agent/stream/log.yml.hbs
@@ -14,7 +14,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0
   - script:
       lang: javascript
       id: gworkspace-common

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: 0.2.2
+version: 0.2.3
 release: experimental
 description: Google Workspace Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?

This PR updates the google_workspace package to use ecs 1.9.0.

## Checklist

- [x] I have added an entry to my package's `changelog.yml` file.