### PR TITLE
Update iptables to ecs 1.9.0

### DIFF
--- a/packages/iptables/changelog.yml
+++ b/packages/iptables/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.0.4"
+  changes:
+    - description: update to ECS 1.9.0
+      type: enhancement
+      link: https://github.com/elastic/package-storage/pull/xxx
 - version: "0.0.3"
   changes:
     - description: Fix compatibility with Kibana

--- a/packages/iptables/changelog.yml
+++ b/packages/iptables/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: update to ECS 1.9.0
       type: enhancement
-      link: https://github.com/elastic/package-storage/pull/xxx
+      link: https://github.com/elastic/integrations/pull/852
 - version: "0.0.3"
   changes:
     - description: Fix compatibility with Kibana

--- a/packages/iptables/data_stream/log/agent/stream/log.yml.hbs
+++ b/packages/iptables/data_stream/log/agent/stream/log.yml.hbs
@@ -47,4 +47,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.6.0
+        ecs.version: 1.9.0

--- a/packages/iptables/data_stream/log/agent/stream/syslog.yml.hbs
+++ b/packages/iptables/data_stream/log/agent/stream/syslog.yml.hbs
@@ -44,4 +44,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.6.0
+        ecs.version: 1.9.0

--- a/packages/iptables/manifest.yml
+++ b/packages/iptables/manifest.yml
@@ -1,6 +1,6 @@
 name: iptables
 title: Iptables
-version: 0.0.3
+version: 0.0.4
 release: experimental
 description: Iptables Integration
 type: integration
@@ -31,10 +31,10 @@ policy_templates:
     description: Collect logs from iptables instances
     inputs:
       - type: syslog
-        title: 'Collect iptables application logs (input: syslog)'
-        description: 'Collecting application logs from iptables instances (input: syslog)'
+        title: "Collect iptables application logs (input: syslog)"
+        description: "Collecting application logs from iptables instances (input: syslog)"
       - type: logfile
-        title: 'Collect iptables application logs (input: logfile)'
-        description: 'Collecting application logs from iptables instances (input: logfile)'
+        title: "Collect iptables application logs (input: logfile)"
+        description: "Collecting application logs from iptables instances (input: logfile)"
 owner:
   github: elastic/security-external-integrations


### PR DESCRIPTION
## What does this PR do?

This PR updates the iptables package to use ecs 1.9.0.

## Checklist

- [x] I have added an entry to my package's `changelog.yml` file.