### PR TITLE
Update o365 to ecs 1.9.0

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.2"
+  changes:
+    - description: update to ECS 1.9.0
+      type: enhancement
+      link: https://github.com/elastic/package-storage/pull/xxx
 - version: "0.3.1"
   changes:
     - description: Change kibana.version constraint to be more conservative.

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: update to ECS 1.9.0
       type: enhancement
-      link: https://github.com/elastic/package-storage/pull/xxx
+      link: https://github.com/elastic/integrations/pull/860
 - version: "0.3.1"
   changes:
     - description: Change kibana.version constraint to be more conservative.

--- a/packages/o365/data_stream/audit/agent/stream/log.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/log.yml.hbs
@@ -1078,4 +1078,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/o365/data_stream/audit/agent/stream/o365audit.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/o365audit.yml.hbs
@@ -1088,4 +1088,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Office 365
-version: 0.3.1
+version: 0.3.2
 release: experimental
 description: Office 365 Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?

This PR updates the o365 package to use ecs 1.9.0.

## Checklist

- [x] I have added an entry to my package's `changelog.yml` file.