### PR TITLE
Update rabbitmq to ecs 1.9.0

### DIFF
--- a/packages/rabbitmq/changelog.yml
+++ b/packages/rabbitmq/changelog.yml
@@ -4,6 +4,9 @@
     - description: Updating package owner
       type: enhancement
       link: https://github.com/elastic/integrations/pull/766
+    - description: update to ECS 1.9.0
+      type: enhancement
+      link: https://github.com/elastic/package-storage/pull/xxx
 - version: "0.2.7"
   changes:
     - description: Correct sample event file.

--- a/packages/rabbitmq/changelog.yml
+++ b/packages/rabbitmq/changelog.yml
@@ -6,7 +6,7 @@
       link: https://github.com/elastic/integrations/pull/766
     - description: update to ECS 1.9.0
       type: enhancement
-      link: https://github.com/elastic/package-storage/pull/xxx
+      link: https://github.com/elastic/integrations/pull/866
 - version: "0.2.7"
   changes:
     - description: Correct sample event file.

--- a/packages/rabbitmq/data_stream/log/agent/stream/log.yml.hbs
+++ b/packages/rabbitmq/data_stream/log/agent/stream/log.yml.hbs
@@ -15,4 +15,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.5.0
+        ecs.version: 1.9.0

--- a/packages/rabbitmq/manifest.yml
+++ b/packages/rabbitmq/manifest.yml
@@ -9,7 +9,7 @@ categories:
   - message_queue
 release: experimental
 conditions:
-  kibana.version: '^7.9.0'
+  kibana.version: "^7.9.0"
 icons:
   - src: /img/logo_rabbitmq.svg
     title: RabbitMQ Logo


### PR DESCRIPTION
## What does this PR do?

This PR updates the rabbitmq package to use ecs 1.9.0.

## Checklist

- [x] I have added an entry to my package's `changelog.yml` file.