### PR TITLE
Update traefik to ecs 1.9.0

### DIFF
--- a/packages/traefik/changelog.yml
+++ b/packages/traefik/changelog.yml
@@ -4,6 +4,9 @@
     - description: parse either commonlog- or json-formatted logs
       type: enhancement
       link: https://github.com/elastic/integrations/pull/770
+    - description: update to ECS 1.9.0
+      type: enhancement
+      link: https://github.com/elastic/package-storage/pull/xxx
 - version: "0.1.0"
   changes:
     - description: initial release

--- a/packages/traefik/changelog.yml
+++ b/packages/traefik/changelog.yml
@@ -6,7 +6,7 @@
       link: https://github.com/elastic/integrations/pull/770
     - description: update to ECS 1.9.0
       type: enhancement
-      link: https://github.com/elastic/package-storage/pull/xxx
+      link: https://github.com/elastic/integrations/pull/876
 - version: "0.1.0"
   changes:
     - description: initial release

--- a/packages/traefik/data_stream/access/agent/stream/log.yml.hbs
+++ b/packages/traefik/data_stream/access/agent/stream/log.yml.hbs
@@ -7,4 +7,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.9.0

--- a/packages/traefik/manifest.yml
+++ b/packages/traefik/manifest.yml
@@ -1,6 +1,6 @@
 name: traefik
 title: Traefik
-version: 0.0.1
+version: 0.1.1
 release: experimental
 description: Traefik Integration
 type: integration
@@ -27,8 +27,8 @@ policy_templates:
     description: Collect logs and metrics from Traefik instances
     inputs:
       - type: logfile
-        title: 'Collect Traefik access logs'
-        description: 'Collecting access logs from Traefik instances'
+        title: "Collect Traefik access logs"
+        description: "Collecting access logs from Traefik instances"
       - type: traefik/metrics
         vars:
           - name: hosts


### PR DESCRIPTION
## What does this PR do?

This PR updates the traefik package to use ecs 1.9.0.

## Checklist

- [x] I have added an entry to my package's `changelog.yml` file.