### PR TITLE
Set a few data streams to enabled in the linux integration

### DIFF
--- a/packages/linux/changelog.yml
+++ b/packages/linux/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.10"
+  changes:
+    - description: Updating package owner
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/883
 - version: "0.3.9"
   changes:
     - description: Updating package owner

--- a/packages/linux/changelog.yml
+++ b/packages/linux/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "0.3.10"
   changes:
-    - description: Updating package owner
+    - description: Enable some Linux datastreams by default
       type: bugfix
       link: https://github.com/elastic/integrations/pull/883
 - version: "0.3.9"

--- a/packages/linux/data_stream/iostat/manifest.yml
+++ b/packages/linux/data_stream/iostat/manifest.yml
@@ -11,6 +11,5 @@ streams:
         required: true
         show_user: true
         default: 10s
-    enabled: false
     title: Linux iostat metrics
     description: Linux disk stat metrics

--- a/packages/linux/data_stream/memory/manifest.yml
+++ b/packages/linux/data_stream/memory/manifest.yml
@@ -11,6 +11,5 @@ streams:
         required: true
         show_user: true
         default: 10s
-    enabled: false
     title: Linux memory metrics
     description: Linux paging and memory management metrics

--- a/packages/linux/data_stream/network_summary/manifest.yml
+++ b/packages/linux/data_stream/network_summary/manifest.yml
@@ -10,5 +10,6 @@ streams:
         multi: false
         required: true
         show_user: true
+        default: 10s
     title: Linux host network summary metrics
     description: Collect Linux network_summary metrics

--- a/packages/linux/data_stream/network_summary/manifest.yml
+++ b/packages/linux/data_stream/network_summary/manifest.yml
@@ -10,7 +10,5 @@ streams:
         multi: false
         required: true
         show_user: true
-        default: 10s
-    enabled: false
     title: Linux host network summary metrics
     description: Collect Linux network_summary metrics

--- a/packages/linux/manifest.yml
+++ b/packages/linux/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: linux
 title: Linux
-version: 0.3.8
+version: 0.3.10
 license: basic
 description: Linux Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?

Right now, all the data streams in `linux` are disabled by default, which can be a tad confusing when a user clicks the slider to enable the data stream groups, and Kibana just enables all of the data streams, even when some streams like `raid` require a specific system config. This enables a few basic data streams, so uses get some data streams by default, and so they won't blindly enable the entire integration.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.

## How to test this PR locally

- Pull down, build, start stack
- Add the linux integration in the Kibana UI, make sure the data stream groups are on by default.

