### PR TITLE
Update dependency on elastic-package

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -97,8 +97,9 @@ pipeline {
                       }
 
                       // Check compatibility with previous stacks
-                      checkPackageCompatibility(it, ELASTIC_STACK_VERSION_PREV)
-                      checkPackageCompatibility(it, ELASTIC_STACK_VERSION_PREV_PREV)
+                      // FIXME: Enable compatibility check once we have a new stack released (compatibility with Fleet Server)
+                      // checkPackageCompatibility(it, ELASTIC_STACK_VERSION_PREV)
+                      // checkPackageCompatibility(it, ELASTIC_STACK_VERSION_PREV_PREV)
                     }
                   }
                 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/elastic/elastic-package v0.0.0-20210406214749-f187867c3cb6
+	github.com/elastic/elastic-package v0.0.0-20210407085849-f171846c52f3
 	github.com/elastic/package-registry v0.17.0
 	github.com/magefile/mage v1.11.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/elastic/elastic-package v0.0.0-20210406214749-f187867c3cb6 h1:z5/tYvKGGdB5DUZCUoqvzFhWup/b1BFKg0HG0GtVImw=
-github.com/elastic/elastic-package v0.0.0-20210406214749-f187867c3cb6/go.mod h1:zE/RmGwaG/pY0/YV/hR1uq/IiRQyGsZm206ZOLZJgtQ=
+github.com/elastic/elastic-package v0.0.0-20210407085849-f171846c52f3 h1:CrJYf/cr+fdBO2D0fr8DS+Ow31OZk2WElz9+jVOJyGU=
+github.com/elastic/elastic-package v0.0.0-20210407085849-f171846c52f3/go.mod h1:zE/RmGwaG/pY0/YV/hR1uq/IiRQyGsZm206ZOLZJgtQ=
 github.com/elastic/go-elasticsearch/v7 v7.9.0 h1:UEau+a1MiiE/F+UrDj60kqIHFWdzU1M2y/YtBU2NC2M=
 github.com/elastic/go-elasticsearch/v7 v7.9.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/go-licenser v0.3.1/go.mod h1:D8eNQk70FOCVBl3smCGQt/lv7meBeQno2eI1S5apiHQ=


### PR DESCRIPTION
This PR updates dependency on elastic-package to enable the Fleet Server in the default stack.

Fixes: https://github.com/elastic/elastic-package/issues/278