### PR TITLE
Add fail_on_template_error in okta

### DIFF
--- a/packages/okta/changelog.yml
+++ b/packages/okta/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.2"
+  changes:
+    - description: add fail_on_template_error on pagination
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/901
 - version: "0.4.1"
   changes:
     - description: update to ECS 1.9.0

--- a/packages/okta/data_stream/system/agent/stream/httpjson.yml.hbs
+++ b/packages/okta/data_stream/system/agent/stream/httpjson.yml.hbs
@@ -28,6 +28,7 @@ response.pagination:
   - set:
       target: url.value
       value: '[[ getRFC5988Link "next" .last_response.header.Link ]]'
+      fail_on_template_error: true
 
 cursor:
   published:

--- a/packages/okta/manifest.yml
+++ b/packages/okta/manifest.yml
@@ -1,6 +1,6 @@
 name: okta
 title: Okta
-version: 0.4.1
+version: 0.4.2
 release: experimental
 description: Okta Integration
 type: integration
@@ -8,7 +8,7 @@ format_version: 1.0.0
 license: basic
 categories: [security]
 conditions:
-  kibana.version: "^7.11"
+  kibana.version: "^7.12.1"
 icons:
   - src: /img/okta-logo.svg
     title: Okta


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Uses fail_on_template_error option for google_workspace and okta modules pagination.


In some cases, the expected value used to paginate might not be there, and we want this to interrupt the execution instead of doing a request with an unexpected empty value.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
