### PR TITLE
Explicit mapping for all osquery fields

### DIFF
--- a/packages/osquery_manager/data_stream/result/fields/osquery.yml
+++ b/packages/osquery_manager/data_stream/result/fields/osquery.yml
@@ -3,6100 +3,8 @@
   description: Fields related to the Osquery result
   type: group
   fields:
-    - name: arguments
-      description: Kernel arguments
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: stderr_path
-      description: Pipe stderr to a target path
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: model_family
-      description: Drive model family
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: usb_address
-      description: USB Device used address
-      type: keyword
-      ignore_above: 1024
-    - name: sigurl
-      description: Signature url
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: bundle_identifier
-      description: Info properties CFBundleIdentifier label
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: vm_size
-      description: VM size
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: zone
-      description: Availability zone of the VM
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: store
-      description: Certificate system store
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: chassis_types
-      description: A comma-separated list of chassis types, such as Desktop or Laptop.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: storage_driver
-      description: Storage driver
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: fan
-      description: Fan number
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: power_8023at_power_source
-      description: 802.3at power source
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: protected
-      description: 1 if this handler is protected (reserved) by OS X, else 0
-      type: keyword
-      ignore_above: 1024
-    - name: message
-      description: Raw audit message
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: serial_number
-      description: The certificate serial number
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: physical_memory
-      description: Total physical memory in bytes
-      type: keyword
-      ignore_above: 1024
-    - name: update_source_certificate
-      description: Certificate for update source server
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: perf_ctl
-      description: Performance setting for the processor.
-      type: keyword
-      ignore_above: 1024
-    - name: package
-      description: Package name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: active_disks
-      description: Number of active disks in array
-      type: keyword
-      ignore_above: 1024
-    - name: refs
-      description: Module reverse dependencies
-      type: keyword
-      ignore_above: 1024
-    - name: pci_class_id
-      description: PCI Device class ID in hex format
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: script_block_count
-      description: The total number of script blocks for this script
-      type: keyword
-      ignore_above: 1024
-    - name: bluetooth_sharing
-      description: 1 If bluetooth sharing is enabled for any user else 0
-      type: keyword
-      ignore_above: 1024
-    - name: encryption_method
-      description: The encryption type of the device.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: guest
-      description: Time spent running a virtual CPU for a guest OS under the control of the Linux kernel
-      type: keyword
-      ignore_above: 1024
-    - name: oom_kill_disable
-      description: 1 if Out-of-memory kill is disabled. 0 otherwise
-      type: keyword
-      ignore_above: 1024
-    - name: event_tapped
-      description: The mask that identifies the set of events to be observed.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: upid
-      description: A 64bit pid that is never reused. Returns -1 if we couldn't gather them from the system.
-      type: keyword
-      ignore_above: 1024
-    - name: blocks
-      description: Number of blocks
-      type: keyword
-      ignore_above: 1024
-    - name: writable
-      description: 1 if writable, 0 if not
-      type: keyword
-      ignore_above: 1024
-    - name: vaddr
-      description: Section virtual address in memory
-      type: keyword
-      ignore_above: 1024
-    - name: msize
-      description: Segment offset in memory
-      type: keyword
-      ignore_above: 1024
-    - name: turbo_ratio_limit
-      description: The turbo feature ratio limit.
-      type: keyword
-      ignore_above: 1024
-    - name: keyword
-      description: The keyword applied to the package
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: policy_mappings
-      description: Policy Mappings
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: options
-      description: Resolver options
-      type: keyword
-      ignore_above: 1024
-    - name: cpu_shares
-      description: 1 if CPU share weighting support is enabled. 0 otherwise
-      type: keyword
-      ignore_above: 1024
-    - name: logon_server
-      description: The name of the server used to authenticate the owner of the logon session.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: consumer
-      description: Reference to an instance of __EventConsumer that represents the object path to a logical consumer, the recipient of an event.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: cycle_count
-      description: The number of charge/discharge cycles
-      type: keyword
-      ignore_above: 1024
-    - name: network_id
-      description: Network ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: base64
-      description: 1 if the value is base64 encoded else 0
-      type: keyword
-      ignore_above: 1024
-    - name: channel_width
-      description: Channel width
-      type: keyword
-      ignore_above: 1024
-    - name: protocol
-      description: The network protocol ID
-      type: keyword
-      ignore_above: 1024
-    - name: sensor_ip_addr
-      description: IP address of the sensor
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: tags
-      description: Comma-separated list of tags
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: coprocessor_version
-      description: The manufacturer and chip version
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: dhcp_enabled
-      description: If TRUE, the dynamic host configuration protocol (DHCP) server automatically assigns an IP address to the computer system when establishing a network connection.
-      type: keyword
-      ignore_above: 1024
-    - name: uid
-      description: User ID
-      type: keyword
-      ignore_above: 1024
-    - name: stealth_enabled
-      description: 1 If stealth mode is enabled else 0
-      type: keyword
-      ignore_above: 1024
-    - name: health
-      description: 'One of the following: "Good" describes a well-performing battery, "Fair" describes a functional battery with limited capacity, or "Poor" describes a battery that''s not capable of providing power'
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ppvids_enabled
-      description: Comma delimited list of enabled PPVIDs
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: metadata_endpoint
-      description: Endpoint used to fetch VM metadata
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: content
-      description: Disk event content
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: rw
-      description: 1 if read/write. 0 otherwise
-      type: keyword
-      ignore_above: 1024
-    - name: config_entrypoint
-      description: Container entrypoint(s)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: vm_id
-      description: Unique identifier for the VM
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: executable_path
-      description: Module to execute. The string can specify the full path and file name of the module to execute, or it can specify a partial name. If a partial name is specified, the current drive and current directory are assumed.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: subkey
-      description: Intermediate key path, includes lists/dicts
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: percent_processor_time
-      description: Returns elapsed time that all of the threads of this process used the processor to execute instructions in 100 nanoseconds ticks.
-      type: keyword
-      ignore_above: 1024
-    - name: printer_sharing
-      description: 1 If printer sharing is enabled else 0
-      type: keyword
-      ignore_above: 1024
-    - name: subsystem
-      description: Subsystem ID, control type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: job_type
-      description: Job type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: signing_algorithm
-      description: Signing algorithm used
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: subnet
-      description: Network subnet
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: power_class
-      description: Power class
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: image
-      description: Docker image (name) used to launch this container
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: iniface
-      description: Input interface for the rule.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: power_device_type
-      description: Dot3 power device type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: shmid
-      description: Shared memory segment ID
-      type: keyword
-      ignore_above: 1024
-    - name: dump_certificate
-      description: Set this value to '1' to dump certificate
-      type: keyword
-      ignore_above: 1024
-    - name: disk_size
-      description: Size of the disk.
-      type: keyword
-      ignore_above: 1024
-    - name: resync_finish
-      description: Estimated duration of resync activity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: disc_sharing
-      description: 1 If CD or DVD sharing is enabled else 0
-      type: keyword
-      ignore_above: 1024
-    - name: issuer_name
-      description: The certificate issuer name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: serial
-      description: Certificate serial number
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: store_location
-      description: Certificate system store location
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: cpu_total_usage
-      description: Total CPU usage
-      type: keyword
-      ignore_above: 1024
-    - name: hardware_version
-      description: Hardware version
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ipv4_no_traffic
-      description: True if any interface is connected via IPv4, but has seen no traffic
-      type: keyword
-      ignore_above: 1024
-    - name: filevault_status
-      description: 'FileVault status with one of following values: on | off | unknown'
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: cpu
-      description: CPU utilization as percentage
-      type: keyword
-      ignore_above: 1024
-    - name: bsd_flags
-      description: 'The BSD file flags (chflags). Possible values: NODUMP, UF_IMMUTABLE, UF_APPEND, OPAQUE, HIDDEN, ARCHIVED, SF_IMMUTABLE, SF_APPEND'
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: dst_ip
-      description: Destination IP address.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: root_directory
-      description: Key used to specify a directory to chroot to before launch
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: chassis_bridge_capability_available
-      description: Chassis bridge capability availability
-      type: keyword
-      ignore_above: 1024
-    - name: developer_id
-      description: Optional developer identifier
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: shared
-      description: Label top-level key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: from_webstore
-      description: True if this extension was installed from the web store
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: threads
-      description: Number of threads used by process
-      type: keyword
-      ignore_above: 1024
-    - name: partition_row_position
-      description: Identifies the position of the referenced memory device in a row of the address partition
-      type: keyword
-      ignore_above: 1024
-    - name: end
-      description: End address of memory region
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: discovery_executions
-      description: The number of times that the discovery queries have been executed since the last time the config was reloaded
-      type: keyword
-      ignore_above: 1024
-    - name: manifest_hash
-      description: The SHA256 hash of the manifest.json file
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: blocks_size
-      description: Byte size of each block
-      type: keyword
-      ignore_above: 1024
-    - name: umci_policy_status
-      description: The status of the User Mode Code Integrity security settings. Returns UNKNOWN if an error is encountered.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: pem
-      description: Certificate PEM format
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: oerrors
-      description: Output errors
-      type: keyword
-      ignore_above: 1024
-    - name: channel_band
-      description: Channel band
-      type: keyword
-      ignore_above: 1024
-    - name: med_capability_inventory
-      description: Is MED inventory capability enabled
-      type: keyword
-      ignore_above: 1024
-    - name: device_locator
-      description: String number of the string that identifies the physically-labeled socket or board position where the memory device is located
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sector_sizes
-      description: Bytes of drive sector sizes
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: failed_login_timestamp
-      description: The time of the last failed login attempt. Resets after a correct password is entered
-      type: keyword
-      ignore_above: 1024
-    - name: modified
-      description: Label top-level key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: variable
-      description: Name of the environment variable
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: csname
-      description: The name of the host the patch is installed on.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: unmask
-      description: If the package is unmasked
-      type: keyword
-      ignore_above: 1024
-    - name: transaction_id
-      description: ID used during bulk update
-      type: keyword
-      ignore_above: 1024
-    - name: link_speed
-      description: Interface speed in Mb/s
-      type: keyword
-      ignore_above: 1024
-    - name: packets_sent
-      description: Number of packets sent on this network
-      type: keyword
-      ignore_above: 1024
-    - name: uid_signed
-      description: User ID as int64 signed (Apple)
-      type: keyword
-      ignore_above: 1024
-    - name: pid
-      description: Process ID
-      type: keyword
-      ignore_above: 1024
-    - name: maintainer
-      description: Repository maintainer
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sha256_fingerprint
-      description: SHA-256 fingerprint
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: signatures_up_to_date
-      description: 1 if product signatures are up to date, else 0
-      type: keyword
-      ignore_above: 1024
-    - name: components
-      description: Repository components
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ipv6_internet
-      description: True if any interface is connected to the Internet via IPv6
-      type: keyword
-      ignore_above: 1024
-    - name: last_loaded
-      description: Last loaded module before panic
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: env_variables
-      description: Container environmental variables
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: other
-      description: Other information associated with array from /proc/mdstat
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: voltage
-      description: The battery's current voltage in mV
-      type: keyword
-      ignore_above: 1024
-    - name: bridge_nf_iptables
-      description: 1 if bridge netfilter iptables is enabled. 0 otherwise
-      type: keyword
-      ignore_above: 1024
-    - name: hostnames
-      description: Raw hosts mapping
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: UUID
       description: Extension unique id
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: cpu_brand
-      description: CPU brand string, contains vendor and model
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: local_ipv4
-      description: Private IPv4 address of the first interface of this instance
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: superblock_state
-      description: State of the superblock
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: interleave_position
-      description: The position of the device in a interleave, i.e. 0 indicates non-interleave, 1 indicates 1st interleave, 2 indicates 2nd interleave, etc.
-      type: keyword
-      ignore_above: 1024
-    - name: mime_encoding
-      description: MIME encoding data from libmagic
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: day
-      description: Current day in the system
-      type: keyword
-      ignore_above: 1024
-    - name: header_size
-      description: Header size in bytes
-      type: keyword
-      ignore_above: 1024
-    - name: args
-      description: Arguments provided to startup executable
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: action
-      description: Appear or disappear
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: actual
-      description: Actual speed
-      type: keyword
-      ignore_above: 1024
-    - name: power_mode
-      description: Device power mode
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: subject_key_id
-      description: SKID an optionally included SHA1
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: chassis_docsis_capability_enabled
-      description: Chassis DOCSIS capability enabled
-      type: keyword
-      ignore_above: 1024
-    - name: statename
-      description: Installation state name. 'Enabled','Disabled','Absent'
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: memory_array_handle
-      description: Handle of the memory array associated with this structure
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: disk_id
-      description: Physical slot number of device, only exists when hardware storage controller exists
-      type: keyword
-      ignore_above: 1024
-    - name: bytes_available
-      description: Bytes available on volume
-      type: keyword
-      ignore_above: 1024
-    - name: remote_port
-      description: Remote network protocol port number
-      type: keyword
-      ignore_above: 1024
-    - name: kernel_memory
-      description: 1 if kernel memory limit support is enabled. 0 otherwise
-      type: keyword
-      ignore_above: 1024
-    - name: event_tap_id
-      description: Unique ID for the Tap
-      type: keyword
-      ignore_above: 1024
-    - name: package_filename
-      description: Filename of original .pkg file
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: fragment_path
-      description: The unit file path this unit was read from, if there is any
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: category
-      description: The UTI that categorizes the app for the App Store
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: lock
-      description: If TRUE, the frame is equipped with a lock.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: stack_trace
-      description: Most recent frame from the stack trace
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: friendly_name
-      description: The friendly display name of the interface.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: idrops
-      description: Input drops
-      type: keyword
-      ignore_above: 1024
-    - name: outiface_mask
-      description: Output interface mask for the rule.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: transmit_rate
-      description: The current transmit rate
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: parent
-      description: Parent process PID
-      type: keyword
-      ignore_above: 1024
-    - name: build_time
-      description: Build time
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: chassis_wlan_capability_enabled
-      description: Chassis wlan capability enabled
-      type: keyword
-      ignore_above: 1024
-    - name: block_size
-      description: Block size in bytes
-      type: keyword
-      ignore_above: 1024
-    - name: script
-      description: The content script used by the extension
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: soft_limit
-      description: Current limit value
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: dns_host_name
-      description: Host name used to identify the local computer for authentication by some utilities.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: tty
-      description: Entry terminal
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: swap_total
-      description: The total amount of swap available, in bytes
-      type: keyword
-      ignore_above: 1024
-    - name: issuer_organization_unit
-      description: Issuer organization unit
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: filename
-      description: Name portion of file path
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: instance_id
-      description: EC2 instance ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: avg_disk_bytes_per_read
-      description: Average number of bytes transferred from the disk during read operations
-      type: keyword
-      ignore_above: 1024
-    - name: env
-      description: Environment variables delimited by spaces
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: next_run_time
-      description: Timestamp the task is scheduled to run next
-      type: keyword
-      ignore_above: 1024
-    - name: algorithm
-      description: algorithm of key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: wired_size
-      description: Bytes of unpageable memory used by process
-      type: keyword
-      ignore_above: 1024
-    - name: kernel_version
-      description: Kernel version
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: board_model
-      description: Board model
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: days
-      description: Days of uptime
-      type: keyword
-      ignore_above: 1024
-    - name: sigrule
-      description: Signature strings used
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: vendor
-      description: Block device vendor string
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: go_version
-      description: Go version
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: port_autoneg_100baset2_fd_enabled
-      description: 100Base-T2 FD auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-    - name: maximum_allowed
-      description: Limit on the maximum number of users allowed to use this resource concurrently. The value is only valid if the AllowMaximum property is set to FALSE.
-      type: keyword
-      ignore_above: 1024
-    - name: cpu_logical_cores
-      description: Number of logical CPU cores available to the system
-      type: keyword
-      ignore_above: 1024
-    - name: task
-      description: Task value associated with the event
-      type: keyword
-      ignore_above: 1024
-    - name: attributes
-      description: 'File attrib string. See: https://ss64.com/nt/attrib.html'
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: vbs_status
-      description: The status of the virtualization based security settings. Returns UNKNOWN if an error is encountered.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: package_group
-      description: Package group
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: crash_path
-      description: Location of log file
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: extended_key_usage
-      description: Extended usage of key in certificate
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: network_tx_bytes
-      description: Total network bytes transmitted
-      type: keyword
-      ignore_above: 1024
-    - name: process_type
-      description: Key describes the intended purpose of the job
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: oid
-      description: Control MIB
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: last_opened_time
-      description: The time that the app was last used
-      type: keyword
-      ignore_above: 1024
-    - name: local_port
-      description: Local network protocol port number
-      type: keyword
-      ignore_above: 1024
-    - name: abi_version
-      description: Section virtual address in memory
-      type: keyword
-      ignore_above: 1024
-    - name: minutes
-      description: Current minutes in the system
-      type: keyword
-      ignore_above: 1024
-    - name: superblock_version
-      description: Version of the superblock
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: domain_controller_name
-      description: The name of the discovered domain controller.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: job_path
-      description: The object path for the job
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: remote_login
-      description: 1 If remote login is enabled else 0
-      type: keyword
-      ignore_above: 1024
-    - name: availability
-      description: The availability and status of the CPU.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: odrops
-      description: Output drops
-      type: keyword
-      ignore_above: 1024
-    - name: inherited_from
-      description: The inheritance policy of the ACE.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: start
-      description: Start address of memory region
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: dc_site_name
-      description: The name of the site where the domain controller is located.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: success
-      description: The socket open attempt status
-      type: keyword
-      ignore_above: 1024
-    - name: user_action
-      description: Action taken by user after prompted
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: port_aggregation_id
-      description: Port aggregation ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: power_8023at_power_type
-      description: 802.3at power type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: med_policies
-      description: Comma delimited list of MED policies
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: atime
-      description: Last access time
-      type: keyword
-      ignore_above: 1024
-    - name: symlink
-      description: 1 if the path is a symlink, otherwise 0
-      type: keyword
-      ignore_above: 1024
-    - name: member_config_value
-      description: Config value
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: reshape_finish
-      description: Estimated duration of reshape activity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: bundle_version
-      description: Info properties CFBundleVersion label
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: homepage
-      description: Package supplied homepage
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: output_bit
-      description: Bit in register value for feature value
-      type: keyword
-      ignore_above: 1024
-    - name: ending_address
-      description: Physical ending address of last kilobyte of a range of memory mapped to physical memory array
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: subsystem_model
-      description: Device description of PCI device subsystem
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: local_time
-      description: Current local UNIX time in the system
-      type: keyword
-      ignore_above: 1024
-    - name: mask
-      description: Interface netmask
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: port_mau_type
-      description: MAU type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: recovery_finish
-      description: Estimated duration of recovery activity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: local_timezone
-      description: Current local timezone in the system
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: uptime
-      description: Time of execution in system uptime
-      type: keyword
-      ignore_above: 1024
-    - name: status
-      description: Status of the carve, can be STARTING, PENDING, SUCCESS, or FAILED
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: psize
-      description: Size of segment in file
-      type: keyword
-      ignore_above: 1024
-    - name: copyright
-      description: Info properties NSHumanReadableCopyright label
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: process_being_tapped
-      description: The process ID of the target application
-      type: keyword
-      ignore_above: 1024
-    - name: resync_progress
-      description: Progress of the resync activity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: bank_locator
-      description: String number of the string that identifies the physically-labeled bank where the memory device is located
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: avg_disk_read_queue_length
-      description: Average number of read requests that were queued for the selected disk during the sample interval
-      type: keyword
-      ignore_above: 1024
-    - name: size
-      description: Size of compiled table data
-      type: keyword
-      ignore_above: 1024
-    - name: version
-      description: Application Layer Firewall version
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: info_string
-      description: Info properties CFBundleGetInfoString label
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: id
-      description: The unique identifier of the drive on the system.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: dhcp_lease_obtained
-      description: Date and time the lease was obtained for the IP address assigned to the computer by the dynamic host configuration protocol (DHCP) server.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: socket
-      description: Socket handle or inode number
-      type: keyword
-      ignore_above: 1024
-    - name: transport_type
-      description: Drive transport type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: bundle_short_version
-      description: Info properties CFBundleShortVersionString label
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: entry
-      description: The whole string entry
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: creator
-      description: Addon-supported creator string
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: policy_constraints
-      description: Policy Constraints
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: redirect_accept
-      description: Accept ICMP redirect messages
-      type: keyword
-      ignore_above: 1024
-    - name: locked
-      description: 1 if segment is locked else 0
-      type: keyword
-      ignore_above: 1024
-    - name: interface
-      description: Interface of the network for the MAC
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: cwd
-      description: Current working directory
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: config_name
-      description: Sensor group
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: keywords
-      description: A bitmask of the keywords defined in the event
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ouid
-      description: Object owner's user ID
-      type: keyword
-      ignore_above: 1024
-    - name: machine
-      description: Machine type
-      type: keyword
-      ignore_above: 1024
-    - name: chassis_docsis_capability_available
-      description: Chassis DOCSIS capability availability
-      type: keyword
-      ignore_above: 1024
-    - name: part_number
-      description: Manufacturer specific serial number of memory device
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: log_file_disk_quota_mb
-      description: Event file disk quota in MB
-      type: keyword
-      ignore_above: 1024
-    - name: user_namespace
-      description: User namespace
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: med_capability_capabilities
-      description: Is MED capabilities enabled
-      type: keyword
-      ignore_above: 1024
-    - name: password_last_set_time
-      description: The time the password was last changed
-      type: keyword
-      ignore_above: 1024
-    - name: timeout
-      description: Label top-level key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: blocks_available
-      description: Mounted device available blocks
-      type: keyword
-      ignore_above: 1024
-    - name: total_size
-      description: Total virtual memory size
-      type: keyword
-      ignore_above: 1024
-    - name: containers
-      description: Total number of containers
-      type: keyword
-      ignore_above: 1024
-    - name: file_version
-      description: File version
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: inetd_compatibility
-      description: Run this daemon or agent as it was launched from inetd
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: chassis_station_capability_available
-      description: Chassis station capability availability
-      type: keyword
-      ignore_above: 1024
-    - name: event_queue
-      description: Size in bytes of Carbon Black event files on disk
-      type: keyword
-      ignore_above: 1024
-    - name: referenced
-      description: 1 if this extension is referenced by the Preferences file of the profile
-      type: keyword
-      ignore_above: 1024
-    - name: port
-      description: Port inside the container
-      type: keyword
-      ignore_above: 1024
-    - name: md_device_name
-      description: md device name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: compressed
-      description: The total number of pages that have been compressed by the VM compressor.
-      type: keyword
-      ignore_above: 1024
-    - name: remediation_path
-      description: Remediation path
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: series
-      description: The series of the gpu.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: wall_time
-      description: Total wall time spent executing
-      type: keyword
-      ignore_above: 1024
-    - name: file_sharing
-      description: 1 If file sharing is enabled else 0
-      type: keyword
-      ignore_above: 1024
-    - name: fahrenheit
-      description: Temperature in Fahrenheit
-      type: keyword
-      ignore_above: 1024
-    - name: major_version
-      description: Windows major version of the machine
-      type: keyword
-      ignore_above: 1024
-    - name: rtadv_accept
-      description: Accept ICMP Router Advertisement
-      type: keyword
-      ignore_above: 1024
-    - name: asset_tag
-      description: Manufacturer specific asset tag of memory device
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: object_type
-      description: Object Type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: current_clock_speed
-      description: The current frequency of the CPU.
-      type: keyword
-      ignore_above: 1024
-    - name: chassis_tel_capability_available
-      description: Chassis telephone capability availability
-      type: keyword
-      ignore_above: 1024
-    - name: client_site_name
-      description: The name of the site where the domain controller is configured.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: script_path
-      description: The path for the Powershell script
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: icon_mode
-      description: Thumbnail icon mode
-      type: keyword
-      ignore_above: 1024
-    - name: percent_remaining
-      description: The percentage of battery remaining before it is drained
-      type: keyword
-      ignore_above: 1024
-    - name: drive_letter
-      description: Drive letter of the encrypted drive.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: username
-      description: Username
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: shell
-      description: User's configured default shell
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: average_memory
-      description: Average private memory left after executing
-      type: keyword
-      ignore_above: 1024
-    - name: encryption
-      description: Last known encrypted state
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: kva_shadow_enabled
-      description: Kernel Virtual Address shadowing is enabled.
-      type: keyword
-      ignore_above: 1024
-    - name: nr_raid_disks
-      description: Number of partitions or disk devices to comprise the array
-      type: keyword
-      ignore_above: 1024
-    - name: error_granularity
-      description: Granularity to which the error can be resolved
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ata_version
-      description: ATA version of drive
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sku
-      description: SKU for the VM image
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: option_name
-      description: Option name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: connection_id
-      description: Name of the network connection as it appears in the Network Connections Control Panel program.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: date
-      description: Driver date
-      type: keyword
-      ignore_above: 1024
-    - name: content_type
-      description: Package content_type (optional)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: volume_size
-      description: (Optional) size of firmware volume
-      type: keyword
-      ignore_above: 1024
-    - name: current_directory
-      description: Current working directory of the crashed process
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: signature
-      description: Signature
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ejectable
-      description: 1 if ejectable, 0 if not
-      type: keyword
-      ignore_above: 1024
-    - name: cpu_kernelmode_usage
-      description: CPU kernel mode usage
-      type: keyword
-      ignore_above: 1024
-    - name: recovery_progress
-      description: Progress of the recovery activity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: executions
-      description: Number of times the query was executed
-      type: keyword
-      ignore_above: 1024
-    - name: cosine_similarity
-      description: How similar the Powershell script is to a provided 'normal' character frequency
-      type: keyword
-      ignore_above: 1024
-    - name: logging_option
-      description: Firewall logging option
-      type: keyword
-      ignore_above: 1024
-    - name: operation
-      description: Permission requested by the process
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: guest_nice
-      description: 'Time spent running a niced guest '
-      type: keyword
-      ignore_above: 1024
-    - name: http_proxy
-      description: HTTP proxy
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: major
-      description: Major release version
-      type: keyword
-      ignore_above: 1024
-    - name: sdk_version
-      description: osquery SDK version used to build the extension
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: hit_count
-      description: Number of cache hits on thumbnail
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: designed_capacity
-      description: The battery's designed capacity in mAh
-      type: keyword
-      ignore_above: 1024
-    - name: authority_key_id
-      description: AKID an optionally included SHA1
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: started_at
-      description: Container start time as string
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: blocks_free
-      description: Mounted device free blocks
-      type: keyword
-      ignore_above: 1024
-    - name: win_timestamp
-      description: Timestamp value in 100 nanosecond units.
-      type: keyword
-      ignore_above: 1024
-    - name: bssid
-      description: The current basic service set identifier
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: datetime
-      description: Date/Time at which the crash occurred
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: registry_path
-      description: Extension identifier
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: serial_port_enabled
-      description: Indicates if serial port is enabled for the VM
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: error
-      description: Error information
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: key_file
-      description: Path to the authorized_keys file
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: os_type
-      description: Linux or Windows
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: port_id_type
-      description: Port ID type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: port_autoneg_10baset_fd_enabled
-      description: 10Base-T FD auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-    - name: update_source_server
-      description: Server for image update
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: disk_bytes_written
-      description: Bytes written to disk
-      type: keyword
-      ignore_above: 1024
-    - name: uninstall_string
-      description: Path and filename of the uninstaller.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: session_owner
-      description: Label top-level key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: collect_file_mods
-      description: If the sensor is configured to collect file modification events
-      type: keyword
-      ignore_above: 1024
-    - name: mem
-      description: Memory utilization as percentage
-      type: keyword
-      ignore_above: 1024
-    - name: opaque_version
-      description: Version of Gatekeeper's gkopaque.bundle
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: auid
-      description: Audit User ID at process start
-      type: keyword
-      ignore_above: 1024
-    - name: ppid
-      description: Parent process ID
-      type: keyword
-      ignore_above: 1024
-    - name: query_language
-      description: Query language that the query is written in.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: carve_guid
-      description: Identifying value of the carve session
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: info_access
-      description: Authority Information Access
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: has_expired
-      description: 1 if the certificate has expired, 0 otherwise
-      type: keyword
-      ignore_above: 1024
-    - name: check_array_progress
-      description: Progress of the check array activity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: applescript_enabled
-      description: Info properties NSAppleScriptEnabled label
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: optional_permissions
-      description: The permissions optionally required by the extensions
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: dns_domain_suffix_search_order
-      description: Array of DNS domain suffixes to be appended to the end of host names during name resolution.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: board_serial
-      description: Board serial number
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: mac
-      description: MAC address of broadcasted address
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: cpu_usermode_usage
-      description: CPU user mode usage
-      type: keyword
-      ignore_above: 1024
-    - name: chassis_id
-      description: Neighbor chassis ID value
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: core
-      description: Name of the cpu (core)
-      type: keyword
-      ignore_above: 1024
-    - name: inode
-      description: Filesystem inode number
-      type: keyword
-      ignore_above: 1024
-    - name: power_8023at_enabled
-      description: Is 802.3at enabled
-      type: keyword
-      ignore_above: 1024
-    - name: reshape_progress
-      description: Progress of the reshape activity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: percent_disk_time
-      description: Percentage of elapsed time that the selected disk drive is busy servicing read or write requests
-      type: keyword
-      ignore_above: 1024
-    - name: path
-      description: Path to the executable that is excepted
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: device_id
-      description: ID of the encrypted drive.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: persistent
-      description: 1 If extension is persistent across all tabs else 0
-      type: keyword
-      ignore_above: 1024
-    - name: sig_group
-      description: Signature group used
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: env_count
-      description: Number of environment variables
-      type: keyword
-      ignore_above: 1024
-    - name: computer_name
-      description: Friendly computer name (optional)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: free
-      description: Total number of free pages.
-      type: keyword
-      ignore_above: 1024
-    - name: watch_paths
-      description: Key that launches daemon or agent if path is modified
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: discovery_cache_hits
-      description: The number of times that the discovery query used cached values since the last time the config was reloaded
-      type: keyword
-      ignore_above: 1024
-    - name: root
-      description: Process virtual root directory
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: database
-      description: Whether the server is a database node (1) or not (0)
-      type: keyword
-      ignore_above: 1024
-    - name: total_width
-      description: Total width, in bits, of this memory device, including any check or error-correction bits
-      type: keyword
-      ignore_above: 1024
-    - name: parent_ref_number
-      description: The ordinal that associates a journal record with a filename's parent directory
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: address_width
-      description: The width of the CPU address bus.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: format
-      description: The format of the print job
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: last_run_time
-      description: Timestamp the task last ran
-      type: keyword
-      ignore_above: 1024
-    - name: profile
-      description: Apparmor profile name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: comm
-      description: Command-line name of the command that was used to invoke the analyzed process
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: tries
-      description: Label top-level key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: active_state
-      description: The high-level unit activation state, i.e. generalization of SUB
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: color_depth
-      description: The amount of bits per pixel to represent color.
-      type: keyword
-      ignore_above: 1024
-    - name: folder_id
-      description: Folder identifier for the VM
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: handler
-      description: Application label for the handler
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: collect_data_file_writes
-      description: If the sensor is configured to collect non binary file writes
-      type: keyword
-      ignore_above: 1024
-    - name: memory_array_mapped_address_handle
-      description: Handle of the memory array mapped address to which this device range is mapped to
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: vendor_id
-      description: Hex encoded Hardware vendor identifier
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: mtu
-      description: Network MTU
-      type: keyword
-      ignore_above: 1024
-    - name: kva_shadow_inv_pcid
-      description: Kernel VA INVPCID is enabled.
-      type: keyword
-      ignore_above: 1024
-    - name: hwaddr
-      description: Hardware address for this network
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: inactive
-      description: The total amount of buffer or page cache memory, in bytes, that are free and available
-      type: keyword
-      ignore_above: 1024
-    - name: pid_namespace
-      description: PID namespace
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: layer_id
-      description: Layer ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: tapping_process
-      description: The process ID of the application that created the event tap.
-      type: keyword
-      ignore_above: 1024
-    - name: kva_shadow_pcid
-      description: Kernel VA PCID flushing optimization is enabled.
-      type: keyword
-      ignore_above: 1024
-    - name: update_source_alias
-      description: Alias of image at update source server
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: fsgid
-      description: Filesystem group ID at process start
-      type: keyword
-      ignore_above: 1024
-    - name: audible_alarm
-      description: If TRUE, the frame is equipped with an audible alarm.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: cpu_cfs_period
-      description: 1 if CPU Completely Fair Scheduler (CFS) period support is enabled. 0 otherwise
-      type: keyword
-      ignore_above: 1024
-    - name: service_key
-      description: Driver service registry key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: rssi
-      description: The current received signal strength indication (dbm)
-      type: keyword
-      ignore_above: 1024
-    - name: build_number
-      description: Windows build number of the crashing machine
-      type: keyword
-      ignore_above: 1024
-    - name: minute
-      description: The exact minute for the job
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: memory_max_usage
-      description: Memory maximum usage
-      type: keyword
-      ignore_above: 1024
-    - name: port_autoneg_100basetx_fd_enabled
-      description: 100Base-TX FD auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-    - name: elapsed_time
-      description: Elapsed time in seconds this process has been running.
-      type: keyword
-      ignore_above: 1024
-    - name: smart_supported
-      description: SMART support status
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: filter
-      description: Reference to an instance of __EventFilter that represents the object path to an event filter which is a query that specifies the type of event to be received.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ipv4_forwarding
-      description: 1 if IPv4 forwarding is enabled. 0 otherwise
-      type: keyword
-      ignore_above: 1024
-    - name: dns_domain_name
-      description: The DNS name for the owner of the logon session.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: data
-      description: Magic number data from libmagic
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: min_version
-      description: The minimum allowed plugin version.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: offer
-      description: Offer information for the VM image (Azure image gallery VMs only)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: memory_device_handle
-      description: Handle of the memory device structure associated with this structure
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: subsystem_model_id
-      description: Model ID of PCI device subsystem
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: superblock_update_time
-      description: Unix timestamp of last update
-      type: keyword
-      ignore_above: 1024
-    - name: owner_uuid
-      description: Extension route UUID (0 for core)
-      type: keyword
-      ignore_above: 1024
-    - name: privileged
-      description: If privileged it will run as root, else as an anonymous user
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: device
-      description: Absolute file path to device node
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: dependencies
-      description: Module dependencies existing in crashed module's backtrace
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: disk_index
-      description: Physical drive number of the disk.
-      type: keyword
-      ignore_above: 1024
-    - name: logon_type
-      description: The logon method.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: watcher
-      description: Process (or thread/handle) ID of optional watcher process
-      type: keyword
-      ignore_above: 1024
-    - name: unix_time
-      description: Current UNIX time in the system, converted to UTC if --utc enabled
-      type: keyword
-      ignore_above: 1024
-    - name: option
-      description: Canonical name of option
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: permanent
-      description: 1 for true, 0 for false
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: breach_description
-      description: If provided, gives a more detailed description of a detected security breach.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: md5
-      description: MD5 hash of table content
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: node
-      description: The node path of the configuration item
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: uncompressed
-      description: Total number of uncompressed pages.
-      type: keyword
-      ignore_above: 1024
-    - name: basic_constraint
-      description: Basic Constraints
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: memory_error_info_handle
-      description: Handle, or instance number, associated with any error that was detected for the array
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: registers
-      description: The value of the system registers
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: event
-      description: The job @event name (rare)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: bytes
-      description: Number of bytes in the response
-      type: keyword
-      ignore_above: 1024
-    - name: optional
-      description: Match any of the identities/patterns for this XProtect name
-      type: keyword
-      ignore_above: 1024
-    - name: carve
-      description: Set this value to '1' to start a file carve
-      type: keyword
-      ignore_above: 1024
-    - name: chassis_station_capability_enabled
-      description: Chassis station capability enabled
-      type: keyword
-      ignore_above: 1024
-    - name: rapl_power_units
-      description: Run Time Average Power Limiting power units.
-      type: keyword
-      ignore_above: 1024
-    - name: ctime
-      description: Creation time
-      type: keyword
-      ignore_above: 1024
-    - name: inodes
-      description: Number of meta nodes
-      type: keyword
-      ignore_above: 1024
-    - name: on_demand
-      description: Deprecated key, replaced by keep_alive
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: port_description
-      description: Port description
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: value
-      description: Variable typed option value
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: disabled
-      description: Is the plugin disabled. 1 = Disabled
-      type: keyword
-      ignore_above: 1024
-    - name: irq
-      description: Time spent servicing interrupts
-      type: keyword
-      ignore_above: 1024
-    - name: destination
-      description: The printer the job was sent to
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: home_directory_drive
-      description: The drive location of the home directory of the logon session.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: array_handle
-      description: The memory array that the device is attached to
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: error_operation
-      description: Memory access operation that caused the error
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: build_distro
-      description: osquery toolkit platform distribution name (os version)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: domain
-      description: Active Directory trust domain
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: info
-      description: Additional information
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: amperage
-      description: The battery's current amperage in mA
-      type: keyword
-      ignore_above: 1024
-    - name: mft_entry
-      description: Directory master file table entry.
-      type: keyword
-      ignore_above: 1024
-    - name: time_range
-      description: System time to selectively filter the events
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: packets
-      description: Number of matching packets for this rule.
-      type: keyword
-      ignore_above: 1024
-    - name: server_name
-      description: Name of the LXD server node
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: principal
-      description: User or group to which the ACE applies.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: enabled
-      description: 1 if this handler is the OS default, else 0
-      type: keyword
-      ignore_above: 1024
-    - name: minimum_system_version
-      description: Minimum version of OS X required for the app to run
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: bitmap_chunk_size
-      description: Bitmap chunk size
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: record_timestamp
-      description: Journal record timestamp
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: build
-      description: Optional build-specific or variant string
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: max
-      description: Maximum speed
-      type: keyword
-      ignore_above: 1024
-    - name: strings
-      description: Matching strings
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: apparmor
-      description: Apparmor Status like ALLOWED, DENIED etc.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: attach
-      description: Which executable(s) a profile will attach to.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: description
-      description: Description of the SDB.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: passpoint
-      description: 1 if Passpoint is supported, 0 otherwise
-      type: keyword
-      ignore_above: 1024
-    - name: bytes_received
-      description: Number of bytes received on this network
-      type: keyword
-      ignore_above: 1024
-    - name: rapl_energy_status
-      description: Run Time Average Power Limiting energy status.
-      type: keyword
-      ignore_above: 1024
-    - name: model
-      description: The battery's model number
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: day_of_week
-      description: The day of the week for the job
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: chassis_other_capability_available
-      description: Chassis other capability availability
-      type: keyword
-      ignore_above: 1024
-    - name: group_sid
-      description: Unique group ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: port_id
-      description: Port ID value
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: label
-      description: AppArmor label
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: swap_cached
-      description: The amount of swap, in bytes, used as cache memory
-      type: keyword
-      ignore_above: 1024
-    - name: ssid
-      description: SSID octets of the network
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: firewall
-      description: The health of the monitored Firewall (see windows_security_products)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: command_line_template
-      description: Standard string template that specifies the process to be started. This property can be NULL, and the ExecutablePath property is used as the command line.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: external
-      description: 1 if this handler does NOT exist on OS X by default, else 0
-      type: keyword
-      ignore_above: 1024
-    - name: iam_arn
-      description: If there is an IAM role associated with the instance, contains instance profile ARN
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: is_elevated_token
-      description: Process uses elevated token yes=1, no=0
-      type: keyword
-      ignore_above: 1024
-    - name: cdhash
-      description: Hash of the application Code Directory
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: hardware_vendor
-      description: Hardware vendor
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: organization_unit
-      description: Organization unit issued to
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: busy_state
-      description: 1 if the device is in a busy state else 0
-      type: keyword
-      ignore_above: 1024
-    - name: content_caching
-      description: 1 If content caching is enabled else 0
-      type: keyword
-      ignore_above: 1024
-    - name: cache_path
-      description: Path to cache data
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: internet_sharing
-      description: 1 If internet sharing is enabled else 0
-      type: keyword
-      ignore_above: 1024
-    - name: copy
-      description: Total number of copy-on-write pages.
-      type: keyword
-      ignore_above: 1024
-    - name: finished_at
-      description: Container finish time as string
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: driver_key
-      description: Driver key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: target_path
-      description: The path associated with the event
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: config_hash
-      description: Hash of the working configuration state
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: repository
-      description: From which repository the ebuild was used
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: env_size
-      description: Actual size (bytes) of environment list
-      type: keyword
-      ignore_above: 1024
-    - name: hash_resources
-      description: Set to 1 to also hash resources, or 0 otherwise. Default is 1
-      type: keyword
-      ignore_above: 1024
-    - name: hours
-      description: Hours of uptime
-      type: keyword
-      ignore_above: 1024
-    - name: release
-      description: Release name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: port_autoneg_1000basex_fd_enabled
-      description: 1000Base-X FD auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-    - name: memory_array_error_address
-      description: 32 bit physical address of the error based on the addressing of the bus to which the memory array is connected
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: max_voltage
-      description: Maximum operating voltage of device in millivolts
-      type: keyword
-      ignore_above: 1024
-    - name: is_active
-      description: 1 if the application is in focus, 0 otherwise
-      type: keyword
-      ignore_above: 1024
-    - name: input_eax
-      description: Value of EAX used
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: images
-      description: Number of images
-      type: keyword
-      ignore_above: 1024
-    - name: power_paircontrol_enabled
-      description: Is power pair control enabled
-      type: keyword
-      ignore_above: 1024
-    - name: provider_guid
-      description: Provider guid of the event
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: disk_read
-      description: Total disk read bytes
-      type: keyword
-      ignore_above: 1024
-    - name: member_config_name
-      description: Name of configuration parameter
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: domain_name
-      description: The name of the domain.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: hash_alg
-      description: Password hashing algorithm
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: block
-      description: The host or match block
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sha1_fingerprint
-      description: SHA1 fingerprint
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: signature_algorithm
-      description: Signature Algorithm
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: preread
-      description: UNIX time when stats were last read
-      type: keyword
-      ignore_above: 1024
-    - name: containers_running
-      description: Number of containers currently running
-      type: keyword
-      ignore_above: 1024
-    - name: dtime
-      description: Detached time
-      type: keyword
-      ignore_above: 1024
-    - name: subject_name
-      description: The certificate subject name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: resource_group_name
-      description: Resource group for the VM
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: response_code
-      description: The HTTP status code for the response
-      type: keyword
-      ignore_above: 1024
-    - name: warnings
-      description: Warning messages from SMART controller
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: zero_fill
-      description: Total number of zero filled pages.
-      type: keyword
-      ignore_above: 1024
-    - name: antispyware
-      description: The health of the monitored Antispyware solution (see windows_security_products)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: dev_id_enabled
-      description: 1 If a Gatekeeper allows execution from identified developers else 0
-      type: keyword
-      ignore_above: 1024
-    - name: denylisted
-      description: 1 if the query is denylisted else 0
-      type: keyword
-      ignore_above: 1024
-    - name: title
-      description: Title of the printed job
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: valid_from
-      description: Period of validity start date
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: cgroup_driver
-      description: Control groups driver
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: root_volume_uuid
-      description: Root UUID of backup volume
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: wired
-      description: Total number of wired down pages.
-      type: keyword
-      ignore_above: 1024
-    - name: auto_login
-      description: 1 if auto login is enabled, 0 otherwise
-      type: keyword
-      ignore_above: 1024
-    - name: exception_type
-      description: Exception type of the crash
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: network_rx_bytes
-      description: Total network bytes read
-      type: keyword
-      ignore_above: 1024
-    - name: pseudo
-      description: 1 If path is a pseudo path, else 0
-      type: keyword
-      ignore_above: 1024
-    - name: session_id
-      description: The Terminal Services session identifier.
-      type: keyword
-      ignore_above: 1024
-    - name: collect_module_loads
-      description: If the sensor is configured to capture module loads
-      type: keyword
-      ignore_above: 1024
-    - name: filesystem
-      description: Filesystem if available
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ami_id
-      description: AMI ID used to launch this EC2 instance
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: authority_key_identifier
-      description: Authority Key Identifier
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: owner_gid
-      description: File owner group ID
-      type: keyword
-      ignore_above: 1024
-    - name: internal
-      description: 1 If the plugin is internal else 0
-      type: keyword
-      ignore_above: 1024
-    - name: bundle_path
-      description: Application bundle used by the sandbox
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: creator_uid
-      description: User ID of creator process
-      type: keyword
-      ignore_above: 1024
-    - name: team
-      description: Signing team ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: address
-      description: IPv4 address target
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: collect_reg_mods
-      description: If the sensor is configured to collect registry modification events
-      type: keyword
-      ignore_above: 1024
-    - name: created_by
-      description: Created by instruction
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: security_options
-      description: List of container security options
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: net_namespace
-      description: Network namespace
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: unique_chip_id
-      description: Unique id of the iBridge controller
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: opackets
-      description: Output packets
-      type: keyword
-      ignore_above: 1024
-    - name: error_type
-      description: type of error associated with current error status for array or device
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: allow_root
-      description: Label top-level key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: iowait
-      description: Time spent waiting for I/O to complete
-      type: keyword
-      ignore_above: 1024
-    - name: start_time
-      description: Process start in seconds since boot (non-sleeping)
-      type: keyword
-      ignore_above: 1024
-    - name: cpu_type
-      description: Indicates the specific processor designed for installation.
-      type: keyword
-      ignore_above: 1024
-    - name: chassis_repeater_capability_available
-      description: Chassis repeater capability availability
-      type: keyword
-      ignore_above: 1024
-    - name: count
-      description: Number of times the application has been executed.
-      type: keyword
-      ignore_above: 1024
-    - name: med_capability_mdi_pse
-      description: Is MED MDI PSE capability enabled
-      type: keyword
-      ignore_above: 1024
-    - name: med_capability_mdi_pd
-      description: Is MED MDI PD capability enabled
-      type: keyword
-      ignore_above: 1024
-    - name: bitmap_on_mem
-      description: Pages allocated in in-memory bitmap, if enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: install_timestamp
-      description: Extension install time, converted to unix time
-      type: keyword
-      ignore_above: 1024
-    - name: https_proxy
-      description: HTTPS proxy
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: file_id
-      description: file ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: config_valid
-      description: 1 if the config was loaded and considered valid, else 0
-      type: keyword
-      ignore_above: 1024
-    - name: development_region
-      description: Info properties CFBundleDevelopmentRegion label
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: log_file_disk_quota_percentage
-      description: Event file disk quota in a percentage
-      type: keyword
-      ignore_above: 1024
-    - name: processor_type
-      description: The processor type, such as Central, Math, or Video.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: max_clock_speed
-      description: The maximum possible frequency of the CPU.
-      type: keyword
-      ignore_above: 1024
-    - name: policies
-      description: Certificate Policies
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: authorizations
-      description: A space delimited set of authorization attributes
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: space_used
-      description: Storage space used in bytes
-      type: keyword
-      ignore_above: 1024
-    - name: space_total
-      description: Total available storage space in bytes for this storage pool
-      type: keyword
-      ignore_above: 1024
-    - name: minutes_to_full_charge
-      description: The number of minutes until the battery is fully charged. This value is -1 if this time is still being calculated
-      type: keyword
-      ignore_above: 1024
-    - name: probe_error
-      description: Set to 1 if one or more buffers could not be captured
-      type: keyword
-      ignore_above: 1024
-    - name: browser_type
-      description: 'The browser type (Valid values: chrome, chromium, opera, yandex, brave)'
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: metric_name
-      description: Name of collected Prometheus metric
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: partition_width
-      description: Number of memory devices that form a single row of memory for the address partition of this structure
-      type: keyword
-      ignore_above: 1024
-    - name: subscriptions
-      description: Number of subscriptions the publisher received or subscriber used
-      type: keyword
-      ignore_above: 1024
-    - name: execution_flag
-      description: Boolean Execution flag, 1 for execution, 0 for no execution, -1 for missing (this flag does not exist on Windows 10 and higher).
-      type: keyword
-      ignore_above: 1024
-    - name: speculative
-      description: Total number of speculative pages.
-      type: keyword
-      ignore_above: 1024
-    - name: mount_namespace_id
-      description: Mount namespace id
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: system_model
-      description: Physical system model, for example 'MacBookPro12,1 (Mac-E43C1C25D4880AD6)'
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: valuetype
-      description: CoreFoundation type of data stored in value
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: logging_driver
-      description: Logging driver
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: bp_mitigations
-      description: Branch Prediction mitigations are enabled.
-      type: keyword
-      ignore_above: 1024
-    - name: expires_at
-      description: ISO time of image expiration
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: target_name
-      description: Address of prometheus target
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sdb_id
-      description: Unique GUID of the SDB.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: extra
-      description: Extra columns, in JSON format. Queries against this column are performed entirely in SQLite, so do not benefit from efficient querying via asl.h.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: security_breach
-      description: The physical status of the chassis such as Breach Successful, Breach Attempted, etc.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: throttled
-      description: Total number of throttled pages.
-      type: keyword
-      ignore_above: 1024
-    - name: last_connected
-      description: Last time this netword was connected to as a unix_time
-      type: keyword
-      ignore_above: 1024
-    - name: type
-      description: Event type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: cpu_pred_cmd_supported
-      description: PRED_CMD MSR supported by CPU Microcode.
-      type: keyword
-      ignore_above: 1024
-    - name: partner_fd
-      description: File descriptor of shared pipe at partner's end
-      type: keyword
-      ignore_above: 1024
-    - name: refreshes
-      description: 'Publisher only: number of runloop restarts'
-      type: keyword
-      ignore_above: 1024
-    - name: password_status
-      description: Password status
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: binary_queue
-      description: Size in bytes of binaries waiting to be sent to Carbon Black server
-      type: keyword
-      ignore_above: 1024
-    - name: idle
-      description: Time spent in the idle task
-      type: keyword
-      ignore_above: 1024
-    - name: gid_signed
-      description: A signed int64 version of gid
-      type: keyword
-      ignore_above: 1024
-    - name: packets_received
-      description: Number of packets received on this network
-      type: keyword
-      ignore_above: 1024
-    - name: original_program_name
-      description: The original program name that the publisher has signed
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ipv4_internet
-      description: True if any interface is connected to the Internet via IPv4
-      type: keyword
-      ignore_above: 1024
-    - name: netmask
-      description: Address (sortlist) netmask length
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: base_image
-      description: ID of image used to launch this instance
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: slot
-      description: Slot position of disk
-      type: keyword
-      ignore_above: 1024
-    - name: current_locale
-      description: Current locale supported by extension
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: gateway
-      description: Gateway
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: read
-      description: UNIX time when stats were read
-      type: keyword
-      ignore_above: 1024
-    - name: identifying_number
-      description: Product identification such as a serial number on software, or a die number on a hardware chip.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: hardware_serial
-      description: Device serial number
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: class
-      description: Label top-level key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: binding
-      description: Binding type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: certificate
-      description: Certificate content
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: pgroup
-      description: Process group
-      type: keyword
-      ignore_above: 1024
-    - name: facility
-      description: Sender's facility.  Default is 'user'.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: authenticate_user
-      description: Label top-level key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: day_of_month
-      description: The day of the month for the job
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: subsystem_vendor_id
-      description: Vendor ID of PCI device subsystem
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: hidden
-      description: Whether or not the task is visible in the UI
-      type: keyword
-      ignore_above: 1024
-    - name: smbios_tag
-      description: The assigned asset tag number of the chassis.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: month
-      description: The month of the year for the job
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: port_autoneg_enabled
-      description: Is auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-    - name: retain_count
-      description: The device reference count
-      type: keyword
-      ignore_above: 1024
-    - name: record_usn
-      description: The update sequence number that identifies the journal record
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: hard_limit
-      description: Maximum limit value
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: command_line
-      description: Command-line string passed to the crashed process
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: optional_permissions_json
-      description: The JSON-encoded permissions optionally required by the extensions
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: processing_time
-      description: How long the job took to process
-      type: keyword
-      ignore_above: 1024
-    - name: alias
-      description: Protocol alias
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: platform_mask
-      description: The osquery platform bitmask
-      type: keyword
-      ignore_above: 1024
-    - name: service_type
-      description: 'Service Type: OWN_PROCESS, SHARE_PROCESS and maybe Interactive (can interact with the desktop)'
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: max_capacity
-      description: The battery's actual capacity when it is fully charged in mAh
-      type: keyword
-      ignore_above: 1024
-    - name: visible
-      description: 1 If the addon is shown in browser else 0
-      type: keyword
-      ignore_above: 1024
-    - name: vlans
-      description: Comma delimited list of vlan ids
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: turbo_disabled
-      description: Whether the turbo feature is disabled.
-      type: keyword
-      ignore_above: 1024
-    - name: collect_store_files
-      description: If the sensor is configured to send back binaries to the Carbon Black server
-      type: keyword
-      ignore_above: 1024
-    - name: queue_directories
-      description: Similar to watch_paths but only with non-empty directories
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: port_autoneg_100basetx_hd_enabled
-      description: 100Base-TX HD auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-    - name: video_mode
-      description: The current resolution of the display.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sha1
-      description: A unique hash that identifies this policy.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ipv6_local_network
-      description: True if any interface is connected to a routed network via IPv6
-      type: keyword
-      ignore_above: 1024
-    - name: driver_date
-      description: The date listed on the installed driver.
-      type: keyword
-      ignore_above: 1024
-    - name: collect_module_info
-      description: If the sensor is configured to collect metadata of binaries
-      type: keyword
-      ignore_above: 1024
-    - name: inf
-      description: Associated inf file
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: power_8023at_power_requested
-      description: 802.3at power requested
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: collect_process_user_context
-      description: If the sensor is configured to collect the user running a process
-      type: keyword
-      ignore_above: 1024
-    - name: logical_processors
-      description: The number of logical processors of the CPU.
-      type: keyword
-      ignore_above: 1024
-    - name: physical_adapter
-      description: Indicates whether the adapter is a physical or a logical adapter.
-      type: keyword
-      ignore_above: 1024
-    - name: chassis_other_capability_enabled
-      description: Chassis other capability enabled
-      type: keyword
-      ignore_above: 1024
-    - name: provider_name
-      description: Provider name of the event
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: state
-      description: Firewall exception state
-      type: keyword
-      ignore_above: 1024
-    - name: denied_mask
-      description: Denied permissions for the process
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: identifier
-      description: Plugin identifier
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: level
-      description: Log level number.  See levels in asl.h.
-      type: keyword
-      ignore_above: 1024
-    - name: manufacturer
-      description: The battery manufacturer's name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: assessments_enabled
-      description: 1 If a Gatekeeper is enabled else 0
-      type: keyword
-      ignore_above: 1024
-    - name: cpus
-      description: Number of CPUs
-      type: keyword
-      ignore_above: 1024
-    - name: logon_domain
-      description: The name of the domain used to authenticate the owner of the logon session.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: bitmap_external_file
-      description: External referenced bitmap file
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: vendor_syndrome
-      description: Vendor specific ECC syndrome or CRC data associated with the erroneous access
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: field_name
-      description: Specific attribute of opaque type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: name
-      description: ACPI table name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: tid
-      description: Thread ID
-      type: keyword
-      ignore_above: 1024
-    - name: encryption_status
-      description: 'Disk encryption status with one of following values: encrypted | not encrypted | undefined'
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: url
-      description: The url for the request
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: security_groups
-      description: Comma separated list of security group names
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: dns_server_search_order
-      description: Array of server IP addresses to be used in querying for DNS servers.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: allow_signed_enabled
-      description: 1 If allow signed mode is enabled else 0
-      type: keyword
-      ignore_above: 1024
-    - name: offset
-      type: keyword
-      ignore_above: 1024
-    - name: removable
-      description: 1 If USB device is removable else 0
-      type: keyword
-      ignore_above: 1024
-    - name: fd
-      description: The file description for the process socket
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: network_name
-      description: Name of the network
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: bytes_sent
-      description: Number of bytes sent on this network
-      type: keyword
-      ignore_above: 1024
-    - name: device_model
-      description: Device Model
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: rule_details
-      description: Rule definition
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ca
-      description: '1 if CA: true (certificate is an authority) else 0'
-      type: keyword
-      ignore_above: 1024
-    - name: mtime
-      description: Last modification time
-      type: keyword
-      ignore_above: 1024
-    - name: points
-      description: This is a signed SQLite int column
-      type: keyword
-      ignore_above: 1024
-    - name: logon_script
-      description: The script used for logging on.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: created_at
-      description: ISO time of image creation
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: scripting_engine
-      description: Name of the scripting engine to use, for example, 'VBScript'. This property cannot be NULL.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: issuer_common_name
-      description: Issuer common name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: name_constraints
-      description: Name Constraints
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: server_version
-      description: Server version
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: packet_device_type
-      description: Packet device type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: rotation_rate
-      description: Drive RPM
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ipv6_no_traffic
-      description: True if any interface is connected via IPv6, but has seen no traffic
-      type: keyword
-      ignore_above: 1024
-    - name: used_by
-      description: Module reverse dependencies
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: check_array_finish
-      description: Estimated duration of the check array activity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: package_id
-      description: Label packageIdentifiers
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: build_id
-      description: Sandbox-specific identifier
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: location
-      description: Azure Region the VM is running in
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: section
-      description: Package section
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: src_port
-      description: Protocol source port(s).
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: member_config_key
-      description: Config key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: pci_subclass
-      description: PCI Device subclass
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: pre_system_cpu_usage
-      description: Last read CPU system usage
-      type: keyword
-      ignore_above: 1024
-    - name: instance_type
-      description: EC2 instance type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: kva_shadow_user_global
-      description: User pages are marked as global.
-      type: keyword
-      ignore_above: 1024
-    - name: failed_disks
-      description: Number of failed disks in array
-      type: keyword
-      ignore_above: 1024
-    - name: additional_product_id
-      description: An additional drive identifier if any
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: machine_name
-      description: Name of the machine where the crash happened
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: lock_status
-      description: The accessibility status of the drive from Windows.
-      type: keyword
-      ignore_above: 1024
-    - name: local_address
-      description: Local address associated with socket
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: subject_key_identifier
-      description: Subject Key Identifier
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: model_id
-      description: Hex encoded Hardware model identifier
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: load_state
-      description: Reflects whether the unit definition was properly loaded
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sub_state
-      description: The low-level unit activation state, values depend on unit type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: persistent_volume_id
-      description: Persistent ID of the drive.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: encrypted
-      description: '1 If encrypted: true (disk is encrypted), else 0'
-      type: keyword
-      ignore_above: 1024
-    - name: free_space
-      description: The amount of free space, in bytes, of the drive (-1 on failure).
-      type: keyword
-      ignore_above: 1024
-    - name: system_time
-      description: Total system time spent executing
-      type: keyword
-      ignore_above: 1024
-    - name: number_of_cores
-      description: The number of cores of the CPU.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: pre_cpu_total_usage
-      description: Last read total CPU usage
-      type: keyword
-      ignore_above: 1024
-    - name: root_dir
-      description: Docker root directory
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: output_size
-      description: Total number of bytes generated by the query
-      type: keyword
-      ignore_above: 1024
-    - name: program_arguments
-      description: Command line arguments passed to program
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: power_8023at_power_allocated
-      description: 802.3at power allocated
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: memory_total
-      description: Total amount of physical RAM, in bytes
-      type: keyword
-      ignore_above: 1024
-    - name: subject
-      description: Certificate distinguished name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: os
-      description: Operating system
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: bp_system_pol_disabled
-      description: Branch Predictions are disabled via system policy.
-      type: keyword
-      ignore_above: 1024
-    - name: file_system
-      description: The file system of the drive.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: volume_id
-      description: Parsed volume ID from fs_id
-      type: keyword
-      ignore_above: 1024
-    - name: exit_code
-      description: Exit code of the system call
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: endpoint_id
-      description: Endpoint ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: outiface
-      description: Output interface for the rule.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: store_id
-      description: Exists for service/user stores. Contains raw store id provided by WinAPI.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: expand
-      description: 1 if the variable needs expanding, 0 otherwise
-      type: keyword
-      ignore_above: 1024
-    - name: total_seconds
-      description: Total uptime seconds
-      type: keyword
-      ignore_above: 1024
-    - name: hashed
-      description: 1 if the file was hashed, 0 if not, -1 if hashing failed
-      type: keyword
-      ignore_above: 1024
-    - name: med_capability_location
-      description: Is MED location capability enabled
-      type: keyword
-      ignore_above: 1024
-    - name: home_directory
-      description: The home directory for the logon session.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: install_location
-      description: The installation location directory of the product.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: user_capacity
-      description: Bytes of drive capacity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sid
-      description: User SID.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sensor_backend_server
-      description: Carbon Black server
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: online_cpus
-      description: Online CPUs
-      type: keyword
-      ignore_above: 1024
-    - name: read_device_identity_failure
-      description: Error string for device id read, if any
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: driver_type
-      description: The explicit device type used to retrieve the SMART information
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: swap_limit
-      description: 1 if swap limit support is enabled. 0 otherwise
-      type: keyword
-      ignore_above: 1024
-    - name: tag
-      description: Tag ID
-      type: keyword
-      ignore_above: 1024
-    - name: pci_subclass_id
-      description: PCI Device  subclass in hex format
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: usb_port
-      description: USB Device used port
-      type: keyword
-      ignore_above: 1024
-    - name: exception_address
-      description: Address (in hex) where the exception occurred
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: xpath
-      description: The custom query to filter events
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: med_capability_policy
-      description: Is MED policy capability enabled
-      type: keyword
-      ignore_above: 1024
-    - name: memory_type
-      description: Type of memory used
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: fs_id
-      description: Quicklook file fs_id key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: user_uuid
-      description: UUID of authenticated user if available
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: depth
-      description: Device nested depth
-      type: keyword
-      ignore_above: 1024
-    - name: global_state
-      description: 1 If the firewall is enabled with exceptions, 2 if the firewall is configured to block all incoming connections, else 0
-      type: keyword
-      ignore_above: 1024
-    - name: feature
-      description: Present feature flags
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: partition
-      description: A partition number
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: public
-      description: Whether image is public (1) or not (0)
-      type: keyword
-      ignore_above: 1024
-    - name: update_source_protocol
-      description: Protocol used for image information update and image import from source server
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: epoch
-      description: Package epoch value
-      type: keyword
-      ignore_above: 1024
-    - name: module_path
-      description: Path to ServiceDll
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ip_prefix_len
-      description: IP subnet prefix length
-      type: keyword
-      ignore_above: 1024
-    - name: layer_order
-      description: Layer Order (1 = base layer)
-      type: keyword
-      ignore_above: 1024
-    - name: chassis_router_capability_enabled
-      description: Chassis router capability enabled
-      type: keyword
-      ignore_above: 1024
-    - name: port_autoneg_100baset4_hd_enabled
-      description: 100Base-T4 HD auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-    - name: ssh_config_file
-      description: Path to the ssh_config file
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: manifest_json
-      description: The manifest file of the extension
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: completed_time
-      description: When the job completed printing
-      type: keyword
-      ignore_above: 1024
-    - name: linked_against
-      description: Indexes of extensions this extension is linked against
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: max_speed
-      description: Max speed of memory device in megatransfers per second (MT/s)
-      type: keyword
-      ignore_above: 1024
-    - name: readonly
-      description: 1 if the share is exported readonly else 0
-      type: keyword
-      ignore_above: 1024
-    - name: uppid
-      description: The 64bit parent pid that is never reused. Returns -1 if we couldn't gather them from the system.
-      type: keyword
-      ignore_above: 1024
-    - name: cid
-      description: Cgroup ID
-      type: keyword
-      ignore_above: 1024
-    - name: rowid
-      description: Quicklook file rowid key
-      type: keyword
-      ignore_above: 1024
-    - name: checksum
-      description: UDIF Master checksum if available (CRC32)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: region
-      description: AWS region in which this instance launched
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: min
-      description: Minimum speed
-      type: keyword
-      ignore_above: 1024
-    - name: target
-      description: Target speed
-      type: keyword
-      ignore_above: 1024
-    - name: os_version
-      description: Version of the operating system
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: mode
-      description: How the policy is applied.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: created
-      description: Label top-level key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: system
-      description: Time spent in system mode
-      type: keyword
-      ignore_above: 1024
-    - name: hopcount
-      description: Max hops expected
-      type: keyword
-      ignore_above: 1024
-    - name: filetype
-      description: Use this file type to match
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: form_factor
-      description: Implementation form factor for this memory device
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: object_name
-      description: Object Name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: state_timestamp
-      description: Timestamp for the product state
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ssdeep
-      description: ssdeep hash of provided filesystem data
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: pci_slot
-      description: PCI slot number
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: cpu_spec_ctrl_supported
-      description: SPEC_CTRL MSR supported by CPU Microcode.
-      type: keyword
-      ignore_above: 1024
-    - name: configured_voltage
-      description: Configured operating voltage of device in millivolts
-      type: keyword
-      ignore_above: 1024
-    - name: fsuid
-      description: Filesystem user ID
-      type: keyword
-      ignore_above: 1024
-    - name: ipv6_prefix_len
-      description: IPv6 subnet prefix length
-      type: keyword
-      ignore_above: 1024
-    - name: requirement
-      description: Code signing requirement language
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: memory_error_correction
-      description: Primary hardware error correction or detection method supported
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: caption
-      description: Short description of the patch.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: placement_group_id
-      description: Placement group for the VM scale set
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: no_proxy
-      description: Comma-separated list of domain extensions proxy should not be used for
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: boot_partition
-      description: True if Windows booted from this drive.
-      type: keyword
-      ignore_above: 1024
-    - name: port_autoneg_1000baset_hd_enabled
-      description: 1000Base-T HD auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-    - name: last_run_code
-      description: Exit status code of the last task run
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: identity
-      description: XProtect identity (SHA1) of content
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: last_execution_time
-      description: Most recent time application was executed.
-      type: keyword
-      ignore_above: 1024
-    - name: hardware_model
-      description: Hard drive model.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: image_id
-      description: Docker image ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: timezone
-      description: Current timezone in the system
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: hostname
-      description: Hostname (domain[:port]) to CURL
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: mac_address
-      description: MAC address
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: boot_uuid
-      description: Boot UUID of the iBridge controller
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: port_autoneg_100baset4_fd_enabled
-      description: 100Base-T4 FD auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-    - name: board_version
-      description: Board version
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: decompressed
-      description: The total number of pages that have been decompressed by the VM compressor.
-      type: keyword
-      ignore_above: 1024
-    - name: logon_sid
-      description: The user's security identifier (SID).
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: error_resolution
-      description: Range, in bytes, within which this error can be determined, when an error address is given
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: avg_disk_sec_per_write
-      description: Average time, in seconds, of a write operation of data to the disk
-      type: keyword
-      ignore_above: 1024
-    - name: eid
-      description: Event ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: match
-      description: The pattern that the script is matched against
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: memory_usage
-      description: Memory usage
-      type: keyword
-      ignore_above: 1024
-    - name: chunk_size
-      description: chunk size in bytes
-      type: keyword
-      ignore_above: 1024
-    - name: data_width
-      description: Data width, in bits, of this memory device
-      type: keyword
-      ignore_above: 1024
-    - name: dest_path
-      description: The canonical path associated with the event
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: swap_ins
-      description: The total number of compressed pages that have been swapped out to disk.
-      type: keyword
-      ignore_above: 1024
-    - name: gid
-      description: GID that sent the log message (set by the server).
-      type: keyword
-      ignore_above: 1024
-    - name: rid
-      description: Neighbor chassis index
-      type: keyword
-      ignore_above: 1024
-    - name: port_autoneg_1000basex_hd_enabled
-      description: 1000Base-X HD auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-    - name: old_path
-      description: Old path (renames only)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: extensions
-      description: osquery extensions status
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: partner_pid
-      description: Process ID of partner process sharing a particular pipe
-      type: keyword
-      ignore_above: 1024
-    - name: result
-      description: The signature check result
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: uploaded_at
-      description: ISO time of image upload
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: device_alias
-      description: Mounted device alias
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: revision
-      description: Package revision
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: service_exit_code
-      description: The service-specific error code that the service returns when an error occurs while the service is starting or stopping
-      type: keyword
-      ignore_above: 1024
-    - name: created_time
-      description: Directory Created time.
-      type: keyword
-      ignore_above: 1024
-    - name: valid_to
-      description: Period of validity end date
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: logon_time
-      description: The time the session owner logged on.
-      type: keyword
-      ignore_above: 1024
-    - name: plugin
-      description: Authorization plugin name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: cpu_status
-      description: The current operating status of the CPU.
-      type: keyword
-      ignore_above: 1024
-    - name: nice
-      description: Time spent in user mode with low priority (nice)
-      type: keyword
-      ignore_above: 1024
-    - name: user_account
-      description: The name of the account that the service process will be logged on as when it runs. This name can be of the form Domain\UserName. If the account belongs to the built-in domain, the name can be of the form .\UserName.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: environment
-      description: Application-set environment variables
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: euid
-      description: Effective user ID
-      type: keyword
-      ignore_above: 1024
-    - name: program
-      description: Path to target program
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: timestamp
-      description: Current timestamp (log format) in the system
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: uuid
-      description: Block device Universally Unique Identifier
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: addr
-      description: Symbol address (value)
-      type: keyword
-      ignore_above: 1024
-    - name: handle
-      description: Handle, or instance number, associated with the structure
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: faults
-      description: Total number of calls to vm_faults.
-      type: keyword
-      ignore_above: 1024
-    - name: install_date
-      description: The install date of the OS.
-      type: keyword
-      ignore_above: 1024
-    - name: handle_count
-      description: Total number of handles that the process has open. This number is the sum of the handles currently opened by each thread in the process.
-      type: keyword
-      ignore_above: 1024
-    - name: allow_maximum
-      description: Number of concurrent users for this resource has been limited. If True, the value in the MaximumAllowed property is ignored.
-      type: keyword
-      ignore_above: 1024
-    - name: avg_disk_write_queue_length
-      description: Average number of write requests that were queued for the selected disk during the sample interval
-      type: keyword
-      ignore_above: 1024
-    - name: subclass
-      description: USB Device subclass
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sdk
-      description: Build SDK used to compile plugin
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: port_ttl
-      description: Age of neighbor port
-      type: keyword
-      ignore_above: 1024
-    - name: resync_speed
-      description: Speed of resync activity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: roaming
-      description: 1 if roaming is supported, 0 otherwise
-      type: keyword
-      ignore_above: 1024
-    - name: hour
-      description: The hour of the day for the job
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: containers_stopped
-      description: Number of containers in stopped state
-      type: keyword
-      ignore_above: 1024
-    - name: link
-      description: Link to other section
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: backup_date
-      description: Backup Date
-      type: keyword
-      ignore_above: 1024
-    - name: option_value
-      description: Option value
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: module_backtrace
-      description: Modules appearing in the crashed module's backtrace
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: registry_hive
-      description: HKEY_USERS registry hive
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ntime
-      description: The nsecs uptime timestamp as obtained from BPF
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: current_disk_queue_length
-      description: Number of requests outstanding on the disk at the time the performance data is collected
-      type: keyword
-      ignore_above: 1024
-    - name: script_block_id
-      description: The unique GUID of the powershell script to which this block belongs
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: bundle_executable
-      description: Info properties CFBundleExecutable label
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: conversion_status
-      description: The bitlocker conversion status of the drive.
-      type: keyword
-      ignore_above: 1024
-    - name: issuer_organization
-      description: Issuer organization
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: keep_alive
-      description: Should the process be restarted if killed
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: access
-      description: Specific permissions that indicate the rights described by the ACE.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: subsystem_vendor
-      description: Vendor of PCI device subsystem
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: flatsize
-      description: Package size in bytes
-      type: keyword
-      ignore_above: 1024
-    - name: key_algorithm
-      description: Key algorithm used
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: pids
-      description: Number of processes
-      type: keyword
-      ignore_above: 1024
-    - name: ipc_namespace
-      description: IPC namespace
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: windows_security_center_service
-      description: The health of the Windows Security Center Service
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: hop_limit
-      description: Current Hop Limit
-      type: keyword
-      ignore_above: 1024
-    - name: iniface_mask
-      description: Input interface mask for the rule.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: run_at_load
-      description: Should the program run on launch load
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: screen_sharing
-      description: 1 If screen sharing is enabled else 0
-      type: keyword
-      ignore_above: 1024
-    - name: creation_time
-      description: When the account was first created
-      type: keyword
-      ignore_above: 1024
-    - name: namespace
-      description: AppArmor namespace
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: system_cpu_usage
-      description: CPU system usage
-      type: keyword
-      ignore_above: 1024
-    - name: upn
-      description: The user principal name (UPN) for the owner of the logon session.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: recovery_speed
-      description: Speed of recovery activity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: use
-      description: Function for which the array is used
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: disk_bytes_read
-      description: Bytes read from disk
-      type: keyword
-      ignore_above: 1024
-    - name: swap_outs
-      description: The total number of compressed pages that have been swapped back in from disk.
-      type: keyword
-      ignore_above: 1024
-    - name: time
-      description: Time of execution in UNIX time
-      type: keyword
-      ignore_above: 1024
-    - name: stibp_support_enabled
-      description: Windows uses STIBP.
-      type: keyword
-      ignore_above: 1024
-    - name: power_mdi_supported
-      description: MDI power supported
-      type: keyword
-      ignore_above: 1024
-    - name: seconds
-      description: Current seconds in the system
-      type: keyword
-      ignore_above: 1024
-    - name: noise
-      description: The current noise measurement (dBm)
-      type: keyword
-      ignore_above: 1024
-    - name: key
-      description: parsed authorized keys line
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -6113,16 +21,16 @@
           type: text
           norms: false
           default_field: false
-    - name: last_change
-      description: Time of last device modification (optional)
+    - name: abi_version
+      description: Section virtual address in memory
       type: keyword
       ignore_above: 1024
-    - name: ibytes
-      description: Input bytes
-      type: keyword
-      ignore_above: 1024
-    - name: dns_forest_name
-      description: The name of the root of the DNS tree.
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: access
+      description: Specific permissions that indicate the rights described by the ACE.
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -6130,412 +38,13 @@
           type: text
           norms: false
           default_field: false
-    - name: events
-      description: Number of events emitted or received since osquery started
-      type: keyword
-      ignore_above: 1024
-    - name: captive_portal
-      description: 1 if this network has a captive portal, 0 otherwise
-      type: keyword
-      ignore_above: 1024
-    - name: update_url
-      description: Extension-supplied update URI
+    - name: accessed_time
+      description: Directory Accessed time.
       type: keyword
       ignore_above: 1024
       multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: permissions
-      description: The permissions required by the extension
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: partitions
-      description: Number of detected partitions on disk.
-      type: keyword
-      ignore_above: 1024
-    - name: not_valid_before
-      description: Lower bound of valid date
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: scope
-      description: Where the key is located inside the SELinuxFS mount point.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: reactivated
-      description: Total number of reactivated pages.
-      type: keyword
-      ignore_above: 1024
-    - name: ppvids_supported
-      description: Comma delimited list of supported PPVIDs
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ipv4_address
-      description: IPv4 address
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: bytes_used
-      description: Bytes used on volume
-      type: keyword
-      ignore_above: 1024
-    - name: ssh_public_key
-      description: SSH public key. Only available if supplied at instance launch time
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: managed
-      description: 1 if network created by LXD, 0 otherwise
-      type: keyword
-      ignore_above: 1024
-    - name: antivirus
-      description: The health of the monitored Antivirus solution (see windows_security_products)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: summary
-      description: Package-supplied summary
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: subject_info_access
-      description: Subject Information Access
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: reservation_id
-      description: ID of the reservation
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: frame_backtrace
-      description: Backtrace of the crashed module
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: collect_sensor_operations
-      description: Unknown
-      type: keyword
-      ignore_above: 1024
-    - name: propagation
-      description: Mount propagation
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: availability_zone
-      description: Availability zone in which this instance launched
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: memory_limit
-      description: Memory limit
-      type: keyword
-      ignore_above: 1024
-    - name: min_api_version
-      description: Minimum API version supported
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: chassis_repeater_capability_enabled
-      description: Chassis repeater capability enabled
-      type: keyword
-      ignore_above: 1024
-    - name: inodes_used
-      description: Number of inodes used
-      type: keyword
-      ignore_above: 1024
-    - name: metric_value
-      description: Value of collected Prometheus metric
-      type: keyword
-      ignore_above: 1024
-    - name: issuer
-      description: Certificate issuer distinguished name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: not_valid_after
-      description: Certificate expiration data
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: key_usage
-      description: Certificate key usage and extended key usage
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: unused_devices
-      description: Unused devices
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: node_ref_number
-      description: The ordinal that associates a journal record with a filename
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: user_account_control
-      description: The health of the User Account Control (UAC) capability in Windows
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: chassis_mgmt_ips
-      description: Comma delimited list of chassis management IPS
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: build_platform
-      description: osquery toolkit build platform
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: pci_class
-      description: PCI Device class
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ipv4_local_network
-      description: True if any interface is connected to a routed network via IPv4
-      type: keyword
-      ignore_above: 1024
-    - name: num_procs
-      description: Number of processors
-      type: keyword
-      ignore_above: 1024
-    - name: mount_point
-      description: Mount point
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: forwarding_enabled
-      description: Enable IP forwarding
-      type: keyword
-      ignore_above: 1024
-    - name: manual
-      description: 1 if policy was loaded manually, otherwise 0
-      type: keyword
-      ignore_above: 1024
-    - name: memory_type_details
-      description: Additional details for memory device
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: hotfix_id
-      description: The KB ID of the patch.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: current_value
-      description: Value of setting
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: install_time
-      description: Install time of the SDB
-      type: keyword
-      ignore_above: 1024
-    - name: collect_cross_processes
-      description: If the sensor is configured to cross process events
-      type: keyword
-      ignore_above: 1024
-    - name: firmware_version
-      description: The build version of the firmware
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: user_time
-      description: Total user time spent executing
-      type: keyword
-      ignore_above: 1024
-    - name: flag
-      description: Reserved
-      type: keyword
-      ignore_above: 1024
-    - name: collect_processes
-      description: If the sensor is configured to process events
-      type: keyword
-      ignore_above: 1024
-    - name: pvid
-      description: Primary VLAN id
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: magic_db_files
-      description: 'Colon(:) separated list of files where the magic db file can be found. By default one of the following is used: /usr/share/file/magic/magic, /usr/share/misc/magic or /usr/share/misc/magic.mgc'
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: memory_free
-      description: The amount of physical RAM, in bytes, left unused by the system
-      type: keyword
-      ignore_above: 1024
-    - name: installer_name
-      description: Name of installer process
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: installed_by
-      description: The system context in which the patch as installed.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: percent_idle_time
-      description: Percentage of time during the sample interval that the disk was idle
-      type: keyword
-      ignore_above: 1024
-    - name: driver_version
-      description: The version of the installed driver.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: pre_cpu_kernelmode_usage
-      description: Last read CPU kernel mode usage
-      type: keyword
-      ignore_above: 1024
-    - name: device_name
-      description: Device name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
+        - name: number
+          type: long
           default_field: false
     - name: account_id
       description: AWS account ID which owns this EC2 instance
@@ -6546,862 +55,8 @@
           type: text
           norms: false
           default_field: false
-    - name: processor_number
-      description: The processor number as reported in /proc/cpuinfo
-      type: keyword
-      ignore_above: 1024
-    - name: capname
-      description: Capability requested by the process
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: charged
-      description: 1 if the battery is currently completely charged. 0 otherwise
-      type: keyword
-      ignore_above: 1024
-    - name: resident_size
-      description: Bytes of private memory used by process
-      type: keyword
-      ignore_above: 1024
-    - name: member_config_description
-      description: Config description
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: auto_update
-      description: Whether the image auto-updates (1) or not (0)
-      type: keyword
-      ignore_above: 1024
-    - name: share
-      description: Filesystem path to the share
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: modified_time
-      description: Timestamp the file was installed
-      type: keyword
-      ignore_above: 1024
-    - name: security_type
-      description: Type of security on this network
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: organization
-      description: Organization issued to
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: host_ip
-      description: Host IP address on which public port is listening
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: port_autoneg_supported
-      description: Auto negotiation supported
-      type: keyword
-      ignore_above: 1024
-    - name: arch
-      description: Package architecture
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: port_autoneg_10baset_hd_enabled
-      description: 10Base-T HD auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-    - name: cached
-      description: Whether image is cached (1) or not (0)
-      type: keyword
-      ignore_above: 1024
-    - name: filepath
-      description: Package file or directory
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: severity
-      description: Syslog severity
-      type: keyword
-      ignore_above: 1024
-    - name: bundle_package_type
-      description: Info properties CFBundlePackageType label
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: cpu_set
-      description: 1 if CPU set selection support is enabled. 0 otherwise
-      type: keyword
-      ignore_above: 1024
-    - name: last_unloaded
-      description: Last unloaded module before panic
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: cpu_subtype
-      description: Indicates the specific processor on which an entry may be used.
-      type: keyword
-      ignore_above: 1024
-    - name: start_type
-      description: 'Service start type: BOOT_START, SYSTEM_START, AUTO_START, DEMAND_START, DISABLED'
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: channel
-      description: Channel number
-      type: keyword
-      ignore_above: 1024
-    - name: subscription_id
-      description: Azure subscription for the VM
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: dhcp_server
-      description: IP address of the dynamic host configuration protocol (DHCP) server.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: buffers
-      description: The amount of physical RAM, in bytes, used for file buffers
-      type: keyword
-      ignore_above: 1024
-    - name: host_port
-      description: Host port
-      type: keyword
-      ignore_above: 1024
-    - name: sgid
-      description: Saved group ID
-      type: keyword
-      ignore_above: 1024
-    - name: number
-      description: Protocol number
-      type: keyword
-      ignore_above: 1024
-    - name: src_ip
-      description: Source IP address.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: chassis_sysname
-      description: CPU brand string, contains vendor and model
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: collect_emet_events
-      description: If the sensor is configured to EMET events
-      type: keyword
-      ignore_above: 1024
-    - name: subject_alternative_names
-      description: Subject Alternative Name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ipv6_gateway
-      description: IPv6 gateway
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: country_code
-      description: The country code (ISO/IEC 3166-1:1997) for the network
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: history_file
-      description: Path to the .*_history for this user
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: user
-      description: Time spent in user mode
-      type: keyword
-      ignore_above: 1024
-    - name: cpu_cfs_quota
-      description: 1 if CPU Completely Fair Scheduler (CFS) quota support is enabled. 0 otherwise
-      type: keyword
-      ignore_above: 1024
-    - name: attached
-      description: Number of attached processes
-      type: keyword
-      ignore_above: 1024
-    - name: platform_fault_domain
-      description: Fault domain the VM is running in
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: vm_scale_set_name
-      description: VM scale set name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: temporarily_disabled
-      description: 1 if this network is temporarily disabled, 0 otherwise
-      type: keyword
-      ignore_above: 1024
-    - name: relative_path
-      description: Relative path to the class or instance.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: local_hostname
-      description: Private IPv4 DNS hostname of the first interface of this instance
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: board_vendor
-      description: Board vendor
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: consistency_scan_date
-      description: Consistency scan date
-      type: keyword
-      ignore_above: 1024
-    - name: architecture
-      description: Hardware architecture
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: platform
-      description: OS Platform or ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: avg_disk_bytes_per_write
-      description: Average number of bytes transferred to the disk during write operations
-      type: keyword
-      ignore_above: 1024
-    - name: requested_mask
-      description: Requested access mask
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: issuer_alternative_names
-      description: Issuer Alternative Name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: hard_links
-      description: Number of hard links
-      type: keyword
-      ignore_above: 1024
-    - name: start_on_mount
-      description: Run daemon or agent every time a filesystem is mounted
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: terminal
-      description: The network protocol ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: installed_on
-      description: The date when the patch was installed.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: cpu_physical_cores
-      description: Number of physical CPU cores in to the system
-      type: keyword
-      ignore_above: 1024
-    - name: volume_serial
-      description: Volume serial number
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: obytes
-      description: Output bytes
-      type: keyword
-      ignore_above: 1024
-    - name: member_config_entity
-      description: Type of configuration parameter for this node
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: port_mfs
-      description: Port max frame size
-      type: keyword
-      ignore_above: 1024
-    - name: executable
-      description: Name of the executable that is being shimmed. This is pulled from the registry.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: interval
-      description: Difference between read and preread in nano-seconds
-      type: keyword
-      ignore_above: 1024
-    - name: policy
-      description: Policy that applies for this rule.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: header
-      description: Symbol for given rule
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: connection_status
-      description: State of the network adapter connection to the network.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: power_8023at_power_priority
-      description: 802.3at power priority
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: grace_period
-      description: The amount of time in seconds the screen must be asleep or the screensaver on before a password is required on-wake. 0 = immediately; -1 = no password is required on-wake
-      type: keyword
-      ignore_above: 1024
-    - name: firewall_unload
-      description: 1 If firewall unloading enabled else 0
-      type: keyword
-      ignore_above: 1024
-    - name: keychain_path
-      description: The path of the keychain
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: raid_disks
-      description: Number of configured RAID disks in array
-      type: keyword
-      ignore_above: 1024
-    - name: autoupdate
-      description: 1 If the addon applies background updates else 0
-      type: keyword
-      ignore_above: 1024
-    - name: working_disks
-      description: Number of working disks in array
-      type: keyword
-      ignore_above: 1024
-    - name: world
-      description: If package is in the world file
-      type: keyword
-      ignore_above: 1024
-    - name: baseurl
-      description: Repository base URL
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: source
-      description: Source file
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: percentage_encrypted
-      description: The percentage of the drive that is encrypted.
-      type: keyword
-      ignore_above: 1024
-    - name: visible_alarm
-      description: If TRUE, the frame is equipped with a visual alarm.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: mft_sequence
-      description: Directory master file table sequence.
-      type: keyword
-      ignore_above: 1024
-    - name: exception_code
-      description: The Windows exception code
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: start_interval
-      description: Frequency to run in seconds
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: number_memory_devices
-      description: Number of memory devices on array
-      type: keyword
-      ignore_above: 1024
-    - name: win32_exit_code
-      description: The error code that the service uses to report an error that occurs when it is starting or stopping
-      type: keyword
-      ignore_above: 1024
-    - name: config_flag
-      description: The System Integrity Protection config flag
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: gpgkey
-      description: URL to GPG key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ipv6_subnet
-      description: True if any interface is connected to the local subnet via IPv6
-      type: keyword
-      ignore_above: 1024
-    - name: signed
-      description: Whether the driver is signed or not
-      type: keyword
-      ignore_above: 1024
-    - name: warning
-      description: Number of days before password expires to warn user about it
-      type: keyword
-      ignore_above: 1024
-    - name: stdout_path
-      description: Pipe stdout to a target path
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: file_attributes
-      description: File attributes
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: overflows
-      description: List of structures that overflowed
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: broadcast
-      description: Broadcast address for the interface
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: script_name
-      description: The name of the Powershell script
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: exception_message
-      description: The NTSTATUS error message associated with the exception code
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: eventid
-      description: Event ID of the event
-      type: keyword
-      ignore_above: 1024
-    - name: failed_login_count
-      description: The number of failed login attempts using an incorrect password. Count resets after a correct password is entered.
-      type: keyword
-      ignore_above: 1024
-    - name: base_uri
-      description: Repository base URI
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sha256
-      description: A SHA256 sum of the carved archive
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: source_url
-      description: URL that installed the addon
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: chain
-      description: Size of module content.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: med_device_type
-      description: Chassis MED type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ephemeral
-      description: Whether the instance is ephemeral(1) or not(0)
-      type: keyword
-      ignore_above: 1024
-    - name: fix_comments
-      description: Additional comments about the patch.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: command
-      description: Raw command string
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: method
-      description: The HTTP method for the request
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: provider
-      description: Driver provider
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: language
-      description: The language of the product.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sata_version
-      description: SATA version, if any
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: average
-      description: Load average over the specified period.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: interleave_data_depth
-      description: The max number of consecutive rows from memory device that are accessed in a single interleave transfer; 0 indicates device is non-interleave
-      type: keyword
-      ignore_above: 1024
-    - name: device_error_address
-      description: 32 bit physical address of the error relative to the start of the failing memory address, in bytes
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: user_agent
-      description: The user-agent string to use for the request
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: host
-      description: Sender's address (set by the server).
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: family
-      description: The Internet protocol family ID
-      type: keyword
-      ignore_above: 1024
-    - name: permissions_json
-      description: The JSON-encoded permissions required by the extension
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: on_disk
-      description: The process path exists yes=1, no=0, unknown=-1
-      type: keyword
-      ignore_above: 1024
-    - name: anonymous
-      description: Total number of anonymous pages.
-      type: keyword
-      ignore_above: 1024
-    - name: request_id
-      description: Identifying value of the carve request (e.g., scheduled query name, distributed request, etc)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: flags
-      type: keyword
-      ignore_above: 1024
-    - name: eapi
-      description: The eapi for the ebuild
-      type: keyword
-      ignore_above: 1024
-    - name: sensor_id
-      description: Sensor ID of the Carbon Black sensor
-      type: keyword
-      ignore_above: 1024
-    - name: chassis_router_capability_available
-      description: Chassis router capability availability
-      type: keyword
-      ignore_above: 1024
-    - name: mime_type
-      description: MIME type data from libmagic
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: spare_disks
-      description: Number of idle disks in array
-      type: keyword
-      ignore_above: 1024
-    - name: architectures
-      description: Repository architectures
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: current_capacity
-      description: The battery's current charged capacity in mAh
-      type: keyword
-      ignore_above: 1024
-    - name: json_cmdline
-      description: Command line arguments, in JSON format
+    - name: action
+      description: Appear or disappear
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -7413,12 +68,20 @@
       description: 1 If the addon is active else 0
       type: keyword
       ignore_above: 1024
-    - name: chassis_sys_description
-      description: Max number of CPU physical cores
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: active_disks
+      description: Number of active disks in array
       type: keyword
       ignore_above: 1024
-    - name: platform_like
-      description: Closely related platforms
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: active_state
+      description: The high-level unit activation state, i.e. generalization of SUB
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -7426,16 +89,16 @@
           type: text
           norms: false
           default_field: false
-    - name: duration
-      description: How much time was spent inside the syscall (nsecs)
+    - name: actual
+      description: Actual speed
       type: keyword
       ignore_above: 1024
-    - name: ipv4_subnet
-      description: True if any interface is connected to the local subnet via IPv4
-      type: keyword
-      ignore_above: 1024
-    - name: output_register
-      description: Register used to for feature value
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: additional_product_id
+      description: An additional drive identifier if any
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -7443,8 +106,16 @@
           type: text
           norms: false
           default_field: false
-    - name: cpu_microcode
-      description: Microcode version
+    - name: addr
+      description: Symbol address (value)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: address
+      description: IPv4 address target
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -7452,12 +123,8 @@
           type: text
           norms: false
           default_field: false
-    - name: purgeable
-      description: Total number of purgeable pages.
-      type: keyword
-      ignore_above: 1024
-    - name: gpgcheck
-      description: Whether packages are GPG checked
+    - name: address_width
+      description: The width of the CPU address bus.
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -7465,16 +132,8 @@
           type: text
           norms: false
           default_field: false
-    - name: ref_pid
-      description: Reference PID for messages proxied by launchd
-      type: keyword
-      ignore_above: 1024
-    - name: suid
-      description: Saved user ID
-      type: keyword
-      ignore_above: 1024
-    - name: query
-      description: The query that was run to find the file
+    - name: algorithm
+      description: algorithm of key
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -7482,217 +141,8 @@
           type: text
           norms: false
           default_field: false
-    - name: softirq
-      description: Time spent servicing softirqs
-      type: keyword
-      ignore_above: 1024
-    - name: steal
-      description: Time spent in other operating systems when running in a virtualized environment
-      type: keyword
-      ignore_above: 1024
-    - name: inodes_free
-      description: Mounted device free inodes
-      type: keyword
-      ignore_above: 1024
-    - name: memory
-      description: Total memory
-      type: keyword
-      ignore_above: 1024
-    - name: port_autoneg_100baset2_hd_enabled
-      description: 100Base-T2 HD auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-    - name: power_pairs
-      description: Dot3 power pairs
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: swap_free
-      description: The total amount of swap free, in bytes
-      type: keyword
-      ignore_above: 1024
-    - name: object_path
-      description: The object path for this unit
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: compiler
-      description: Info properties DTCompiler label
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: charging
-      description: 1 if the battery is currently being charged by a power source. 0 otherwise
-      type: keyword
-      ignore_above: 1024
-    - name: containers_paused
-      description: Number of containers in paused state
-      type: keyword
-      ignore_above: 1024
-    - name: max_instances
-      description: The maximum number of instances creatable for this pipe
-      type: keyword
-      ignore_above: 1024
-    - name: team_identifier
-      description: The team signing identifier sealed into the signature
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: uses_pattern
-      description: Uses a match pattern instead of identity
-      type: keyword
-      ignore_above: 1024
-    - name: time_nano_sec
-      description: Nanosecond time.
-      type: keyword
-      ignore_above: 1024
-    - name: author
-      description: Optional package author
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: chassis_id_type
-      description: Neighbor chassis ID type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: working_directory
-      description: Key used to specify a directory to chdir to before launch
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: collect_net_conns
-      description: If the sensor is configured to collect network connections
-      type: keyword
-      ignore_above: 1024
-    - name: protection_disabled
-      description: If the sensor is configured to report tamper events
-      type: keyword
-      ignore_above: 1024
-    - name: priority
-      description: Package priority
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: code_integrity_policy_enforcement_status
-      description: The status of the code integrity policy enforcement settings. Returns UNKNOWN if an error is encountered.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: iso_8601
-      description: Current time (ISO format) in the system
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: script_file_name
-      description: Name of the file from which the script text is read, intended as an alternative to specifying the text of the script in the ScriptText property.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: last_used_at
-      description: ISO time for the most recent use of this image in terms of container spawn
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: platform_info
-      description: Platform information.
-      type: keyword
-      ignore_above: 1024
-    - name: celsius
-      description: Temperature in Celsius
-      type: keyword
-      ignore_above: 1024
-    - name: pre_cpu_usermode_usage
-      description: Last read CPU user mode usage
-      type: keyword
-      ignore_above: 1024
-    - name: ierrors
-      description: Input errors
-      type: keyword
-      ignore_above: 1024
-    - name: configured_clock_speed
-      description: Configured speed of memory device in megatransfers per second (MT/s)
-      type: keyword
-      ignore_above: 1024
-    - name: minor_version
-      description: Windows minor version of the machine
-      type: keyword
-      ignore_above: 1024
-    - name: element
-      description: Does the app identify as a background agent
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: manufacture_date
-      description: The date the battery was manufactured UNIX Epoch
-      type: keyword
-      ignore_above: 1024
-    - name: pre_online_cpus
-      description: Last read online CPUs
-      type: keyword
-      ignore_above: 1024
-    - name: metric
-      description: Metric based on the speed of the interface
-      type: keyword
-      ignore_above: 1024
-    - name: bp_microcode_disabled
-      description: Branch Predictions are disabled due to lack of microcode update.
-      type: keyword
-      ignore_above: 1024
-    - name: domain_controller_address
-      description: The IP Address of the discovered domain controller..
+    - name: alias
+      description: Protocol alias
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -7709,189 +159,23 @@
           type: text
           norms: false
           default_field: false
-    - name: license
-      description: License for package
+    - name: align
+      description: Segment alignment
       type: keyword
       ignore_above: 1024
       multi_fields:
-        - name: text
-          type: text
-          norms: false
+        - name: number
+          type: long
           default_field: false
-    - name: cmdline
-      description: Command line arguments
+    - name: allow_maximum
+      description: Number of concurrent users for this resource has been limited. If True, the value in the MaximumAllowed property is ignored.
       type: keyword
       ignore_above: 1024
       multi_fields:
-        - name: text
-          type: text
-          norms: false
+        - name: number
+          type: long
           default_field: false
-    - name: service
-      description: Driver service name, if one exists
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: launch_type
-      description: Launch services content type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: platform_update_domain
-      description: Update domain the VM is running in
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: disconnected
-      description: True if the all interfaces are not connected to any network
-      type: keyword
-      ignore_above: 1024
-    - name: exception_codes
-      description: Exception codes from the crash
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: following
-      description: The name of another unit that this unit follows in state
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: internet_settings
-      description: The health of the Internet Settings
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: authentication_package
-      description: The authentication package used to authenticate the owner of the logon session.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: registry
-      description: Name of the osquery registry
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: remote_management
-      description: 1 If remote management is enabled else 0
-      type: keyword
-      ignore_above: 1024
-    - name: mountable
-      description: 1 if mountable, 0 if not
-      type: keyword
-      ignore_above: 1024
-    - name: directory
-      description: Directory of file(s)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: install_source
-      description: The installation source of the product.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: config_value
-      description: The MIB value set in /etc/sysctl.conf
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: remote_address
-      description: Remote address associated with socket
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: profile_path
-      description: The profile path
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: socket_designation
-      description: The assigned socket on the board for the given CPU.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: chassis_bridge_capability_enabled
-      description: Is chassis bridge capability enabled.
-      type: keyword
-      ignore_above: 1024
-    - name: creator_pid
-      description: Process ID that created the segment
-      type: keyword
-      ignore_above: 1024
-    - name: smart_enabled
-      description: SMART enabled status
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ref_proc
-      description: Reference process for messages proxied by launchd
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: comment
+    - name: allow_root
       description: Label top-level key
       type: keyword
       ignore_above: 1024
@@ -7900,8 +184,16 @@
           type: text
           norms: false
           default_field: false
-    - name: dhcp_lease_expires
-      description: Expiration date and time for a leased IP address that was assigned to the computer by the dynamic host configuration protocol (DHCP) server.
+    - name: allow_signed_enabled
+      description: 1 If allow signed mode is enabled else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: ami_id
+      description: AMI ID used to launch this EC2 instance
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -7909,12 +201,24 @@
           type: text
           norms: false
           default_field: false
-    - name: year
-      description: Current year in the system
+    - name: amperage
+      description: The battery's current amperage in mA
       type: keyword
       ignore_above: 1024
-    - name: default_locale
-      description: Default locale supported by extension
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: anonymous
+      description: Total number of anonymous pages.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: antispyware
+      description: The health of the monitored Antispyware solution (see windows_security_products)
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -7922,8 +226,8 @@
           type: text
           norms: false
           default_field: false
-    - name: src_mask
-      description: Source IP address mask.
+    - name: antivirus
+      description: The health of the monitored Antivirus solution (see windows_security_products)
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -7931,87 +235,6 @@
           type: text
           norms: false
           default_field: false
-    - name: perf_status
-      description: Performance status for the processor.
-      type: keyword
-      ignore_above: 1024
-    - name: speed
-      description: Estimate of the current bandwidth in bits per second.
-      type: keyword
-      ignore_above: 1024
-    - name: processes
-      description: Number of processes running inside this instance
-      type: keyword
-      ignore_above: 1024
-    - name: rapl_power_limit
-      description: Run Time Average Power Limiting power limit.
-      type: keyword
-      ignore_above: 1024
-    - name: owner_uid
-      description: File owner user ID
-      type: keyword
-      ignore_above: 1024
-    - name: module
-      description: Path of the crashed module within the process
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: display_name
-      description: Info properties CFBundleDisplayName label
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ipv6_address
-      description: IPv6 address
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: groupname
-      description: Canonical local group name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: process_uptime
-      description: Uptime of the process in seconds
-      type: keyword
-      ignore_above: 1024
-    - name: chassis_wlan_capability_available
-      description: Chassis wlan capability availability
-      type: keyword
-      ignore_above: 1024
-    - name: lu_wwn_device_id
-      description: Device Identifier
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: protection_status
-      description: The bitlocker protection status of the drive.
-      type: keyword
-      ignore_above: 1024
-    - name: disk_write
-      description: Total disk write bytes
-      type: keyword
-      ignore_above: 1024
     - name: api_version
       description: API version
       type: keyword
@@ -8021,8 +244,8 @@
           type: text
           norms: false
           default_field: false
-    - name: check_array_speed
-      description: Speed of the check array activity
+    - name: apparmor
+      description: Apparmor Status like ALLOWED, DENIED etc.
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -8030,230 +253,8 @@
           type: text
           norms: false
           default_field: false
-    - name: percent_disk_write_time
-      description: Percentage of elapsed time that the selected disk drive is busy servicing write requests
-      type: keyword
-      ignore_above: 1024
-    - name: destination_id
-      description: Time Machine destination ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sender
-      description: Sender's identification string.  Default is process name.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: publisher
-      description: Publisher of the VM image
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: instance_identifier
-      description: The instance ID of Device Guard.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: period
-      description: Period over which the average is calculated.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: device_type
-      description: Device type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: raid_level
-      description: Current raid level of the array
-      type: keyword
-      ignore_above: 1024
-    - name: cmdline_size
-      description: Actual size (bytes) of command line arguments
-      type: keyword
-      ignore_above: 1024
-    - name: partner_mode
-      description: Mode of shared pipe at partner's end
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: process
-      description: Process name explicitly allowed
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: change_type
-      description: 'Type of change: C:Modified, A:Added, D:Deleted'
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: egid
-      description: Effective group ID
-      type: keyword
-      ignore_above: 1024
-    - name: authority
-      description: Certificate Common Name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: port_autoneg_1000baset_fd_enabled
-      description: 1000Base-T FD auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-    - name: power_mdi_enabled
-      description: Is MDI power enabled
-      type: keyword
-      ignore_above: 1024
-    - name: drive_name
-      description: Drive device name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: mechanism
-      description: Name of the mechanism that will be called
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ipackets
-      description: Input packets
-      type: keyword
-      ignore_above: 1024
-    - name: dns_domain
-      description: Organization name followed by a period and an extension that indicates the type of organization, such as 'microsoft.com'.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: driver
-      description: Driver providing the mount
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: page_ins
-      description: The total number of requests for pages from a pager.
-      type: keyword
-      ignore_above: 1024
-    - name: sigfile
-      description: Signature file used
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: collisions
-      description: Packet Collisions detected
-      type: keyword
-      ignore_above: 1024
-    - name: chassis_tel_capability_enabled
-      description: Chassis telephone capability enabled
-      type: keyword
-      ignore_above: 1024
-    - name: logon_id
-      description: A locally unique identifier (LUID) that identifies a logon session.
-      type: keyword
-      ignore_above: 1024
-    - name: inodes_total
-      description: Total number of inodes available in this storage pool
-      type: keyword
-      ignore_above: 1024
-    - name: percent_disk_read_time
-      description: Percentage of elapsed time that the selected disk drive is busy servicing read requests
-      type: keyword
-      ignore_above: 1024
-    - name: native
-      description: Plugin requires native execution
-      type: keyword
-      ignore_above: 1024
-    - name: common_name
-      description: Certificate CommonName
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: pid_with_namespace
-      description: Pids that contain a namespace
-      type: keyword
-      ignore_above: 1024
-    - name: script_text
-      description: The text content of the Powershell script
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: table
-      description: Table name containing symbol
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: dst_mask
-      description: Destination IP address mask.
+    - name: applescript_enabled
+      description: Info properties NSAppleScriptEnabled label
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -8270,12 +271,540 @@
           type: text
           norms: false
           default_field: false
-    - name: minutes_until_empty
-      description: The number of minutes until the battery is fully depleted. This value is -1 if this time is still being calculated
+    - name: arch
+      description: Package architecture
       type: keyword
       ignore_above: 1024
-    - name: media_name
-      description: Disk event media name string
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: architecture
+      description: Hardware architecture
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: architectures
+      description: Repository architectures
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: args
+      description: Arguments provided to startup executable
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: arguments
+      description: Kernel arguments
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: array_handle
+      description: The memory array that the device is attached to
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: assessments_enabled
+      description: 1 If a Gatekeeper is enabled else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: asset_tag
+      description: Manufacturer specific asset tag of memory device
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ata_version
+      description: ATA version of drive
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: atime
+      description: Last access time
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: attach
+      description: Which executable(s) a profile will attach to.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: attached
+      description: Number of attached processes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: attributes
+      description: 'File attrib string. See: https://ss64.com/nt/attrib.html'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: audible_alarm
+      description: If TRUE, the frame is equipped with an audible alarm.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: auid
+      description: Audit User ID at process start
+      type: keyword
+      ignore_above: 1024
+    - name: authenticate_user
+      description: Label top-level key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: authentication_package
+      description: The authentication package used to authenticate the owner of the logon session.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: author
+      description: Optional package author
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: authority
+      description: Certificate Common Name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: authority_key_id
+      description: AKID an optionally included SHA1
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: authority_key_identifier
+      description: Authority Key Identifier
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: authorizations
+      description: A space delimited set of authorization attributes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: auto_login
+      description: 1 if auto login is enabled, 0 otherwise
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: auto_update
+      description: Whether the image auto-updates (1) or not (0)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: autoupdate
+      description: 1 If the addon applies background updates else 0
+      type: keyword
+      ignore_above: 1024
+    - name: availability
+      description: The availability and status of the CPU.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: availability_zone
+      description: Availability zone in which this instance launched
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: average
+      description: Load average over the specified period.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: average_memory
+      description: Average private memory left after executing
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: avg_disk_bytes_per_read
+      description: Average number of bytes transferred from the disk during read operations
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: avg_disk_bytes_per_write
+      description: Average number of bytes transferred to the disk during write operations
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: avg_disk_read_queue_length
+      description: Average number of read requests that were queued for the selected disk during the sample interval
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: avg_disk_sec_per_read
+      description: Average time, in seconds, of a read operation of data from the disk
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: avg_disk_sec_per_write
+      description: Average time, in seconds, of a write operation of data to the disk
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: avg_disk_write_queue_length
+      description: Average number of write requests that were queued for the selected disk during the sample interval
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: backup_date
+      description: Backup Date
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: bank_locator
+      description: String number of the string that identifies the physically-labeled bank where the memory device is located
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: base64
+      description: 1 if the value is base64 encoded else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: base_image
+      description: ID of image used to launch this instance
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: base_uri
+      description: Repository base URI
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: baseurl
+      description: Repository base URL
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: basic_constraint
+      description: Basic Constraints
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: binary_queue
+      description: Size in bytes of binaries waiting to be sent to Carbon Black server
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: binding
+      description: Binding type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: bitmap_chunk_size
+      description: Bitmap chunk size
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: bitmap_external_file
+      description: External referenced bitmap file
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: bitmap_on_mem
+      description: Pages allocated in in-memory bitmap, if enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: block
+      description: The host or match block
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: block_size
+      description: Block size in bytes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: blocks
+      description: Number of blocks
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: blocks_available
+      description: Mounted device available blocks
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: blocks_free
+      description: Mounted device free blocks
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: blocks_size
+      description: Byte size of each block
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: bluetooth_sharing
+      description: 1 If bluetooth sharing is enabled for any user else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: board_model
+      description: Board model
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: board_serial
+      description: Board serial number
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: board_vendor
+      description: Board vendor
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: board_version
+      description: Board version
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: boot_partition
+      description: True if Windows booted from this drive.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: boot_uuid
+      description: Boot UUID of the iBridge controller
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: bp_microcode_disabled
+      description: Branch Predictions are disabled due to lack of microcode update.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: bp_mitigations
+      description: Branch Prediction mitigations are enabled.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: bp_system_pol_disabled
+      description: Branch Predictions are disabled via system policy.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: breach_description
+      description: If provided, gives a more detailed description of a detected security breach.
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -8287,16 +816,20 @@
       description: 1 if bridge netfilter ip6tables is enabled. 0 otherwise
       type: keyword
       ignore_above: 1024
-    - name: min_voltage
-      description: Minimum operating voltage of device in millivolts
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: bridge_nf_iptables
+      description: 1 if bridge netfilter iptables is enabled. 0 otherwise
       type: keyword
       ignore_above: 1024
-    - name: partial
-      description: Set to 1 if either path or old_path only contains the file or folder name
-      type: keyword
-      ignore_above: 1024
-    - name: codename
-      description: OS version codename
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: broadcast
+      description: Broadcast address for the interface
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -8304,12 +837,8 @@
           type: text
           norms: false
           default_field: false
-    - name: enabled_nvram
-      description: 1 if this configuration is enabled, otherwise 0
-      type: keyword
-      ignore_above: 1024
-    - name: syscall
-      description: System call name
+    - name: browser_type
+      description: 'The browser type (Valid values: chrome, chromium, opera, yandex, brave)'
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -8317,28 +846,8 @@
           type: text
           norms: false
           default_field: false
-    - name: stateful
-      description: Whether the instance is stateful(1) or not(0)
-      type: keyword
-      ignore_above: 1024
-    - name: set
-      description: Identifies if memory device is one of a set of devices.  A value of 0 indicates no set affiliation.
-      type: keyword
-      ignore_above: 1024
-    - name: shell_only
-      description: Is the flag shell only?
-      type: keyword
-      ignore_above: 1024
-    - name: accessed_time
-      description: Directory Accessed time.
-      type: keyword
-      ignore_above: 1024
-    - name: align
-      description: Segment alignment
-      type: keyword
-      ignore_above: 1024
-    - name: product_version
-      description: File product version
+    - name: bsd_flags
+      description: 'The BSD file flags (chflags). Possible values: NODUMP, UF_IMMUTABLE, UF_APPEND, OPAQUE, HIDDEN, ARCHIVED, SF_IMMUTABLE, SF_APPEND'
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -8346,29 +855,8 @@
           type: text
           norms: false
           default_field: false
-    - name: feature_control
-      description: Bitfield controlling enabled features.
-      type: keyword
-      ignore_above: 1024
-    - name: minor
-      description: Minor release version
-      type: keyword
-      ignore_above: 1024
-    - name: last_hit_date
-      description: Apple date format for last thumbnail cache hit
-      type: keyword
-      ignore_above: 1024
-    - name: mnt_namespace
-      description: Mount namespace
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: git_commit
-      description: Docker build git commit
+    - name: bssid
+      description: The current basic service set identifier
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -8380,8 +868,20 @@
       description: (B)irth or (cr)eate time
       type: keyword
       ignore_above: 1024
-    - name: starting_address
-      description: Physical stating address, in kilobytes, of a range of memory mapped to physical memory array
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: buffers
+      description: The amount of physical RAM, in bytes, used for file buffers
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: build
+      description: Optional build-specific or variant string
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -8389,10 +889,68 @@
           type: text
           norms: false
           default_field: false
-    - name: last_executed
-      description: UNIX time stamp in seconds of the last completed execution
+    - name: build_distro
+      description: osquery toolkit platform distribution name (os version)
       type: keyword
       ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: build_id
+      description: Sandbox-specific identifier
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: build_number
+      description: Windows build number of the crashing machine
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: build_platform
+      description: osquery toolkit build platform
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: build_time
+      description: Build time
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: bundle_executable
+      description: Info properties CFBundleExecutable label
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: bundle_identifier
+      description: Info properties CFBundleIdentifier label
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
     - name: bundle_name
       description: Info properties CFBundleName label
       type: keyword
@@ -8402,10 +960,210 @@
           type: text
           norms: false
           default_field: false
-    - name: readonly_rootfs
-      description: Is the root filesystem mounted as read only
+    - name: bundle_package_type
+      description: Info properties CFBundlePackageType label
       type: keyword
       ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: bundle_path
+      description: Application bundle used by the sandbox
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: bundle_short_version
+      description: Info properties CFBundleShortVersionString label
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: bundle_version
+      description: Info properties CFBundleVersion label
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: busy_state
+      description: 1 if the device is in a busy state else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: bytes
+      description: Number of bytes in the response
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: bytes_available
+      description: Bytes available on volume
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: bytes_received
+      description: Number of bytes received on this network
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: bytes_sent
+      description: Number of bytes sent on this network
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: bytes_used
+      description: Bytes used on volume
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: ca
+      description: '1 if CA: true (certificate is an authority) else 0'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: cache_path
+      description: Path to cache data
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cached
+      description: Whether image is cached (1) or not (0)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: capability
+      description: Capability number
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: capname
+      description: Capability requested by the process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: caption
+      description: Short description of the patch.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: captive_portal
+      description: 1 if this network has a captive portal, 0 otherwise
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: carve
+      description: Set this value to '1' to start a file carve
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: carve_guid
+      description: Identifying value of the carve session
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: category
+      description: The UTI that categorizes the app for the App Store
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cdhash
+      description: Hash of the application Code Directory
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: celsius
+      description: Temperature in Celsius
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: double
+          default_field: false
+    - name: certificate
+      description: Certificate content
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cgroup_driver
+      description: Control groups driver
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
     - name: cgroup_namespace
       description: cgroup namespace
       type: keyword
@@ -8415,8 +1173,8 @@
           type: text
           norms: false
           default_field: false
-    - name: weekday
-      description: Current weekday in the system
+    - name: chain
+      description: Size of module content.
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -8424,16 +1182,8 @@
           type: text
           norms: false
           default_field: false
-    - name: purged
-      description: Total number of purged pages.
-      type: keyword
-      ignore_above: 1024
-    - name: timestamp_ms
-      description: Unix timestamp of collected data in MS
-      type: keyword
-      ignore_above: 1024
-    - name: last_run_message
-      description: Exit status message of the last task run
+    - name: change_type
+      description: 'Type of change: C:Modified, A:Added, D:Deleted'
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -8441,16 +1191,76 @@
           type: text
           norms: false
           default_field: false
-    - name: job_id
-      description: Next queued job id
+    - name: channel
+      description: Channel number
       type: keyword
       ignore_above: 1024
-    - name: logging_enabled
-      description: 1 If logging mode is enabled else 0
+    - name: channel_band
+      description: Channel band
       type: keyword
       ignore_above: 1024
-    - name: uts_namespace
-      description: UTS namespace
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: channel_width
+      description: Channel width
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: charged
+      description: 1 if the battery is currently completely charged. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: charging
+      description: 1 if the battery is currently being charged by a power source. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: chassis_bridge_capability_available
+      description: Chassis bridge capability availability
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: chassis_bridge_capability_enabled
+      description: Is chassis bridge capability enabled.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: chassis_docsis_capability_available
+      description: Chassis DOCSIS capability availability
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: chassis_docsis_capability_enabled
+      description: Chassis DOCSIS capability enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: chassis_id
+      description: Neighbor chassis ID value
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -8458,29 +1268,461 @@
           type: text
           norms: false
           default_field: false
-    - name: expire
-      description: Number of days since UNIX epoch date until account is disabled
-      type: keyword
-      ignore_above: 1024
-    - name: filter_name
-      description: Packet matching filter table name.
+    - name: chassis_id_type
+      description: Neighbor chassis ID type
       type: keyword
       ignore_above: 1024
       multi_fields:
         - name: text
           type: text
           norms: false
+          default_field: false
+    - name: chassis_mgmt_ips
+      description: Comma delimited list of chassis management IPS
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: chassis_other_capability_available
+      description: Chassis other capability availability
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: chassis_other_capability_enabled
+      description: Chassis other capability enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: chassis_repeater_capability_available
+      description: Chassis repeater capability availability
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: chassis_repeater_capability_enabled
+      description: Chassis repeater capability enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: chassis_router_capability_available
+      description: Chassis router capability availability
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: chassis_router_capability_enabled
+      description: Chassis router capability enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: chassis_station_capability_available
+      description: Chassis station capability availability
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: chassis_station_capability_enabled
+      description: Chassis station capability enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: chassis_sys_description
+      description: Max number of CPU physical cores
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: chassis_sysname
+      description: CPU brand string, contains vendor and model
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: chassis_tel_capability_available
+      description: Chassis telephone capability availability
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: chassis_tel_capability_enabled
+      description: Chassis telephone capability enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: chassis_types
+      description: A comma-separated list of chassis types, such as Desktop or Laptop.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: chassis_wlan_capability_available
+      description: Chassis wlan capability availability
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: chassis_wlan_capability_enabled
+      description: Chassis wlan capability enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: check_array_finish
+      description: Estimated duration of the check array activity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: check_array_progress
+      description: Progress of the check array activity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: check_array_speed
+      description: Speed of the check array activity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: checksum
+      description: UDIF Master checksum if available (CRC32)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: chunk_size
+      description: chunk size in bytes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: cid
+      description: Cgroup ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: class
+      description: Label top-level key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: client_site_name
+      description: The name of the site where the domain controller is configured.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cmdline
+      description: Command line arguments
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cmdline_size
+      description: Actual size (bytes) of command line arguments
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: code_integrity_policy_enforcement_status
+      description: The status of the code integrity policy enforcement settings. Returns UNKNOWN if an error is encountered.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: codename
+      description: OS version codename
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: collect_cross_processes
+      description: If the sensor is configured to cross process events
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: collect_data_file_writes
+      description: If the sensor is configured to collect non binary file writes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: collect_emet_events
+      description: If the sensor is configured to EMET events
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: collect_file_mods
+      description: If the sensor is configured to collect file modification events
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: collect_module_info
+      description: If the sensor is configured to collect metadata of binaries
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: collect_module_loads
+      description: If the sensor is configured to capture module loads
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: collect_net_conns
+      description: If the sensor is configured to collect network connections
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: collect_process_user_context
+      description: If the sensor is configured to collect the user running a process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: collect_processes
+      description: If the sensor is configured to process events
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: collect_reg_mods
+      description: If the sensor is configured to collect registry modification events
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: collect_sensor_operations
+      description: Unknown
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: collect_store_files
+      description: If the sensor is configured to send back binaries to the Carbon Black server
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: collisions
+      description: Packet Collisions detected
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: color_depth
+      description: The amount of bits per pixel to represent color.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: comm
+      description: Command-line name of the command that was used to invoke the analyzed process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: command
+      description: Raw command string
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: command_line
+      description: Command-line string passed to the crashed process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: command_line_template
+      description: Standard string template that specifies the process to be started. This property can be NULL, and the ExecutablePath property is used as the command line.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: comment
+      description: Label top-level key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: common_name
+      description: Certificate CommonName
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: compiler
+      description: Info properties DTCompiler label
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: completed_time
+      description: When the job completed printing
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: components
+      description: Repository components
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: compressed
+      description: The total number of pages that have been compressed by the VM compressor.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
           default_field: false
     - name: compressor
       description: The number of pages used to store compressed VM pages.
       type: keyword
       ignore_above: 1024
-    - name: page_outs
-      description: Total number of pages paged out.
-      type: keyword
-      ignore_above: 1024
-    - name: exception_notes
-      description: Exception notes from the crash
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: computer_name
+      description: Friendly computer name (optional)
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -8488,10 +1730,818 @@
           type: text
           norms: false
           default_field: false
-    - name: is_hidden
-      description: IsHidden attribute set in OpenDirectory
+    - name: condition
+      description: 'One of the following: "Normal" indicates the condition of the battery is within normal tolerances, "Service Needed" indicates that the battery should be checked out by a licensed Mac repair service, "Permanent Failure" indicates the battery needs replacement'
       type: keyword
       ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: config_entrypoint
+      description: Container entrypoint(s)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: config_flag
+      description: The System Integrity Protection config flag
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: config_hash
+      description: Hash of the working configuration state
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: config_name
+      description: Sensor group
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: config_valid
+      description: 1 if the config was loaded and considered valid, else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: config_value
+      description: The MIB value set in /etc/sysctl.conf
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: configured_clock_speed
+      description: Configured speed of memory device in megatransfers per second (MT/s)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: configured_voltage
+      description: Configured operating voltage of device in millivolts
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: connection_id
+      description: Name of the network connection as it appears in the Network Connections Control Panel program.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: connection_status
+      description: State of the network adapter connection to the network.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: consistency_scan_date
+      description: Consistency scan date
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: consumer
+      description: Reference to an instance of __EventConsumer that represents the object path to a logical consumer, the recipient of an event.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: containers
+      description: Total number of containers
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: containers_paused
+      description: Number of containers in paused state
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: containers_running
+      description: Number of containers currently running
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: containers_stopped
+      description: Number of containers in stopped state
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: content
+      description: Disk event content
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: content_caching
+      description: 1 If content caching is enabled else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: content_type
+      description: Package content_type (optional)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: conversion_status
+      description: The bitlocker conversion status of the drive.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: coprocessor_version
+      description: The manufacturer and chip version
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: copy
+      description: Total number of copy-on-write pages.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: copyright
+      description: Info properties NSHumanReadableCopyright label
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: core
+      description: Name of the cpu (core)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: cosine_similarity
+      description: How similar the Powershell script is to a provided 'normal' character frequency
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: double
+          default_field: false
+    - name: count
+      description: Number of times the application has been executed.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: country_code
+      description: The country code (ISO/IEC 3166-1:1997) for the network
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cpu
+      description: CPU utilization as percentage
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: double
+          default_field: false
+    - name: cpu_brand
+      description: CPU brand string, contains vendor and model
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cpu_cfs_period
+      description: 1 if CPU Completely Fair Scheduler (CFS) period support is enabled. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: cpu_cfs_quota
+      description: 1 if CPU Completely Fair Scheduler (CFS) quota support is enabled. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: cpu_kernelmode_usage
+      description: CPU kernel mode usage
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: cpu_logical_cores
+      description: Number of logical CPU cores available to the system
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: cpu_microcode
+      description: Microcode version
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cpu_physical_cores
+      description: Number of physical CPU cores in to the system
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: cpu_pred_cmd_supported
+      description: PRED_CMD MSR supported by CPU Microcode.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: cpu_set
+      description: 1 if CPU set selection support is enabled. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: cpu_shares
+      description: 1 if CPU share weighting support is enabled. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: cpu_spec_ctrl_supported
+      description: SPEC_CTRL MSR supported by CPU Microcode.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: cpu_status
+      description: The current operating status of the CPU.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: cpu_subtype
+      description: Indicates the specific processor on which an entry may be used.
+      type: keyword
+      ignore_above: 1024
+    - name: cpu_total_usage
+      description: Total CPU usage
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: cpu_type
+      description: Indicates the specific processor designed for installation.
+      type: keyword
+      ignore_above: 1024
+    - name: cpu_usermode_usage
+      description: CPU user mode usage
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: cpus
+      description: Number of CPUs
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: crash_path
+      description: Location of log file
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: crashed_thread
+      description: Thread ID which crashed
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: created
+      description: Label top-level key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: created_at
+      description: ISO time of image creation
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: created_by
+      description: Created by instruction
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: created_time
+      description: Directory Created time.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: creation_time
+      description: When the account was first created
+      type: keyword
+      ignore_above: 1024
+    - name: creator
+      description: Addon-supported creator string
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: creator_pid
+      description: Process ID that created the segment
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: creator_uid
+      description: User ID of creator process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: csname
+      description: The name of the host the patch is installed on.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ctime
+      description: Creation time
+      type: keyword
+      ignore_above: 1024
+    - name: current_capacity
+      description: The battery's current charged capacity in mAh
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: current_clock_speed
+      description: The current frequency of the CPU.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: current_directory
+      description: Current working directory of the crashed process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: current_disk_queue_length
+      description: Number of requests outstanding on the disk at the time the performance data is collected
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: current_locale
+      description: Current locale supported by extension
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: current_value
+      description: Value of setting
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cwd
+      description: Current working directory
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cycle_count
+      description: The number of charge/discharge cycles
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: data
+      description: Magic number data from libmagic
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: data_width
+      description: Data width, in bits, of this memory device
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: database
+      description: Whether the server is a database node (1) or not (0)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: date
+      description: Driver date
+      type: keyword
+      ignore_above: 1024
+    - name: datetime
+      description: Date/Time at which the crash occurred
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: day
+      description: Current day in the system
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: day_of_month
+      description: The day of the month for the job
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: day_of_week
+      description: The day of the week for the job
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: days
+      description: Days of uptime
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: dc_site_name
+      description: The name of the site where the domain controller is located.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: decompressed
+      description: The total number of pages that have been decompressed by the VM compressor.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: default_locale
+      description: Default locale supported by extension
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: default_value
+      description: Flag default value
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: denied_mask
+      description: Denied permissions for the process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: denylisted
+      description: 1 if the query is denylisted else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: dependencies
+      description: Module dependencies existing in crashed module's backtrace
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: depth
+      description: Device nested depth
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: description
+      description: Description of the SDB.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: designed_capacity
+      description: The battery's designed capacity in mAh
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: dest_path
+      description: The canonical path associated with the event
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: destination
+      description: The printer the job was sent to
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: destination_id
+      description: Time Machine destination ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: dev_id_enabled
+      description: 1 If a Gatekeeper allows execution from identified developers else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: developer_id
+      description: Optional developer identifier
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: development_region
+      description: Info properties CFBundleDevelopmentRegion label
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: device
+      description: Absolute file path to device node
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: device_alias
+      description: Mounted device alias
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: device_error_address
+      description: 32 bit physical address of the error relative to the start of the failing memory address, in bytes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: device_id
+      description: ID of the encrypted drive.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: device_locator
+      description: String number of the string that identifies the physically-labeled socket or board position where the memory device is located
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: device_model
+      description: Device Model
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: device_name
+      description: Device name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
     - name: device_path
       description: Device tree path
       type: keyword
@@ -8501,12 +2551,8 @@
           type: text
           norms: false
           default_field: false
-    - name: idx
-      description: Extension load tag or index
-      type: keyword
-      ignore_above: 1024
-    - name: reshape_speed
-      description: Speed of reshape activity
+    - name: device_type
+      description: Device type
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -8514,16 +2560,16 @@
           type: text
           norms: false
           default_field: false
-    - name: remote_apple_events
-      description: 1 If remote apple events are enabled else 0
+    - name: dhcp_enabled
+      description: If TRUE, the dynamic host configuration protocol (DHCP) server automatically assigns an IP address to the computer system when establishing a network connection.
       type: keyword
       ignore_above: 1024
-    - name: in_smartctl_db
-      description: Boolean value for if drive is recognized
-      type: keyword
-      ignore_above: 1024
-    - name: source_path
-      description: Path to the (possibly generated) unit configuration file
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: dhcp_lease_expires
+      description: Expiration date and time for a leased IP address that was assigned to the computer by the dynamic host configuration protocol (DHCP) server.
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -8531,8 +2577,8 @@
           type: text
           norms: false
           default_field: false
-    - name: responsible
-      description: Process responsible for the crashed process
+    - name: dhcp_lease_obtained
+      description: Date and time the lease was obtained for the IP address assigned to the computer by the dynamic host configuration protocol (DHCP) server.
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -8540,20 +2586,288 @@
           type: text
           norms: false
           default_field: false
-    - name: size_bytes
-      description: Size of image in bytes
+    - name: dhcp_server
+      description: IP address of the dynamic host configuration protocol (DHCP) server.
       type: keyword
       ignore_above: 1024
-    - name: enable_ipv6
-      description: 1 if IPv6 is enabled on this network. 0 otherwise
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: directory
+      description: Directory of file(s)
       type: keyword
       ignore_above: 1024
-    - name: possibly_hidden
-      description: 1 if network is possibly a hidden network, 0 otherwise
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: disabled
+      description: Is the plugin disabled. 1 = Disabled
       type: keyword
       ignore_above: 1024
-    - name: roaming_profile
-      description: Describe the roaming profile, usually one of Single, Dual  or Multi
+    - name: disc_sharing
+      description: 1 If CD or DVD sharing is enabled else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: disconnected
+      description: True if the all interfaces are not connected to any network
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: discovery_cache_hits
+      description: The number of times that the discovery query used cached values since the last time the config was reloaded
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: discovery_executions
+      description: The number of times that the discovery queries have been executed since the last time the config was reloaded
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: disk_bytes_read
+      description: Bytes read from disk
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: disk_bytes_written
+      description: Bytes written to disk
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: disk_id
+      description: Physical slot number of device, only exists when hardware storage controller exists
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: disk_index
+      description: Physical drive number of the disk.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: disk_read
+      description: Total disk read bytes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: disk_size
+      description: Size of the disk.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: disk_write
+      description: Total disk write bytes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: display_name
+      description: Info properties CFBundleDisplayName label
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: dns_domain
+      description: Organization name followed by a period and an extension that indicates the type of organization, such as 'microsoft.com'.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: dns_domain_name
+      description: The DNS name for the owner of the logon session.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: dns_domain_suffix_search_order
+      description: Array of DNS domain suffixes to be appended to the end of host names during name resolution.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: dns_forest_name
+      description: The name of the root of the DNS tree.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: dns_host_name
+      description: Host name used to identify the local computer for authentication by some utilities.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: dns_server_search_order
+      description: Array of server IP addresses to be used in querying for DNS servers.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: domain
+      description: Active Directory trust domain
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: domain_controller_address
+      description: The IP Address of the discovered domain controller..
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: domain_controller_name
+      description: The name of the discovered domain controller.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: domain_name
+      description: The name of the domain.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: drive_letter
+      description: Drive letter of the encrypted drive.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: drive_name
+      description: Drive device name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: driver
+      description: Driver providing the mount
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: driver_date
+      description: The date listed on the installed driver.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: driver_key
+      description: Driver key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: driver_type
+      description: The explicit device type used to retrieve the SMART information
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: driver_version
+      description: The version of the installed driver.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: dst_ip
+      description: Destination IP address.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: dst_mask
+      description: Destination IP address mask.
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -8570,6 +2884,698 @@
           type: text
           norms: false
           default_field: false
+    - name: dtime
+      description: Detached time
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: dump_certificate
+      description: Set this value to '1' to dump certificate
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: duration
+      description: How much time was spent inside the syscall (nsecs)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: eapi
+      description: The eapi for the ebuild
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: egid
+      description: Effective group ID
+      type: keyword
+      ignore_above: 1024
+    - name: eid
+      description: Event ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ejectable
+      description: 1 if ejectable, 0 if not
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: elapsed_time
+      description: Elapsed time in seconds this process has been running.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: element
+      description: Does the app identify as a background agent
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: enable_ipv6
+      description: 1 if IPv6 is enabled on this network. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: enabled
+      description: 1 if this handler is the OS default, else 0
+      type: keyword
+      ignore_above: 1024
+    - name: enabled_nvram
+      description: 1 if this configuration is enabled, otherwise 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: encrypted
+      description: '1 If encrypted: true (disk is encrypted), else 0'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: encryption
+      description: Last known encrypted state
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: encryption_method
+      description: The encryption type of the device.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: encryption_status
+      description: 'Disk encryption status with one of following values: encrypted | not encrypted | undefined'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: end
+      description: End address of memory region
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ending_address
+      description: Physical ending address of last kilobyte of a range of memory mapped to physical memory array
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: endpoint_id
+      description: Endpoint ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: entry
+      description: The whole string entry
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: env
+      description: Environment variables delimited by spaces
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: env_count
+      description: Number of environment variables
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: env_size
+      description: Actual size (bytes) of environment list
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: env_variables
+      description: Container environmental variables
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: environment
+      description: Application-set environment variables
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ephemeral
+      description: Whether the instance is ephemeral(1) or not(0)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: epoch
+      description: Package epoch value
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: error
+      description: Error information
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: error_granularity
+      description: Granularity to which the error can be resolved
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: error_operation
+      description: Memory access operation that caused the error
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: error_resolution
+      description: Range, in bytes, within which this error can be determined, when an error address is given
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: error_type
+      description: type of error associated with current error status for array or device
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: euid
+      description: Effective user ID
+      type: keyword
+      ignore_above: 1024
+    - name: event
+      description: The job @event name (rare)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: event_queue
+      description: Size in bytes of Carbon Black event files on disk
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: event_tap_id
+      description: Unique ID for the Tap
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: event_tapped
+      description: The mask that identifies the set of events to be observed.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: eventid
+      description: Event ID of the event
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: events
+      description: Number of events emitted or received since osquery started
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: exception_address
+      description: Address (in hex) where the exception occurred
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: exception_code
+      description: The Windows exception code
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: exception_codes
+      description: Exception codes from the crash
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: exception_message
+      description: The NTSTATUS error message associated with the exception code
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: exception_notes
+      description: Exception notes from the crash
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: exception_type
+      description: Exception type of the crash
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: executable
+      description: Name of the executable that is being shimmed. This is pulled from the registry.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: executable_path
+      description: Module to execute. The string can specify the full path and file name of the module to execute, or it can specify a partial name. If a partial name is specified, the current drive and current directory are assumed.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: execution_flag
+      description: Boolean Execution flag, 1 for execution, 0 for no execution, -1 for missing (this flag does not exist on Windows 10 and higher).
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: executions
+      description: Number of times the query was executed
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: exit_code
+      description: Exit code of the system call
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: expand
+      description: 1 if the variable needs expanding, 0 otherwise
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: expire
+      description: Number of days since UNIX epoch date until account is disabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: expires_at
+      description: ISO time of image expiration
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: extended_key_usage
+      description: Extended usage of key in certificate
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: extensions
+      description: osquery extensions status
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: external
+      description: 1 if this handler does NOT exist on OS X by default, else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: extra
+      description: Extra columns, in JSON format. Queries against this column are performed entirely in SQLite, so do not benefit from efficient querying via asl.h.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: facility
+      description: Sender's facility.  Default is 'user'.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: fahrenheit
+      description: Temperature in Fahrenheit
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: double
+          default_field: false
+    - name: failed_disks
+      description: Number of failed disks in array
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: failed_login_count
+      description: The number of failed login attempts using an incorrect password. Count resets after a correct password is entered.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: failed_login_timestamp
+      description: The time of the last failed login attempt. Resets after a correct password is entered
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: double
+          default_field: false
+    - name: family
+      description: The Internet protocol family ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: fan
+      description: Fan number
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: faults
+      description: Total number of calls to vm_faults.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: fd
+      description: The file description for the process socket
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: feature
+      description: Present feature flags
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: feature_control
+      description: Bitfield controlling enabled features.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: field_name
+      description: Specific attribute of opaque type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: file_attributes
+      description: File attributes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: file_backed
+      description: Total number of file backed pages.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: file_id
+      description: file ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: file_sharing
+      description: 1 If file sharing is enabled else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: file_system
+      description: The file system of the drive.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: file_version
+      description: File version
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: filename
+      description: Name portion of file path
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: filepath
+      description: Package file or directory
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: filesystem
+      description: Filesystem if available
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: filetype
+      description: Use this file type to match
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: filevault_status
+      description: 'FileVault status with one of following values: on | off | unknown'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: filter
+      description: Reference to an instance of __EventFilter that represents the object path to an event filter which is a query that specifies the type of event to be received.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: filter_name
+      description: Packet matching filter table name.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
     - name: fingerprint
       description: SHA256 hash of the certificate
       type: keyword
@@ -8579,12 +3585,8 @@
           type: text
           norms: false
           default_field: false
-    - name: shard
-      description: Shard restriction limit, 1-100, 0 meaning no restriction
-      type: keyword
-      ignore_above: 1024
-    - name: pnp_device_id
-      description: The unique identifier of the drive on the system.
+    - name: finished_at
+      description: Container finish time as string
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -8592,24 +3594,594 @@
           type: text
           norms: false
           default_field: false
-    - name: instances
-      description: Number of instances of the named pipe
+    - name: firewall
+      description: The health of the monitored Firewall (see windows_security_products)
       type: keyword
       ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: firewall_unload
+      description: 1 If firewall unloading enabled else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: firmware_version
+      description: The build version of the firmware
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: fix_comments
+      description: Additional comments about the patch.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: flag
+      description: Reserved
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: flags
+      type: keyword
+      ignore_above: 1024
+    - name: flatsize
+      description: Package size in bytes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: folder_id
+      description: Folder identifier for the VM
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: following
+      description: The name of another unit that this unit follows in state
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
     - name: forced
       description: 1 if the value is forced/managed, else 0
       type: keyword
       ignore_above: 1024
-    - name: patch
-      description: Optional patch release
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: form_factor
+      description: Implementation form factor for this memory device
       type: keyword
       ignore_above: 1024
-    - name: self_signed
-      description: 1 if self-signed, else 0
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: format
+      description: The format of the print job
       type: keyword
       ignore_above: 1024
-    - name: ip_address
-      description: IP address
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: forwarding_enabled
+      description: Enable IP forwarding
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: fragment_path
+      description: The unit file path this unit was read from, if there is any
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: frame_backtrace
+      description: Backtrace of the crashed module
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: free
+      description: Total number of free pages.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: free_space
+      description: The amount of free space, in bytes, of the drive (-1 on failure).
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: friendly_name
+      description: The friendly display name of the interface.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: from_webstore
+      description: True if this extension was installed from the web store
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: fs_id
+      description: Quicklook file fs_id key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: fsgid
+      description: Filesystem group ID at process start
+      type: keyword
+      ignore_above: 1024
+    - name: fsuid
+      description: Filesystem user ID
+      type: keyword
+      ignore_above: 1024
+    - name: gateway
+      description: Gateway
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: gid
+      description: GID that sent the log message (set by the server).
+      type: keyword
+      ignore_above: 1024
+    - name: gid_signed
+      description: A signed int64 version of gid
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: git_commit
+      description: Docker build git commit
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: global_state
+      description: 1 If the firewall is enabled with exceptions, 2 if the firewall is configured to block all incoming connections, else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: go_version
+      description: Go version
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: gpgcheck
+      description: Whether packages are GPG checked
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: gpgkey
+      description: URL to GPG key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: grace_period
+      description: The amount of time in seconds the screen must be asleep or the screensaver on before a password is required on-wake. 0 = immediately; -1 = no password is required on-wake
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: group_sid
+      description: Unique group ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: groupname
+      description: Canonical local group name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: guest
+      description: Time spent running a virtual CPU for a guest OS under the control of the Linux kernel
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: guest_nice
+      description: 'Time spent running a niced guest '
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: handle
+      description: Handle, or instance number, associated with the structure
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: handle_count
+      description: Total number of handles that the process has open. This number is the sum of the handles currently opened by each thread in the process.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: handler
+      description: Application label for the handler
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: hard_limit
+      description: Maximum limit value
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: hard_links
+      description: Number of hard links
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: hardware_model
+      description: Hard drive model.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: hardware_serial
+      description: Device serial number
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: hardware_vendor
+      description: Hardware vendor
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: hardware_version
+      description: Hardware version
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: has_expired
+      description: 1 if the certificate has expired, 0 otherwise
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: hash_alg
+      description: Password hashing algorithm
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: hash_resources
+      description: Set to 1 to also hash resources, or 0 otherwise. Default is 1
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: hashed
+      description: 1 if the file was hashed, 0 if not, -1 if hashing failed
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: header
+      description: Symbol for given rule
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: header_size
+      description: Header size in bytes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: health
+      description: 'One of the following: "Good" describes a well-performing battery, "Fair" describes a functional battery with limited capacity, or "Poor" describes a battery that''s not capable of providing power'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: hidden
+      description: Whether or not the task is visible in the UI
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: history_file
+      description: Path to the .*_history for this user
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: hit_count
+      description: Number of cache hits on thumbnail
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: home_directory
+      description: The home directory for the logon session.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: home_directory_drive
+      description: The drive location of the home directory of the logon session.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: homepage
+      description: Package supplied homepage
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: hop_limit
+      description: Current Hop Limit
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: hopcount
+      description: Max hops expected
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: host
+      description: Sender's address (set by the server).
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: host_ip
+      description: Host IP address on which public port is listening
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: host_port
+      description: Host port
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: hostname
+      description: Hostname (domain[:port]) to CURL
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: hostnames
+      description: Raw hosts mapping
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: hotfix_id
+      description: The KB ID of the patch.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: hour
+      description: The hour of the day for the job
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: hours
+      description: Hours of uptime
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: http_proxy
+      description: HTTP proxy
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: https_proxy
+      description: HTTPS proxy
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: hwaddr
+      description: Hardware address for this network
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: iam_arn
+      description: If there is an IAM role associated with the instance, contains instance profile ARN
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -8621,8 +4193,3087 @@
       description: Windows uses IBRS.
       type: keyword
       ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: ibytes
+      description: Input bytes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: icon_mode
+      description: Thumbnail icon mode
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: id
+      description: The unique identifier of the drive on the system.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: identifier
+      description: Plugin identifier
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: identifying_number
+      description: Product identification such as a serial number on software, or a die number on a hardware chip.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: identity
+      description: XProtect identity (SHA1) of content
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: idle
+      description: Time spent in the idle task
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: idrops
+      description: Input drops
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: idx
+      description: Extension load tag or index
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: ierrors
+      description: Input errors
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: image
+      description: Docker image (name) used to launch this container
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: image_id
+      description: Docker image ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: images
+      description: Number of images
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: in_smartctl_db
+      description: Boolean value for if drive is recognized
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: inactive
+      description: The total amount of buffer or page cache memory, in bytes, that are free and available
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: inetd_compatibility
+      description: Run this daemon or agent as it was launched from inetd
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: inf
+      description: Associated inf file
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: info
+      description: Additional information
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: info_access
+      description: Authority Information Access
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: info_string
+      description: Info properties CFBundleGetInfoString label
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: inherited_from
+      description: The inheritance policy of the ACE.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: iniface
+      description: Input interface for the rule.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: iniface_mask
+      description: Input interface mask for the rule.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: inode
+      description: Filesystem inode number
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: inodes
+      description: Number of meta nodes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: inodes_free
+      description: Mounted device free inodes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: inodes_total
+      description: Total number of inodes available in this storage pool
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: inodes_used
+      description: Number of inodes used
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: input_eax
+      description: Value of EAX used
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: install_date
+      description: The install date of the OS.
+      type: keyword
+      ignore_above: 1024
+    - name: install_location
+      description: The installation location directory of the product.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: install_source
+      description: The installation source of the product.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: install_time
+      description: Install time of the SDB
+      type: keyword
+      ignore_above: 1024
+    - name: install_timestamp
+      description: Extension install time, converted to unix time
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: installed_by
+      description: The system context in which the patch as installed.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: installed_on
+      description: The date when the patch was installed.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: installer_name
+      description: Name of installer process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: instance_id
+      description: EC2 instance ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: instance_identifier
+      description: The instance ID of Device Guard.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: instance_type
+      description: EC2 instance type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: instances
+      description: Number of instances of the named pipe
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: interface
+      description: Interface of the network for the MAC
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: interleave_data_depth
+      description: The max number of consecutive rows from memory device that are accessed in a single interleave transfer; 0 indicates device is non-interleave
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: interleave_position
+      description: The position of the device in a interleave, i.e. 0 indicates non-interleave, 1 indicates 1st interleave, 2 indicates 2nd interleave, etc.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: internal
+      description: 1 If the plugin is internal else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: internet_settings
+      description: The health of the Internet Settings
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: internet_sharing
+      description: 1 If internet sharing is enabled else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: interval
+      description: Difference between read and preread in nano-seconds
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: iowait
+      description: Time spent waiting for I/O to complete
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: ip_address
+      description: IP address
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ip_prefix_len
+      description: IP subnet prefix length
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: ipackets
+      description: Input packets
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: ipc_namespace
+      description: IPC namespace
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ipv4_address
+      description: IPv4 address
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ipv4_forwarding
+      description: 1 if IPv4 forwarding is enabled. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: ipv4_internet
+      description: True if any interface is connected to the Internet via IPv4
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: ipv4_local_network
+      description: True if any interface is connected to a routed network via IPv4
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: ipv4_no_traffic
+      description: True if any interface is connected via IPv4, but has seen no traffic
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: ipv4_subnet
+      description: True if any interface is connected to the local subnet via IPv4
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: ipv6_address
+      description: IPv6 address
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ipv6_gateway
+      description: IPv6 gateway
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ipv6_internet
+      description: True if any interface is connected to the Internet via IPv6
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: ipv6_local_network
+      description: True if any interface is connected to a routed network via IPv6
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: ipv6_no_traffic
+      description: True if any interface is connected via IPv6, but has seen no traffic
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: ipv6_prefix_len
+      description: IPv6 subnet prefix length
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: ipv6_subnet
+      description: True if any interface is connected to the local subnet via IPv6
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: irq
+      description: Time spent servicing interrupts
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: is_active
+      description: 1 if the application is in focus, 0 otherwise
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: is_elevated_token
+      description: Process uses elevated token yes=1, no=0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: is_hidden
+      description: IsHidden attribute set in OpenDirectory
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: iso_8601
+      description: Current time (ISO format) in the system
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: issuer
+      description: Certificate issuer distinguished name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: issuer_alternative_names
+      description: Issuer Alternative Name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: issuer_common_name
+      description: Issuer common name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: issuer_name
+      description: The certificate issuer name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: issuer_organization
+      description: Issuer organization
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: issuer_organization_unit
+      description: Issuer organization unit
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: job_id
+      description: Next queued job id
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: job_path
+      description: The object path for the job
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: job_type
+      description: Job type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: json_cmdline
+      description: Command line arguments, in JSON format
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: keep_alive
+      description: Should the process be restarted if killed
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: kernel_memory
+      description: 1 if kernel memory limit support is enabled. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: kernel_version
+      description: Kernel version
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: key
+      description: parsed authorized keys line
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: key_algorithm
+      description: Key algorithm used
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: key_file
+      description: Path to the authorized_keys file
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
     - name: key_strength
       description: Key size used for RSA/DSA, or curve name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: key_usage
+      description: Certificate key usage and extended key usage
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: keychain_path
+      description: The path of the keychain
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: keyword
+      description: The keyword applied to the package
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: keywords
+      description: A bitmask of the keywords defined in the event
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: kva_shadow_enabled
+      description: Kernel Virtual Address shadowing is enabled.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: kva_shadow_inv_pcid
+      description: Kernel VA INVPCID is enabled.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: kva_shadow_pcid
+      description: Kernel VA PCID flushing optimization is enabled.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: kva_shadow_user_global
+      description: User pages are marked as global.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: label
+      description: AppArmor label
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: language
+      description: The language of the product.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: last_change
+      description: Time of last device modification (optional)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: last_connected
+      description: Last time this netword was connected to as a unix_time
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: last_executed
+      description: UNIX time stamp in seconds of the last completed execution
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: last_execution_time
+      description: Most recent time application was executed.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: last_hit_date
+      description: Apple date format for last thumbnail cache hit
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: last_loaded
+      description: Last loaded module before panic
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: last_opened_time
+      description: The time that the app was last used
+      type: keyword
+      ignore_above: 1024
+    - name: last_run_code
+      description: Exit status code of the last task run
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: last_run_message
+      description: Exit status message of the last task run
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: last_run_time
+      description: Timestamp the task last ran
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: last_unloaded
+      description: Last unloaded module before panic
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: last_used_at
+      description: ISO time for the most recent use of this image in terms of container spawn
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: launch_type
+      description: Launch services content type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: layer_id
+      description: Layer ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: layer_order
+      description: Layer Order (1 = base layer)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: level
+      description: Log level number.  See levels in asl.h.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: license
+      description: License for package
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: link
+      description: Link to other section
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: link_speed
+      description: Interface speed in Mb/s
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: linked_against
+      description: Indexes of extensions this extension is linked against
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: load_state
+      description: Reflects whether the unit definition was properly loaded
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: local_address
+      description: Local address associated with socket
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: local_hostname
+      description: Private IPv4 DNS hostname of the first interface of this instance
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: local_ipv4
+      description: Private IPv4 address of the first interface of this instance
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: local_port
+      description: Local network protocol port number
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: local_time
+      description: Current local UNIX time in the system
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: local_timezone
+      description: Current local timezone in the system
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: location
+      description: Azure Region the VM is running in
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: lock
+      description: If TRUE, the frame is equipped with a lock.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: lock_status
+      description: The accessibility status of the drive from Windows.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: locked
+      description: 1 if segment is locked else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: log_file_disk_quota_mb
+      description: Event file disk quota in MB
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: log_file_disk_quota_percentage
+      description: Event file disk quota in a percentage
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: logging_driver
+      description: Logging driver
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: logging_enabled
+      description: 1 If logging mode is enabled else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: logging_option
+      description: Firewall logging option
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: logical_processors
+      description: The number of logical processors of the CPU.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: logon_domain
+      description: The name of the domain used to authenticate the owner of the logon session.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: logon_id
+      description: A locally unique identifier (LUID) that identifies a logon session.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: logon_script
+      description: The script used for logging on.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: logon_server
+      description: The name of the server used to authenticate the owner of the logon session.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: logon_sid
+      description: The user's security identifier (SID).
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: logon_time
+      description: The time the session owner logged on.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: logon_type
+      description: The logon method.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: lu_wwn_device_id
+      description: Device Identifier
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: mac
+      description: MAC address of broadcasted address
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: mac_address
+      description: MAC address
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: machine
+      description: Machine type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: machine_name
+      description: Name of the machine where the crash happened
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: magic_db_files
+      description: 'Colon(:) separated list of files where the magic db file can be found. By default one of the following is used: /usr/share/file/magic/magic, /usr/share/misc/magic or /usr/share/misc/magic.mgc'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: maintainer
+      description: Repository maintainer
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: major
+      description: Major release version
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: major_version
+      description: Windows major version of the machine
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: managed
+      description: 1 if network created by LXD, 0 otherwise
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: manifest_hash
+      description: The SHA256 hash of the manifest.json file
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: manifest_json
+      description: The manifest file of the extension
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: manual
+      description: 1 if policy was loaded manually, otherwise 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: manufacture_date
+      description: The date the battery was manufactured UNIX Epoch
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: manufacturer
+      description: The battery manufacturer's name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: mask
+      description: Interface netmask
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: match
+      description: The pattern that the script is matched against
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: matches
+      description: List of YARA matches
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: max
+      description: Maximum speed
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: max_capacity
+      description: The battery's actual capacity when it is fully charged in mAh
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: max_clock_speed
+      description: The maximum possible frequency of the CPU.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: max_instances
+      description: The maximum number of instances creatable for this pipe
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: max_speed
+      description: Max speed of memory device in megatransfers per second (MT/s)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: max_voltage
+      description: Maximum operating voltage of device in millivolts
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: maximum_allowed
+      description: Limit on the maximum number of users allowed to use this resource concurrently. The value is only valid if the AllowMaximum property is set to FALSE.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: md5
+      description: MD5 hash of table content
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: md_device_name
+      description: md device name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: mechanism
+      description: Name of the mechanism that will be called
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: med_capability_capabilities
+      description: Is MED capabilities enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: med_capability_inventory
+      description: Is MED inventory capability enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: med_capability_location
+      description: Is MED location capability enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: med_capability_mdi_pd
+      description: Is MED MDI PD capability enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: med_capability_mdi_pse
+      description: Is MED MDI PSE capability enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: med_capability_policy
+      description: Is MED policy capability enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: med_device_type
+      description: Chassis MED type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: med_policies
+      description: Comma delimited list of MED policies
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: media_name
+      description: Disk event media name string
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: mem
+      description: Memory utilization as percentage
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: double
+          default_field: false
+    - name: member_config_description
+      description: Config description
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: member_config_entity
+      description: Type of configuration parameter for this node
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: member_config_key
+      description: Config key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: member_config_name
+      description: Name of configuration parameter
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: member_config_value
+      description: Config value
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: memory
+      description: Total memory
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: memory_array_error_address
+      description: 32 bit physical address of the error based on the addressing of the bus to which the memory array is connected
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: memory_array_handle
+      description: Handle of the memory array associated with this structure
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: memory_array_mapped_address_handle
+      description: Handle of the memory array mapped address to which this device range is mapped to
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: memory_device_handle
+      description: Handle of the memory device structure associated with this structure
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: memory_error_correction
+      description: Primary hardware error correction or detection method supported
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: memory_error_info_handle
+      description: Handle, or instance number, associated with any error that was detected for the array
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: memory_free
+      description: The amount of physical RAM, in bytes, left unused by the system
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: memory_limit
+      description: Memory limit
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: memory_max_usage
+      description: Memory maximum usage
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: memory_total
+      description: Total amount of physical RAM, in bytes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: memory_type
+      description: Type of memory used
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: memory_type_details
+      description: Additional details for memory device
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: memory_usage
+      description: Memory usage
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: message
+      description: Raw audit message
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: metadata_endpoint
+      description: Endpoint used to fetch VM metadata
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: method
+      description: The HTTP method for the request
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: metric
+      description: Metric based on the speed of the interface
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: metric_name
+      description: Name of collected Prometheus metric
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: metric_value
+      description: Value of collected Prometheus metric
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: double
+          default_field: false
+    - name: mft_entry
+      description: Directory master file table entry.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: mft_sequence
+      description: Directory master file table sequence.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: mime_encoding
+      description: MIME encoding data from libmagic
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: mime_type
+      description: MIME type data from libmagic
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: min
+      description: Minimum speed
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: min_api_version
+      description: Minimum API version supported
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: min_version
+      description: The minimum allowed plugin version.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: min_voltage
+      description: Minimum operating voltage of device in millivolts
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: minimum_system_version
+      description: Minimum version of OS X required for the app to run
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: minor
+      description: Minor release version
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: minor_version
+      description: Windows minor version of the machine
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: minute
+      description: The exact minute for the job
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: minutes
+      description: Current minutes in the system
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: minutes_to_full_charge
+      description: The number of minutes until the battery is fully charged. This value is -1 if this time is still being calculated
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: minutes_until_empty
+      description: The number of minutes until the battery is fully depleted. This value is -1 if this time is still being calculated
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: mnt_namespace
+      description: Mount namespace
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: mode
+      description: How the policy is applied.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: model
+      description: The battery's model number
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: model_family
+      description: Drive model family
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: model_id
+      description: Hex encoded Hardware model identifier
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: modified
+      description: Label top-level key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: modified_time
+      description: Timestamp the file was installed
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: module
+      description: Path of the crashed module within the process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: module_backtrace
+      description: Modules appearing in the crashed module's backtrace
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: module_path
+      description: Path to ServiceDll
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: month
+      description: The month of the year for the job
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: mount_namespace_id
+      description: Mount namespace id
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: mount_point
+      description: Mount point
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: mountable
+      description: 1 if mountable, 0 if not
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: msize
+      description: Segment offset in memory
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: mtime
+      description: Last modification time
+      type: keyword
+      ignore_above: 1024
+    - name: mtu
+      description: Network MTU
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: name
+      description: ACPI table name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: name_constraints
+      description: Name Constraints
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: namespace
+      description: AppArmor namespace
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: native
+      description: Plugin requires native execution
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: net_namespace
+      description: Network namespace
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: netmask
+      description: Address (sortlist) netmask length
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: network_id
+      description: Network ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: network_name
+      description: Name of the network
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: network_rx_bytes
+      description: Total network bytes read
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: network_tx_bytes
+      description: Total network bytes transmitted
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: next_run_time
+      description: Timestamp the task is scheduled to run next
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: nice
+      description: Time spent in user mode with low priority (nice)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: no_proxy
+      description: Comma-separated list of domain extensions proxy should not be used for
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: node
+      description: The node path of the configuration item
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: node_ref_number
+      description: The ordinal that associates a journal record with a filename
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: noise
+      description: The current noise measurement (dBm)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: not_valid_after
+      description: Certificate expiration data
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: not_valid_before
+      description: Lower bound of valid date
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: nr_raid_disks
+      description: Number of partitions or disk devices to comprise the array
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: ntime
+      description: The nsecs uptime timestamp as obtained from BPF
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: num_procs
+      description: Number of processors
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: number
+      description: Protocol number
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: number_memory_devices
+      description: Number of memory devices on array
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: number_of_cores
+      description: The number of cores of the CPU.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: object_name
+      description: Object Name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: object_path
+      description: The object path for this unit
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: object_type
+      description: Object Type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: obytes
+      description: Output bytes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: odrops
+      description: Output drops
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: oerrors
+      description: Output errors
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: offer
+      description: Offer information for the VM image (Azure image gallery VMs only)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: offset
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: oid
+      description: Control MIB
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: old_path
+      description: Old path (renames only)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: on_demand
+      description: Deprecated key, replaced by keep_alive
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: on_disk
+      description: The process path exists yes=1, no=0, unknown=-1
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: online_cpus
+      description: Online CPUs
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: oom_kill_disable
+      description: 1 if Out-of-memory kill is disabled. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: opackets
+      description: Output packets
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: opaque_version
+      description: Version of Gatekeeper's gkopaque.bundle
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: operation
+      description: Permission requested by the process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: option
+      description: Canonical name of option
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: option_name
+      description: Option name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: option_value
+      description: Option value
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: optional
+      description: Match any of the identities/patterns for this XProtect name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: optional_permissions
+      description: The permissions optionally required by the extensions
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: optional_permissions_json
+      description: The JSON-encoded permissions optionally required by the extensions
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: options
+      description: Resolver options
+      type: keyword
+      ignore_above: 1024
+    - name: organization
+      description: Organization issued to
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: organization_unit
+      description: Organization unit issued to
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: original_program_name
+      description: The original program name that the publisher has signed
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: os
+      description: Operating system
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: os_type
+      description: Linux or Windows
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: os_version
+      description: Version of the operating system
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: other
+      description: Other information associated with array from /proc/mdstat
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ouid
+      description: Object owner's user ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: outiface
+      description: Output interface for the rule.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: outiface_mask
+      description: Output interface mask for the rule.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: output_bit
+      description: Bit in register value for feature value
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: output_register
+      description: Register used to for feature value
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: output_size
+      description: Total number of bytes generated by the query
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: overflows
+      description: List of structures that overflowed
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: owner_gid
+      description: File owner group ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: owner_uid
+      description: File owner user ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: owner_uuid
+      description: Extension route UUID (0 for core)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: package
+      description: Package name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: package_filename
+      description: Filename of original .pkg file
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: package_group
+      description: Package group
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: package_id
+      description: Label packageIdentifiers
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: packet_device_type
+      description: Packet device type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: packets
+      description: Number of matching packets for this rule.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: packets_received
+      description: Number of packets received on this network
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: packets_sent
+      description: Number of packets sent on this network
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: page_ins
+      description: The total number of requests for pages from a pager.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: page_outs
+      description: Total number of pages paged out.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: parent
+      description: Parent process PID
+      type: keyword
+      ignore_above: 1024
+    - name: parent_ref_number
+      description: The ordinal that associates a journal record with a filename's parent directory
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: part_number
+      description: Manufacturer specific serial number of memory device
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: partial
+      description: Set to 1 if either path or old_path only contains the file or folder name
+      type: keyword
+      ignore_above: 1024
+    - name: partition
+      description: A partition number
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: partition_row_position
+      description: Identifies the position of the referenced memory device in a row of the address partition
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: partition_width
+      description: Number of memory devices that form a single row of memory for the address partition of this structure
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: partitions
+      description: Number of detected partitions on disk.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: partner_fd
+      description: File descriptor of shared pipe at partner's end
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: partner_mode
+      description: Mode of shared pipe at partner's end
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: partner_pid
+      description: Process ID of partner process sharing a particular pipe
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: passpoint
+      description: 1 if Passpoint is supported, 0 otherwise
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: password_last_set_time
+      description: The time the password was last changed
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: double
+          default_field: false
+    - name: password_status
+      description: Password status
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: patch
+      description: Optional patch release
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: path
+      description: Path to the executable that is excepted
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: pci_class
+      description: PCI Device class
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: pci_class_id
+      description: PCI Device class ID in hex format
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: pci_slot
+      description: PCI slot number
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: pci_subclass
+      description: PCI Device subclass
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: pci_subclass_id
+      description: PCI Device  subclass in hex format
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: pem
+      description: Certificate PEM format
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: percent_disk_read_time
+      description: Percentage of elapsed time that the selected disk drive is busy servicing read requests
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: percent_disk_time
+      description: Percentage of elapsed time that the selected disk drive is busy servicing read or write requests
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: percent_disk_write_time
+      description: Percentage of elapsed time that the selected disk drive is busy servicing write requests
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: percent_idle_time
+      description: Percentage of time during the sample interval that the disk was idle
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: percent_processor_time
+      description: Returns elapsed time that all of the threads of this process used the processor to execute instructions in 100 nanoseconds ticks.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: percent_remaining
+      description: The percentage of battery remaining before it is drained
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: percentage_encrypted
+      description: The percentage of the drive that is encrypted.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: perf_ctl
+      description: Performance setting for the processor.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: perf_status
+      description: Performance status for the processor.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: period
+      description: Period over which the average is calculated.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: permanent
+      description: 1 for true, 0 for false
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: permissions
+      description: The permissions required by the extension
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: permissions_json
+      description: The JSON-encoded permissions required by the extension
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: persistent
+      description: 1 If extension is persistent across all tabs else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: persistent_volume_id
+      description: Persistent ID of the drive.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: pgroup
+      description: Process group
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: physical_adapter
+      description: Indicates whether the adapter is a physical or a logical adapter.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: physical_memory
+      description: Total physical memory in bytes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: pid
+      description: Process ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: pid_namespace
+      description: PID namespace
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: pid_with_namespace
+      description: Pids that contain a namespace
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: pids
+      description: Number of processes
+      type: keyword
+      ignore_above: 1024
+    - name: placement_group_id
+      description: Placement group for the VM scale set
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: platform
+      description: OS Platform or ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: platform_fault_domain
+      description: Fault domain the VM is running in
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: platform_info
+      description: Platform information.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: platform_like
+      description: Closely related platforms
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: platform_mask
+      description: The osquery platform bitmask
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: platform_update_domain
+      description: Update domain the VM is running in
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: plugin
+      description: Authorization plugin name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: pnp_device_id
+      description: The unique identifier of the drive on the system.
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -8639,12 +7290,16 @@
           type: text
           norms: false
           default_field: false
-    - name: avg_disk_sec_per_read
-      description: Average time, in seconds, of a read operation of data from the disk
+    - name: points
+      description: This is a signed SQLite int column
       type: keyword
       ignore_above: 1024
-    - name: default_value
-      description: Flag default value
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: policies
+      description: Certificate Policies
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -8652,12 +7307,8 @@
           type: text
           norms: false
           default_field: false
-    - name: file_backed
-      description: Total number of file backed pages.
-      type: keyword
-      ignore_above: 1024
-    - name: matches
-      description: List of YARA matches
+    - name: policy
+      description: Policy that applies for this rule.
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -8665,12 +7316,1222 @@
           type: text
           norms: false
           default_field: false
-    - name: capability
-      description: Capability number
+    - name: policy_constraints
+      description: Policy Constraints
       type: keyword
       ignore_above: 1024
-    - name: condition
-      description: 'One of the following: "Normal" indicates the condition of the battery is within normal tolerances, "Service Needed" indicates that the battery should be checked out by a licensed Mac repair service, "Permanent Failure" indicates the battery needs replacement'
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: policy_mappings
+      description: Policy Mappings
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: port
+      description: Port inside the container
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: port_aggregation_id
+      description: Port aggregation ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: port_autoneg_1000baset_fd_enabled
+      description: 1000Base-T FD auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: port_autoneg_1000baset_hd_enabled
+      description: 1000Base-T HD auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: port_autoneg_1000basex_fd_enabled
+      description: 1000Base-X FD auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: port_autoneg_1000basex_hd_enabled
+      description: 1000Base-X HD auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: port_autoneg_100baset2_fd_enabled
+      description: 100Base-T2 FD auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: port_autoneg_100baset2_hd_enabled
+      description: 100Base-T2 HD auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: port_autoneg_100baset4_fd_enabled
+      description: 100Base-T4 FD auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: port_autoneg_100baset4_hd_enabled
+      description: 100Base-T4 HD auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: port_autoneg_100basetx_fd_enabled
+      description: 100Base-TX FD auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: port_autoneg_100basetx_hd_enabled
+      description: 100Base-TX HD auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: port_autoneg_10baset_fd_enabled
+      description: 10Base-T FD auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: port_autoneg_10baset_hd_enabled
+      description: 10Base-T HD auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: port_autoneg_enabled
+      description: Is auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: port_autoneg_supported
+      description: Auto negotiation supported
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: port_description
+      description: Port description
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: port_id
+      description: Port ID value
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: port_id_type
+      description: Port ID type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: port_mau_type
+      description: MAU type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: port_mfs
+      description: Port max frame size
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: port_ttl
+      description: Age of neighbor port
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: possibly_hidden
+      description: 1 if network is possibly a hidden network, 0 otherwise
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: power_8023at_enabled
+      description: Is 802.3at enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: power_8023at_power_allocated
+      description: 802.3at power allocated
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: power_8023at_power_priority
+      description: 802.3at power priority
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: power_8023at_power_requested
+      description: 802.3at power requested
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: power_8023at_power_source
+      description: 802.3at power source
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: power_8023at_power_type
+      description: 802.3at power type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: power_class
+      description: Power class
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: power_device_type
+      description: Dot3 power device type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: power_mdi_enabled
+      description: Is MDI power enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: power_mdi_supported
+      description: MDI power supported
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: power_mode
+      description: Device power mode
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: power_paircontrol_enabled
+      description: Is power pair control enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: power_pairs
+      description: Dot3 power pairs
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ppid
+      description: Parent process ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: ppvids_enabled
+      description: Comma delimited list of enabled PPVIDs
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ppvids_supported
+      description: Comma delimited list of supported PPVIDs
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: pre_cpu_kernelmode_usage
+      description: Last read CPU kernel mode usage
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: pre_cpu_total_usage
+      description: Last read total CPU usage
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: pre_cpu_usermode_usage
+      description: Last read CPU user mode usage
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: pre_online_cpus
+      description: Last read online CPUs
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: pre_system_cpu_usage
+      description: Last read CPU system usage
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: preread
+      description: UNIX time when stats were last read
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: principal
+      description: User or group to which the ACE applies.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: printer_sharing
+      description: 1 If printer sharing is enabled else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: priority
+      description: Package priority
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: privileged
+      description: If privileged it will run as root, else as an anonymous user
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: probe_error
+      description: Set to 1 if one or more buffers could not be captured
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: process
+      description: Process name explicitly allowed
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: process_being_tapped
+      description: The process ID of the target application
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: process_type
+      description: Key describes the intended purpose of the job
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: process_uptime
+      description: Uptime of the process in seconds
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: processes
+      description: Number of processes running inside this instance
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: processing_time
+      description: How long the job took to process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: processor_number
+      description: The processor number as reported in /proc/cpuinfo
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: processor_type
+      description: The processor type, such as Central, Math, or Video.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: product_version
+      description: File product version
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: profile
+      description: Apparmor profile name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: profile_path
+      description: The profile path
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: program
+      description: Path to target program
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: program_arguments
+      description: Command line arguments passed to program
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: propagation
+      description: Mount propagation
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: protected
+      description: 1 if this handler is protected (reserved) by OS X, else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: protection_disabled
+      description: If the sensor is configured to report tamper events
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: protection_status
+      description: The bitlocker protection status of the drive.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: protocol
+      description: The network protocol ID
+      type: keyword
+      ignore_above: 1024
+    - name: provider
+      description: Driver provider
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: provider_guid
+      description: Provider guid of the event
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: provider_name
+      description: Provider name of the event
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: pseudo
+      description: 1 If path is a pseudo path, else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: psize
+      description: Size of segment in file
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: public
+      description: Whether image is public (1) or not (0)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: publisher
+      description: Publisher of the VM image
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: purgeable
+      description: Total number of purgeable pages.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: purged
+      description: Total number of purged pages.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: pvid
+      description: Primary VLAN id
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: query
+      description: The query that was run to find the file
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: query_language
+      description: Query language that the query is written in.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: queue_directories
+      description: Similar to watch_paths but only with non-empty directories
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: raid_disks
+      description: Number of configured RAID disks in array
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: raid_level
+      description: Current raid level of the array
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: rapl_energy_status
+      description: Run Time Average Power Limiting energy status.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: rapl_power_limit
+      description: Run Time Average Power Limiting power limit.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: rapl_power_units
+      description: Run Time Average Power Limiting power units.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: reactivated
+      description: Total number of reactivated pages.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: read
+      description: UNIX time when stats were read
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: read_device_identity_failure
+      description: Error string for device id read, if any
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: readonly
+      description: 1 if the share is exported readonly else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: readonly_rootfs
+      description: Is the root filesystem mounted as read only
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: record_timestamp
+      description: Journal record timestamp
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: record_usn
+      description: The update sequence number that identifies the journal record
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: recovery_finish
+      description: Estimated duration of recovery activity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: recovery_progress
+      description: Progress of the recovery activity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: recovery_speed
+      description: Speed of recovery activity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: redirect_accept
+      description: Accept ICMP redirect messages
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: ref_pid
+      description: Reference PID for messages proxied by launchd
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: ref_proc
+      description: Reference process for messages proxied by launchd
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: referenced
+      description: 1 if this extension is referenced by the Preferences file of the profile
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: refreshes
+      description: 'Publisher only: number of runloop restarts'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: refs
+      description: Module reverse dependencies
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: region
+      description: AWS region in which this instance launched
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: registers
+      description: The value of the system registers
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: registry
+      description: Name of the osquery registry
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: registry_hive
+      description: HKEY_USERS registry hive
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: registry_path
+      description: Extension identifier
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: relative_path
+      description: Relative path to the class or instance.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: release
+      description: Release name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: remediation_path
+      description: Remediation path
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: remote_address
+      description: Remote address associated with socket
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: remote_apple_events
+      description: 1 If remote apple events are enabled else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: remote_login
+      description: 1 If remote login is enabled else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: remote_management
+      description: 1 If remote management is enabled else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: remote_port
+      description: Remote network protocol port number
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: removable
+      description: 1 If USB device is removable else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: repository
+      description: From which repository the ebuild was used
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: request_id
+      description: Identifying value of the carve request (e.g., scheduled query name, distributed request, etc)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: requested_mask
+      description: Requested access mask
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: requirement
+      description: Code signing requirement language
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: reservation_id
+      description: ID of the reservation
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: reshape_finish
+      description: Estimated duration of reshape activity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: reshape_progress
+      description: Progress of the reshape activity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: reshape_speed
+      description: Speed of reshape activity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: resident_size
+      description: Bytes of private memory used by process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: resource_group_name
+      description: Resource group for the VM
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: response_code
+      description: The HTTP status code for the response
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: responsible
+      description: Process responsible for the crashed process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: result
+      description: The signature check result
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: resync_finish
+      description: Estimated duration of resync activity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: resync_progress
+      description: Progress of the resync activity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: resync_speed
+      description: Speed of resync activity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: retain_count
+      description: The device reference count
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: revision
+      description: Package revision
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: rid
+      description: Neighbor chassis index
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: roaming
+      description: 1 if roaming is supported, 0 otherwise
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: roaming_profile
+      description: Describe the roaming profile, usually one of Single, Dual  or Multi
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: root
+      description: Process virtual root directory
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: root_dir
+      description: Docker root directory
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: root_directory
+      description: Key used to specify a directory to chroot to before launch
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: root_volume_uuid
+      description: Root UUID of backup volume
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: rotation_rate
+      description: Drive RPM
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -8682,6 +8543,69 @@
       description: Time taken to complete the request
       type: keyword
       ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: rowid
+      description: Quicklook file rowid key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: rssi
+      description: The current received signal strength indication (dbm)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: rtadv_accept
+      description: Accept ICMP Router Advertisement
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: rule_details
+      description: Rule definition
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: run_at_load
+      description: Should the program run on launch load
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: rw
+      description: 1 if read/write. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: sata_version
+      description: SATA version, if any
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
     - name: scheme
       description: Name of the scheme/protocol
       type: keyword
@@ -8691,7 +8615,2171 @@
           type: text
           norms: false
           default_field: false
-    - name: crashed_thread
-      description: Thread ID which crashed
+    - name: scope
+      description: Where the key is located inside the SELinuxFS mount point.
       type: keyword
       ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: screen_sharing
+      description: 1 If screen sharing is enabled else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: script
+      description: The content script used by the extension
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: script_block_count
+      description: The total number of script blocks for this script
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: script_block_id
+      description: The unique GUID of the powershell script to which this block belongs
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: script_file_name
+      description: Name of the file from which the script text is read, intended as an alternative to specifying the text of the script in the ScriptText property.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: script_name
+      description: The name of the Powershell script
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: script_path
+      description: The path for the Powershell script
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: script_text
+      description: The text content of the Powershell script
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: scripting_engine
+      description: Name of the scripting engine to use, for example, 'VBScript'. This property cannot be NULL.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sdb_id
+      description: Unique GUID of the SDB.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sdk
+      description: Build SDK used to compile plugin
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sdk_version
+      description: osquery SDK version used to build the extension
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: seconds
+      description: Current seconds in the system
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: section
+      description: Package section
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sector_sizes
+      description: Bytes of drive sector sizes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: security_breach
+      description: The physical status of the chassis such as Breach Successful, Breach Attempted, etc.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: security_groups
+      description: Comma separated list of security group names
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: security_options
+      description: List of container security options
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: security_type
+      description: Type of security on this network
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: self_signed
+      description: 1 if self-signed, else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: sender
+      description: Sender's identification string.  Default is process name.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sensor_backend_server
+      description: Carbon Black server
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sensor_id
+      description: Sensor ID of the Carbon Black sensor
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: sensor_ip_addr
+      description: IP address of the sensor
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: serial
+      description: Certificate serial number
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: serial_number
+      description: The certificate serial number
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: serial_port_enabled
+      description: Indicates if serial port is enabled for the VM
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: series
+      description: The series of the gpu.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: server_name
+      description: Name of the LXD server node
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: server_version
+      description: Server version
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: service
+      description: Driver service name, if one exists
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: service_exit_code
+      description: The service-specific error code that the service returns when an error occurs while the service is starting or stopping
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: service_key
+      description: Driver service registry key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: service_type
+      description: 'Service Type: OWN_PROCESS, SHARE_PROCESS and maybe Interactive (can interact with the desktop)'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: session_id
+      description: The Terminal Services session identifier.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: session_owner
+      description: Label top-level key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: set
+      description: Identifies if memory device is one of a set of devices.  A value of 0 indicates no set affiliation.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: severity
+      description: Syslog severity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: sgid
+      description: Saved group ID
+      type: keyword
+      ignore_above: 1024
+    - name: sha1
+      description: A unique hash that identifies this policy.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sha1_fingerprint
+      description: SHA1 fingerprint
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sha256
+      description: A SHA256 sum of the carved archive
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sha256_fingerprint
+      description: SHA-256 fingerprint
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: shard
+      description: Shard restriction limit, 1-100, 0 meaning no restriction
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: share
+      description: Filesystem path to the share
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: shared
+      description: Label top-level key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: shell
+      description: User's configured default shell
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: shell_only
+      description: Is the flag shell only?
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: shmid
+      description: Shared memory segment ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: sid
+      description: User SID.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sig_group
+      description: Signature group used
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sigfile
+      description: Signature file used
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: signature
+      description: Signature
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: signature_algorithm
+      description: Signature Algorithm
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: signatures_up_to_date
+      description: 1 if product signatures are up to date, else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: signed
+      description: Whether the driver is signed or not
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: signing_algorithm
+      description: Signing algorithm used
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sigrule
+      description: Signature strings used
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sigurl
+      description: Signature url
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: size
+      description: Size of compiled table data
+      type: keyword
+      ignore_above: 1024
+    - name: size_bytes
+      description: Size of image in bytes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: sku
+      description: SKU for the VM image
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: slot
+      description: Slot position of disk
+      type: keyword
+      ignore_above: 1024
+    - name: smart_enabled
+      description: SMART enabled status
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: smart_supported
+      description: SMART support status
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: smbios_tag
+      description: The assigned asset tag number of the chassis.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: socket
+      description: Socket handle or inode number
+      type: keyword
+      ignore_above: 1024
+    - name: socket_designation
+      description: The assigned socket on the board for the given CPU.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: soft_limit
+      description: Current limit value
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: softirq
+      description: Time spent servicing softirqs
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: source
+      description: Source file
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: source_path
+      description: Path to the (possibly generated) unit configuration file
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: source_url
+      description: URL that installed the addon
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: space_total
+      description: Total available storage space in bytes for this storage pool
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: space_used
+      description: Storage space used in bytes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: spare_disks
+      description: Number of idle disks in array
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: speculative
+      description: Total number of speculative pages.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: speed
+      description: Estimate of the current bandwidth in bits per second.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: src_ip
+      description: Source IP address.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: src_mask
+      description: Source IP address mask.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: src_port
+      description: Protocol source port(s).
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ssdeep
+      description: ssdeep hash of provided filesystem data
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ssh_config_file
+      description: Path to the ssh_config file
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ssh_public_key
+      description: SSH public key. Only available if supplied at instance launch time
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ssid
+      description: SSID octets of the network
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: stack_trace
+      description: Most recent frame from the stack trace
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: start
+      description: Start address of memory region
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: start_interval
+      description: Frequency to run in seconds
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: start_on_mount
+      description: Run daemon or agent every time a filesystem is mounted
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: start_time
+      description: Process start in seconds since boot (non-sleeping)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: start_type
+      description: 'Service start type: BOOT_START, SYSTEM_START, AUTO_START, DEMAND_START, DISABLED'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: started_at
+      description: Container start time as string
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: starting_address
+      description: Physical stating address, in kilobytes, of a range of memory mapped to physical memory array
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: state
+      description: Firewall exception state
+      type: keyword
+      ignore_above: 1024
+    - name: state_timestamp
+      description: Timestamp for the product state
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: stateful
+      description: Whether the instance is stateful(1) or not(0)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: statename
+      description: Installation state name. 'Enabled','Disabled','Absent'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: status
+      description: Status of the carve, can be STARTING, PENDING, SUCCESS, or FAILED
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: stderr_path
+      description: Pipe stderr to a target path
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: stdout_path
+      description: Pipe stdout to a target path
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: steal
+      description: Time spent in other operating systems when running in a virtualized environment
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: stealth_enabled
+      description: 1 If stealth mode is enabled else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: stibp_support_enabled
+      description: Windows uses STIBP.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: storage_driver
+      description: Storage driver
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: store
+      description: Certificate system store
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: store_id
+      description: Exists for service/user stores. Contains raw store id provided by WinAPI.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: store_location
+      description: Certificate system store location
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: strings
+      description: Matching strings
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sub_state
+      description: The low-level unit activation state, values depend on unit type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subclass
+      description: USB Device subclass
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subject
+      description: Certificate distinguished name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subject_alternative_names
+      description: Subject Alternative Name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subject_info_access
+      description: Subject Information Access
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subject_key_id
+      description: SKID an optionally included SHA1
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subject_key_identifier
+      description: Subject Key Identifier
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subject_name
+      description: The certificate subject name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subkey
+      description: Intermediate key path, includes lists/dicts
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subnet
+      description: Network subnet
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subscription_id
+      description: Azure subscription for the VM
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subscriptions
+      description: Number of subscriptions the publisher received or subscriber used
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: subsystem
+      description: Subsystem ID, control type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subsystem_model
+      description: Device description of PCI device subsystem
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subsystem_model_id
+      description: Model ID of PCI device subsystem
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subsystem_vendor
+      description: Vendor of PCI device subsystem
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subsystem_vendor_id
+      description: Vendor ID of PCI device subsystem
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: success
+      description: The socket open attempt status
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: suid
+      description: Saved user ID
+      type: keyword
+      ignore_above: 1024
+    - name: summary
+      description: Package-supplied summary
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: superblock_state
+      description: State of the superblock
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: superblock_update_time
+      description: Unix timestamp of last update
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: superblock_version
+      description: Version of the superblock
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: swap_cached
+      description: The amount of swap, in bytes, used as cache memory
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: swap_free
+      description: The total amount of swap free, in bytes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: swap_ins
+      description: The total number of compressed pages that have been swapped out to disk.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: swap_limit
+      description: 1 if swap limit support is enabled. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: swap_outs
+      description: The total number of compressed pages that have been swapped back in from disk.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: swap_total
+      description: The total amount of swap available, in bytes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: symlink
+      description: 1 if the path is a symlink, otherwise 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: syscall
+      description: System call name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: system
+      description: Time spent in system mode
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: system_cpu_usage
+      description: CPU system usage
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: system_model
+      description: Physical system model, for example 'MacBookPro12,1 (Mac-E43C1C25D4880AD6)'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: system_time
+      description: Total system time spent executing
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: table
+      description: Table name containing symbol
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: tag
+      description: Tag ID
+      type: keyword
+      ignore_above: 1024
+    - name: tags
+      description: Comma-separated list of tags
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: tapping_process
+      description: The process ID of the application that created the event tap.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: target
+      description: Target speed
+      type: keyword
+      ignore_above: 1024
+    - name: target_name
+      description: Address of prometheus target
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: target_path
+      description: The path associated with the event
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: task
+      description: Task value associated with the event
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: team
+      description: Signing team ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: team_identifier
+      description: The team signing identifier sealed into the signature
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: temporarily_disabled
+      description: 1 if this network is temporarily disabled, 0 otherwise
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: terminal
+      description: The network protocol ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: threads
+      description: Number of threads used by process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: throttled
+      description: Total number of throttled pages.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: tid
+      description: Thread ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: time
+      description: Time of execution in UNIX time
+      type: keyword
+      ignore_above: 1024
+    - name: time_nano_sec
+      description: Nanosecond time.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: time_range
+      description: System time to selectively filter the events
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: timeout
+      description: Label top-level key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: timestamp
+      description: Current timestamp (log format) in the system
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: timestamp_ms
+      description: Unix timestamp of collected data in MS
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: timezone
+      description: Current timezone in the system
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: title
+      description: Title of the printed job
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: total_seconds
+      description: Total uptime seconds
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: total_size
+      description: Total virtual memory size
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: total_width
+      description: Total width, in bits, of this memory device, including any check or error-correction bits
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: transaction_id
+      description: ID used during bulk update
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: transmit_rate
+      description: The current transmit rate
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: transport_type
+      description: Drive transport type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: tries
+      description: Label top-level key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: tty
+      description: Entry terminal
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: turbo_disabled
+      description: Whether the turbo feature is disabled.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: turbo_ratio_limit
+      description: The turbo feature ratio limit.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: type
+      description: Event type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: uid
+      description: User ID
+      type: keyword
+      ignore_above: 1024
+    - name: uid_signed
+      description: User ID as int64 signed (Apple)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: umci_policy_status
+      description: The status of the User Mode Code Integrity security settings. Returns UNKNOWN if an error is encountered.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: uncompressed
+      description: Total number of uncompressed pages.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: uninstall_string
+      description: Path and filename of the uninstaller.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: unique_chip_id
+      description: Unique id of the iBridge controller
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: unix_time
+      description: Current UNIX time in the system, converted to UTC if --utc enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: unmask
+      description: If the package is unmasked
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: unused_devices
+      description: Unused devices
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: update_source_alias
+      description: Alias of image at update source server
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: update_source_certificate
+      description: Certificate for update source server
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: update_source_protocol
+      description: Protocol used for image information update and image import from source server
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: update_source_server
+      description: Server for image update
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: update_url
+      description: Extension-supplied update URI
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: upid
+      description: A 64bit pid that is never reused. Returns -1 if we couldn't gather them from the system.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: uploaded_at
+      description: ISO time of image upload
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: upn
+      description: The user principal name (UPN) for the owner of the logon session.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: uppid
+      description: The 64bit parent pid that is never reused. Returns -1 if we couldn't gather them from the system.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: uptime
+      description: Time of execution in system uptime
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: url
+      description: The url for the request
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: usb_address
+      description: USB Device used address
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: usb_port
+      description: USB Device used port
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: use
+      description: Function for which the array is used
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: used_by
+      description: Module reverse dependencies
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: user
+      description: Time spent in user mode
+      type: keyword
+      ignore_above: 1024
+    - name: user_account
+      description: The name of the account that the service process will be logged on as when it runs. This name can be of the form Domain\UserName. If the account belongs to the built-in domain, the name can be of the form .\UserName.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: user_account_control
+      description: The health of the User Account Control (UAC) capability in Windows
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: user_action
+      description: Action taken by user after prompted
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: user_agent
+      description: The user-agent string to use for the request
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: user_capacity
+      description: Bytes of drive capacity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: user_namespace
+      description: User namespace
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: user_time
+      description: Total user time spent executing
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: user_uuid
+      description: UUID of authenticated user if available
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: username
+      description: Username
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: uses_pattern
+      description: Uses a match pattern instead of identity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: uts_namespace
+      description: UTS namespace
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: uuid
+      description: Block device Universally Unique Identifier
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: vaddr
+      description: Section virtual address in memory
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: valid_from
+      description: Period of validity start date
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: valid_to
+      description: Period of validity end date
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: value
+      description: Variable typed option value
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: valuetype
+      description: CoreFoundation type of data stored in value
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: variable
+      description: Name of the environment variable
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: vbs_status
+      description: The status of the virtualization based security settings. Returns UNKNOWN if an error is encountered.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: vendor
+      description: Block device vendor string
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: vendor_id
+      description: Hex encoded Hardware vendor identifier
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: vendor_syndrome
+      description: Vendor specific ECC syndrome or CRC data associated with the erroneous access
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: version
+      description: Application Layer Firewall version
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: video_mode
+      description: The current resolution of the display.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: visible
+      description: 1 If the addon is shown in browser else 0
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: visible_alarm
+      description: If TRUE, the frame is equipped with a visual alarm.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: vlans
+      description: Comma delimited list of vlan ids
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: vm_id
+      description: Unique identifier for the VM
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: vm_scale_set_name
+      description: VM scale set name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: vm_size
+      description: VM size
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: voltage
+      description: The battery's current voltage in mV
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: volume_id
+      description: Parsed volume ID from fs_id
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: volume_serial
+      description: Volume serial number
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: volume_size
+      description: (Optional) size of firmware volume
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: wall_time
+      description: Total wall time spent executing
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: warning
+      description: Number of days before password expires to warn user about it
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: warnings
+      description: Warning messages from SMART controller
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: watch_paths
+      description: Key that launches daemon or agent if path is modified
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: watcher
+      description: Process (or thread/handle) ID of optional watcher process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: weekday
+      description: Current weekday in the system
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: win32_exit_code
+      description: The error code that the service uses to report an error that occurs when it is starting or stopping
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: win_timestamp
+      description: Timestamp value in 100 nanosecond units.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: windows_security_center_service
+      description: The health of the Windows Security Center Service
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: wired
+      description: Total number of wired down pages.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: wired_size
+      description: Bytes of unpageable memory used by process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: working_directory
+      description: Key used to specify a directory to chdir to before launch
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: working_disks
+      description: Number of working disks in array
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: world
+      description: If package is in the world file
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: writable
+      description: 1 if writable, 0 if not
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: xpath
+      description: The custom query to filter events
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: year
+      description: Current year in the system
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: zero_fill
+      description: Total number of zero filled pages.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: zone
+      description: Availability zone of the VM
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false

--- a/packages/osquery_manager/data_stream/result/fields/osquery.yml
+++ b/packages/osquery_manager/data_stream/result/fields/osquery.yml
@@ -1,0 +1,8697 @@
+- name: osquery
+  title: Osquery result
+  description: Fields related to the Osquery result
+  type: group
+  fields:
+    - name: arguments
+      description: Kernel arguments
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: stderr_path
+      description: Pipe stderr to a target path
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: model_family
+      description: Drive model family
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: usb_address
+      description: USB Device used address
+      type: keyword
+      ignore_above: 1024
+    - name: sigurl
+      description: Signature url
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: bundle_identifier
+      description: Info properties CFBundleIdentifier label
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: vm_size
+      description: VM size
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: zone
+      description: Availability zone of the VM
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: store
+      description: Certificate system store
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: chassis_types
+      description: A comma-separated list of chassis types, such as Desktop or Laptop.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: storage_driver
+      description: Storage driver
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: fan
+      description: Fan number
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: power_8023at_power_source
+      description: 802.3at power source
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: protected
+      description: 1 if this handler is protected (reserved) by OS X, else 0
+      type: keyword
+      ignore_above: 1024
+    - name: message
+      description: Raw audit message
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: serial_number
+      description: The certificate serial number
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: physical_memory
+      description: Total physical memory in bytes
+      type: keyword
+      ignore_above: 1024
+    - name: update_source_certificate
+      description: Certificate for update source server
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: perf_ctl
+      description: Performance setting for the processor.
+      type: keyword
+      ignore_above: 1024
+    - name: package
+      description: Package name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: active_disks
+      description: Number of active disks in array
+      type: keyword
+      ignore_above: 1024
+    - name: refs
+      description: Module reverse dependencies
+      type: keyword
+      ignore_above: 1024
+    - name: pci_class_id
+      description: PCI Device class ID in hex format
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: script_block_count
+      description: The total number of script blocks for this script
+      type: keyword
+      ignore_above: 1024
+    - name: bluetooth_sharing
+      description: 1 If bluetooth sharing is enabled for any user else 0
+      type: keyword
+      ignore_above: 1024
+    - name: encryption_method
+      description: The encryption type of the device.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: guest
+      description: Time spent running a virtual CPU for a guest OS under the control of the Linux kernel
+      type: keyword
+      ignore_above: 1024
+    - name: oom_kill_disable
+      description: 1 if Out-of-memory kill is disabled. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+    - name: event_tapped
+      description: The mask that identifies the set of events to be observed.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: upid
+      description: A 64bit pid that is never reused. Returns -1 if we couldn't gather them from the system.
+      type: keyword
+      ignore_above: 1024
+    - name: blocks
+      description: Number of blocks
+      type: keyword
+      ignore_above: 1024
+    - name: writable
+      description: 1 if writable, 0 if not
+      type: keyword
+      ignore_above: 1024
+    - name: vaddr
+      description: Section virtual address in memory
+      type: keyword
+      ignore_above: 1024
+    - name: msize
+      description: Segment offset in memory
+      type: keyword
+      ignore_above: 1024
+    - name: turbo_ratio_limit
+      description: The turbo feature ratio limit.
+      type: keyword
+      ignore_above: 1024
+    - name: keyword
+      description: The keyword applied to the package
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: policy_mappings
+      description: Policy Mappings
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: options
+      description: Resolver options
+      type: keyword
+      ignore_above: 1024
+    - name: cpu_shares
+      description: 1 if CPU share weighting support is enabled. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+    - name: logon_server
+      description: The name of the server used to authenticate the owner of the logon session.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: consumer
+      description: Reference to an instance of __EventConsumer that represents the object path to a logical consumer, the recipient of an event.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cycle_count
+      description: The number of charge/discharge cycles
+      type: keyword
+      ignore_above: 1024
+    - name: network_id
+      description: Network ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: base64
+      description: 1 if the value is base64 encoded else 0
+      type: keyword
+      ignore_above: 1024
+    - name: channel_width
+      description: Channel width
+      type: keyword
+      ignore_above: 1024
+    - name: protocol
+      description: The network protocol ID
+      type: keyword
+      ignore_above: 1024
+    - name: sensor_ip_addr
+      description: IP address of the sensor
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: tags
+      description: Comma-separated list of tags
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: coprocessor_version
+      description: The manufacturer and chip version
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: dhcp_enabled
+      description: If TRUE, the dynamic host configuration protocol (DHCP) server automatically assigns an IP address to the computer system when establishing a network connection.
+      type: keyword
+      ignore_above: 1024
+    - name: uid
+      description: User ID
+      type: keyword
+      ignore_above: 1024
+    - name: stealth_enabled
+      description: 1 If stealth mode is enabled else 0
+      type: keyword
+      ignore_above: 1024
+    - name: health
+      description: 'One of the following: "Good" describes a well-performing battery, "Fair" describes a functional battery with limited capacity, or "Poor" describes a battery that''s not capable of providing power'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ppvids_enabled
+      description: Comma delimited list of enabled PPVIDs
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: metadata_endpoint
+      description: Endpoint used to fetch VM metadata
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: content
+      description: Disk event content
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: rw
+      description: 1 if read/write. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+    - name: config_entrypoint
+      description: Container entrypoint(s)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: vm_id
+      description: Unique identifier for the VM
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: executable_path
+      description: Module to execute. The string can specify the full path and file name of the module to execute, or it can specify a partial name. If a partial name is specified, the current drive and current directory are assumed.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subkey
+      description: Intermediate key path, includes lists/dicts
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: percent_processor_time
+      description: Returns elapsed time that all of the threads of this process used the processor to execute instructions in 100 nanoseconds ticks.
+      type: keyword
+      ignore_above: 1024
+    - name: printer_sharing
+      description: 1 If printer sharing is enabled else 0
+      type: keyword
+      ignore_above: 1024
+    - name: subsystem
+      description: Subsystem ID, control type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: job_type
+      description: Job type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: signing_algorithm
+      description: Signing algorithm used
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subnet
+      description: Network subnet
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: power_class
+      description: Power class
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: image
+      description: Docker image (name) used to launch this container
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: iniface
+      description: Input interface for the rule.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: power_device_type
+      description: Dot3 power device type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: shmid
+      description: Shared memory segment ID
+      type: keyword
+      ignore_above: 1024
+    - name: dump_certificate
+      description: Set this value to '1' to dump certificate
+      type: keyword
+      ignore_above: 1024
+    - name: disk_size
+      description: Size of the disk.
+      type: keyword
+      ignore_above: 1024
+    - name: resync_finish
+      description: Estimated duration of resync activity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: disc_sharing
+      description: 1 If CD or DVD sharing is enabled else 0
+      type: keyword
+      ignore_above: 1024
+    - name: issuer_name
+      description: The certificate issuer name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: serial
+      description: Certificate serial number
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: store_location
+      description: Certificate system store location
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cpu_total_usage
+      description: Total CPU usage
+      type: keyword
+      ignore_above: 1024
+    - name: hardware_version
+      description: Hardware version
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ipv4_no_traffic
+      description: True if any interface is connected via IPv4, but has seen no traffic
+      type: keyword
+      ignore_above: 1024
+    - name: filevault_status
+      description: 'FileVault status with one of following values: on | off | unknown'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cpu
+      description: CPU utilization as percentage
+      type: keyword
+      ignore_above: 1024
+    - name: bsd_flags
+      description: 'The BSD file flags (chflags). Possible values: NODUMP, UF_IMMUTABLE, UF_APPEND, OPAQUE, HIDDEN, ARCHIVED, SF_IMMUTABLE, SF_APPEND'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: dst_ip
+      description: Destination IP address.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: root_directory
+      description: Key used to specify a directory to chroot to before launch
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: chassis_bridge_capability_available
+      description: Chassis bridge capability availability
+      type: keyword
+      ignore_above: 1024
+    - name: developer_id
+      description: Optional developer identifier
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: shared
+      description: Label top-level key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: from_webstore
+      description: True if this extension was installed from the web store
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: threads
+      description: Number of threads used by process
+      type: keyword
+      ignore_above: 1024
+    - name: partition_row_position
+      description: Identifies the position of the referenced memory device in a row of the address partition
+      type: keyword
+      ignore_above: 1024
+    - name: end
+      description: End address of memory region
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: discovery_executions
+      description: The number of times that the discovery queries have been executed since the last time the config was reloaded
+      type: keyword
+      ignore_above: 1024
+    - name: manifest_hash
+      description: The SHA256 hash of the manifest.json file
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: blocks_size
+      description: Byte size of each block
+      type: keyword
+      ignore_above: 1024
+    - name: umci_policy_status
+      description: The status of the User Mode Code Integrity security settings. Returns UNKNOWN if an error is encountered.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: pem
+      description: Certificate PEM format
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: oerrors
+      description: Output errors
+      type: keyword
+      ignore_above: 1024
+    - name: channel_band
+      description: Channel band
+      type: keyword
+      ignore_above: 1024
+    - name: med_capability_inventory
+      description: Is MED inventory capability enabled
+      type: keyword
+      ignore_above: 1024
+    - name: device_locator
+      description: String number of the string that identifies the physically-labeled socket or board position where the memory device is located
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sector_sizes
+      description: Bytes of drive sector sizes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: failed_login_timestamp
+      description: The time of the last failed login attempt. Resets after a correct password is entered
+      type: keyword
+      ignore_above: 1024
+    - name: modified
+      description: Label top-level key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: variable
+      description: Name of the environment variable
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: csname
+      description: The name of the host the patch is installed on.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: unmask
+      description: If the package is unmasked
+      type: keyword
+      ignore_above: 1024
+    - name: transaction_id
+      description: ID used during bulk update
+      type: keyword
+      ignore_above: 1024
+    - name: link_speed
+      description: Interface speed in Mb/s
+      type: keyword
+      ignore_above: 1024
+    - name: packets_sent
+      description: Number of packets sent on this network
+      type: keyword
+      ignore_above: 1024
+    - name: uid_signed
+      description: User ID as int64 signed (Apple)
+      type: keyword
+      ignore_above: 1024
+    - name: pid
+      description: Process ID
+      type: keyword
+      ignore_above: 1024
+    - name: maintainer
+      description: Repository maintainer
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sha256_fingerprint
+      description: SHA-256 fingerprint
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: signatures_up_to_date
+      description: 1 if product signatures are up to date, else 0
+      type: keyword
+      ignore_above: 1024
+    - name: components
+      description: Repository components
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ipv6_internet
+      description: True if any interface is connected to the Internet via IPv6
+      type: keyword
+      ignore_above: 1024
+    - name: last_loaded
+      description: Last loaded module before panic
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: env_variables
+      description: Container environmental variables
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: other
+      description: Other information associated with array from /proc/mdstat
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: voltage
+      description: The battery's current voltage in mV
+      type: keyword
+      ignore_above: 1024
+    - name: bridge_nf_iptables
+      description: 1 if bridge netfilter iptables is enabled. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+    - name: hostnames
+      description: Raw hosts mapping
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: UUID
+      description: Extension unique id
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cpu_brand
+      description: CPU brand string, contains vendor and model
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: local_ipv4
+      description: Private IPv4 address of the first interface of this instance
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: superblock_state
+      description: State of the superblock
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: interleave_position
+      description: The position of the device in a interleave, i.e. 0 indicates non-interleave, 1 indicates 1st interleave, 2 indicates 2nd interleave, etc.
+      type: keyword
+      ignore_above: 1024
+    - name: mime_encoding
+      description: MIME encoding data from libmagic
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: day
+      description: Current day in the system
+      type: keyword
+      ignore_above: 1024
+    - name: header_size
+      description: Header size in bytes
+      type: keyword
+      ignore_above: 1024
+    - name: args
+      description: Arguments provided to startup executable
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: action
+      description: Appear or disappear
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: actual
+      description: Actual speed
+      type: keyword
+      ignore_above: 1024
+    - name: power_mode
+      description: Device power mode
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subject_key_id
+      description: SKID an optionally included SHA1
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: chassis_docsis_capability_enabled
+      description: Chassis DOCSIS capability enabled
+      type: keyword
+      ignore_above: 1024
+    - name: statename
+      description: Installation state name. 'Enabled','Disabled','Absent'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: memory_array_handle
+      description: Handle of the memory array associated with this structure
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: disk_id
+      description: Physical slot number of device, only exists when hardware storage controller exists
+      type: keyword
+      ignore_above: 1024
+    - name: bytes_available
+      description: Bytes available on volume
+      type: keyword
+      ignore_above: 1024
+    - name: remote_port
+      description: Remote network protocol port number
+      type: keyword
+      ignore_above: 1024
+    - name: kernel_memory
+      description: 1 if kernel memory limit support is enabled. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+    - name: event_tap_id
+      description: Unique ID for the Tap
+      type: keyword
+      ignore_above: 1024
+    - name: package_filename
+      description: Filename of original .pkg file
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: fragment_path
+      description: The unit file path this unit was read from, if there is any
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: category
+      description: The UTI that categorizes the app for the App Store
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: lock
+      description: If TRUE, the frame is equipped with a lock.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: stack_trace
+      description: Most recent frame from the stack trace
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: friendly_name
+      description: The friendly display name of the interface.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: idrops
+      description: Input drops
+      type: keyword
+      ignore_above: 1024
+    - name: outiface_mask
+      description: Output interface mask for the rule.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: transmit_rate
+      description: The current transmit rate
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: parent
+      description: Parent process PID
+      type: keyword
+      ignore_above: 1024
+    - name: build_time
+      description: Build time
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: chassis_wlan_capability_enabled
+      description: Chassis wlan capability enabled
+      type: keyword
+      ignore_above: 1024
+    - name: block_size
+      description: Block size in bytes
+      type: keyword
+      ignore_above: 1024
+    - name: script
+      description: The content script used by the extension
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: soft_limit
+      description: Current limit value
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: dns_host_name
+      description: Host name used to identify the local computer for authentication by some utilities.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: tty
+      description: Entry terminal
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: swap_total
+      description: The total amount of swap available, in bytes
+      type: keyword
+      ignore_above: 1024
+    - name: issuer_organization_unit
+      description: Issuer organization unit
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: filename
+      description: Name portion of file path
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: instance_id
+      description: EC2 instance ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: avg_disk_bytes_per_read
+      description: Average number of bytes transferred from the disk during read operations
+      type: keyword
+      ignore_above: 1024
+    - name: env
+      description: Environment variables delimited by spaces
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: next_run_time
+      description: Timestamp the task is scheduled to run next
+      type: keyword
+      ignore_above: 1024
+    - name: algorithm
+      description: algorithm of key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: wired_size
+      description: Bytes of unpageable memory used by process
+      type: keyword
+      ignore_above: 1024
+    - name: kernel_version
+      description: Kernel version
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: board_model
+      description: Board model
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: days
+      description: Days of uptime
+      type: keyword
+      ignore_above: 1024
+    - name: sigrule
+      description: Signature strings used
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: vendor
+      description: Block device vendor string
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: go_version
+      description: Go version
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: port_autoneg_100baset2_fd_enabled
+      description: 100Base-T2 FD auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+    - name: maximum_allowed
+      description: Limit on the maximum number of users allowed to use this resource concurrently. The value is only valid if the AllowMaximum property is set to FALSE.
+      type: keyword
+      ignore_above: 1024
+    - name: cpu_logical_cores
+      description: Number of logical CPU cores available to the system
+      type: keyword
+      ignore_above: 1024
+    - name: task
+      description: Task value associated with the event
+      type: keyword
+      ignore_above: 1024
+    - name: attributes
+      description: 'File attrib string. See: https://ss64.com/nt/attrib.html'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: vbs_status
+      description: The status of the virtualization based security settings. Returns UNKNOWN if an error is encountered.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: package_group
+      description: Package group
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: crash_path
+      description: Location of log file
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: extended_key_usage
+      description: Extended usage of key in certificate
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: network_tx_bytes
+      description: Total network bytes transmitted
+      type: keyword
+      ignore_above: 1024
+    - name: process_type
+      description: Key describes the intended purpose of the job
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: oid
+      description: Control MIB
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: last_opened_time
+      description: The time that the app was last used
+      type: keyword
+      ignore_above: 1024
+    - name: local_port
+      description: Local network protocol port number
+      type: keyword
+      ignore_above: 1024
+    - name: abi_version
+      description: Section virtual address in memory
+      type: keyword
+      ignore_above: 1024
+    - name: minutes
+      description: Current minutes in the system
+      type: keyword
+      ignore_above: 1024
+    - name: superblock_version
+      description: Version of the superblock
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: domain_controller_name
+      description: The name of the discovered domain controller.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: job_path
+      description: The object path for the job
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: remote_login
+      description: 1 If remote login is enabled else 0
+      type: keyword
+      ignore_above: 1024
+    - name: availability
+      description: The availability and status of the CPU.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: odrops
+      description: Output drops
+      type: keyword
+      ignore_above: 1024
+    - name: inherited_from
+      description: The inheritance policy of the ACE.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: start
+      description: Start address of memory region
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: dc_site_name
+      description: The name of the site where the domain controller is located.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: success
+      description: The socket open attempt status
+      type: keyword
+      ignore_above: 1024
+    - name: user_action
+      description: Action taken by user after prompted
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: port_aggregation_id
+      description: Port aggregation ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: power_8023at_power_type
+      description: 802.3at power type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: med_policies
+      description: Comma delimited list of MED policies
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: atime
+      description: Last access time
+      type: keyword
+      ignore_above: 1024
+    - name: symlink
+      description: 1 if the path is a symlink, otherwise 0
+      type: keyword
+      ignore_above: 1024
+    - name: member_config_value
+      description: Config value
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: reshape_finish
+      description: Estimated duration of reshape activity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: bundle_version
+      description: Info properties CFBundleVersion label
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: homepage
+      description: Package supplied homepage
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: output_bit
+      description: Bit in register value for feature value
+      type: keyword
+      ignore_above: 1024
+    - name: ending_address
+      description: Physical ending address of last kilobyte of a range of memory mapped to physical memory array
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subsystem_model
+      description: Device description of PCI device subsystem
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: local_time
+      description: Current local UNIX time in the system
+      type: keyword
+      ignore_above: 1024
+    - name: mask
+      description: Interface netmask
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: port_mau_type
+      description: MAU type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: recovery_finish
+      description: Estimated duration of recovery activity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: local_timezone
+      description: Current local timezone in the system
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: uptime
+      description: Time of execution in system uptime
+      type: keyword
+      ignore_above: 1024
+    - name: status
+      description: Status of the carve, can be STARTING, PENDING, SUCCESS, or FAILED
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: psize
+      description: Size of segment in file
+      type: keyword
+      ignore_above: 1024
+    - name: copyright
+      description: Info properties NSHumanReadableCopyright label
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: process_being_tapped
+      description: The process ID of the target application
+      type: keyword
+      ignore_above: 1024
+    - name: resync_progress
+      description: Progress of the resync activity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: bank_locator
+      description: String number of the string that identifies the physically-labeled bank where the memory device is located
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: avg_disk_read_queue_length
+      description: Average number of read requests that were queued for the selected disk during the sample interval
+      type: keyword
+      ignore_above: 1024
+    - name: size
+      description: Size of compiled table data
+      type: keyword
+      ignore_above: 1024
+    - name: version
+      description: Application Layer Firewall version
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: info_string
+      description: Info properties CFBundleGetInfoString label
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: id
+      description: The unique identifier of the drive on the system.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: dhcp_lease_obtained
+      description: Date and time the lease was obtained for the IP address assigned to the computer by the dynamic host configuration protocol (DHCP) server.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: socket
+      description: Socket handle or inode number
+      type: keyword
+      ignore_above: 1024
+    - name: transport_type
+      description: Drive transport type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: bundle_short_version
+      description: Info properties CFBundleShortVersionString label
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: entry
+      description: The whole string entry
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: creator
+      description: Addon-supported creator string
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: policy_constraints
+      description: Policy Constraints
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: redirect_accept
+      description: Accept ICMP redirect messages
+      type: keyword
+      ignore_above: 1024
+    - name: locked
+      description: 1 if segment is locked else 0
+      type: keyword
+      ignore_above: 1024
+    - name: interface
+      description: Interface of the network for the MAC
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cwd
+      description: Current working directory
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: config_name
+      description: Sensor group
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: keywords
+      description: A bitmask of the keywords defined in the event
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ouid
+      description: Object owner's user ID
+      type: keyword
+      ignore_above: 1024
+    - name: machine
+      description: Machine type
+      type: keyword
+      ignore_above: 1024
+    - name: chassis_docsis_capability_available
+      description: Chassis DOCSIS capability availability
+      type: keyword
+      ignore_above: 1024
+    - name: part_number
+      description: Manufacturer specific serial number of memory device
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: log_file_disk_quota_mb
+      description: Event file disk quota in MB
+      type: keyword
+      ignore_above: 1024
+    - name: user_namespace
+      description: User namespace
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: med_capability_capabilities
+      description: Is MED capabilities enabled
+      type: keyword
+      ignore_above: 1024
+    - name: password_last_set_time
+      description: The time the password was last changed
+      type: keyword
+      ignore_above: 1024
+    - name: timeout
+      description: Label top-level key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: blocks_available
+      description: Mounted device available blocks
+      type: keyword
+      ignore_above: 1024
+    - name: total_size
+      description: Total virtual memory size
+      type: keyword
+      ignore_above: 1024
+    - name: containers
+      description: Total number of containers
+      type: keyword
+      ignore_above: 1024
+    - name: file_version
+      description: File version
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: inetd_compatibility
+      description: Run this daemon or agent as it was launched from inetd
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: chassis_station_capability_available
+      description: Chassis station capability availability
+      type: keyword
+      ignore_above: 1024
+    - name: event_queue
+      description: Size in bytes of Carbon Black event files on disk
+      type: keyword
+      ignore_above: 1024
+    - name: referenced
+      description: 1 if this extension is referenced by the Preferences file of the profile
+      type: keyword
+      ignore_above: 1024
+    - name: port
+      description: Port inside the container
+      type: keyword
+      ignore_above: 1024
+    - name: md_device_name
+      description: md device name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: compressed
+      description: The total number of pages that have been compressed by the VM compressor.
+      type: keyword
+      ignore_above: 1024
+    - name: remediation_path
+      description: Remediation path
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: series
+      description: The series of the gpu.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: wall_time
+      description: Total wall time spent executing
+      type: keyword
+      ignore_above: 1024
+    - name: file_sharing
+      description: 1 If file sharing is enabled else 0
+      type: keyword
+      ignore_above: 1024
+    - name: fahrenheit
+      description: Temperature in Fahrenheit
+      type: keyword
+      ignore_above: 1024
+    - name: major_version
+      description: Windows major version of the machine
+      type: keyword
+      ignore_above: 1024
+    - name: rtadv_accept
+      description: Accept ICMP Router Advertisement
+      type: keyword
+      ignore_above: 1024
+    - name: asset_tag
+      description: Manufacturer specific asset tag of memory device
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: object_type
+      description: Object Type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: current_clock_speed
+      description: The current frequency of the CPU.
+      type: keyword
+      ignore_above: 1024
+    - name: chassis_tel_capability_available
+      description: Chassis telephone capability availability
+      type: keyword
+      ignore_above: 1024
+    - name: client_site_name
+      description: The name of the site where the domain controller is configured.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: script_path
+      description: The path for the Powershell script
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: icon_mode
+      description: Thumbnail icon mode
+      type: keyword
+      ignore_above: 1024
+    - name: percent_remaining
+      description: The percentage of battery remaining before it is drained
+      type: keyword
+      ignore_above: 1024
+    - name: drive_letter
+      description: Drive letter of the encrypted drive.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: username
+      description: Username
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: shell
+      description: User's configured default shell
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: average_memory
+      description: Average private memory left after executing
+      type: keyword
+      ignore_above: 1024
+    - name: encryption
+      description: Last known encrypted state
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: kva_shadow_enabled
+      description: Kernel Virtual Address shadowing is enabled.
+      type: keyword
+      ignore_above: 1024
+    - name: nr_raid_disks
+      description: Number of partitions or disk devices to comprise the array
+      type: keyword
+      ignore_above: 1024
+    - name: error_granularity
+      description: Granularity to which the error can be resolved
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ata_version
+      description: ATA version of drive
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sku
+      description: SKU for the VM image
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: option_name
+      description: Option name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: connection_id
+      description: Name of the network connection as it appears in the Network Connections Control Panel program.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: date
+      description: Driver date
+      type: keyword
+      ignore_above: 1024
+    - name: content_type
+      description: Package content_type (optional)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: volume_size
+      description: (Optional) size of firmware volume
+      type: keyword
+      ignore_above: 1024
+    - name: current_directory
+      description: Current working directory of the crashed process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: signature
+      description: Signature
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ejectable
+      description: 1 if ejectable, 0 if not
+      type: keyword
+      ignore_above: 1024
+    - name: cpu_kernelmode_usage
+      description: CPU kernel mode usage
+      type: keyword
+      ignore_above: 1024
+    - name: recovery_progress
+      description: Progress of the recovery activity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: executions
+      description: Number of times the query was executed
+      type: keyword
+      ignore_above: 1024
+    - name: cosine_similarity
+      description: How similar the Powershell script is to a provided 'normal' character frequency
+      type: keyword
+      ignore_above: 1024
+    - name: logging_option
+      description: Firewall logging option
+      type: keyword
+      ignore_above: 1024
+    - name: operation
+      description: Permission requested by the process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: guest_nice
+      description: 'Time spent running a niced guest '
+      type: keyword
+      ignore_above: 1024
+    - name: http_proxy
+      description: HTTP proxy
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: major
+      description: Major release version
+      type: keyword
+      ignore_above: 1024
+    - name: sdk_version
+      description: osquery SDK version used to build the extension
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: hit_count
+      description: Number of cache hits on thumbnail
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: designed_capacity
+      description: The battery's designed capacity in mAh
+      type: keyword
+      ignore_above: 1024
+    - name: authority_key_id
+      description: AKID an optionally included SHA1
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: started_at
+      description: Container start time as string
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: blocks_free
+      description: Mounted device free blocks
+      type: keyword
+      ignore_above: 1024
+    - name: win_timestamp
+      description: Timestamp value in 100 nanosecond units.
+      type: keyword
+      ignore_above: 1024
+    - name: bssid
+      description: The current basic service set identifier
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: datetime
+      description: Date/Time at which the crash occurred
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: registry_path
+      description: Extension identifier
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: serial_port_enabled
+      description: Indicates if serial port is enabled for the VM
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: error
+      description: Error information
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: key_file
+      description: Path to the authorized_keys file
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: os_type
+      description: Linux or Windows
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: port_id_type
+      description: Port ID type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: port_autoneg_10baset_fd_enabled
+      description: 10Base-T FD auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+    - name: update_source_server
+      description: Server for image update
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: disk_bytes_written
+      description: Bytes written to disk
+      type: keyword
+      ignore_above: 1024
+    - name: uninstall_string
+      description: Path and filename of the uninstaller.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: session_owner
+      description: Label top-level key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: collect_file_mods
+      description: If the sensor is configured to collect file modification events
+      type: keyword
+      ignore_above: 1024
+    - name: mem
+      description: Memory utilization as percentage
+      type: keyword
+      ignore_above: 1024
+    - name: opaque_version
+      description: Version of Gatekeeper's gkopaque.bundle
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: auid
+      description: Audit User ID at process start
+      type: keyword
+      ignore_above: 1024
+    - name: ppid
+      description: Parent process ID
+      type: keyword
+      ignore_above: 1024
+    - name: query_language
+      description: Query language that the query is written in.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: carve_guid
+      description: Identifying value of the carve session
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: info_access
+      description: Authority Information Access
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: has_expired
+      description: 1 if the certificate has expired, 0 otherwise
+      type: keyword
+      ignore_above: 1024
+    - name: check_array_progress
+      description: Progress of the check array activity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: applescript_enabled
+      description: Info properties NSAppleScriptEnabled label
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: optional_permissions
+      description: The permissions optionally required by the extensions
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: dns_domain_suffix_search_order
+      description: Array of DNS domain suffixes to be appended to the end of host names during name resolution.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: board_serial
+      description: Board serial number
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: mac
+      description: MAC address of broadcasted address
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cpu_usermode_usage
+      description: CPU user mode usage
+      type: keyword
+      ignore_above: 1024
+    - name: chassis_id
+      description: Neighbor chassis ID value
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: core
+      description: Name of the cpu (core)
+      type: keyword
+      ignore_above: 1024
+    - name: inode
+      description: Filesystem inode number
+      type: keyword
+      ignore_above: 1024
+    - name: power_8023at_enabled
+      description: Is 802.3at enabled
+      type: keyword
+      ignore_above: 1024
+    - name: reshape_progress
+      description: Progress of the reshape activity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: percent_disk_time
+      description: Percentage of elapsed time that the selected disk drive is busy servicing read or write requests
+      type: keyword
+      ignore_above: 1024
+    - name: path
+      description: Path to the executable that is excepted
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: device_id
+      description: ID of the encrypted drive.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: persistent
+      description: 1 If extension is persistent across all tabs else 0
+      type: keyword
+      ignore_above: 1024
+    - name: sig_group
+      description: Signature group used
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: env_count
+      description: Number of environment variables
+      type: keyword
+      ignore_above: 1024
+    - name: computer_name
+      description: Friendly computer name (optional)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: free
+      description: Total number of free pages.
+      type: keyword
+      ignore_above: 1024
+    - name: watch_paths
+      description: Key that launches daemon or agent if path is modified
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: discovery_cache_hits
+      description: The number of times that the discovery query used cached values since the last time the config was reloaded
+      type: keyword
+      ignore_above: 1024
+    - name: root
+      description: Process virtual root directory
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: database
+      description: Whether the server is a database node (1) or not (0)
+      type: keyword
+      ignore_above: 1024
+    - name: total_width
+      description: Total width, in bits, of this memory device, including any check or error-correction bits
+      type: keyword
+      ignore_above: 1024
+    - name: parent_ref_number
+      description: The ordinal that associates a journal record with a filename's parent directory
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: address_width
+      description: The width of the CPU address bus.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: format
+      description: The format of the print job
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: last_run_time
+      description: Timestamp the task last ran
+      type: keyword
+      ignore_above: 1024
+    - name: profile
+      description: Apparmor profile name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: comm
+      description: Command-line name of the command that was used to invoke the analyzed process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: tries
+      description: Label top-level key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: active_state
+      description: The high-level unit activation state, i.e. generalization of SUB
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: color_depth
+      description: The amount of bits per pixel to represent color.
+      type: keyword
+      ignore_above: 1024
+    - name: folder_id
+      description: Folder identifier for the VM
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: handler
+      description: Application label for the handler
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: collect_data_file_writes
+      description: If the sensor is configured to collect non binary file writes
+      type: keyword
+      ignore_above: 1024
+    - name: memory_array_mapped_address_handle
+      description: Handle of the memory array mapped address to which this device range is mapped to
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: vendor_id
+      description: Hex encoded Hardware vendor identifier
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: mtu
+      description: Network MTU
+      type: keyword
+      ignore_above: 1024
+    - name: kva_shadow_inv_pcid
+      description: Kernel VA INVPCID is enabled.
+      type: keyword
+      ignore_above: 1024
+    - name: hwaddr
+      description: Hardware address for this network
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: inactive
+      description: The total amount of buffer or page cache memory, in bytes, that are free and available
+      type: keyword
+      ignore_above: 1024
+    - name: pid_namespace
+      description: PID namespace
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: layer_id
+      description: Layer ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: tapping_process
+      description: The process ID of the application that created the event tap.
+      type: keyword
+      ignore_above: 1024
+    - name: kva_shadow_pcid
+      description: Kernel VA PCID flushing optimization is enabled.
+      type: keyword
+      ignore_above: 1024
+    - name: update_source_alias
+      description: Alias of image at update source server
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: fsgid
+      description: Filesystem group ID at process start
+      type: keyword
+      ignore_above: 1024
+    - name: audible_alarm
+      description: If TRUE, the frame is equipped with an audible alarm.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cpu_cfs_period
+      description: 1 if CPU Completely Fair Scheduler (CFS) period support is enabled. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+    - name: service_key
+      description: Driver service registry key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: rssi
+      description: The current received signal strength indication (dbm)
+      type: keyword
+      ignore_above: 1024
+    - name: build_number
+      description: Windows build number of the crashing machine
+      type: keyword
+      ignore_above: 1024
+    - name: minute
+      description: The exact minute for the job
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: memory_max_usage
+      description: Memory maximum usage
+      type: keyword
+      ignore_above: 1024
+    - name: port_autoneg_100basetx_fd_enabled
+      description: 100Base-TX FD auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+    - name: elapsed_time
+      description: Elapsed time in seconds this process has been running.
+      type: keyword
+      ignore_above: 1024
+    - name: smart_supported
+      description: SMART support status
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: filter
+      description: Reference to an instance of __EventFilter that represents the object path to an event filter which is a query that specifies the type of event to be received.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ipv4_forwarding
+      description: 1 if IPv4 forwarding is enabled. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+    - name: dns_domain_name
+      description: The DNS name for the owner of the logon session.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: data
+      description: Magic number data from libmagic
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: min_version
+      description: The minimum allowed plugin version.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: offer
+      description: Offer information for the VM image (Azure image gallery VMs only)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: memory_device_handle
+      description: Handle of the memory device structure associated with this structure
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subsystem_model_id
+      description: Model ID of PCI device subsystem
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: superblock_update_time
+      description: Unix timestamp of last update
+      type: keyword
+      ignore_above: 1024
+    - name: owner_uuid
+      description: Extension route UUID (0 for core)
+      type: keyword
+      ignore_above: 1024
+    - name: privileged
+      description: If privileged it will run as root, else as an anonymous user
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: device
+      description: Absolute file path to device node
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: dependencies
+      description: Module dependencies existing in crashed module's backtrace
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: disk_index
+      description: Physical drive number of the disk.
+      type: keyword
+      ignore_above: 1024
+    - name: logon_type
+      description: The logon method.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: watcher
+      description: Process (or thread/handle) ID of optional watcher process
+      type: keyword
+      ignore_above: 1024
+    - name: unix_time
+      description: Current UNIX time in the system, converted to UTC if --utc enabled
+      type: keyword
+      ignore_above: 1024
+    - name: option
+      description: Canonical name of option
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: permanent
+      description: 1 for true, 0 for false
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: breach_description
+      description: If provided, gives a more detailed description of a detected security breach.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: md5
+      description: MD5 hash of table content
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: node
+      description: The node path of the configuration item
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: uncompressed
+      description: Total number of uncompressed pages.
+      type: keyword
+      ignore_above: 1024
+    - name: basic_constraint
+      description: Basic Constraints
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: memory_error_info_handle
+      description: Handle, or instance number, associated with any error that was detected for the array
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: registers
+      description: The value of the system registers
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: event
+      description: The job @event name (rare)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: bytes
+      description: Number of bytes in the response
+      type: keyword
+      ignore_above: 1024
+    - name: optional
+      description: Match any of the identities/patterns for this XProtect name
+      type: keyword
+      ignore_above: 1024
+    - name: carve
+      description: Set this value to '1' to start a file carve
+      type: keyword
+      ignore_above: 1024
+    - name: chassis_station_capability_enabled
+      description: Chassis station capability enabled
+      type: keyword
+      ignore_above: 1024
+    - name: rapl_power_units
+      description: Run Time Average Power Limiting power units.
+      type: keyword
+      ignore_above: 1024
+    - name: ctime
+      description: Creation time
+      type: keyword
+      ignore_above: 1024
+    - name: inodes
+      description: Number of meta nodes
+      type: keyword
+      ignore_above: 1024
+    - name: on_demand
+      description: Deprecated key, replaced by keep_alive
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: port_description
+      description: Port description
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: value
+      description: Variable typed option value
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: disabled
+      description: Is the plugin disabled. 1 = Disabled
+      type: keyword
+      ignore_above: 1024
+    - name: irq
+      description: Time spent servicing interrupts
+      type: keyword
+      ignore_above: 1024
+    - name: destination
+      description: The printer the job was sent to
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: home_directory_drive
+      description: The drive location of the home directory of the logon session.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: array_handle
+      description: The memory array that the device is attached to
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: error_operation
+      description: Memory access operation that caused the error
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: build_distro
+      description: osquery toolkit platform distribution name (os version)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: domain
+      description: Active Directory trust domain
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: info
+      description: Additional information
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: amperage
+      description: The battery's current amperage in mA
+      type: keyword
+      ignore_above: 1024
+    - name: mft_entry
+      description: Directory master file table entry.
+      type: keyword
+      ignore_above: 1024
+    - name: time_range
+      description: System time to selectively filter the events
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: packets
+      description: Number of matching packets for this rule.
+      type: keyword
+      ignore_above: 1024
+    - name: server_name
+      description: Name of the LXD server node
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: principal
+      description: User or group to which the ACE applies.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: enabled
+      description: 1 if this handler is the OS default, else 0
+      type: keyword
+      ignore_above: 1024
+    - name: minimum_system_version
+      description: Minimum version of OS X required for the app to run
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: bitmap_chunk_size
+      description: Bitmap chunk size
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: record_timestamp
+      description: Journal record timestamp
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: build
+      description: Optional build-specific or variant string
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: max
+      description: Maximum speed
+      type: keyword
+      ignore_above: 1024
+    - name: strings
+      description: Matching strings
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: apparmor
+      description: Apparmor Status like ALLOWED, DENIED etc.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: attach
+      description: Which executable(s) a profile will attach to.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: description
+      description: Description of the SDB.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: passpoint
+      description: 1 if Passpoint is supported, 0 otherwise
+      type: keyword
+      ignore_above: 1024
+    - name: bytes_received
+      description: Number of bytes received on this network
+      type: keyword
+      ignore_above: 1024
+    - name: rapl_energy_status
+      description: Run Time Average Power Limiting energy status.
+      type: keyword
+      ignore_above: 1024
+    - name: model
+      description: The battery's model number
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: day_of_week
+      description: The day of the week for the job
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: chassis_other_capability_available
+      description: Chassis other capability availability
+      type: keyword
+      ignore_above: 1024
+    - name: group_sid
+      description: Unique group ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: port_id
+      description: Port ID value
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: label
+      description: AppArmor label
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: swap_cached
+      description: The amount of swap, in bytes, used as cache memory
+      type: keyword
+      ignore_above: 1024
+    - name: ssid
+      description: SSID octets of the network
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: firewall
+      description: The health of the monitored Firewall (see windows_security_products)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: command_line_template
+      description: Standard string template that specifies the process to be started. This property can be NULL, and the ExecutablePath property is used as the command line.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: external
+      description: 1 if this handler does NOT exist on OS X by default, else 0
+      type: keyword
+      ignore_above: 1024
+    - name: iam_arn
+      description: If there is an IAM role associated with the instance, contains instance profile ARN
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: is_elevated_token
+      description: Process uses elevated token yes=1, no=0
+      type: keyword
+      ignore_above: 1024
+    - name: cdhash
+      description: Hash of the application Code Directory
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: hardware_vendor
+      description: Hardware vendor
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: organization_unit
+      description: Organization unit issued to
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: busy_state
+      description: 1 if the device is in a busy state else 0
+      type: keyword
+      ignore_above: 1024
+    - name: content_caching
+      description: 1 If content caching is enabled else 0
+      type: keyword
+      ignore_above: 1024
+    - name: cache_path
+      description: Path to cache data
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: internet_sharing
+      description: 1 If internet sharing is enabled else 0
+      type: keyword
+      ignore_above: 1024
+    - name: copy
+      description: Total number of copy-on-write pages.
+      type: keyword
+      ignore_above: 1024
+    - name: finished_at
+      description: Container finish time as string
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: driver_key
+      description: Driver key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: target_path
+      description: The path associated with the event
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: config_hash
+      description: Hash of the working configuration state
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: repository
+      description: From which repository the ebuild was used
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: env_size
+      description: Actual size (bytes) of environment list
+      type: keyword
+      ignore_above: 1024
+    - name: hash_resources
+      description: Set to 1 to also hash resources, or 0 otherwise. Default is 1
+      type: keyword
+      ignore_above: 1024
+    - name: hours
+      description: Hours of uptime
+      type: keyword
+      ignore_above: 1024
+    - name: release
+      description: Release name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: port_autoneg_1000basex_fd_enabled
+      description: 1000Base-X FD auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+    - name: memory_array_error_address
+      description: 32 bit physical address of the error based on the addressing of the bus to which the memory array is connected
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: max_voltage
+      description: Maximum operating voltage of device in millivolts
+      type: keyword
+      ignore_above: 1024
+    - name: is_active
+      description: 1 if the application is in focus, 0 otherwise
+      type: keyword
+      ignore_above: 1024
+    - name: input_eax
+      description: Value of EAX used
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: images
+      description: Number of images
+      type: keyword
+      ignore_above: 1024
+    - name: power_paircontrol_enabled
+      description: Is power pair control enabled
+      type: keyword
+      ignore_above: 1024
+    - name: provider_guid
+      description: Provider guid of the event
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: disk_read
+      description: Total disk read bytes
+      type: keyword
+      ignore_above: 1024
+    - name: member_config_name
+      description: Name of configuration parameter
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: domain_name
+      description: The name of the domain.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: hash_alg
+      description: Password hashing algorithm
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: block
+      description: The host or match block
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sha1_fingerprint
+      description: SHA1 fingerprint
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: signature_algorithm
+      description: Signature Algorithm
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: preread
+      description: UNIX time when stats were last read
+      type: keyword
+      ignore_above: 1024
+    - name: containers_running
+      description: Number of containers currently running
+      type: keyword
+      ignore_above: 1024
+    - name: dtime
+      description: Detached time
+      type: keyword
+      ignore_above: 1024
+    - name: subject_name
+      description: The certificate subject name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: resource_group_name
+      description: Resource group for the VM
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: response_code
+      description: The HTTP status code for the response
+      type: keyword
+      ignore_above: 1024
+    - name: warnings
+      description: Warning messages from SMART controller
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: zero_fill
+      description: Total number of zero filled pages.
+      type: keyword
+      ignore_above: 1024
+    - name: antispyware
+      description: The health of the monitored Antispyware solution (see windows_security_products)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: dev_id_enabled
+      description: 1 If a Gatekeeper allows execution from identified developers else 0
+      type: keyword
+      ignore_above: 1024
+    - name: denylisted
+      description: 1 if the query is denylisted else 0
+      type: keyword
+      ignore_above: 1024
+    - name: title
+      description: Title of the printed job
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: valid_from
+      description: Period of validity start date
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cgroup_driver
+      description: Control groups driver
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: root_volume_uuid
+      description: Root UUID of backup volume
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: wired
+      description: Total number of wired down pages.
+      type: keyword
+      ignore_above: 1024
+    - name: auto_login
+      description: 1 if auto login is enabled, 0 otherwise
+      type: keyword
+      ignore_above: 1024
+    - name: exception_type
+      description: Exception type of the crash
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: network_rx_bytes
+      description: Total network bytes read
+      type: keyword
+      ignore_above: 1024
+    - name: pseudo
+      description: 1 If path is a pseudo path, else 0
+      type: keyword
+      ignore_above: 1024
+    - name: session_id
+      description: The Terminal Services session identifier.
+      type: keyword
+      ignore_above: 1024
+    - name: collect_module_loads
+      description: If the sensor is configured to capture module loads
+      type: keyword
+      ignore_above: 1024
+    - name: filesystem
+      description: Filesystem if available
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ami_id
+      description: AMI ID used to launch this EC2 instance
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: authority_key_identifier
+      description: Authority Key Identifier
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: owner_gid
+      description: File owner group ID
+      type: keyword
+      ignore_above: 1024
+    - name: internal
+      description: 1 If the plugin is internal else 0
+      type: keyword
+      ignore_above: 1024
+    - name: bundle_path
+      description: Application bundle used by the sandbox
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: creator_uid
+      description: User ID of creator process
+      type: keyword
+      ignore_above: 1024
+    - name: team
+      description: Signing team ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: address
+      description: IPv4 address target
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: collect_reg_mods
+      description: If the sensor is configured to collect registry modification events
+      type: keyword
+      ignore_above: 1024
+    - name: created_by
+      description: Created by instruction
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: security_options
+      description: List of container security options
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: net_namespace
+      description: Network namespace
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: unique_chip_id
+      description: Unique id of the iBridge controller
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: opackets
+      description: Output packets
+      type: keyword
+      ignore_above: 1024
+    - name: error_type
+      description: type of error associated with current error status for array or device
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: allow_root
+      description: Label top-level key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: iowait
+      description: Time spent waiting for I/O to complete
+      type: keyword
+      ignore_above: 1024
+    - name: start_time
+      description: Process start in seconds since boot (non-sleeping)
+      type: keyword
+      ignore_above: 1024
+    - name: cpu_type
+      description: Indicates the specific processor designed for installation.
+      type: keyword
+      ignore_above: 1024
+    - name: chassis_repeater_capability_available
+      description: Chassis repeater capability availability
+      type: keyword
+      ignore_above: 1024
+    - name: count
+      description: Number of times the application has been executed.
+      type: keyword
+      ignore_above: 1024
+    - name: med_capability_mdi_pse
+      description: Is MED MDI PSE capability enabled
+      type: keyword
+      ignore_above: 1024
+    - name: med_capability_mdi_pd
+      description: Is MED MDI PD capability enabled
+      type: keyword
+      ignore_above: 1024
+    - name: bitmap_on_mem
+      description: Pages allocated in in-memory bitmap, if enabled
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: install_timestamp
+      description: Extension install time, converted to unix time
+      type: keyword
+      ignore_above: 1024
+    - name: https_proxy
+      description: HTTPS proxy
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: file_id
+      description: file ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: config_valid
+      description: 1 if the config was loaded and considered valid, else 0
+      type: keyword
+      ignore_above: 1024
+    - name: development_region
+      description: Info properties CFBundleDevelopmentRegion label
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: log_file_disk_quota_percentage
+      description: Event file disk quota in a percentage
+      type: keyword
+      ignore_above: 1024
+    - name: processor_type
+      description: The processor type, such as Central, Math, or Video.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: max_clock_speed
+      description: The maximum possible frequency of the CPU.
+      type: keyword
+      ignore_above: 1024
+    - name: policies
+      description: Certificate Policies
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: authorizations
+      description: A space delimited set of authorization attributes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: space_used
+      description: Storage space used in bytes
+      type: keyword
+      ignore_above: 1024
+    - name: space_total
+      description: Total available storage space in bytes for this storage pool
+      type: keyword
+      ignore_above: 1024
+    - name: minutes_to_full_charge
+      description: The number of minutes until the battery is fully charged. This value is -1 if this time is still being calculated
+      type: keyword
+      ignore_above: 1024
+    - name: probe_error
+      description: Set to 1 if one or more buffers could not be captured
+      type: keyword
+      ignore_above: 1024
+    - name: browser_type
+      description: 'The browser type (Valid values: chrome, chromium, opera, yandex, brave)'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: metric_name
+      description: Name of collected Prometheus metric
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: partition_width
+      description: Number of memory devices that form a single row of memory for the address partition of this structure
+      type: keyword
+      ignore_above: 1024
+    - name: subscriptions
+      description: Number of subscriptions the publisher received or subscriber used
+      type: keyword
+      ignore_above: 1024
+    - name: execution_flag
+      description: Boolean Execution flag, 1 for execution, 0 for no execution, -1 for missing (this flag does not exist on Windows 10 and higher).
+      type: keyword
+      ignore_above: 1024
+    - name: speculative
+      description: Total number of speculative pages.
+      type: keyword
+      ignore_above: 1024
+    - name: mount_namespace_id
+      description: Mount namespace id
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: system_model
+      description: Physical system model, for example 'MacBookPro12,1 (Mac-E43C1C25D4880AD6)'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: valuetype
+      description: CoreFoundation type of data stored in value
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: logging_driver
+      description: Logging driver
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: bp_mitigations
+      description: Branch Prediction mitigations are enabled.
+      type: keyword
+      ignore_above: 1024
+    - name: expires_at
+      description: ISO time of image expiration
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: target_name
+      description: Address of prometheus target
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sdb_id
+      description: Unique GUID of the SDB.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: extra
+      description: Extra columns, in JSON format. Queries against this column are performed entirely in SQLite, so do not benefit from efficient querying via asl.h.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: security_breach
+      description: The physical status of the chassis such as Breach Successful, Breach Attempted, etc.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: throttled
+      description: Total number of throttled pages.
+      type: keyword
+      ignore_above: 1024
+    - name: last_connected
+      description: Last time this netword was connected to as a unix_time
+      type: keyword
+      ignore_above: 1024
+    - name: type
+      description: Event type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cpu_pred_cmd_supported
+      description: PRED_CMD MSR supported by CPU Microcode.
+      type: keyword
+      ignore_above: 1024
+    - name: partner_fd
+      description: File descriptor of shared pipe at partner's end
+      type: keyword
+      ignore_above: 1024
+    - name: refreshes
+      description: 'Publisher only: number of runloop restarts'
+      type: keyword
+      ignore_above: 1024
+    - name: password_status
+      description: Password status
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: binary_queue
+      description: Size in bytes of binaries waiting to be sent to Carbon Black server
+      type: keyword
+      ignore_above: 1024
+    - name: idle
+      description: Time spent in the idle task
+      type: keyword
+      ignore_above: 1024
+    - name: gid_signed
+      description: A signed int64 version of gid
+      type: keyword
+      ignore_above: 1024
+    - name: packets_received
+      description: Number of packets received on this network
+      type: keyword
+      ignore_above: 1024
+    - name: original_program_name
+      description: The original program name that the publisher has signed
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ipv4_internet
+      description: True if any interface is connected to the Internet via IPv4
+      type: keyword
+      ignore_above: 1024
+    - name: netmask
+      description: Address (sortlist) netmask length
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: base_image
+      description: ID of image used to launch this instance
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: slot
+      description: Slot position of disk
+      type: keyword
+      ignore_above: 1024
+    - name: current_locale
+      description: Current locale supported by extension
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: gateway
+      description: Gateway
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: read
+      description: UNIX time when stats were read
+      type: keyword
+      ignore_above: 1024
+    - name: identifying_number
+      description: Product identification such as a serial number on software, or a die number on a hardware chip.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: hardware_serial
+      description: Device serial number
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: class
+      description: Label top-level key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: binding
+      description: Binding type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: certificate
+      description: Certificate content
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: pgroup
+      description: Process group
+      type: keyword
+      ignore_above: 1024
+    - name: facility
+      description: Sender's facility.  Default is 'user'.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: authenticate_user
+      description: Label top-level key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: day_of_month
+      description: The day of the month for the job
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subsystem_vendor_id
+      description: Vendor ID of PCI device subsystem
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: hidden
+      description: Whether or not the task is visible in the UI
+      type: keyword
+      ignore_above: 1024
+    - name: smbios_tag
+      description: The assigned asset tag number of the chassis.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: month
+      description: The month of the year for the job
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: port_autoneg_enabled
+      description: Is auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+    - name: retain_count
+      description: The device reference count
+      type: keyword
+      ignore_above: 1024
+    - name: record_usn
+      description: The update sequence number that identifies the journal record
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: hard_limit
+      description: Maximum limit value
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: command_line
+      description: Command-line string passed to the crashed process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: optional_permissions_json
+      description: The JSON-encoded permissions optionally required by the extensions
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: processing_time
+      description: How long the job took to process
+      type: keyword
+      ignore_above: 1024
+    - name: alias
+      description: Protocol alias
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: platform_mask
+      description: The osquery platform bitmask
+      type: keyword
+      ignore_above: 1024
+    - name: service_type
+      description: 'Service Type: OWN_PROCESS, SHARE_PROCESS and maybe Interactive (can interact with the desktop)'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: max_capacity
+      description: The battery's actual capacity when it is fully charged in mAh
+      type: keyword
+      ignore_above: 1024
+    - name: visible
+      description: 1 If the addon is shown in browser else 0
+      type: keyword
+      ignore_above: 1024
+    - name: vlans
+      description: Comma delimited list of vlan ids
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: turbo_disabled
+      description: Whether the turbo feature is disabled.
+      type: keyword
+      ignore_above: 1024
+    - name: collect_store_files
+      description: If the sensor is configured to send back binaries to the Carbon Black server
+      type: keyword
+      ignore_above: 1024
+    - name: queue_directories
+      description: Similar to watch_paths but only with non-empty directories
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: port_autoneg_100basetx_hd_enabled
+      description: 100Base-TX HD auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+    - name: video_mode
+      description: The current resolution of the display.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sha1
+      description: A unique hash that identifies this policy.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ipv6_local_network
+      description: True if any interface is connected to a routed network via IPv6
+      type: keyword
+      ignore_above: 1024
+    - name: driver_date
+      description: The date listed on the installed driver.
+      type: keyword
+      ignore_above: 1024
+    - name: collect_module_info
+      description: If the sensor is configured to collect metadata of binaries
+      type: keyword
+      ignore_above: 1024
+    - name: inf
+      description: Associated inf file
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: power_8023at_power_requested
+      description: 802.3at power requested
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: collect_process_user_context
+      description: If the sensor is configured to collect the user running a process
+      type: keyword
+      ignore_above: 1024
+    - name: logical_processors
+      description: The number of logical processors of the CPU.
+      type: keyword
+      ignore_above: 1024
+    - name: physical_adapter
+      description: Indicates whether the adapter is a physical or a logical adapter.
+      type: keyword
+      ignore_above: 1024
+    - name: chassis_other_capability_enabled
+      description: Chassis other capability enabled
+      type: keyword
+      ignore_above: 1024
+    - name: provider_name
+      description: Provider name of the event
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: state
+      description: Firewall exception state
+      type: keyword
+      ignore_above: 1024
+    - name: denied_mask
+      description: Denied permissions for the process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: identifier
+      description: Plugin identifier
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: level
+      description: Log level number.  See levels in asl.h.
+      type: keyword
+      ignore_above: 1024
+    - name: manufacturer
+      description: The battery manufacturer's name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: assessments_enabled
+      description: 1 If a Gatekeeper is enabled else 0
+      type: keyword
+      ignore_above: 1024
+    - name: cpus
+      description: Number of CPUs
+      type: keyword
+      ignore_above: 1024
+    - name: logon_domain
+      description: The name of the domain used to authenticate the owner of the logon session.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: bitmap_external_file
+      description: External referenced bitmap file
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: vendor_syndrome
+      description: Vendor specific ECC syndrome or CRC data associated with the erroneous access
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: field_name
+      description: Specific attribute of opaque type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: name
+      description: ACPI table name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: tid
+      description: Thread ID
+      type: keyword
+      ignore_above: 1024
+    - name: encryption_status
+      description: 'Disk encryption status with one of following values: encrypted | not encrypted | undefined'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: url
+      description: The url for the request
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: security_groups
+      description: Comma separated list of security group names
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: dns_server_search_order
+      description: Array of server IP addresses to be used in querying for DNS servers.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: allow_signed_enabled
+      description: 1 If allow signed mode is enabled else 0
+      type: keyword
+      ignore_above: 1024
+    - name: offset
+      type: keyword
+      ignore_above: 1024
+    - name: removable
+      description: 1 If USB device is removable else 0
+      type: keyword
+      ignore_above: 1024
+    - name: fd
+      description: The file description for the process socket
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: network_name
+      description: Name of the network
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: bytes_sent
+      description: Number of bytes sent on this network
+      type: keyword
+      ignore_above: 1024
+    - name: device_model
+      description: Device Model
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: rule_details
+      description: Rule definition
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ca
+      description: '1 if CA: true (certificate is an authority) else 0'
+      type: keyword
+      ignore_above: 1024
+    - name: mtime
+      description: Last modification time
+      type: keyword
+      ignore_above: 1024
+    - name: points
+      description: This is a signed SQLite int column
+      type: keyword
+      ignore_above: 1024
+    - name: logon_script
+      description: The script used for logging on.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: created_at
+      description: ISO time of image creation
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: scripting_engine
+      description: Name of the scripting engine to use, for example, 'VBScript'. This property cannot be NULL.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: issuer_common_name
+      description: Issuer common name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: name_constraints
+      description: Name Constraints
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: server_version
+      description: Server version
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: packet_device_type
+      description: Packet device type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: rotation_rate
+      description: Drive RPM
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ipv6_no_traffic
+      description: True if any interface is connected via IPv6, but has seen no traffic
+      type: keyword
+      ignore_above: 1024
+    - name: used_by
+      description: Module reverse dependencies
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: check_array_finish
+      description: Estimated duration of the check array activity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: package_id
+      description: Label packageIdentifiers
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: build_id
+      description: Sandbox-specific identifier
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: location
+      description: Azure Region the VM is running in
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: section
+      description: Package section
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: src_port
+      description: Protocol source port(s).
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: member_config_key
+      description: Config key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: pci_subclass
+      description: PCI Device subclass
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: pre_system_cpu_usage
+      description: Last read CPU system usage
+      type: keyword
+      ignore_above: 1024
+    - name: instance_type
+      description: EC2 instance type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: kva_shadow_user_global
+      description: User pages are marked as global.
+      type: keyword
+      ignore_above: 1024
+    - name: failed_disks
+      description: Number of failed disks in array
+      type: keyword
+      ignore_above: 1024
+    - name: additional_product_id
+      description: An additional drive identifier if any
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: machine_name
+      description: Name of the machine where the crash happened
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: lock_status
+      description: The accessibility status of the drive from Windows.
+      type: keyword
+      ignore_above: 1024
+    - name: local_address
+      description: Local address associated with socket
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subject_key_identifier
+      description: Subject Key Identifier
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: model_id
+      description: Hex encoded Hardware model identifier
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: load_state
+      description: Reflects whether the unit definition was properly loaded
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sub_state
+      description: The low-level unit activation state, values depend on unit type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: persistent_volume_id
+      description: Persistent ID of the drive.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: encrypted
+      description: '1 If encrypted: true (disk is encrypted), else 0'
+      type: keyword
+      ignore_above: 1024
+    - name: free_space
+      description: The amount of free space, in bytes, of the drive (-1 on failure).
+      type: keyword
+      ignore_above: 1024
+    - name: system_time
+      description: Total system time spent executing
+      type: keyword
+      ignore_above: 1024
+    - name: number_of_cores
+      description: The number of cores of the CPU.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: pre_cpu_total_usage
+      description: Last read total CPU usage
+      type: keyword
+      ignore_above: 1024
+    - name: root_dir
+      description: Docker root directory
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: output_size
+      description: Total number of bytes generated by the query
+      type: keyword
+      ignore_above: 1024
+    - name: program_arguments
+      description: Command line arguments passed to program
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: power_8023at_power_allocated
+      description: 802.3at power allocated
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: memory_total
+      description: Total amount of physical RAM, in bytes
+      type: keyword
+      ignore_above: 1024
+    - name: subject
+      description: Certificate distinguished name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: os
+      description: Operating system
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: bp_system_pol_disabled
+      description: Branch Predictions are disabled via system policy.
+      type: keyword
+      ignore_above: 1024
+    - name: file_system
+      description: The file system of the drive.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: volume_id
+      description: Parsed volume ID from fs_id
+      type: keyword
+      ignore_above: 1024
+    - name: exit_code
+      description: Exit code of the system call
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: endpoint_id
+      description: Endpoint ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: outiface
+      description: Output interface for the rule.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: store_id
+      description: Exists for service/user stores. Contains raw store id provided by WinAPI.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: expand
+      description: 1 if the variable needs expanding, 0 otherwise
+      type: keyword
+      ignore_above: 1024
+    - name: total_seconds
+      description: Total uptime seconds
+      type: keyword
+      ignore_above: 1024
+    - name: hashed
+      description: 1 if the file was hashed, 0 if not, -1 if hashing failed
+      type: keyword
+      ignore_above: 1024
+    - name: med_capability_location
+      description: Is MED location capability enabled
+      type: keyword
+      ignore_above: 1024
+    - name: home_directory
+      description: The home directory for the logon session.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: install_location
+      description: The installation location directory of the product.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: user_capacity
+      description: Bytes of drive capacity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sid
+      description: User SID.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sensor_backend_server
+      description: Carbon Black server
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: online_cpus
+      description: Online CPUs
+      type: keyword
+      ignore_above: 1024
+    - name: read_device_identity_failure
+      description: Error string for device id read, if any
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: driver_type
+      description: The explicit device type used to retrieve the SMART information
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: swap_limit
+      description: 1 if swap limit support is enabled. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+    - name: tag
+      description: Tag ID
+      type: keyword
+      ignore_above: 1024
+    - name: pci_subclass_id
+      description: PCI Device  subclass in hex format
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: usb_port
+      description: USB Device used port
+      type: keyword
+      ignore_above: 1024
+    - name: exception_address
+      description: Address (in hex) where the exception occurred
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: xpath
+      description: The custom query to filter events
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: med_capability_policy
+      description: Is MED policy capability enabled
+      type: keyword
+      ignore_above: 1024
+    - name: memory_type
+      description: Type of memory used
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: fs_id
+      description: Quicklook file fs_id key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: user_uuid
+      description: UUID of authenticated user if available
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: depth
+      description: Device nested depth
+      type: keyword
+      ignore_above: 1024
+    - name: global_state
+      description: 1 If the firewall is enabled with exceptions, 2 if the firewall is configured to block all incoming connections, else 0
+      type: keyword
+      ignore_above: 1024
+    - name: feature
+      description: Present feature flags
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: partition
+      description: A partition number
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: public
+      description: Whether image is public (1) or not (0)
+      type: keyword
+      ignore_above: 1024
+    - name: update_source_protocol
+      description: Protocol used for image information update and image import from source server
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: epoch
+      description: Package epoch value
+      type: keyword
+      ignore_above: 1024
+    - name: module_path
+      description: Path to ServiceDll
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ip_prefix_len
+      description: IP subnet prefix length
+      type: keyword
+      ignore_above: 1024
+    - name: layer_order
+      description: Layer Order (1 = base layer)
+      type: keyword
+      ignore_above: 1024
+    - name: chassis_router_capability_enabled
+      description: Chassis router capability enabled
+      type: keyword
+      ignore_above: 1024
+    - name: port_autoneg_100baset4_hd_enabled
+      description: 100Base-T4 HD auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+    - name: ssh_config_file
+      description: Path to the ssh_config file
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: manifest_json
+      description: The manifest file of the extension
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: completed_time
+      description: When the job completed printing
+      type: keyword
+      ignore_above: 1024
+    - name: linked_against
+      description: Indexes of extensions this extension is linked against
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: max_speed
+      description: Max speed of memory device in megatransfers per second (MT/s)
+      type: keyword
+      ignore_above: 1024
+    - name: readonly
+      description: 1 if the share is exported readonly else 0
+      type: keyword
+      ignore_above: 1024
+    - name: uppid
+      description: The 64bit parent pid that is never reused. Returns -1 if we couldn't gather them from the system.
+      type: keyword
+      ignore_above: 1024
+    - name: cid
+      description: Cgroup ID
+      type: keyword
+      ignore_above: 1024
+    - name: rowid
+      description: Quicklook file rowid key
+      type: keyword
+      ignore_above: 1024
+    - name: checksum
+      description: UDIF Master checksum if available (CRC32)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: region
+      description: AWS region in which this instance launched
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: min
+      description: Minimum speed
+      type: keyword
+      ignore_above: 1024
+    - name: target
+      description: Target speed
+      type: keyword
+      ignore_above: 1024
+    - name: os_version
+      description: Version of the operating system
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: mode
+      description: How the policy is applied.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: created
+      description: Label top-level key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: system
+      description: Time spent in system mode
+      type: keyword
+      ignore_above: 1024
+    - name: hopcount
+      description: Max hops expected
+      type: keyword
+      ignore_above: 1024
+    - name: filetype
+      description: Use this file type to match
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: form_factor
+      description: Implementation form factor for this memory device
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: object_name
+      description: Object Name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: state_timestamp
+      description: Timestamp for the product state
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ssdeep
+      description: ssdeep hash of provided filesystem data
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: pci_slot
+      description: PCI slot number
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cpu_spec_ctrl_supported
+      description: SPEC_CTRL MSR supported by CPU Microcode.
+      type: keyword
+      ignore_above: 1024
+    - name: configured_voltage
+      description: Configured operating voltage of device in millivolts
+      type: keyword
+      ignore_above: 1024
+    - name: fsuid
+      description: Filesystem user ID
+      type: keyword
+      ignore_above: 1024
+    - name: ipv6_prefix_len
+      description: IPv6 subnet prefix length
+      type: keyword
+      ignore_above: 1024
+    - name: requirement
+      description: Code signing requirement language
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: memory_error_correction
+      description: Primary hardware error correction or detection method supported
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: caption
+      description: Short description of the patch.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: placement_group_id
+      description: Placement group for the VM scale set
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: no_proxy
+      description: Comma-separated list of domain extensions proxy should not be used for
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: boot_partition
+      description: True if Windows booted from this drive.
+      type: keyword
+      ignore_above: 1024
+    - name: port_autoneg_1000baset_hd_enabled
+      description: 1000Base-T HD auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+    - name: last_run_code
+      description: Exit status code of the last task run
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: identity
+      description: XProtect identity (SHA1) of content
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: last_execution_time
+      description: Most recent time application was executed.
+      type: keyword
+      ignore_above: 1024
+    - name: hardware_model
+      description: Hard drive model.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: image_id
+      description: Docker image ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: timezone
+      description: Current timezone in the system
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: hostname
+      description: Hostname (domain[:port]) to CURL
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: mac_address
+      description: MAC address
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: boot_uuid
+      description: Boot UUID of the iBridge controller
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: port_autoneg_100baset4_fd_enabled
+      description: 100Base-T4 FD auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+    - name: board_version
+      description: Board version
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: decompressed
+      description: The total number of pages that have been decompressed by the VM compressor.
+      type: keyword
+      ignore_above: 1024
+    - name: logon_sid
+      description: The user's security identifier (SID).
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: error_resolution
+      description: Range, in bytes, within which this error can be determined, when an error address is given
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: avg_disk_sec_per_write
+      description: Average time, in seconds, of a write operation of data to the disk
+      type: keyword
+      ignore_above: 1024
+    - name: eid
+      description: Event ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: match
+      description: The pattern that the script is matched against
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: memory_usage
+      description: Memory usage
+      type: keyword
+      ignore_above: 1024
+    - name: chunk_size
+      description: chunk size in bytes
+      type: keyword
+      ignore_above: 1024
+    - name: data_width
+      description: Data width, in bits, of this memory device
+      type: keyword
+      ignore_above: 1024
+    - name: dest_path
+      description: The canonical path associated with the event
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: swap_ins
+      description: The total number of compressed pages that have been swapped out to disk.
+      type: keyword
+      ignore_above: 1024
+    - name: gid
+      description: GID that sent the log message (set by the server).
+      type: keyword
+      ignore_above: 1024
+    - name: rid
+      description: Neighbor chassis index
+      type: keyword
+      ignore_above: 1024
+    - name: port_autoneg_1000basex_hd_enabled
+      description: 1000Base-X HD auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+    - name: old_path
+      description: Old path (renames only)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: extensions
+      description: osquery extensions status
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: partner_pid
+      description: Process ID of partner process sharing a particular pipe
+      type: keyword
+      ignore_above: 1024
+    - name: result
+      description: The signature check result
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: uploaded_at
+      description: ISO time of image upload
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: device_alias
+      description: Mounted device alias
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: revision
+      description: Package revision
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: service_exit_code
+      description: The service-specific error code that the service returns when an error occurs while the service is starting or stopping
+      type: keyword
+      ignore_above: 1024
+    - name: created_time
+      description: Directory Created time.
+      type: keyword
+      ignore_above: 1024
+    - name: valid_to
+      description: Period of validity end date
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: logon_time
+      description: The time the session owner logged on.
+      type: keyword
+      ignore_above: 1024
+    - name: plugin
+      description: Authorization plugin name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cpu_status
+      description: The current operating status of the CPU.
+      type: keyword
+      ignore_above: 1024
+    - name: nice
+      description: Time spent in user mode with low priority (nice)
+      type: keyword
+      ignore_above: 1024
+    - name: user_account
+      description: The name of the account that the service process will be logged on as when it runs. This name can be of the form Domain\UserName. If the account belongs to the built-in domain, the name can be of the form .\UserName.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: environment
+      description: Application-set environment variables
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: euid
+      description: Effective user ID
+      type: keyword
+      ignore_above: 1024
+    - name: program
+      description: Path to target program
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: timestamp
+      description: Current timestamp (log format) in the system
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: uuid
+      description: Block device Universally Unique Identifier
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: addr
+      description: Symbol address (value)
+      type: keyword
+      ignore_above: 1024
+    - name: handle
+      description: Handle, or instance number, associated with the structure
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: faults
+      description: Total number of calls to vm_faults.
+      type: keyword
+      ignore_above: 1024
+    - name: install_date
+      description: The install date of the OS.
+      type: keyword
+      ignore_above: 1024
+    - name: handle_count
+      description: Total number of handles that the process has open. This number is the sum of the handles currently opened by each thread in the process.
+      type: keyword
+      ignore_above: 1024
+    - name: allow_maximum
+      description: Number of concurrent users for this resource has been limited. If True, the value in the MaximumAllowed property is ignored.
+      type: keyword
+      ignore_above: 1024
+    - name: avg_disk_write_queue_length
+      description: Average number of write requests that were queued for the selected disk during the sample interval
+      type: keyword
+      ignore_above: 1024
+    - name: subclass
+      description: USB Device subclass
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sdk
+      description: Build SDK used to compile plugin
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: port_ttl
+      description: Age of neighbor port
+      type: keyword
+      ignore_above: 1024
+    - name: resync_speed
+      description: Speed of resync activity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: roaming
+      description: 1 if roaming is supported, 0 otherwise
+      type: keyword
+      ignore_above: 1024
+    - name: hour
+      description: The hour of the day for the job
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: containers_stopped
+      description: Number of containers in stopped state
+      type: keyword
+      ignore_above: 1024
+    - name: link
+      description: Link to other section
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: backup_date
+      description: Backup Date
+      type: keyword
+      ignore_above: 1024
+    - name: option_value
+      description: Option value
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: module_backtrace
+      description: Modules appearing in the crashed module's backtrace
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: registry_hive
+      description: HKEY_USERS registry hive
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ntime
+      description: The nsecs uptime timestamp as obtained from BPF
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: current_disk_queue_length
+      description: Number of requests outstanding on the disk at the time the performance data is collected
+      type: keyword
+      ignore_above: 1024
+    - name: script_block_id
+      description: The unique GUID of the powershell script to which this block belongs
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: bundle_executable
+      description: Info properties CFBundleExecutable label
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: conversion_status
+      description: The bitlocker conversion status of the drive.
+      type: keyword
+      ignore_above: 1024
+    - name: issuer_organization
+      description: Issuer organization
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: keep_alive
+      description: Should the process be restarted if killed
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: access
+      description: Specific permissions that indicate the rights described by the ACE.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subsystem_vendor
+      description: Vendor of PCI device subsystem
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: flatsize
+      description: Package size in bytes
+      type: keyword
+      ignore_above: 1024
+    - name: key_algorithm
+      description: Key algorithm used
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: pids
+      description: Number of processes
+      type: keyword
+      ignore_above: 1024
+    - name: ipc_namespace
+      description: IPC namespace
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: windows_security_center_service
+      description: The health of the Windows Security Center Service
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: hop_limit
+      description: Current Hop Limit
+      type: keyword
+      ignore_above: 1024
+    - name: iniface_mask
+      description: Input interface mask for the rule.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: run_at_load
+      description: Should the program run on launch load
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: screen_sharing
+      description: 1 If screen sharing is enabled else 0
+      type: keyword
+      ignore_above: 1024
+    - name: creation_time
+      description: When the account was first created
+      type: keyword
+      ignore_above: 1024
+    - name: namespace
+      description: AppArmor namespace
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: system_cpu_usage
+      description: CPU system usage
+      type: keyword
+      ignore_above: 1024
+    - name: upn
+      description: The user principal name (UPN) for the owner of the logon session.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: recovery_speed
+      description: Speed of recovery activity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: use
+      description: Function for which the array is used
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: disk_bytes_read
+      description: Bytes read from disk
+      type: keyword
+      ignore_above: 1024
+    - name: swap_outs
+      description: The total number of compressed pages that have been swapped back in from disk.
+      type: keyword
+      ignore_above: 1024
+    - name: time
+      description: Time of execution in UNIX time
+      type: keyword
+      ignore_above: 1024
+    - name: stibp_support_enabled
+      description: Windows uses STIBP.
+      type: keyword
+      ignore_above: 1024
+    - name: power_mdi_supported
+      description: MDI power supported
+      type: keyword
+      ignore_above: 1024
+    - name: seconds
+      description: Current seconds in the system
+      type: keyword
+      ignore_above: 1024
+    - name: noise
+      description: The current noise measurement (dBm)
+      type: keyword
+      ignore_above: 1024
+    - name: key
+      description: parsed authorized keys line
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: abi
+      description: Section type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: last_change
+      description: Time of last device modification (optional)
+      type: keyword
+      ignore_above: 1024
+    - name: ibytes
+      description: Input bytes
+      type: keyword
+      ignore_above: 1024
+    - name: dns_forest_name
+      description: The name of the root of the DNS tree.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: events
+      description: Number of events emitted or received since osquery started
+      type: keyword
+      ignore_above: 1024
+    - name: captive_portal
+      description: 1 if this network has a captive portal, 0 otherwise
+      type: keyword
+      ignore_above: 1024
+    - name: update_url
+      description: Extension-supplied update URI
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: permissions
+      description: The permissions required by the extension
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: partitions
+      description: Number of detected partitions on disk.
+      type: keyword
+      ignore_above: 1024
+    - name: not_valid_before
+      description: Lower bound of valid date
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: scope
+      description: Where the key is located inside the SELinuxFS mount point.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: reactivated
+      description: Total number of reactivated pages.
+      type: keyword
+      ignore_above: 1024
+    - name: ppvids_supported
+      description: Comma delimited list of supported PPVIDs
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ipv4_address
+      description: IPv4 address
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: bytes_used
+      description: Bytes used on volume
+      type: keyword
+      ignore_above: 1024
+    - name: ssh_public_key
+      description: SSH public key. Only available if supplied at instance launch time
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: managed
+      description: 1 if network created by LXD, 0 otherwise
+      type: keyword
+      ignore_above: 1024
+    - name: antivirus
+      description: The health of the monitored Antivirus solution (see windows_security_products)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: summary
+      description: Package-supplied summary
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subject_info_access
+      description: Subject Information Access
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: reservation_id
+      description: ID of the reservation
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: frame_backtrace
+      description: Backtrace of the crashed module
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: collect_sensor_operations
+      description: Unknown
+      type: keyword
+      ignore_above: 1024
+    - name: propagation
+      description: Mount propagation
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: availability_zone
+      description: Availability zone in which this instance launched
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: memory_limit
+      description: Memory limit
+      type: keyword
+      ignore_above: 1024
+    - name: min_api_version
+      description: Minimum API version supported
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: chassis_repeater_capability_enabled
+      description: Chassis repeater capability enabled
+      type: keyword
+      ignore_above: 1024
+    - name: inodes_used
+      description: Number of inodes used
+      type: keyword
+      ignore_above: 1024
+    - name: metric_value
+      description: Value of collected Prometheus metric
+      type: keyword
+      ignore_above: 1024
+    - name: issuer
+      description: Certificate issuer distinguished name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: not_valid_after
+      description: Certificate expiration data
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: key_usage
+      description: Certificate key usage and extended key usage
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: unused_devices
+      description: Unused devices
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: node_ref_number
+      description: The ordinal that associates a journal record with a filename
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: user_account_control
+      description: The health of the User Account Control (UAC) capability in Windows
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: chassis_mgmt_ips
+      description: Comma delimited list of chassis management IPS
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: build_platform
+      description: osquery toolkit build platform
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: pci_class
+      description: PCI Device class
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ipv4_local_network
+      description: True if any interface is connected to a routed network via IPv4
+      type: keyword
+      ignore_above: 1024
+    - name: num_procs
+      description: Number of processors
+      type: keyword
+      ignore_above: 1024
+    - name: mount_point
+      description: Mount point
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: forwarding_enabled
+      description: Enable IP forwarding
+      type: keyword
+      ignore_above: 1024
+    - name: manual
+      description: 1 if policy was loaded manually, otherwise 0
+      type: keyword
+      ignore_above: 1024
+    - name: memory_type_details
+      description: Additional details for memory device
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: hotfix_id
+      description: The KB ID of the patch.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: current_value
+      description: Value of setting
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: install_time
+      description: Install time of the SDB
+      type: keyword
+      ignore_above: 1024
+    - name: collect_cross_processes
+      description: If the sensor is configured to cross process events
+      type: keyword
+      ignore_above: 1024
+    - name: firmware_version
+      description: The build version of the firmware
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: user_time
+      description: Total user time spent executing
+      type: keyword
+      ignore_above: 1024
+    - name: flag
+      description: Reserved
+      type: keyword
+      ignore_above: 1024
+    - name: collect_processes
+      description: If the sensor is configured to process events
+      type: keyword
+      ignore_above: 1024
+    - name: pvid
+      description: Primary VLAN id
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: magic_db_files
+      description: 'Colon(:) separated list of files where the magic db file can be found. By default one of the following is used: /usr/share/file/magic/magic, /usr/share/misc/magic or /usr/share/misc/magic.mgc'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: memory_free
+      description: The amount of physical RAM, in bytes, left unused by the system
+      type: keyword
+      ignore_above: 1024
+    - name: installer_name
+      description: Name of installer process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: installed_by
+      description: The system context in which the patch as installed.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: percent_idle_time
+      description: Percentage of time during the sample interval that the disk was idle
+      type: keyword
+      ignore_above: 1024
+    - name: driver_version
+      description: The version of the installed driver.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: pre_cpu_kernelmode_usage
+      description: Last read CPU kernel mode usage
+      type: keyword
+      ignore_above: 1024
+    - name: device_name
+      description: Device name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: account_id
+      description: AWS account ID which owns this EC2 instance
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: processor_number
+      description: The processor number as reported in /proc/cpuinfo
+      type: keyword
+      ignore_above: 1024
+    - name: capname
+      description: Capability requested by the process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: charged
+      description: 1 if the battery is currently completely charged. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+    - name: resident_size
+      description: Bytes of private memory used by process
+      type: keyword
+      ignore_above: 1024
+    - name: member_config_description
+      description: Config description
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: auto_update
+      description: Whether the image auto-updates (1) or not (0)
+      type: keyword
+      ignore_above: 1024
+    - name: share
+      description: Filesystem path to the share
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: modified_time
+      description: Timestamp the file was installed
+      type: keyword
+      ignore_above: 1024
+    - name: security_type
+      description: Type of security on this network
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: organization
+      description: Organization issued to
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: host_ip
+      description: Host IP address on which public port is listening
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: port_autoneg_supported
+      description: Auto negotiation supported
+      type: keyword
+      ignore_above: 1024
+    - name: arch
+      description: Package architecture
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: port_autoneg_10baset_hd_enabled
+      description: 10Base-T HD auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+    - name: cached
+      description: Whether image is cached (1) or not (0)
+      type: keyword
+      ignore_above: 1024
+    - name: filepath
+      description: Package file or directory
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: severity
+      description: Syslog severity
+      type: keyword
+      ignore_above: 1024
+    - name: bundle_package_type
+      description: Info properties CFBundlePackageType label
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cpu_set
+      description: 1 if CPU set selection support is enabled. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+    - name: last_unloaded
+      description: Last unloaded module before panic
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cpu_subtype
+      description: Indicates the specific processor on which an entry may be used.
+      type: keyword
+      ignore_above: 1024
+    - name: start_type
+      description: 'Service start type: BOOT_START, SYSTEM_START, AUTO_START, DEMAND_START, DISABLED'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: channel
+      description: Channel number
+      type: keyword
+      ignore_above: 1024
+    - name: subscription_id
+      description: Azure subscription for the VM
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: dhcp_server
+      description: IP address of the dynamic host configuration protocol (DHCP) server.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: buffers
+      description: The amount of physical RAM, in bytes, used for file buffers
+      type: keyword
+      ignore_above: 1024
+    - name: host_port
+      description: Host port
+      type: keyword
+      ignore_above: 1024
+    - name: sgid
+      description: Saved group ID
+      type: keyword
+      ignore_above: 1024
+    - name: number
+      description: Protocol number
+      type: keyword
+      ignore_above: 1024
+    - name: src_ip
+      description: Source IP address.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: chassis_sysname
+      description: CPU brand string, contains vendor and model
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: collect_emet_events
+      description: If the sensor is configured to EMET events
+      type: keyword
+      ignore_above: 1024
+    - name: subject_alternative_names
+      description: Subject Alternative Name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ipv6_gateway
+      description: IPv6 gateway
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: country_code
+      description: The country code (ISO/IEC 3166-1:1997) for the network
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: history_file
+      description: Path to the .*_history for this user
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: user
+      description: Time spent in user mode
+      type: keyword
+      ignore_above: 1024
+    - name: cpu_cfs_quota
+      description: 1 if CPU Completely Fair Scheduler (CFS) quota support is enabled. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+    - name: attached
+      description: Number of attached processes
+      type: keyword
+      ignore_above: 1024
+    - name: platform_fault_domain
+      description: Fault domain the VM is running in
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: vm_scale_set_name
+      description: VM scale set name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: temporarily_disabled
+      description: 1 if this network is temporarily disabled, 0 otherwise
+      type: keyword
+      ignore_above: 1024
+    - name: relative_path
+      description: Relative path to the class or instance.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: local_hostname
+      description: Private IPv4 DNS hostname of the first interface of this instance
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: board_vendor
+      description: Board vendor
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: consistency_scan_date
+      description: Consistency scan date
+      type: keyword
+      ignore_above: 1024
+    - name: architecture
+      description: Hardware architecture
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: platform
+      description: OS Platform or ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: avg_disk_bytes_per_write
+      description: Average number of bytes transferred to the disk during write operations
+      type: keyword
+      ignore_above: 1024
+    - name: requested_mask
+      description: Requested access mask
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: issuer_alternative_names
+      description: Issuer Alternative Name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: hard_links
+      description: Number of hard links
+      type: keyword
+      ignore_above: 1024
+    - name: start_on_mount
+      description: Run daemon or agent every time a filesystem is mounted
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: terminal
+      description: The network protocol ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: installed_on
+      description: The date when the patch was installed.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cpu_physical_cores
+      description: Number of physical CPU cores in to the system
+      type: keyword
+      ignore_above: 1024
+    - name: volume_serial
+      description: Volume serial number
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: obytes
+      description: Output bytes
+      type: keyword
+      ignore_above: 1024
+    - name: member_config_entity
+      description: Type of configuration parameter for this node
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: port_mfs
+      description: Port max frame size
+      type: keyword
+      ignore_above: 1024
+    - name: executable
+      description: Name of the executable that is being shimmed. This is pulled from the registry.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: interval
+      description: Difference between read and preread in nano-seconds
+      type: keyword
+      ignore_above: 1024
+    - name: policy
+      description: Policy that applies for this rule.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: header
+      description: Symbol for given rule
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: connection_status
+      description: State of the network adapter connection to the network.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: power_8023at_power_priority
+      description: 802.3at power priority
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: grace_period
+      description: The amount of time in seconds the screen must be asleep or the screensaver on before a password is required on-wake. 0 = immediately; -1 = no password is required on-wake
+      type: keyword
+      ignore_above: 1024
+    - name: firewall_unload
+      description: 1 If firewall unloading enabled else 0
+      type: keyword
+      ignore_above: 1024
+    - name: keychain_path
+      description: The path of the keychain
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: raid_disks
+      description: Number of configured RAID disks in array
+      type: keyword
+      ignore_above: 1024
+    - name: autoupdate
+      description: 1 If the addon applies background updates else 0
+      type: keyword
+      ignore_above: 1024
+    - name: working_disks
+      description: Number of working disks in array
+      type: keyword
+      ignore_above: 1024
+    - name: world
+      description: If package is in the world file
+      type: keyword
+      ignore_above: 1024
+    - name: baseurl
+      description: Repository base URL
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: source
+      description: Source file
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: percentage_encrypted
+      description: The percentage of the drive that is encrypted.
+      type: keyword
+      ignore_above: 1024
+    - name: visible_alarm
+      description: If TRUE, the frame is equipped with a visual alarm.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: mft_sequence
+      description: Directory master file table sequence.
+      type: keyword
+      ignore_above: 1024
+    - name: exception_code
+      description: The Windows exception code
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: start_interval
+      description: Frequency to run in seconds
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: number_memory_devices
+      description: Number of memory devices on array
+      type: keyword
+      ignore_above: 1024
+    - name: win32_exit_code
+      description: The error code that the service uses to report an error that occurs when it is starting or stopping
+      type: keyword
+      ignore_above: 1024
+    - name: config_flag
+      description: The System Integrity Protection config flag
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: gpgkey
+      description: URL to GPG key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ipv6_subnet
+      description: True if any interface is connected to the local subnet via IPv6
+      type: keyword
+      ignore_above: 1024
+    - name: signed
+      description: Whether the driver is signed or not
+      type: keyword
+      ignore_above: 1024
+    - name: warning
+      description: Number of days before password expires to warn user about it
+      type: keyword
+      ignore_above: 1024
+    - name: stdout_path
+      description: Pipe stdout to a target path
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: file_attributes
+      description: File attributes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: overflows
+      description: List of structures that overflowed
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: broadcast
+      description: Broadcast address for the interface
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: script_name
+      description: The name of the Powershell script
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: exception_message
+      description: The NTSTATUS error message associated with the exception code
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: eventid
+      description: Event ID of the event
+      type: keyword
+      ignore_above: 1024
+    - name: failed_login_count
+      description: The number of failed login attempts using an incorrect password. Count resets after a correct password is entered.
+      type: keyword
+      ignore_above: 1024
+    - name: base_uri
+      description: Repository base URI
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sha256
+      description: A SHA256 sum of the carved archive
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: source_url
+      description: URL that installed the addon
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: chain
+      description: Size of module content.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: med_device_type
+      description: Chassis MED type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ephemeral
+      description: Whether the instance is ephemeral(1) or not(0)
+      type: keyword
+      ignore_above: 1024
+    - name: fix_comments
+      description: Additional comments about the patch.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: command
+      description: Raw command string
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: method
+      description: The HTTP method for the request
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: provider
+      description: Driver provider
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: language
+      description: The language of the product.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sata_version
+      description: SATA version, if any
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: average
+      description: Load average over the specified period.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: interleave_data_depth
+      description: The max number of consecutive rows from memory device that are accessed in a single interleave transfer; 0 indicates device is non-interleave
+      type: keyword
+      ignore_above: 1024
+    - name: device_error_address
+      description: 32 bit physical address of the error relative to the start of the failing memory address, in bytes
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: user_agent
+      description: The user-agent string to use for the request
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: host
+      description: Sender's address (set by the server).
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: family
+      description: The Internet protocol family ID
+      type: keyword
+      ignore_above: 1024
+    - name: permissions_json
+      description: The JSON-encoded permissions required by the extension
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: on_disk
+      description: The process path exists yes=1, no=0, unknown=-1
+      type: keyword
+      ignore_above: 1024
+    - name: anonymous
+      description: Total number of anonymous pages.
+      type: keyword
+      ignore_above: 1024
+    - name: request_id
+      description: Identifying value of the carve request (e.g., scheduled query name, distributed request, etc)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: flags
+      type: keyword
+      ignore_above: 1024
+    - name: eapi
+      description: The eapi for the ebuild
+      type: keyword
+      ignore_above: 1024
+    - name: sensor_id
+      description: Sensor ID of the Carbon Black sensor
+      type: keyword
+      ignore_above: 1024
+    - name: chassis_router_capability_available
+      description: Chassis router capability availability
+      type: keyword
+      ignore_above: 1024
+    - name: mime_type
+      description: MIME type data from libmagic
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: spare_disks
+      description: Number of idle disks in array
+      type: keyword
+      ignore_above: 1024
+    - name: architectures
+      description: Repository architectures
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: current_capacity
+      description: The battery's current charged capacity in mAh
+      type: keyword
+      ignore_above: 1024
+    - name: json_cmdline
+      description: Command line arguments, in JSON format
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: active
+      description: 1 If the addon is active else 0
+      type: keyword
+      ignore_above: 1024
+    - name: chassis_sys_description
+      description: Max number of CPU physical cores
+      type: keyword
+      ignore_above: 1024
+    - name: platform_like
+      description: Closely related platforms
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: duration
+      description: How much time was spent inside the syscall (nsecs)
+      type: keyword
+      ignore_above: 1024
+    - name: ipv4_subnet
+      description: True if any interface is connected to the local subnet via IPv4
+      type: keyword
+      ignore_above: 1024
+    - name: output_register
+      description: Register used to for feature value
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cpu_microcode
+      description: Microcode version
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: purgeable
+      description: Total number of purgeable pages.
+      type: keyword
+      ignore_above: 1024
+    - name: gpgcheck
+      description: Whether packages are GPG checked
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ref_pid
+      description: Reference PID for messages proxied by launchd
+      type: keyword
+      ignore_above: 1024
+    - name: suid
+      description: Saved user ID
+      type: keyword
+      ignore_above: 1024
+    - name: query
+      description: The query that was run to find the file
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: softirq
+      description: Time spent servicing softirqs
+      type: keyword
+      ignore_above: 1024
+    - name: steal
+      description: Time spent in other operating systems when running in a virtualized environment
+      type: keyword
+      ignore_above: 1024
+    - name: inodes_free
+      description: Mounted device free inodes
+      type: keyword
+      ignore_above: 1024
+    - name: memory
+      description: Total memory
+      type: keyword
+      ignore_above: 1024
+    - name: port_autoneg_100baset2_hd_enabled
+      description: 100Base-T2 HD auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+    - name: power_pairs
+      description: Dot3 power pairs
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: swap_free
+      description: The total amount of swap free, in bytes
+      type: keyword
+      ignore_above: 1024
+    - name: object_path
+      description: The object path for this unit
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: compiler
+      description: Info properties DTCompiler label
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: charging
+      description: 1 if the battery is currently being charged by a power source. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+    - name: containers_paused
+      description: Number of containers in paused state
+      type: keyword
+      ignore_above: 1024
+    - name: max_instances
+      description: The maximum number of instances creatable for this pipe
+      type: keyword
+      ignore_above: 1024
+    - name: team_identifier
+      description: The team signing identifier sealed into the signature
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: uses_pattern
+      description: Uses a match pattern instead of identity
+      type: keyword
+      ignore_above: 1024
+    - name: time_nano_sec
+      description: Nanosecond time.
+      type: keyword
+      ignore_above: 1024
+    - name: author
+      description: Optional package author
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: chassis_id_type
+      description: Neighbor chassis ID type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: working_directory
+      description: Key used to specify a directory to chdir to before launch
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: collect_net_conns
+      description: If the sensor is configured to collect network connections
+      type: keyword
+      ignore_above: 1024
+    - name: protection_disabled
+      description: If the sensor is configured to report tamper events
+      type: keyword
+      ignore_above: 1024
+    - name: priority
+      description: Package priority
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: code_integrity_policy_enforcement_status
+      description: The status of the code integrity policy enforcement settings. Returns UNKNOWN if an error is encountered.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: iso_8601
+      description: Current time (ISO format) in the system
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: script_file_name
+      description: Name of the file from which the script text is read, intended as an alternative to specifying the text of the script in the ScriptText property.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: last_used_at
+      description: ISO time for the most recent use of this image in terms of container spawn
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: platform_info
+      description: Platform information.
+      type: keyword
+      ignore_above: 1024
+    - name: celsius
+      description: Temperature in Celsius
+      type: keyword
+      ignore_above: 1024
+    - name: pre_cpu_usermode_usage
+      description: Last read CPU user mode usage
+      type: keyword
+      ignore_above: 1024
+    - name: ierrors
+      description: Input errors
+      type: keyword
+      ignore_above: 1024
+    - name: configured_clock_speed
+      description: Configured speed of memory device in megatransfers per second (MT/s)
+      type: keyword
+      ignore_above: 1024
+    - name: minor_version
+      description: Windows minor version of the machine
+      type: keyword
+      ignore_above: 1024
+    - name: element
+      description: Does the app identify as a background agent
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: manufacture_date
+      description: The date the battery was manufactured UNIX Epoch
+      type: keyword
+      ignore_above: 1024
+    - name: pre_online_cpus
+      description: Last read online CPUs
+      type: keyword
+      ignore_above: 1024
+    - name: metric
+      description: Metric based on the speed of the interface
+      type: keyword
+      ignore_above: 1024
+    - name: bp_microcode_disabled
+      description: Branch Predictions are disabled due to lack of microcode update.
+      type: keyword
+      ignore_above: 1024
+    - name: domain_controller_address
+      description: The IP Address of the discovered domain controller..
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: aliases
+      description: Optional space separated list of other names for a service
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: license
+      description: License for package
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: cmdline
+      description: Command line arguments
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: service
+      description: Driver service name, if one exists
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: launch_type
+      description: Launch services content type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: platform_update_domain
+      description: Update domain the VM is running in
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: disconnected
+      description: True if the all interfaces are not connected to any network
+      type: keyword
+      ignore_above: 1024
+    - name: exception_codes
+      description: Exception codes from the crash
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: following
+      description: The name of another unit that this unit follows in state
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: internet_settings
+      description: The health of the Internet Settings
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: authentication_package
+      description: The authentication package used to authenticate the owner of the logon session.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: registry
+      description: Name of the osquery registry
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: remote_management
+      description: 1 If remote management is enabled else 0
+      type: keyword
+      ignore_above: 1024
+    - name: mountable
+      description: 1 if mountable, 0 if not
+      type: keyword
+      ignore_above: 1024
+    - name: directory
+      description: Directory of file(s)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: install_source
+      description: The installation source of the product.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: config_value
+      description: The MIB value set in /etc/sysctl.conf
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: remote_address
+      description: Remote address associated with socket
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: profile_path
+      description: The profile path
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: socket_designation
+      description: The assigned socket on the board for the given CPU.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: chassis_bridge_capability_enabled
+      description: Is chassis bridge capability enabled.
+      type: keyword
+      ignore_above: 1024
+    - name: creator_pid
+      description: Process ID that created the segment
+      type: keyword
+      ignore_above: 1024
+    - name: smart_enabled
+      description: SMART enabled status
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ref_proc
+      description: Reference process for messages proxied by launchd
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: comment
+      description: Label top-level key
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: dhcp_lease_expires
+      description: Expiration date and time for a leased IP address that was assigned to the computer by the dynamic host configuration protocol (DHCP) server.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: year
+      description: Current year in the system
+      type: keyword
+      ignore_above: 1024
+    - name: default_locale
+      description: Default locale supported by extension
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: src_mask
+      description: Source IP address mask.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: perf_status
+      description: Performance status for the processor.
+      type: keyword
+      ignore_above: 1024
+    - name: speed
+      description: Estimate of the current bandwidth in bits per second.
+      type: keyword
+      ignore_above: 1024
+    - name: processes
+      description: Number of processes running inside this instance
+      type: keyword
+      ignore_above: 1024
+    - name: rapl_power_limit
+      description: Run Time Average Power Limiting power limit.
+      type: keyword
+      ignore_above: 1024
+    - name: owner_uid
+      description: File owner user ID
+      type: keyword
+      ignore_above: 1024
+    - name: module
+      description: Path of the crashed module within the process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: display_name
+      description: Info properties CFBundleDisplayName label
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ipv6_address
+      description: IPv6 address
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: groupname
+      description: Canonical local group name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: process_uptime
+      description: Uptime of the process in seconds
+      type: keyword
+      ignore_above: 1024
+    - name: chassis_wlan_capability_available
+      description: Chassis wlan capability availability
+      type: keyword
+      ignore_above: 1024
+    - name: lu_wwn_device_id
+      description: Device Identifier
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: protection_status
+      description: The bitlocker protection status of the drive.
+      type: keyword
+      ignore_above: 1024
+    - name: disk_write
+      description: Total disk write bytes
+      type: keyword
+      ignore_above: 1024
+    - name: api_version
+      description: API version
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: check_array_speed
+      description: Speed of the check array activity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: percent_disk_write_time
+      description: Percentage of elapsed time that the selected disk drive is busy servicing write requests
+      type: keyword
+      ignore_above: 1024
+    - name: destination_id
+      description: Time Machine destination ID
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: sender
+      description: Sender's identification string.  Default is process name.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: publisher
+      description: Publisher of the VM image
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: instance_identifier
+      description: The instance ID of Device Guard.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: period
+      description: Period over which the average is calculated.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: device_type
+      description: Device type
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: raid_level
+      description: Current raid level of the array
+      type: keyword
+      ignore_above: 1024
+    - name: cmdline_size
+      description: Actual size (bytes) of command line arguments
+      type: keyword
+      ignore_above: 1024
+    - name: partner_mode
+      description: Mode of shared pipe at partner's end
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: process
+      description: Process name explicitly allowed
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: change_type
+      description: 'Type of change: C:Modified, A:Added, D:Deleted'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: egid
+      description: Effective group ID
+      type: keyword
+      ignore_above: 1024
+    - name: authority
+      description: Certificate Common Name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: port_autoneg_1000baset_fd_enabled
+      description: 1000Base-T FD auto negotiation enabled
+      type: keyword
+      ignore_above: 1024
+    - name: power_mdi_enabled
+      description: Is MDI power enabled
+      type: keyword
+      ignore_above: 1024
+    - name: drive_name
+      description: Drive device name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: mechanism
+      description: Name of the mechanism that will be called
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ipackets
+      description: Input packets
+      type: keyword
+      ignore_above: 1024
+    - name: dns_domain
+      description: Organization name followed by a period and an extension that indicates the type of organization, such as 'microsoft.com'.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: driver
+      description: Driver providing the mount
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: page_ins
+      description: The total number of requests for pages from a pager.
+      type: keyword
+      ignore_above: 1024
+    - name: sigfile
+      description: Signature file used
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: collisions
+      description: Packet Collisions detected
+      type: keyword
+      ignore_above: 1024
+    - name: chassis_tel_capability_enabled
+      description: Chassis telephone capability enabled
+      type: keyword
+      ignore_above: 1024
+    - name: logon_id
+      description: A locally unique identifier (LUID) that identifies a logon session.
+      type: keyword
+      ignore_above: 1024
+    - name: inodes_total
+      description: Total number of inodes available in this storage pool
+      type: keyword
+      ignore_above: 1024
+    - name: percent_disk_read_time
+      description: Percentage of elapsed time that the selected disk drive is busy servicing read requests
+      type: keyword
+      ignore_above: 1024
+    - name: native
+      description: Plugin requires native execution
+      type: keyword
+      ignore_above: 1024
+    - name: common_name
+      description: Certificate CommonName
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: pid_with_namespace
+      description: Pids that contain a namespace
+      type: keyword
+      ignore_above: 1024
+    - name: script_text
+      description: The text content of the Powershell script
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: table
+      description: Table name containing symbol
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: dst_mask
+      description: Destination IP address mask.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: application
+      description: Associated Office application
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: minutes_until_empty
+      description: The number of minutes until the battery is fully depleted. This value is -1 if this time is still being calculated
+      type: keyword
+      ignore_above: 1024
+    - name: media_name
+      description: Disk event media name string
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: bridge_nf_ip6tables
+      description: 1 if bridge netfilter ip6tables is enabled. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+    - name: min_voltage
+      description: Minimum operating voltage of device in millivolts
+      type: keyword
+      ignore_above: 1024
+    - name: partial
+      description: Set to 1 if either path or old_path only contains the file or folder name
+      type: keyword
+      ignore_above: 1024
+    - name: codename
+      description: OS version codename
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: enabled_nvram
+      description: 1 if this configuration is enabled, otherwise 0
+      type: keyword
+      ignore_above: 1024
+    - name: syscall
+      description: System call name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: stateful
+      description: Whether the instance is stateful(1) or not(0)
+      type: keyword
+      ignore_above: 1024
+    - name: set
+      description: Identifies if memory device is one of a set of devices.  A value of 0 indicates no set affiliation.
+      type: keyword
+      ignore_above: 1024
+    - name: shell_only
+      description: Is the flag shell only?
+      type: keyword
+      ignore_above: 1024
+    - name: accessed_time
+      description: Directory Accessed time.
+      type: keyword
+      ignore_above: 1024
+    - name: align
+      description: Segment alignment
+      type: keyword
+      ignore_above: 1024
+    - name: product_version
+      description: File product version
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: feature_control
+      description: Bitfield controlling enabled features.
+      type: keyword
+      ignore_above: 1024
+    - name: minor
+      description: Minor release version
+      type: keyword
+      ignore_above: 1024
+    - name: last_hit_date
+      description: Apple date format for last thumbnail cache hit
+      type: keyword
+      ignore_above: 1024
+    - name: mnt_namespace
+      description: Mount namespace
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: git_commit
+      description: Docker build git commit
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: btime
+      description: (B)irth or (cr)eate time
+      type: keyword
+      ignore_above: 1024
+    - name: starting_address
+      description: Physical stating address, in kilobytes, of a range of memory mapped to physical memory array
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: last_executed
+      description: UNIX time stamp in seconds of the last completed execution
+      type: keyword
+      ignore_above: 1024
+    - name: bundle_name
+      description: Info properties CFBundleName label
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: readonly_rootfs
+      description: Is the root filesystem mounted as read only
+      type: keyword
+      ignore_above: 1024
+    - name: cgroup_namespace
+      description: cgroup namespace
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: weekday
+      description: Current weekday in the system
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: purged
+      description: Total number of purged pages.
+      type: keyword
+      ignore_above: 1024
+    - name: timestamp_ms
+      description: Unix timestamp of collected data in MS
+      type: keyword
+      ignore_above: 1024
+    - name: last_run_message
+      description: Exit status message of the last task run
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: job_id
+      description: Next queued job id
+      type: keyword
+      ignore_above: 1024
+    - name: logging_enabled
+      description: 1 If logging mode is enabled else 0
+      type: keyword
+      ignore_above: 1024
+    - name: uts_namespace
+      description: UTS namespace
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: expire
+      description: Number of days since UNIX epoch date until account is disabled
+      type: keyword
+      ignore_above: 1024
+    - name: filter_name
+      description: Packet matching filter table name.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: compressor
+      description: The number of pages used to store compressed VM pages.
+      type: keyword
+      ignore_above: 1024
+    - name: page_outs
+      description: Total number of pages paged out.
+      type: keyword
+      ignore_above: 1024
+    - name: exception_notes
+      description: Exception notes from the crash
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: is_hidden
+      description: IsHidden attribute set in OpenDirectory
+      type: keyword
+      ignore_above: 1024
+    - name: device_path
+      description: Device tree path
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: idx
+      description: Extension load tag or index
+      type: keyword
+      ignore_above: 1024
+    - name: reshape_speed
+      description: Speed of reshape activity
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: remote_apple_events
+      description: 1 If remote apple events are enabled else 0
+      type: keyword
+      ignore_above: 1024
+    - name: in_smartctl_db
+      description: Boolean value for if drive is recognized
+      type: keyword
+      ignore_above: 1024
+    - name: source_path
+      description: Path to the (possibly generated) unit configuration file
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: responsible
+      description: Process responsible for the crashed process
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: size_bytes
+      description: Size of image in bytes
+      type: keyword
+      ignore_above: 1024
+    - name: enable_ipv6
+      description: 1 if IPv6 is enabled on this network. 0 otherwise
+      type: keyword
+      ignore_above: 1024
+    - name: possibly_hidden
+      description: 1 if network is possibly a hidden network, 0 otherwise
+      type: keyword
+      ignore_above: 1024
+    - name: roaming_profile
+      description: Describe the roaming profile, usually one of Single, Dual  or Multi
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: dst_port
+      description: Protocol destination port(s).
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: fingerprint
+      description: SHA256 hash of the certificate
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: shard
+      description: Shard restriction limit, 1-100, 0 meaning no restriction
+      type: keyword
+      ignore_above: 1024
+    - name: pnp_device_id
+      description: The unique identifier of the drive on the system.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: instances
+      description: Number of instances of the named pipe
+      type: keyword
+      ignore_above: 1024
+    - name: forced
+      description: 1 if the value is forced/managed, else 0
+      type: keyword
+      ignore_above: 1024
+    - name: patch
+      description: Optional patch release
+      type: keyword
+      ignore_above: 1024
+    - name: self_signed
+      description: 1 if self-signed, else 0
+      type: keyword
+      ignore_above: 1024
+    - name: ip_address
+      description: IP address
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: ibrs_support_enabled
+      description: Windows uses IBRS.
+      type: keyword
+      ignore_above: 1024
+    - name: key_strength
+      description: Key size used for RSA/DSA, or curve name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: point_to_point
+      description: PtP address for the interface
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: avg_disk_sec_per_read
+      description: Average time, in seconds, of a read operation of data from the disk
+      type: keyword
+      ignore_above: 1024
+    - name: default_value
+      description: Flag default value
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: file_backed
+      description: Total number of file backed pages.
+      type: keyword
+      ignore_above: 1024
+    - name: matches
+      description: List of YARA matches
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: capability
+      description: Capability number
+      type: keyword
+      ignore_above: 1024
+    - name: condition
+      description: 'One of the following: "Normal" indicates the condition of the battery is within normal tolerances, "Service Needed" indicates that the battery should be checked out by a licensed Mac repair service, "Permanent Failure" indicates the battery needs replacement'
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: round_trip_time
+      description: Time taken to complete the request
+      type: keyword
+      ignore_above: 1024
+    - name: scheme
+      description: Name of the scheme/protocol
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: crashed_thread
+      description: Thread ID which crashed
+      type: keyword
+      ignore_above: 1024

--- a/packages/osquery_manager/data_stream/result/fields/package-fields.yml
+++ b/packages/osquery_manager/data_stream/result/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: osquery_manager
-  type: group

--- a/packages/osquery_manager/data_stream/result/fields/primary-fields.yml
+++ b/packages/osquery_manager/data_stream/result/fields/primary-fields.yml
@@ -1,0 +1,9 @@
+- name: action_id
+  type: keyword
+  description: Query action id.
+- name: response_id
+  type: keyword
+  description: Query response id. Present only for scheduled queries.
+- name: action_data
+  type: object
+  description: Original action_data.

--- a/packages/osquery_manager/manifest.yml
+++ b/packages/osquery_manager/manifest.yml
@@ -6,6 +6,9 @@ license: basic
 description: Osquery Manager Integration
 type: integration
 release: experimental
+categories:
+  - security
+  - os_system
 conditions:
   kibana.version: '^7.9.0'
 icons:

--- a/packages/osquery_manager/manifest.yml
+++ b/packages/osquery_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: osquery_manager
 title: Osquery Manager
-version: 0.1.0
+version: 0.2.0
 license: basic
 description: Osquery Manager Integration
 type: integration

--- a/packages/osquery_manager/manifest.yml
+++ b/packages/osquery_manager/manifest.yml
@@ -10,7 +10,7 @@ categories:
   - security
   - os_system
 conditions:
-  kibana.version: '^7.9.0'
+  kibana.version: '^7.13.0'
 icons:
   - src: /img/logo_osquery.svg
     title: logo osquery


### PR DESCRIPTION
## What does this PR do?

Explicit mapping for all osquery fields.

Following this recommendation for mapping
https://www.elastic.co/guide/en/elasticsearch/reference/current/number.html

```
Consider mapping a numeric identifier as a keyword if:
You don’t plan to search for the identifier data using range queries.
Fast retrieval is important. term query searches on keyword fields are often faster than term searches on numeric fields.
If you’re unsure which to use, you can use a multi-field to map the data as both a keyword and a numeric data type.
```

The fields mapping is generated from the official osquery 4.7.0 schema. The numeric fields are mapped to keywords, the text fields had additional text multifield defined.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.

## Author's Checklist

## Related issues
- Relates https://github.com/elastic/security-team/issues/935

## Screenshots

osquery mapping:
<img width="733" alt="Screen Shot 2021-04-10 at 4 27 22 PM" src="https://user-images.githubusercontent.com/872351/114283965-bf0c1780-9a1a-11eb-8e26-6d0989d23fdc.png">

collected osquery data with types converted appropriately with osquerybeat
<img width="695" alt="Screen Shot 2021-04-10 at 4 25 11 PM" src="https://user-images.githubusercontent.com/872351/114283983-d5b26e80-9a1a-11eb-8ef2-53efb7af73ed.png">



