### PR TITLE
[ML] Adds ML jobs for access logs to Apache package

### DIFF
--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.0"
+  changes:
+    - description: Adds ML jobs for finding unusual activity in HTTP access logs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/910
 - version: "0.4.1"
   changes:
     - description: update to ECS 1.9.0

--- a/packages/apache/kibana/ml_module/apache-Logs-ml.json
+++ b/packages/apache/kibana/ml_module/apache-Logs-ml.json
@@ -1,0 +1,400 @@
+{
+  "attributes": {
+    "id": "apache_data_stream",
+    "title": "Apache access logs",
+    "description": "Find unusual activity in HTTP access logs.",
+    "type": "Web Access Logs",
+    "logo": {
+      "icon": "logoApache"
+    },
+    "defaultIndexPattern": "logs-*",
+    "query": {
+      "bool": {
+        "filter": [
+          {
+            "term": {
+              "data_stream.dataset": "apache.access"
+            }
+          },
+          {
+            "exists": {
+              "field": "source.address"
+            }
+          },
+          {
+            "exists": {
+              "field": "url.original"
+            }
+          },
+          {
+            "exists": {
+              "field": "http.response.status_code"
+            }
+          }
+        ]
+      }
+    },
+    "jobs": [
+      {
+        "id": "visitor_rate_apache",
+        "config": {
+          "groups": [
+            "apache"
+          ],
+          "description": "HTTP Access Logs: Detect unusual visitor rates",
+          "analysis_config": {
+            "bucket_span": "15m",
+            "summary_count_field_name": "dc_source_address",
+            "detectors": [
+              {
+                "detector_description": "Apache access visitor rate",
+                "function": "non_zero_count"
+              }
+            ],
+            "influencers": []
+          },
+          "analysis_limits": {
+            "model_memory_limit": "10mb"
+          },
+          "data_description": {
+            "time_field": "@timestamp",
+            "time_format": "epoch_ms"
+          },
+          "model_plot_config": {
+            "enabled": true
+          },
+          "custom_settings": {
+            "created_by": "ml-module-apache-access-data-stream",
+            "custom_urls": [
+              {
+                "url_name": "Apache logs overview",
+                "url_value": "dashboards#/view/apache-Logs-Apache-Dashboard?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(description:\u0027\u0027,filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase))))),query:(language:kuery,query:\u0027\u0027))"
+              },
+              {
+                "url_name": "Raw data",
+                "url_value": "discover#/?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(columns:!(_source),filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase))))),index:\u0027INDEX_PATTERN_ID\u0027,interval:auto,query:(language:kuery,query:\u0027\u0027),sort:!(\u0027@timestamp\u0027,desc))"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "id": "status_code_rate_apache",
+        "config": {
+          "groups": [
+            "apache"
+          ],
+          "description": "HTTP Access Logs: Detect unusual status code rates",
+          "analysis_config": {
+            "bucket_span": "15m",
+            "detectors": [
+              {
+                "detector_description": "Apache access status code rate",
+                "function": "count",
+                "partition_field_name": "http.response.status_code"
+              }
+            ],
+            "influencers": ["http.response.status_code", "source.address"]
+          },
+          "analysis_limits": {
+            "model_memory_limit": "100mb"
+          },
+          "data_description": {
+            "time_field": "@timestamp",
+            "time_format": "epoch_ms"
+          },
+          "model_plot_config": {
+            "enabled": true
+          },
+          "custom_settings": {
+            "created_by": "ml-module-apache-access-data-stream",
+            "custom_urls": [
+              {
+                "url_name": "Apache logs overview",
+                "url_value": "dashboards#/view/apache-Logs-Apache-Dashboard?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(description:\u0027\u0027,filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase)))),(\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:http.response.status_code,negate:!f,params:(query:\u0027$http.response.status_code$\u0027),type:phrase,value:\u0027$http.response.status_code$\u0027),query:(match:(http.response.status_code:(query:\u0027$http.response.status_code$\u0027,type:phrase))))),query:(language:kuery,query:\u0027\u0027))"
+              },
+              {
+                "url_name": "Raw data",
+                "url_value": "discover#/?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(columns:!(_source),filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase)))),(\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:http.response.status_code,negate:!f,params:(query:\u0027$http.response.status_code$\u0027),type:phrase,value:\u0027$http.response.status_code$\u0027),query:(match:(http.response.status_code:(query:\u0027$http.response.status_code$\u0027,type:phrase))))),index:\u0027INDEX_PATTERN_ID\u0027,interval:auto,query:(language:kuery,query:\u0027\u0027),sort:!(\u0027@timestamp\u0027,desc))"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "id": "source_ip_url_count_apache",
+        "config": {
+          "groups": [
+            "apache"
+          ],
+          "description": "HTTP Access Logs: Detect unusual source IPs - high distinct count of URLs",
+          "analysis_config": {
+            "bucket_span": "1h",
+            "detectors": [
+              {
+                "detector_description": "Apache access source IP high dc URL",
+                "function": "high_distinct_count",
+                "field_name": "url.original",
+                "over_field_name": "source.address"
+              }
+            ],
+            "influencers": ["source.address"]
+          },
+          "data_description": {
+            "time_field": "@timestamp",
+            "time_format": "epoch_ms"
+          },
+          "custom_settings": {
+            "created_by": "ml-module-apache-access-data-stream",
+            "custom_urls": [
+              {
+                "url_name": "Apache logs overview",
+                "url_value": "dashboards#/view/apache-Logs-Apache-Dashboard?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(description:\u0027\u0027,filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase)))),(\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:source.address,negate:!f,params:(query:\u0027$source.address$\u0027),type:phrase,value:\u0027$source.address$\u0027),query:(match:(source.address:(query:\u0027$source.address$\u0027,type:phrase))))),query:(language:kuery,query:\u0027\u0027))"
+              },
+              {
+                "url_name": "Raw data",
+                "url_value": "discover#/?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(columns:!(_source),filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase)))),(\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:source.address,negate:!f,params:(query:\u0027$source.address$\u0027),type:phrase,value:\u0027$source.address$\u0027),query:(match:(source.address:(query:\u0027$source.address$\u0027,type:phrase))))),index:\u0027INDEX_PATTERN_ID\u0027,interval:auto,query:(language:kuery,query:\u0027\u0027),sort:!(\u0027@timestamp\u0027,desc))"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "id": "source_ip_request_rate_apache",
+        "config": {
+          "groups": [
+            "apache"
+          ],
+          "description": "HTTP Access Logs: Detect unusual source IPs - high request rates",
+          "analysis_config": {
+            "bucket_span": "1h",
+            "detectors": [
+              {
+                "detector_description": "Apache access source IP high count",
+                "function": "high_count",
+                "over_field_name": "source.address"
+              }
+            ],
+            "influencers": ["source.address"]
+          },
+          "data_description": {
+            "time_field": "@timestamp",
+            "time_format": "epoch_ms"
+          },
+          "custom_settings": {
+            "created_by": "ml-module-apache-access-data-stream",
+            "custom_urls": [
+              {
+                "url_name": "Apache logs overview",
+                "url_value": "dashboards#/view/apache-Logs-Apache-Dashboard?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(description:\u0027\u0027,filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase)))),(\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:source.address,negate:!f,params:(query:\u0027$source.address$\u0027),type:phrase,value:\u0027$source.address$\u0027),query:(match:(source.address:(query:\u0027$source.address$\u0027,type:phrase))))),query:(language:kuery,query:\u0027\u0027))"
+              },
+              {
+                "url_name": "Raw data",
+                "url_value": "discover#/?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(columns:!(_source),filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase)))),(\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:source.address,negate:!f,params:(query:\u0027$source.address$\u0027),type:phrase,value:\u0027$source.address$\u0027),query:(match:(source.address:(query:\u0027$source.address$\u0027,type:phrase))))),index:\u0027INDEX_PATTERN_ID\u0027,interval:auto,query:(language:kuery,query:\u0027\u0027),sort:!(\u0027@timestamp\u0027,desc))"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "id": "low_request_rate_apache",
+        "config": {
+          "groups": [
+            "apache"
+          ],
+          "description": "HTTP Access Logs: Detect low request rates",
+          "analysis_config": {
+            "bucket_span": "15m",
+            "summary_count_field_name": "doc_count",
+            "detectors": [
+              {
+                "detector_description": "Apache access low request rate",
+                "function": "low_count"
+              }
+            ],
+            "influencers": []
+          },
+          "analysis_limits": {
+            "model_memory_limit": "10mb"
+          },
+          "data_description": {
+            "time_field": "@timestamp",
+            "time_format": "epoch_ms"
+          },
+          "model_plot_config": {
+            "enabled": true
+          },
+          "custom_settings": {
+            "created_by": "ml-module-apache-access-data-stream",
+            "custom_urls": [
+              {
+                "url_name": "Apache logs overview",
+                "url_value": "dashboards#/view/apache-Logs-Apache-Dashboard?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(description:\u0027\u0027,filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase))))),query:(language:kuery,query:\u0027\u0027))"
+              },
+              {
+                "url_name": "Raw data",
+                "url_value": "discover#/?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(columns:!(_source),filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase))))),index:\u0027INDEX_PATTERN_ID\u0027,interval:auto,query:(language:kuery,query:\u0027\u0027),sort:!(\u0027@timestamp\u0027,desc))"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "datafeeds": [
+      {
+        "id": "datafeed-visitor_rate_apache",
+        "job_id": "visitor_rate_apache",
+        "config": {
+          "job_id": "visitor_rate_apache",
+          "indices": [
+            "INDEX_PATTERN_NAME"
+          ],
+          "query": {
+            "bool": {
+              "filter": [
+                { "term":  { "data_stream.dataset": "apache.access" } }
+              ]
+            }
+          },
+          "aggregations": {
+            "buckets": {
+              "date_histogram": {
+                "field": "@timestamp",
+                "fixed_interval": "15m",
+                "offset": 0,
+                "order": {
+                  "_key": "asc"
+                },
+                "keyed": false,
+                "min_doc_count": 0
+              },
+              "aggregations": {
+                "@timestamp": {
+                  "max": {
+                    "field": "@timestamp"
+                  }
+                },
+                "dc_source_address": {
+                  "cardinality": {
+                    "field": "source.address"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "id": "datafeed-status_code_rate_apache",
+        "job_id": "status_code_rate_apache",
+        "config": {
+          "job_id": "status_code_rate_apache",
+          "indices": [
+            "INDEX_PATTERN_NAME"
+          ],
+          "query": {
+            "bool": {
+              "filter": [
+                {
+                  "term": {
+                    "data_stream.dataset": "apache.access"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": "datafeed-source_ip_url_count_apache",
+        "job_id": "source_ip_url_count_apache",
+        "config": {
+          "job_id": "source_ip_url_count_apache",
+          "indices": [
+            "INDEX_PATTERN_NAME"
+          ],
+          "query": {
+            "bool": {
+              "filter": [
+                {
+                  "term": {
+                    "data_stream.dataset": "apache.access"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": "datafeed-source_ip_request_rate_apache",
+        "job_id": "source_ip_request_rate_apache",
+        "config": {
+          "job_id": "source_ip_request_rate_apache",
+          "indices": [
+            "INDEX_PATTERN_NAME"
+          ],
+          "query": {
+            "bool": {
+              "filter": [
+                {
+                  "term": {
+                    "data_stream.dataset": "apache.access"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": "datafeed-low_request_rate_apache",
+        "job_id": "low_request_rate_apache",
+        "config": {
+          "job_id": "low_request_rate_apache",
+          "indices": [
+            "INDEX_PATTERN_NAME"
+          ],
+          "query": {
+            "bool": {
+              "filter": [
+                {
+                  "term": {
+                    "data_stream.dataset": "apache.access"
+                  }
+                }
+              ]
+            }
+          },
+          "aggregations": {
+            "buckets": {
+              "date_histogram": {
+                "field": "@timestamp",
+                "fixed_interval": "15m",
+                "offset": 0,
+                "order": {
+                  "_key": "asc"
+                },
+                "keyed": false,
+                "min_doc_count": 0
+              },
+              "aggregations": {
+                "@timestamp": {
+                  "max": {
+                    "field": "@timestamp"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  },
+  "id": "apache-Logs-ml",
+  "migrationVersion": {
+    "search": "7.9.3"
+  },
+  "references": [],
+  "type": "ml-module"
+}

--- a/packages/apache/kibana/ml_module/apache-Logs-ml.json
+++ b/packages/apache/kibana/ml_module/apache-Logs-ml.json
@@ -1,400 +1,411 @@
 {
-  "attributes": {
-    "id": "apache_data_stream",
-    "title": "Apache access logs",
-    "description": "Find unusual activity in HTTP access logs.",
-    "type": "Web Access Logs",
-    "logo": {
-      "icon": "logoApache"
-    },
-    "defaultIndexPattern": "logs-*",
-    "query": {
-      "bool": {
-        "filter": [
-          {
-            "term": {
-              "data_stream.dataset": "apache.access"
+    "attributes": {
+        "id": "apache_data_stream",
+        "title": "Apache access logs",
+        "description": "Find unusual activity in HTTP access logs.",
+        "type": "Web Access Logs",
+        "logo": {
+            "icon": "logoApache"
+        },
+        "defaultIndexPattern": "logs-*",
+        "query": {
+            "bool": {
+                "filter": [
+                    {
+                        "term": {
+                            "data_stream.dataset": "apache.access"
+                        }
+                    },
+                    {
+                        "exists": {
+                            "field": "source.address"
+                        }
+                    },
+                    {
+                        "exists": {
+                            "field": "url.original"
+                        }
+                    },
+                    {
+                        "exists": {
+                            "field": "http.response.status_code"
+                        }
+                    }
+                ]
             }
-          },
-          {
-            "exists": {
-              "field": "source.address"
+        },
+        "jobs": [
+            {
+                "id": "visitor_rate_apache",
+                "config": {
+                    "groups": [
+                        "apache"
+                    ],
+                    "description": "HTTP Access Logs: Detect unusual visitor rates",
+                    "analysis_config": {
+                        "bucket_span": "15m",
+                        "summary_count_field_name": "dc_source_address",
+                        "detectors": [
+                            {
+                                "detector_description": "Apache access visitor rate",
+                                "function": "non_zero_count"
+                            }
+                        ],
+                        "influencers": []
+                    },
+                    "analysis_limits": {
+                        "model_memory_limit": "10mb"
+                    },
+                    "data_description": {
+                        "time_field": "@timestamp",
+                        "time_format": "epoch_ms"
+                    },
+                    "model_plot_config": {
+                        "enabled": true
+                    },
+                    "custom_settings": {
+                        "created_by": "ml-module-apache-access-data-stream",
+                        "custom_urls": [
+                            {
+                                "url_name": "Apache logs overview",
+                                "url_value": "dashboards#/view/apache-Logs-Apache-Dashboard?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))\u0026_a=(description:\u0027\u0027,filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase))))),query:(language:kuery,query:\u0027\u0027))"
+                            },
+                            {
+                                "url_name": "Raw data",
+                                "url_value": "discover#/?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))\u0026_a=(columns:!(_source),filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase))))),index:\u0027INDEX_PATTERN_ID\u0027,interval:auto,query:(language:kuery,query:\u0027\u0027),sort:!(\u0027@timestamp\u0027,desc))"
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "id": "status_code_rate_apache",
+                "config": {
+                    "groups": [
+                        "apache"
+                    ],
+                    "description": "HTTP Access Logs: Detect unusual status code rates",
+                    "analysis_config": {
+                        "bucket_span": "15m",
+                        "detectors": [
+                            {
+                                "detector_description": "Apache access status code rate",
+                                "function": "count",
+                                "partition_field_name": "http.response.status_code"
+                            }
+                        ],
+                        "influencers": [
+                            "http.response.status_code",
+                            "source.address"
+                        ]
+                    },
+                    "analysis_limits": {
+                        "model_memory_limit": "100mb"
+                    },
+                    "data_description": {
+                        "time_field": "@timestamp",
+                        "time_format": "epoch_ms"
+                    },
+                    "model_plot_config": {
+                        "enabled": true
+                    },
+                    "custom_settings": {
+                        "created_by": "ml-module-apache-access-data-stream",
+                        "custom_urls": [
+                            {
+                                "url_name": "Apache logs overview",
+                                "url_value": "dashboards#/view/apache-Logs-Apache-Dashboard?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))\u0026_a=(description:\u0027\u0027,filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase)))),(\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:http.response.status_code,negate:!f,params:(query:\u0027$http.response.status_code$\u0027),type:phrase,value:\u0027$http.response.status_code$\u0027),query:(match:(http.response.status_code:(query:\u0027$http.response.status_code$\u0027,type:phrase))))),query:(language:kuery,query:\u0027\u0027))"
+                            },
+                            {
+                                "url_name": "Raw data",
+                                "url_value": "discover#/?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))\u0026_a=(columns:!(_source),filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase)))),(\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:http.response.status_code,negate:!f,params:(query:\u0027$http.response.status_code$\u0027),type:phrase,value:\u0027$http.response.status_code$\u0027),query:(match:(http.response.status_code:(query:\u0027$http.response.status_code$\u0027,type:phrase))))),index:\u0027INDEX_PATTERN_ID\u0027,interval:auto,query:(language:kuery,query:\u0027\u0027),sort:!(\u0027@timestamp\u0027,desc))"
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "id": "source_ip_url_count_apache",
+                "config": {
+                    "groups": [
+                        "apache"
+                    ],
+                    "description": "HTTP Access Logs: Detect unusual source IPs - high distinct count of URLs",
+                    "analysis_config": {
+                        "bucket_span": "1h",
+                        "detectors": [
+                            {
+                                "detector_description": "Apache access source IP high dc URL",
+                                "function": "high_distinct_count",
+                                "field_name": "url.original",
+                                "over_field_name": "source.address"
+                            }
+                        ],
+                        "influencers": [
+                            "source.address"
+                        ]
+                    },
+                    "data_description": {
+                        "time_field": "@timestamp",
+                        "time_format": "epoch_ms"
+                    },
+                    "custom_settings": {
+                        "created_by": "ml-module-apache-access-data-stream",
+                        "custom_urls": [
+                            {
+                                "url_name": "Apache logs overview",
+                                "url_value": "dashboards#/view/apache-Logs-Apache-Dashboard?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))\u0026_a=(description:\u0027\u0027,filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase)))),(\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:source.address,negate:!f,params:(query:\u0027$source.address$\u0027),type:phrase,value:\u0027$source.address$\u0027),query:(match:(source.address:(query:\u0027$source.address$\u0027,type:phrase))))),query:(language:kuery,query:\u0027\u0027))"
+                            },
+                            {
+                                "url_name": "Raw data",
+                                "url_value": "discover#/?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))\u0026_a=(columns:!(_source),filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase)))),(\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:source.address,negate:!f,params:(query:\u0027$source.address$\u0027),type:phrase,value:\u0027$source.address$\u0027),query:(match:(source.address:(query:\u0027$source.address$\u0027,type:phrase))))),index:\u0027INDEX_PATTERN_ID\u0027,interval:auto,query:(language:kuery,query:\u0027\u0027),sort:!(\u0027@timestamp\u0027,desc))"
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "id": "source_ip_request_rate_apache",
+                "config": {
+                    "groups": [
+                        "apache"
+                    ],
+                    "description": "HTTP Access Logs: Detect unusual source IPs - high request rates",
+                    "analysis_config": {
+                        "bucket_span": "1h",
+                        "detectors": [
+                            {
+                                "detector_description": "Apache access source IP high count",
+                                "function": "high_count",
+                                "over_field_name": "source.address"
+                            }
+                        ],
+                        "influencers": [
+                            "source.address"
+                        ]
+                    },
+                    "data_description": {
+                        "time_field": "@timestamp",
+                        "time_format": "epoch_ms"
+                    },
+                    "custom_settings": {
+                        "created_by": "ml-module-apache-access-data-stream",
+                        "custom_urls": [
+                            {
+                                "url_name": "Apache logs overview",
+                                "url_value": "dashboards#/view/apache-Logs-Apache-Dashboard?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))\u0026_a=(description:\u0027\u0027,filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase)))),(\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:source.address,negate:!f,params:(query:\u0027$source.address$\u0027),type:phrase,value:\u0027$source.address$\u0027),query:(match:(source.address:(query:\u0027$source.address$\u0027,type:phrase))))),query:(language:kuery,query:\u0027\u0027))"
+                            },
+                            {
+                                "url_name": "Raw data",
+                                "url_value": "discover#/?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))\u0026_a=(columns:!(_source),filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase)))),(\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:source.address,negate:!f,params:(query:\u0027$source.address$\u0027),type:phrase,value:\u0027$source.address$\u0027),query:(match:(source.address:(query:\u0027$source.address$\u0027,type:phrase))))),index:\u0027INDEX_PATTERN_ID\u0027,interval:auto,query:(language:kuery,query:\u0027\u0027),sort:!(\u0027@timestamp\u0027,desc))"
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "id": "low_request_rate_apache",
+                "config": {
+                    "groups": [
+                        "apache"
+                    ],
+                    "description": "HTTP Access Logs: Detect low request rates",
+                    "analysis_config": {
+                        "bucket_span": "15m",
+                        "summary_count_field_name": "doc_count",
+                        "detectors": [
+                            {
+                                "detector_description": "Apache access low request rate",
+                                "function": "low_count"
+                            }
+                        ],
+                        "influencers": []
+                    },
+                    "analysis_limits": {
+                        "model_memory_limit": "10mb"
+                    },
+                    "data_description": {
+                        "time_field": "@timestamp",
+                        "time_format": "epoch_ms"
+                    },
+                    "model_plot_config": {
+                        "enabled": true
+                    },
+                    "custom_settings": {
+                        "created_by": "ml-module-apache-access-data-stream",
+                        "custom_urls": [
+                            {
+                                "url_name": "Apache logs overview",
+                                "url_value": "dashboards#/view/apache-Logs-Apache-Dashboard?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))\u0026_a=(description:\u0027\u0027,filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase))))),query:(language:kuery,query:\u0027\u0027))"
+                            },
+                            {
+                                "url_name": "Raw data",
+                                "url_value": "discover#/?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))\u0026_a=(columns:!(_source),filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase))))),index:\u0027INDEX_PATTERN_ID\u0027,interval:auto,query:(language:kuery,query:\u0027\u0027),sort:!(\u0027@timestamp\u0027,desc))"
+                            }
+                        ]
+                    }
+                }
             }
-          },
-          {
-            "exists": {
-              "field": "url.original"
+        ],
+        "datafeeds": [
+            {
+                "id": "datafeed-visitor_rate_apache",
+                "job_id": "visitor_rate_apache",
+                "config": {
+                    "job_id": "visitor_rate_apache",
+                    "indices": [
+                        "INDEX_PATTERN_NAME"
+                    ],
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "data_stream.dataset": "apache.access"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "aggregations": {
+                        "buckets": {
+                            "date_histogram": {
+                                "field": "@timestamp",
+                                "fixed_interval": "15m",
+                                "offset": 0,
+                                "order": {
+                                    "_key": "asc"
+                                },
+                                "keyed": false,
+                                "min_doc_count": 0
+                            },
+                            "aggregations": {
+                                "@timestamp": {
+                                    "max": {
+                                        "field": "@timestamp"
+                                    }
+                                },
+                                "dc_source_address": {
+                                    "cardinality": {
+                                        "field": "source.address"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "id": "datafeed-status_code_rate_apache",
+                "job_id": "status_code_rate_apache",
+                "config": {
+                    "job_id": "status_code_rate_apache",
+                    "indices": [
+                        "INDEX_PATTERN_NAME"
+                    ],
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "data_stream.dataset": "apache.access"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            {
+                "id": "datafeed-source_ip_url_count_apache",
+                "job_id": "source_ip_url_count_apache",
+                "config": {
+                    "job_id": "source_ip_url_count_apache",
+                    "indices": [
+                        "INDEX_PATTERN_NAME"
+                    ],
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "data_stream.dataset": "apache.access"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            {
+                "id": "datafeed-source_ip_request_rate_apache",
+                "job_id": "source_ip_request_rate_apache",
+                "config": {
+                    "job_id": "source_ip_request_rate_apache",
+                    "indices": [
+                        "INDEX_PATTERN_NAME"
+                    ],
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "data_stream.dataset": "apache.access"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            {
+                "id": "datafeed-low_request_rate_apache",
+                "job_id": "low_request_rate_apache",
+                "config": {
+                    "job_id": "low_request_rate_apache",
+                    "indices": [
+                        "INDEX_PATTERN_NAME"
+                    ],
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "data_stream.dataset": "apache.access"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "aggregations": {
+                        "buckets": {
+                            "date_histogram": {
+                                "field": "@timestamp",
+                                "fixed_interval": "15m",
+                                "offset": 0,
+                                "order": {
+                                    "_key": "asc"
+                                },
+                                "keyed": false,
+                                "min_doc_count": 0
+                            },
+                            "aggregations": {
+                                "@timestamp": {
+                                    "max": {
+                                        "field": "@timestamp"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
-          },
-          {
-            "exists": {
-              "field": "http.response.status_code"
-            }
-          }
         ]
-      }
     },
-    "jobs": [
-      {
-        "id": "visitor_rate_apache",
-        "config": {
-          "groups": [
-            "apache"
-          ],
-          "description": "HTTP Access Logs: Detect unusual visitor rates",
-          "analysis_config": {
-            "bucket_span": "15m",
-            "summary_count_field_name": "dc_source_address",
-            "detectors": [
-              {
-                "detector_description": "Apache access visitor rate",
-                "function": "non_zero_count"
-              }
-            ],
-            "influencers": []
-          },
-          "analysis_limits": {
-            "model_memory_limit": "10mb"
-          },
-          "data_description": {
-            "time_field": "@timestamp",
-            "time_format": "epoch_ms"
-          },
-          "model_plot_config": {
-            "enabled": true
-          },
-          "custom_settings": {
-            "created_by": "ml-module-apache-access-data-stream",
-            "custom_urls": [
-              {
-                "url_name": "Apache logs overview",
-                "url_value": "dashboards#/view/apache-Logs-Apache-Dashboard?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(description:\u0027\u0027,filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase))))),query:(language:kuery,query:\u0027\u0027))"
-              },
-              {
-                "url_name": "Raw data",
-                "url_value": "discover#/?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(columns:!(_source),filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase))))),index:\u0027INDEX_PATTERN_ID\u0027,interval:auto,query:(language:kuery,query:\u0027\u0027),sort:!(\u0027@timestamp\u0027,desc))"
-              }
-            ]
-          }
-        }
-      },
-      {
-        "id": "status_code_rate_apache",
-        "config": {
-          "groups": [
-            "apache"
-          ],
-          "description": "HTTP Access Logs: Detect unusual status code rates",
-          "analysis_config": {
-            "bucket_span": "15m",
-            "detectors": [
-              {
-                "detector_description": "Apache access status code rate",
-                "function": "count",
-                "partition_field_name": "http.response.status_code"
-              }
-            ],
-            "influencers": ["http.response.status_code", "source.address"]
-          },
-          "analysis_limits": {
-            "model_memory_limit": "100mb"
-          },
-          "data_description": {
-            "time_field": "@timestamp",
-            "time_format": "epoch_ms"
-          },
-          "model_plot_config": {
-            "enabled": true
-          },
-          "custom_settings": {
-            "created_by": "ml-module-apache-access-data-stream",
-            "custom_urls": [
-              {
-                "url_name": "Apache logs overview",
-                "url_value": "dashboards#/view/apache-Logs-Apache-Dashboard?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(description:\u0027\u0027,filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase)))),(\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:http.response.status_code,negate:!f,params:(query:\u0027$http.response.status_code$\u0027),type:phrase,value:\u0027$http.response.status_code$\u0027),query:(match:(http.response.status_code:(query:\u0027$http.response.status_code$\u0027,type:phrase))))),query:(language:kuery,query:\u0027\u0027))"
-              },
-              {
-                "url_name": "Raw data",
-                "url_value": "discover#/?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(columns:!(_source),filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase)))),(\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:http.response.status_code,negate:!f,params:(query:\u0027$http.response.status_code$\u0027),type:phrase,value:\u0027$http.response.status_code$\u0027),query:(match:(http.response.status_code:(query:\u0027$http.response.status_code$\u0027,type:phrase))))),index:\u0027INDEX_PATTERN_ID\u0027,interval:auto,query:(language:kuery,query:\u0027\u0027),sort:!(\u0027@timestamp\u0027,desc))"
-              }
-            ]
-          }
-        }
-      },
-      {
-        "id": "source_ip_url_count_apache",
-        "config": {
-          "groups": [
-            "apache"
-          ],
-          "description": "HTTP Access Logs: Detect unusual source IPs - high distinct count of URLs",
-          "analysis_config": {
-            "bucket_span": "1h",
-            "detectors": [
-              {
-                "detector_description": "Apache access source IP high dc URL",
-                "function": "high_distinct_count",
-                "field_name": "url.original",
-                "over_field_name": "source.address"
-              }
-            ],
-            "influencers": ["source.address"]
-          },
-          "data_description": {
-            "time_field": "@timestamp",
-            "time_format": "epoch_ms"
-          },
-          "custom_settings": {
-            "created_by": "ml-module-apache-access-data-stream",
-            "custom_urls": [
-              {
-                "url_name": "Apache logs overview",
-                "url_value": "dashboards#/view/apache-Logs-Apache-Dashboard?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(description:\u0027\u0027,filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase)))),(\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:source.address,negate:!f,params:(query:\u0027$source.address$\u0027),type:phrase,value:\u0027$source.address$\u0027),query:(match:(source.address:(query:\u0027$source.address$\u0027,type:phrase))))),query:(language:kuery,query:\u0027\u0027))"
-              },
-              {
-                "url_name": "Raw data",
-                "url_value": "discover#/?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(columns:!(_source),filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase)))),(\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:source.address,negate:!f,params:(query:\u0027$source.address$\u0027),type:phrase,value:\u0027$source.address$\u0027),query:(match:(source.address:(query:\u0027$source.address$\u0027,type:phrase))))),index:\u0027INDEX_PATTERN_ID\u0027,interval:auto,query:(language:kuery,query:\u0027\u0027),sort:!(\u0027@timestamp\u0027,desc))"
-              }
-            ]
-          }
-        }
-      },
-      {
-        "id": "source_ip_request_rate_apache",
-        "config": {
-          "groups": [
-            "apache"
-          ],
-          "description": "HTTP Access Logs: Detect unusual source IPs - high request rates",
-          "analysis_config": {
-            "bucket_span": "1h",
-            "detectors": [
-              {
-                "detector_description": "Apache access source IP high count",
-                "function": "high_count",
-                "over_field_name": "source.address"
-              }
-            ],
-            "influencers": ["source.address"]
-          },
-          "data_description": {
-            "time_field": "@timestamp",
-            "time_format": "epoch_ms"
-          },
-          "custom_settings": {
-            "created_by": "ml-module-apache-access-data-stream",
-            "custom_urls": [
-              {
-                "url_name": "Apache logs overview",
-                "url_value": "dashboards#/view/apache-Logs-Apache-Dashboard?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(description:\u0027\u0027,filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase)))),(\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:source.address,negate:!f,params:(query:\u0027$source.address$\u0027),type:phrase,value:\u0027$source.address$\u0027),query:(match:(source.address:(query:\u0027$source.address$\u0027,type:phrase))))),query:(language:kuery,query:\u0027\u0027))"
-              },
-              {
-                "url_name": "Raw data",
-                "url_value": "discover#/?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(columns:!(_source),filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase)))),(\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:source.address,negate:!f,params:(query:\u0027$source.address$\u0027),type:phrase,value:\u0027$source.address$\u0027),query:(match:(source.address:(query:\u0027$source.address$\u0027,type:phrase))))),index:\u0027INDEX_PATTERN_ID\u0027,interval:auto,query:(language:kuery,query:\u0027\u0027),sort:!(\u0027@timestamp\u0027,desc))"
-              }
-            ]
-          }
-        }
-      },
-      {
-        "id": "low_request_rate_apache",
-        "config": {
-          "groups": [
-            "apache"
-          ],
-          "description": "HTTP Access Logs: Detect low request rates",
-          "analysis_config": {
-            "bucket_span": "15m",
-            "summary_count_field_name": "doc_count",
-            "detectors": [
-              {
-                "detector_description": "Apache access low request rate",
-                "function": "low_count"
-              }
-            ],
-            "influencers": []
-          },
-          "analysis_limits": {
-            "model_memory_limit": "10mb"
-          },
-          "data_description": {
-            "time_field": "@timestamp",
-            "time_format": "epoch_ms"
-          },
-          "model_plot_config": {
-            "enabled": true
-          },
-          "custom_settings": {
-            "created_by": "ml-module-apache-access-data-stream",
-            "custom_urls": [
-              {
-                "url_name": "Apache logs overview",
-                "url_value": "dashboards#/view/apache-Logs-Apache-Dashboard?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(description:\u0027\u0027,filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase))))),query:(language:kuery,query:\u0027\u0027))"
-              },
-              {
-                "url_name": "Raw data",
-                "url_value": "discover#/?_g=(time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(columns:!(_source),filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027INDEX_PATTERN_ID\u0027,key:data_stream.dataset,negate:!f,params:(query:\u0027apache.access\u0027),type:phrase,value:\u0027apache.access\u0027),query:(match:(data_stream.dataset:(query:\u0027apache.access\u0027,type:phrase))))),index:\u0027INDEX_PATTERN_ID\u0027,interval:auto,query:(language:kuery,query:\u0027\u0027),sort:!(\u0027@timestamp\u0027,desc))"
-              }
-            ]
-          }
-        }
-      }
-    ],
-    "datafeeds": [
-      {
-        "id": "datafeed-visitor_rate_apache",
-        "job_id": "visitor_rate_apache",
-        "config": {
-          "job_id": "visitor_rate_apache",
-          "indices": [
-            "INDEX_PATTERN_NAME"
-          ],
-          "query": {
-            "bool": {
-              "filter": [
-                { "term":  { "data_stream.dataset": "apache.access" } }
-              ]
-            }
-          },
-          "aggregations": {
-            "buckets": {
-              "date_histogram": {
-                "field": "@timestamp",
-                "fixed_interval": "15m",
-                "offset": 0,
-                "order": {
-                  "_key": "asc"
-                },
-                "keyed": false,
-                "min_doc_count": 0
-              },
-              "aggregations": {
-                "@timestamp": {
-                  "max": {
-                    "field": "@timestamp"
-                  }
-                },
-                "dc_source_address": {
-                  "cardinality": {
-                    "field": "source.address"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "id": "datafeed-status_code_rate_apache",
-        "job_id": "status_code_rate_apache",
-        "config": {
-          "job_id": "status_code_rate_apache",
-          "indices": [
-            "INDEX_PATTERN_NAME"
-          ],
-          "query": {
-            "bool": {
-              "filter": [
-                {
-                  "term": {
-                    "data_stream.dataset": "apache.access"
-                  }
-                }
-              ]
-            }
-          }
-        }
-      },
-      {
-        "id": "datafeed-source_ip_url_count_apache",
-        "job_id": "source_ip_url_count_apache",
-        "config": {
-          "job_id": "source_ip_url_count_apache",
-          "indices": [
-            "INDEX_PATTERN_NAME"
-          ],
-          "query": {
-            "bool": {
-              "filter": [
-                {
-                  "term": {
-                    "data_stream.dataset": "apache.access"
-                  }
-                }
-              ]
-            }
-          }
-        }
-      },
-      {
-        "id": "datafeed-source_ip_request_rate_apache",
-        "job_id": "source_ip_request_rate_apache",
-        "config": {
-          "job_id": "source_ip_request_rate_apache",
-          "indices": [
-            "INDEX_PATTERN_NAME"
-          ],
-          "query": {
-            "bool": {
-              "filter": [
-                {
-                  "term": {
-                    "data_stream.dataset": "apache.access"
-                  }
-                }
-              ]
-            }
-          }
-        }
-      },
-      {
-        "id": "datafeed-low_request_rate_apache",
-        "job_id": "low_request_rate_apache",
-        "config": {
-          "job_id": "low_request_rate_apache",
-          "indices": [
-            "INDEX_PATTERN_NAME"
-          ],
-          "query": {
-            "bool": {
-              "filter": [
-                {
-                  "term": {
-                    "data_stream.dataset": "apache.access"
-                  }
-                }
-              ]
-            }
-          },
-          "aggregations": {
-            "buckets": {
-              "date_histogram": {
-                "field": "@timestamp",
-                "fixed_interval": "15m",
-                "offset": 0,
-                "order": {
-                  "_key": "asc"
-                },
-                "keyed": false,
-                "min_doc_count": 0
-              },
-              "aggregations": {
-                "@timestamp": {
-                  "max": {
-                    "field": "@timestamp"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    ]
-  },
-  "id": "apache-Logs-ml",
-  "migrationVersion": {
-    "search": "7.9.3"
-  },
-  "references": [],
-  "type": "ml-module"
+    "id": "apache-Logs-ml",
+    "migrationVersion": {
+        "search": "7.9.3"
+    },
+    "references": [],
+    "type": "ml-module"
 }

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: apache
 title: Apache
-version: 0.4.1
+version: 0.5.0
 license: basic
 description: Apache Integration
 type: integration
@@ -9,7 +9,7 @@ categories:
   - web
 release: experimental
 conditions:
-  kibana.version: "^7.12.0"
+  kibana.version: "^7.13.0"
 screenshots:
   - src: /img/apache-metrics-overview.png
     title: Apache metrics overview


### PR DESCRIPTION
## What does this PR do?

Adds an ML module containing anomaly detection jobs for finding unusual activity in HTTP access logs to the Apache integration. Requires Kibana 7.13.0 or later.

These are the same five jobs that have previously been stored inside the ML Kibana plugin:

- Detect unusual visitor rates
- Detect unusual status code rates
- Detect unusual source IPs - high distinct count of URLs
- Detect unusual source IPs - high request rate
- Detect low request rates

Some minor edits have been made to the previous job configurations stored in the ML Kibana plugin:
- ID of the module is `apache_data_stream` compared to `apache_ecs` for the legacy module
- Module and datafeed queries use `data_stream.dataset: apache.access` compared to `event.dataset: apache.access` for the legacy module
- The ML module no longer adds its own Kibana dashboard, but instead links to the `Apache logs overview` dashboard which is already included in the Apache package.
- The suffix `(ECS)` has been removed from the module and job description
- `_apache` is appended to the IDs of the jobs in the module
- The `created_by` property used for telemetry is set to `ml-module-apache-access-data-stream` compared to `ml-module-apache-access` for the legacy module

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.

## How to test this PR locally

To test this PR:
- Kibana 7.13 or later is required
- the Apache package will first need to be added / updated from the Fleet Integrations page, or install the assets from the Settings tab for the Apache package in Fleet. 
- Have an apache data stream configured in Fleet, so that there is data in an index, such as `logs-*`, matching the query in the ML module JSON file:
```
    "query": {
      "bool": {
        "filter": [
          {
            "term": {
              "data_stream.dataset": "apache.access"
            }
          },
          {
            "exists": {
              "field": "source.address"
            }
          },
          {
            "exists": {
              "field": "url.original"
            }
          },
          {
            "exists": {
              "field": "http.response.status_code"
            }
          }
        ]
      }
    },
```
- Go to the ML plugin in Kibana, and create a job, selecting the appropriate index (such as `logs-*`) and select the card for this new Apache access logs module:
![image](https://user-images.githubusercontent.com/7405507/114701523-d39e2780-9d1a-11eb-8138-11c01aae322f.png)
- Create and run the jobs from the ML job wizard
- Test that the custom URLs to the Apache logs overview dashboard and the raw data in Discover work

## Related issues

https://github.com/elastic/package-spec/issues/148

## Screenshots
ML module is now listed in the Kibana assets section for the Apache package:
![image](https://user-images.githubusercontent.com/7405507/114700376-5b833200-9d19-11eb-8ba8-61c57be46c33.png)

List of Apache jobs in the ML Job list:
![image](https://user-images.githubusercontent.com/7405507/114700743-ca608b00-9d19-11eb-85d1-553bd9e8afc0.png)

Screenshot showing results of Apache ML jobs in the ML Anomaly Explorer:
![image](https://user-images.githubusercontent.com/7405507/114700549-8d949400-9d19-11eb-932c-d7fb2cd2e5b4.png)

