### PR TITLE
adjust tcp data_stream check.receive type to text

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.0.3" # unreleased
+  changes:
+    - description: adjust type of tcp data_stream check.receive field
+      type: bugfix # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/914
 - version: "0.0.2" # unreleased
   changes:
     - description: add base fields

--- a/packages/synthetics/data_stream/tcp/manifest.yml
+++ b/packages/synthetics/data_stream/tcp/manifest.yml
@@ -73,7 +73,7 @@ streams:
         required: false
         show_user: true
       - name: check.receive
-        type: yaml
+        type: text
         title: Response includes
         multi: false
         required: false

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Monitor services availability.
-version: 0.0.2
+version: 0.0.3
 categories: ["custom"]
 release: beta
 type: integration


### PR DESCRIPTION
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug

## What does this PR do?

Adjusts the type of the check.receive field in the tcp data_stream. 
