### PR TITLE
Use decode_xml_wineventlog in winlog Splunk inputs

### DIFF
--- a/packages/winlog/changelog.yml
+++ b/packages/winlog/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.1"
+  changes:
+    - description: Change Splunk input to use the decode_xml_wineventlog processor.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "0.2.0"
   changes:
     - description: Add Splunk httpjson input

--- a/packages/winlog/data_stream/winlog/agent/stream/httpjson.yml.hbs
+++ b/packages/winlog/data_stream/winlog/agent/stream/httpjson.yml.hbs
@@ -70,12 +70,12 @@ processors:
       fail_on_error: false
   - drop_fields:
       fields: json
-  - decode_xml:
+  - decode_xml_wineventlog:
       field: event.original
       target_field: winlog
-      schema: wineventlog
       ignore_missing: true
       ignore_failure: true
+      map_ecs_fields: true
   - timestamp:
       field: winlog.time_created
       layouts:

--- a/packages/winlog/manifest.yml
+++ b/packages/winlog/manifest.yml
@@ -4,7 +4,7 @@ title: Custom Windows event logs
 description: |-
   Collect your custom Windows event logs.
 type: integration
-version: 0.2.0
+version: 0.2.1
 release: experimental
 conditions:
   kibana.version: '^7.13.0'


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Uses `decode_xml_wineventlog` processor instead of `decode_xml`

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
