### PR TITLE
Use decode_xml_wineventlog in windows Splunk inputs

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.2"
+  changes:
+    - description: Change Splunk input to use the decode_xml_wineventlog processor.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "0.5.1"
   changes:
     - description: Add support for Sysmon v13 events.

--- a/packages/windows/data_stream/forwarded/agent/stream/httpjson.yml.hbs
+++ b/packages/windows/data_stream/forwarded/agent/stream/httpjson.yml.hbs
@@ -68,12 +68,12 @@ processors:
       fail_on_error: false
   - drop_fields:
       fields: json
-  - decode_xml:
+  - decode_xml_wineventlog:
       field: event.original
       target_field: winlog
-      schema: wineventlog
       ignore_missing: true
       ignore_failure: true
+      map_ecs_fields: true
   - timestamp:
       field: winlog.time_created
       layouts:

--- a/packages/windows/data_stream/powershell/agent/stream/httpjson.yml.hbs
+++ b/packages/windows/data_stream/powershell/agent/stream/httpjson.yml.hbs
@@ -68,12 +68,12 @@ processors:
       fail_on_error: false
   - drop_fields:
       fields: json
-  - decode_xml:
+  - decode_xml_wineventlog:
       field: event.original
       target_field: winlog
-      schema: wineventlog
       ignore_missing: true
       ignore_failure: true
+      map_ecs_fields: true
   - timestamp:
       field: winlog.time_created
       layouts:

--- a/packages/windows/data_stream/powershell_operational/agent/stream/httpjson.yml.hbs
+++ b/packages/windows/data_stream/powershell_operational/agent/stream/httpjson.yml.hbs
@@ -68,12 +68,12 @@ processors:
       fail_on_error: false
   - drop_fields:
       fields: json
-  - decode_xml:
+  - decode_xml_wineventlog:
       field: event.original
       target_field: winlog
-      schema: wineventlog
       ignore_missing: true
       ignore_failure: true
+      map_ecs_fields: true
   - timestamp:
       field: winlog.time_created
       layouts:

--- a/packages/windows/data_stream/sysmon_operational/agent/stream/httpjson.yml.hbs
+++ b/packages/windows/data_stream/sysmon_operational/agent/stream/httpjson.yml.hbs
@@ -68,12 +68,12 @@ processors:
       fail_on_error: false
   - drop_fields:
       fields: json
-  - decode_xml:
+  - decode_xml_wineventlog:
       field: event.original
       target_field: winlog
-      schema: wineventlog
       ignore_missing: true
       ignore_failure: true
+      map_ecs_fields: true
   - timestamp:
       field: winlog.time_created
       layouts:

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 0.5.1
+version: 0.5.2
 description: Windows Integration
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Uses `decode_xml_wineventlog` processor instead of `decode_xml`

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
