### PR TITLE
Use decode_xml_wineventlog in system Splunk inputs

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.12.1"
+  changes:
+    - description: Change Splunk input to use the decode_xml_wineventlog processor.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "0.12.0"
   changes:
     - description: Add Splunk input for application, system, and security data streams.

--- a/packages/system/data_stream/application/agent/stream/httpjson.yml.hbs
+++ b/packages/system/data_stream/application/agent/stream/httpjson.yml.hbs
@@ -68,12 +68,12 @@ processors:
       fail_on_error: false
   - drop_fields:
       fields: json
-  - decode_xml:
+  - decode_xml_wineventlog:
       field: event.original
       target_field: winlog
-      schema: wineventlog
       ignore_missing: true
       ignore_failure: true
+      map_ecs_fields: true
   - timestamp:
       field: winlog.time_created
       layouts:

--- a/packages/system/data_stream/security/agent/stream/httpjson.yml.hbs
+++ b/packages/system/data_stream/security/agent/stream/httpjson.yml.hbs
@@ -68,12 +68,12 @@ processors:
       fail_on_error: false
   - drop_fields:
       fields: json
-  - decode_xml:
+  - decode_xml_wineventlog:
       field: event.original
       target_field: winlog
-      schema: wineventlog
       ignore_missing: true
       ignore_failure: true
+      map_ecs_fields: true
   - timestamp:
       field: winlog.time_created
       layouts:

--- a/packages/system/data_stream/system/agent/stream/httpjson.yml.hbs
+++ b/packages/system/data_stream/system/agent/stream/httpjson.yml.hbs
@@ -68,12 +68,12 @@ processors:
       fail_on_error: false
   - drop_fields:
       fields: json
-  - decode_xml:
+  - decode_xml_wineventlog:
       field: event.original
       target_field: winlog
-      schema: wineventlog
       ignore_missing: true
       ignore_failure: true
+      map_ecs_fields: true
   - timestamp:
       field: winlog.time_created
       layouts:

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 0.12.0
+version: 0.12.1
 license: basic
 description: System Integration
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Uses `decode_xml_wineventlog` processor instead of `decode_xml`

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
