### PR TITLE
Upgrade elastic-package to use updated k8s service deployer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/elastic/elastic-package v0.0.0-20210420104243-4ec40d7c5404
+	github.com/elastic/elastic-package v0.0.0-20210421120352-f092978b96cc
 	github.com/elastic/package-registry v0.17.0
 	github.com/magefile/mage v1.11.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -195,8 +195,8 @@ github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5m
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
-github.com/elastic/elastic-package v0.0.0-20210420104243-4ec40d7c5404 h1:sKl0wi0CP+SKdpTMBVljRDGJFITQBD3v0+CXPZ+4wac=
-github.com/elastic/elastic-package v0.0.0-20210420104243-4ec40d7c5404/go.mod h1:RI2o887liZvtjBuTSz0EGer+5/9cLOhzFR7h55rtP6E=
+github.com/elastic/elastic-package v0.0.0-20210421120352-f092978b96cc h1:c4T66lCTWKNKXq8cKmLc33cjhZzrCK/dAcu5Kytl3TM=
+github.com/elastic/elastic-package v0.0.0-20210421120352-f092978b96cc/go.mod h1:RI2o887liZvtjBuTSz0EGer+5/9cLOhzFR7h55rtP6E=
 github.com/elastic/go-elasticsearch/v7 v7.9.0 h1:UEau+a1MiiE/F+UrDj60kqIHFWdzU1M2y/YtBU2NC2M=
 github.com/elastic/go-elasticsearch/v7 v7.9.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/go-licenser v0.3.1/go.mod h1:D8eNQk70FOCVBl3smCGQt/lv7meBeQno2eI1S5apiHQ=


### PR DESCRIPTION
## What does this PR do?

Updating elastic-package dep to include https://github.com/elastic/elastic-package/pull/332