### PR TITLE
[Suricata] Up the minimum version of kibana

### DIFF
--- a/packages/suricata/manifest.yml
+++ b/packages/suricata/manifest.yml
@@ -13,7 +13,7 @@ format_version: 1.0.0
 license: basic
 categories: [network, security]
 conditions:
-  kibana.version: "^7.10.0"
+  kibana.version: "^7.13.0"
 screenshots:
   - src: /img/filebeat-suricata-events.png
     title: filebeat suricata events


### PR DESCRIPTION
## What does this PR do?

Changes minimum version of Kibana/ES to 7.13 to work with the newer processors introduced in 7.12 and 7.13 for suricata. This is an addition to the 0.6.0 package version, so no new changelog is added.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.

