### PR TITLE
[Zeek] Change minimum version to 7.13

### DIFF
--- a/packages/zeek/manifest.yml
+++ b/packages/zeek/manifest.yml
@@ -13,7 +13,7 @@ format_version: 1.0.0
 license: basic
 categories: [network, monitoring, security]
 conditions:
-  kibana.version: '^7.12.0'
+  kibana.version: '^7.13.0'
 screenshots:
   - src: /img/kibana-zeek.png
     title: kibana zeek


### PR DESCRIPTION
## What does this PR do?

Sets the minimum version of ES/Kibana for zeek package to 7.13 for the `registered_domain` processor

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
