### PR TITLE
[fleet_server] Add yaml block for custom configurations

### DIFF
--- a/packages/fleet_server/agent/input/agent.yml.hbs
+++ b/packages/fleet_server/agent/input/agent.yml.hbs
@@ -9,4 +9,6 @@ server:
   max_connections: {{max_connections}}
 {{/if}}
 
+{{#if custom}}
 {{custom}}
+{{/if}}

--- a/packages/fleet_server/agent/input/agent.yml.hbs
+++ b/packages/fleet_server/agent/input/agent.yml.hbs
@@ -8,3 +8,5 @@ server:
 {{#if max_connections}}
   max_connections: {{max_connections}}
 {{/if}}
+
+{{custom}}

--- a/packages/fleet_server/changelog.yml
+++ b/packages/fleet_server/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.3"
+  changes:
+    - description: Add yaml block for configuration
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/?
 - version: "0.2.1"
   changes:
     - description: Remove fleet indices mappings that are supported by ES system indices plugin

--- a/packages/fleet_server/manifest.yml
+++ b/packages/fleet_server/manifest.yml
@@ -1,6 +1,6 @@
 name: fleet_server
 title: Fleet Server
-version: 0.2.2
+version: 0.2.3
 release: experimental
 description: Fleet Server Integration
 type: integration
@@ -22,6 +22,11 @@ policy_templates:
     description: Fleet Server setup
     inputs:
       - type: fleet-server
+
+        title: "Fleet Server"
+        description: "Fleet Server Configuration"
+        template_path: "agent.yml.hbs"
+
         vars:
           - name: host
             type: text
@@ -42,7 +47,11 @@ policy_templates:
             title: Max connections
             required: false
             show_user: true
-        title: "Fleet Server"
-        description: "Fleet Server Configuration"
-        template_path: "agent.yml.hbs"
-# TODO: Make this package hidden?
+          - name: custom
+            title: Custom fleet-server configurations
+            description: >
+              Here YAML configuration options can be used to be added to your configuration. Be careful using this as it might break your configuration file.
+
+            type: yaml
+            default: ""
+

--- a/packages/fleet_server/manifest.yml
+++ b/packages/fleet_server/manifest.yml
@@ -22,11 +22,9 @@ policy_templates:
     description: Fleet Server setup
     inputs:
       - type: fleet-server
-
         title: "Fleet Server"
         description: "Fleet Server Configuration"
         template_path: "agent.yml.hbs"
-
         vars:
           - name: host
             type: text
@@ -54,4 +52,3 @@ policy_templates:
 
             type: yaml
             default: ""
-

--- a/packages/fleet_server/manifest.yml
+++ b/packages/fleet_server/manifest.yml
@@ -48,7 +48,7 @@ policy_templates:
           - name: custom
             title: Custom fleet-server configurations
             description: >
-              Here YAML configuration options can be used to be added to your configuration. Be careful using this as it might break your configuration file.
+              Additional YAML configuration options. Be careful using this as it might break your configuration file.
 
             type: yaml
             default: ""


### PR DESCRIPTION
There are a few expert configurations available for fleet-server which should be tuned especially when scaling it. In the future, fleet-server should be able to potentially tune this automatically. For now we should allow expert users to configure these.

With this change, the policy UI looks as following:

![Screenshot 2021-04-29 at 13 00 33](https://user-images.githubusercontent.com/244900/116541670-0b48ca00-a8ec-11eb-97fa-663e66d81d9f.png)
