### PR TITLE
Fix k8s package's env references

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.1"
+  changes:
+    - description: Fix references to env variables
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/970
 - version: "0.5.0"
   changes:
     - description: Add missing field "kubernetes.selectors.*" and extra https settings for controllermanager and scheduler datastreams

--- a/packages/kubernetes/data_stream/apiserver/manifest.yml
+++ b/packages/kubernetes/data_stream/apiserver/manifest.yml
@@ -18,7 +18,7 @@ streams:
         required: true
         show_user: true
         default:
-          - https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}
+          - https://${env.KUBERNETES_SERVICE_HOST}:${env.KUBERNETES_SERVICE_PORT}
       - name: period
         type: text
         title: Period

--- a/packages/kubernetes/data_stream/container/manifest.yml
+++ b/packages/kubernetes/data_stream/container/manifest.yml
@@ -25,7 +25,7 @@ streams:
         required: true
         show_user: true
         default:
-          - https://${NODE_NAME}:10250
+          - https://${env.NODE_NAME}:10250
       - name: period
         type: text
         title: Period

--- a/packages/kubernetes/data_stream/node/manifest.yml
+++ b/packages/kubernetes/data_stream/node/manifest.yml
@@ -25,7 +25,7 @@ streams:
         required: true
         show_user: true
         default:
-          - https://${NODE_NAME}:10250
+          - https://${env.NODE_NAME}:10250
       - name: period
         type: text
         title: Period

--- a/packages/kubernetes/data_stream/pod/manifest.yml
+++ b/packages/kubernetes/data_stream/pod/manifest.yml
@@ -25,7 +25,7 @@ streams:
         required: true
         show_user: true
         default:
-          - https://${NODE_NAME}:10250
+          - https://${env.NODE_NAME}:10250
       - name: period
         type: text
         title: Period

--- a/packages/kubernetes/data_stream/scheduler/manifest.yml
+++ b/packages/kubernetes/data_stream/scheduler/manifest.yml
@@ -27,13 +27,6 @@ streams:
         required: true
         show_user: true
         default: 10s
-      - name: period
-        type: text
-        title: Period
-        multi: false
-        required: true
-        show_user: true
-        default: 10s
       - name: ssl.verification_mode
         type: text
         title: SSL Verification Mode

--- a/packages/kubernetes/data_stream/system/manifest.yml
+++ b/packages/kubernetes/data_stream/system/manifest.yml
@@ -25,7 +25,7 @@ streams:
         required: true
         show_user: true
         default:
-          - https://${NODE_NAME}:10250
+          - https://${env.NODE_NAME}:10250
       - name: period
         type: text
         title: Period

--- a/packages/kubernetes/data_stream/volume/manifest.yml
+++ b/packages/kubernetes/data_stream/volume/manifest.yml
@@ -25,7 +25,7 @@ streams:
         required: true
         show_user: true
         default:
-          - https://${NODE_NAME}:10250
+          - https://${env.NODE_NAME}:10250
       - name: period
         type: text
         title: Period

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 0.5.0
+version: 0.5.1
 license: basic
 description: Kubernetes Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?

This PR fixes default values for k8s package and more specifically references to env variables which should be prefixed with `env.` so as to be properly evaluated by Agent.