### PR TITLE
[Synthetics] fix add fields formatting

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,20 +1,25 @@
 # newer versions go on top
-- version: "0.0.4" # unreleased
+- version: "0.0.5"
+  changes:
+    - description: fix add_fields processor to support to support telemetry
+      type: bugfix # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/981
+- version: "0.0.4"
   changes:
     - description: add monitor.fleet_managed to support telemetry
       type: enhancement # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/920
-- version: "0.0.3" # unreleased
+- version: "0.0.3"
   changes:
     - description: adjust type of tcp data_stream check.receive field
       type: bugfix # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/914
-- version: "0.0.2" # unreleased
+- version: "0.0.2"
   changes:
     - description: add base fields
       type: bugfix # can be one of: enhancement, bugfix, breaking-change
       link: https://github.com/elastic/integrations/pull/904
-- version: "0.0.1" # unreleased
+- version: "0.0.1"
   changes:
     - description: initial release
       type: enhancement # can be one of: enhancement, bugfix, breaking-change

--- a/packages/synthetics/data_stream/icmp/agent/stream/icmp.yml.hbs
+++ b/packages/synthetics/data_stream/icmp/agent/stream/icmp.yml.hbs
@@ -15,6 +15,6 @@ processors:
       geo: 
         name: Fleet managed
   - add_fields:
-    target: ''
-    fields:
-      monitor.fleet_managed: true
+      target: ''
+      fields:
+        monitor.fleet_managed: true

--- a/packages/synthetics/data_stream/tcp/agent/stream/tcp.yml.hbs
+++ b/packages/synthetics/data_stream/tcp/agent/stream/tcp.yml.hbs
@@ -42,6 +42,6 @@ processors:
       geo: 
         name: Fleet managed
   - add_fields:
-    target: ''
-    fields:
-      monitor.fleet_managed: true
+      target: ''
+      fields:
+        monitor.fleet_managed: true

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Monitor services availability.
-version: 0.0.4
+version: 0.0.5
 categories: ["custom"]
 release: beta
 type: integration


### PR DESCRIPTION
Fixes #980 

<!-- Type of change
- Bug
-->

## What does this PR do?

Adjusts formatting of the `add_fields` processor.

Previously, the processor was formatted with incorrect yaml, this caused the nasty error described in #980 

<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Reviewers Checklist for Testing

- [x] I can create a TCP monitor without agent errors
- [x] I can create an ICMP monitor without agent errors

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
1. Pull down this PR
2. Navigate to the `packages/synthetics` directory
3. Run `elastic-package build`
4. Run `elastic-package stack up -s 'package-registry'`
5. Update the registry url in kibana.dev.yml to `xpack.fleet.registryUrl: "http://localhost:8080"`
6. Pull down Kibana locally and run Kibana with `yarn start --no-base-path` and ES with `yarn es snapshot -E xpack.security.authc.api_key.enabled=true --license trial`
7. Navigate to fleet and add an agent
8. Navigate to the synthetics integration and configure a tcp and icmp monitor. Ensure the monitors are displayed in Uptime