### PR TITLE
[fleet_server] Fix max_connection config issue

### DIFF
--- a/packages/fleet_server/agent/input/agent.yml.hbs
+++ b/packages/fleet_server/agent/input/agent.yml.hbs
@@ -6,7 +6,7 @@ server:
   host: {{host}}
 {{/if}}
 {{#if max_connections}}
-  max_connections: {{max_connections}}
+    limits.max_connections: {{max_connections}}
 {{/if}}
 
 {{#if custom}}

--- a/packages/fleet_server/agent/input/agent.yml.hbs
+++ b/packages/fleet_server/agent/input/agent.yml.hbs
@@ -6,7 +6,7 @@ server:
   host: {{host}}
 {{/if}}
 {{#if max_connections}}
-    limits.max_connections: {{max_connections}}
+  limits.max_connections: {{max_connections}}
 {{/if}}
 
 {{#if custom}}

--- a/packages/fleet_server/changelog.yml
+++ b/packages/fleet_server/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix max_connection config which was not working becase limits prefix was missing.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/?
+      link: https://github.com/elastic/integrations/pull/988
 - version: "0.2.3"
   changes:
     - description: Add yaml block for configuration

--- a/packages/fleet_server/changelog.yml
+++ b/packages/fleet_server/changelog.yml
@@ -1,9 +1,14 @@
 # newer versions go on top
+- version: "0.2.4"
+  changes:
+    - description: Fix max_connection config which was not working becase limits prefix was missing.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/?
 - version: "0.2.3"
   changes:
     - description: Add yaml block for configuration
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/?
+      link: https://github.com/elastic/integrations/pull/959
 - version: "0.2.1"
   changes:
     - description: Remove fleet indices mappings that are supported by ES system indices plugin

--- a/packages/fleet_server/manifest.yml
+++ b/packages/fleet_server/manifest.yml
@@ -1,6 +1,6 @@
 name: fleet_server
 title: Fleet Server
-version: 0.2.3
+version: 0.2.4
 release: experimental
 description: Fleet Server Integration
 type: integration


### PR DESCRIPTION
The max_connection config was missing the limits prefix and was not working because of this.
