### PR TITLE
[auditd] Move edge to ingest pipeline and make event.original optional

### DIFF
--- a/packages/auditd/changelog.yml
+++ b/packages/auditd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.2"
+  changes:
+    - description: set version in the ingest pipeline and make event.original optional
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/989
 - version: "0.1.1"
   changes:
     - description: update to ECS 1.9.0

--- a/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-raw.log-expected.json
+++ b/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-raw.log-expected.json
@@ -2,6 +2,9 @@
     "expected": [
         {
             "@timestamp": "2017-01-31T20:17:14.891Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "destination": {
                 "address": "192.168.0.0"
             },
@@ -11,8 +14,7 @@
             },
             "event": {
                 "action": "mac_ipsec_event",
-                "ingested": "2021-04-23T12:52:53.824546269Z",
-                "original": "type=MAC_IPSEC_EVENT msg=audit(1485893834.891:18877201): op=SPD-delete auid=4294967295 ses=4294967295 res=1 src=192.168.2.0 src_prefixlen=24 dst=192.168.0.0 dst_prefixlen=16",
+                "ingested": "2021-05-14T09:45:48.016589900Z",
                 "kind": "event",
                 "outcome": "1"
             },
@@ -40,13 +42,15 @@
                 "ppid": 1240
             },
             "@timestamp": "2017-01-31T20:17:14.891Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "host": {
                 "architecture": "x86_64"
             },
             "event": {
                 "action": "syscall",
-                "ingested": "2021-04-23T12:52:53.824556418Z",
-                "original": "type=SYSCALL msg=audit(1485893834.891:18877199): arch=c000003e syscall=44 success=yes exit=184 a0=9 items=0 ppid=1240 pid=1281 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=\"charon\" exe=2F7573722F6C6962657865632F7374726F6E677377616E2F636861726F6E202864656C6574656429 key=(null)",
+                "ingested": "2021-05-14T09:45:48.016611300Z",
                 "category": [
                     "process"
                 ],
@@ -109,19 +113,21 @@
                 "args_count": 3
             },
             "@timestamp": "2017-03-14T19:20:56.192Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824558890Z",
-                "original": "type=USER_CMD msg=audit(1489519256.192:19600329): user pid=4151 uid=497 auid=700 ses=11988 msg='cwd=\"/\" cmd=2F7573722F6C696236342F6E6167696F732F706C7567696E732F636865636B5F617374657269736B5F7369705F7065657273202D7020323032 terminal=? res=success'",
-                "kind": "event",
                 "action": [
                     "ran-command"
                 ],
+                "ingested": "2021-05-14T09:45:48.016665700Z",
                 "category": [
                     "process"
                 ],
                 "type": [
                     "start"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -144,6 +150,9 @@
                 "executable": "/usr/sbin/sshd"
             },
             "@timestamp": "2016-12-07T02:17:21.515Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "source": {
                 "geo": {
                     "continent_name": "North America",
@@ -167,18 +176,17 @@
                 "ip": "96.241.146.97"
             },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824561012Z",
-                "original": "type=CRYPTO_SESSION msg=audit(1481077041.515:406): pid=1298 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 msg='op=start direction=from-server cipher=chacha20-poly1305@openssh.com ksize=512 mac= pfs=curve25519-sha256@libssh.org spid=1299 suid=74 rport=63927 laddr=10.142.0.2 lport=22  exe=\"/usr/sbin/sshd\" hostname=? addr=96.241.146.97 terminal=? res=success'",
-                "kind": "event",
                 "action": [
                     "started-crypto-session"
                 ],
+                "ingested": "2021-05-14T09:45:48.016674700Z",
                 "category": [
                     "process"
                 ],
                 "type": [
                     "info"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -214,12 +222,14 @@
                 "pid": 27930
             },
             "@timestamp": "2017-04-11T15:21:03.550Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
                 "action": [
                     "typed"
                 ],
-                "ingested": "2021-04-23T12:52:53.824563104Z",
-                "original": "type=TTY msg=audit(1491924063.550:1065565): tty pid=27930 uid=1000 auid=1000 ses=762 major=136 minor=0 comm=\"bash\" data=65687F7F6563686F20746573740D76696D202F6574632F70616D2E642F70617373776F72642D617574682D61630D6D616E2070616D5F7474795F61756469740D6D616E2070616D2E640D76696D202F657463017375646F20052F70616D642E73797F7F7F7F7F2E7F6D2E642F7379092D6109617F2D61090D6D616E2070616D0D747F67726570207379737F7F7F2F7661722F6C6F09672F6D65097309207C20677265702070616D5F7474790D677265702070616D5F747479202F7661722F6C6F672F6D6573090D1B5B41017375646F200D7375646F2073750D",
+                "ingested": "2021-05-14T09:45:48.016678600Z",
                 "kind": "event"
             },
             "auditd": {
@@ -241,10 +251,12 @@
         },
         {
             "@timestamp": "2016-01-03T00:37:51.394Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
                 "action": "proctitle",
-                "ingested": "2021-04-23T12:52:53.824565167Z",
-                "original": "type=PROCTITLE msg=audit(1451781471.394:194438): proctitle=\"bash\"",
+                "ingested": "2021-05-14T09:45:48.016686100Z",
                 "kind": "event"
             },
             "auditd": {
@@ -256,10 +268,12 @@
         },
         {
             "@timestamp": "2016-01-03T00:37:51.394Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
                 "action": "proctitle",
-                "ingested": "2021-04-23T12:52:53.824567220Z",
-                "original": "type=PROCTITLE msg=audit(1451781471.394:194440): proctitle=737368643A206275726E205B707269765D",
+                "ingested": "2021-05-14T09:45:48.016697800Z",
                 "kind": "event"
             },
             "auditd": {
@@ -276,19 +290,21 @@
                 "executable": "/usr/bin/python2.7"
             },
             "@timestamp": "2019-11-15T19:01:24.309Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824569304Z",
-                "original": "type=SOFTWARE_UPDATE msg=audit(1573844484.309:785): pid=3157 uid=0 auid=1000 ses=3 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='sw=\"gcc-4.8.5-39.el7.x86_64\" sw_type=rpm key_enforce=0 gpg_res=1 root_dir=\"/\" comm=\"yum\" exe=\"/usr/bin/python2.7\" hostname=? addr=? terminal=? res=success'",
-                "kind": "event",
                 "action": [
                     "package-updated"
                 ],
+                "ingested": "2021-05-14T09:45:48.016708700Z",
                 "category": [
                     "package"
                 ],
                 "type": [
                     "info"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -318,15 +334,17 @@
                 "executable": "/usr/lib/systemd/systemd-update-utmp"
             },
             "@timestamp": "2019-11-15T19:00:56.144Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824571324Z",
-                "original": "type=SYSTEM_BOOT msg=audit(1573844456.144:5): pid=678 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg=' comm=\"systemd-update-utmp\" exe=\"/usr/lib/systemd/systemd-update-utmp\" hostname=? addr=? terminal=? res=success'",
-                "kind": "event",
                 "action": [
                     "booted-system"
                 ],
+                "ingested": "2021-05-14T09:45:48.016719800Z",
                 "category": "host",
                 "type": "info",
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -351,15 +369,17 @@
                 "executable": "/usr/lib/systemd/systemd-update-utmp"
             },
             "@timestamp": "2019-11-15T19:01:57.054Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824573302Z",
-                "original": "type=SYSTEM_SHUTDOWN msg=audit(1573844517.054:1163): pid=4440 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg=' comm=\"systemd-update-utmp\" exe=\"/usr/lib/systemd/systemd-update-utmp\" hostname=? addr=? terminal=? res=success'",
-                "kind": "event",
                 "action": [
                     "shutdown-system"
                 ],
+                "ingested": "2021-05-14T09:45:48.016730600Z",
                 "category": "host",
                 "type": "info",
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -382,10 +402,12 @@
                 "args_count": 1
             },
             "@timestamp": "2020-02-10T21:59:44.206Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
                 "action": "execve",
-                "ingested": "2021-04-23T12:52:53.824575301Z",
-                "original": "type=EXECVE msg=audit(1581371984.206:579393): argc=1 a0=top",
+                "ingested": "2021-05-14T09:45:48.016741400Z",
                 "kind": "event"
             },
             "auditd": {
@@ -397,12 +419,14 @@
         },
         {
             "@timestamp": "2020-02-10T21:59:44.206Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
                 "action": [
                     "loaded-kernel-module"
                 ],
-                "ingested": "2021-04-23T12:52:53.824577469Z",
-                "original": "type=KERN_MODULE msg=audit(1581371984.206:579397): name=mymodule",
+                "ingested": "2021-05-14T09:45:48.016752700Z",
                 "category": [
                     "driver"
                 ],
@@ -425,15 +449,17 @@
                 "executable": "/usr/bin/dockerd-current"
             },
             "@timestamp": "2017-12-17T10:44:41.075Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824617575Z",
-                "original": "type=VIRT_CONTROL msg=audit(1513507481.075:145): pid=1431 uid=0 auid=100 ses=3 subj=system_u:system_r:container_runtime_t:s0 msg='user=root reason=api op=create vm=? vm-pid=? hostname=? exe=\"/usr/bin/dockerd-current\" addr=? terminal=? res=success'",
-                "kind": "event",
                 "action": [
                     "issued-vm-control"
                 ],
+                "ingested": "2021-05-14T09:45:48.016763900Z",
                 "category": "host",
                 "type": "creation",
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -464,15 +490,17 @@
                 "executable": "/usr/sbin/libvirtd"
             },
             "@timestamp": "2016-12-16T15:45:43.572Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824622526Z",
-                "original": "type=VIRT_MACHINE_ID msg=audit(1481903143.572:23118): pid=5637 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:virtd_t:s0-s0:c0.c1023 msg='virt=kvm vm=\"rhel-work3\" uuid=5501263b-181d-47ed-ab03-a6066f3d26bf vm-ctx=system_u:system_r:svirt_t:s0:c444,c977 img-ctx=system_u:object_r:svirt_image_t:s0:c444,c977 model=selinux exe=\"/usr/sbin/libvirtd\" hostname=? addr=? terminal=? res=success'",
-                "kind": "event",
                 "action": [
                     "assigned-vm-id"
                 ],
+                "ingested": "2021-05-14T09:45:48.016775Z",
                 "category": "host",
                 "type": "creation",
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -501,19 +529,21 @@
                 "pid": 1643
             },
             "@timestamp": "2020-07-06T16:38:34.588Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824626788Z",
-                "original": "node=localhost.localdomain type=DAEMON_START msg=audit(1594053514.588:4686): op=start ver=2.8.5 format=raw kernel=3.10.0-1062.9.1.el7.x86_64 auid=4294967295 pid=1643 uid=0 ses=4294967295 subj=system_u:system_r:auditd_t:s0 res=success",
-                "kind": "event",
                 "action": [
                     "started-audit"
                 ],
+                "ingested": "2021-05-14T09:45:48.016785800Z",
                 "category": [
                     "process"
                 ],
                 "type": [
                     "start"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -538,13 +568,14 @@
         },
         {
             "@timestamp": "2020-07-06T16:38:34.707Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824629370Z",
-                "original": "node=localhost.localdomain type=CONFIG_CHANGE msg=audit(1594053514.707:5): audit_failure=1 old=1 auid=4294967295 ses=4294967295 subj=system_u:system_r:unconfined_service_t:s0 res=1",
-                "kind": "event",
                 "action": [
                     "changed-audit-configuration"
                 ],
+                "ingested": "2021-05-14T09:45:48.016797Z",
                 "category": [
                     "process",
                     "configuration"
@@ -552,6 +583,7 @@
                 "type": [
                     "change"
                 ],
+                "kind": "event",
                 "outcome": "1"
             },
             "auditd": {
@@ -578,19 +610,21 @@
                 "executable": "/usr/lib/systemd/systemd"
             },
             "@timestamp": "2020-07-06T16:38:34.709Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824632075Z",
-                "original": "node=localhost.localdomain type=SERVICE_START msg=audit(1594053514.709:6): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='unit=auditd comm=\"systemd\" exe=\"/usr/lib/systemd/systemd\" hostname=? addr=? terminal=? res=success'",
-                "kind": "event",
                 "action": [
                     "started-service"
                 ],
+                "ingested": "2021-05-14T09:45:48.016808100Z",
                 "category": [
                     "process"
                 ],
                 "type": [
                     "start"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -617,15 +651,17 @@
                 "executable": "/usr/lib/systemd/systemd-update-utmp"
             },
             "@timestamp": "2020-07-06T16:38:34.725Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824634148Z",
-                "original": "node=localhost.localdomain type=SYSTEM_BOOT msg=audit(1594053514.725:7): pid=1667 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg=' comm=\"systemd-update-utmp\" exe=\"/usr/lib/systemd/systemd-update-utmp\" hostname=? addr=? terminal=? res=success'",
-                "kind": "event",
                 "action": [
                     "booted-system"
                 ],
+                "ingested": "2021-05-14T09:45:48.016817700Z",
                 "category": "host",
                 "type": "info",
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -650,19 +686,21 @@
                 "executable": "/usr/bin/sudo"
             },
             "@timestamp": "2017-03-14T19:20:30.178Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824636209Z",
-                "original": "type=USER_END msg=audit(1489519230.178:19600327): user pid=4121 uid=0 auid=700 ses=11988 msg='op=PAM:session_close acct=\"root\" exe=\"/usr/bin/sudo\" hostname=? addr=? terminal=? res=success'",
-                "kind": "event",
                 "action": [
                     "ended-session"
                 ],
+                "ingested": "2021-05-14T09:45:48.016822100Z",
                 "category": [
                     "session"
                 ],
                 "type": [
                     "end"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -691,19 +729,21 @@
                 "executable": "/usr/bin/sudo"
             },
             "@timestamp": "2017-03-14T19:20:30.178Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824638278Z",
-                "original": "type=CRED_DISP msg=audit(1489519230.178:19600328): user pid=4121 uid=0 auid=700 ses=11988 msg='op=PAM:setcred acct=\"root\" exe=\"/usr/bin/sudo\" hostname=? addr=? terminal=? res=success'",
-                "kind": "event",
                 "action": [
                     "disposed-credentials"
                 ],
+                "ingested": "2021-05-14T09:45:48.016826Z",
                 "category": [
                     "authentication"
                 ],
                 "type": [
                     "info"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -732,19 +772,21 @@
                 "executable": "/usr/bin/sudo"
             },
             "@timestamp": "2017-03-14T19:20:56.193Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824640332Z",
-                "original": "type=CRED_ACQ msg=audit(1489519256.193:19600330): user pid=4151 uid=0 auid=700 ses=11988 msg='op=PAM:setcred acct=\"root\" exe=\"/usr/bin/sudo\" hostname=? addr=? terminal=? res=success'",
-                "kind": "event",
                 "action": [
                     "acquired-credentials"
                 ],
+                "ingested": "2021-05-14T09:45:48.016832900Z",
                 "category": [
                     "authentication"
                 ],
                 "type": [
                     "info"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -773,19 +815,21 @@
                 "executable": "/usr/bin/sudo"
             },
             "@timestamp": "2017-03-14T19:20:56.193Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824642407Z",
-                "original": "type=USER_START msg=audit(1489519256.193:19600331): user pid=4151 uid=0 auid=700 ses=11988 msg='op=PAM:session_open acct=\"root\" exe=\"/usr/bin/sudo\" hostname=? addr=? terminal=? res=success'",
-                "kind": "event",
                 "action": [
                     "started-session"
                 ],
+                "ingested": "2021-05-14T09:45:48.016844600Z",
                 "category": [
                     "session"
                 ],
                 "type": [
                     "start"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -813,12 +857,14 @@
                 "pid": 28281
             },
             "@timestamp": "2017-03-16T04:02:40.072Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
                 "action": [
                     "changed-login-id-to"
                 ],
-                "ingested": "2021-04-23T12:52:53.824644398Z",
-                "original": "type=LOGIN msg=audit(1489636960.072:19623791): pid=28281 uid=0 old auid=700 new auid=700 old ses=6793 new ses=12286",
+                "ingested": "2021-05-14T09:45:48.016855600Z",
                 "category": [
                     "authentication"
                 ],
@@ -851,6 +897,9 @@
                 "executable": "/usr/sbin/sshd"
             },
             "@timestamp": "2017-03-16T04:02:40.070Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "source": {
                 "geo": {
                     "continent_name": "North America",
@@ -874,18 +923,17 @@
                 "ip": "96.241.146.97"
             },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824646650Z",
-                "original": "type=CRYPTO_KEY_USER msg=audit(1489636960.070:19623788): user pid=28281 uid=0 auid=700 ses=6793 msg='op=destroy kind=session fp=? direction=both spid=28282 suid=74 rport=58994 laddr=107.170.139.210 lport=50022  exe=\"/usr/sbin/sshd\" hostname=? addr=96.241.146.97 terminal=? res=success'",
-                "kind": "event",
                 "action": [
                     "negotiated-crypto-key"
                 ],
+                "ingested": "2021-05-14T09:45:48.016866800Z",
                 "category": [
                     "process"
                 ],
                 "type": [
                     "info"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -918,6 +966,9 @@
                 "executable": "/usr/sbin/sshd"
             },
             "@timestamp": "2017-03-16T04:02:40.072Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "source": {
                 "geo": {
                     "continent_name": "North America",
@@ -941,18 +992,17 @@
                 "ip": "96.241.146.97"
             },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824648733Z",
-                "original": "type=USER_AUTH msg=audit(1489636960.072:19623789): user pid=28281 uid=0 auid=700 ses=6793 msg='op=success acct=\"admin\" exe=\"/usr/sbin/sshd\" hostname=? addr=96.241.146.97 terminal=ssh res=success'",
-                "kind": "event",
                 "action": [
                     "authenticated"
                 ],
+                "ingested": "2021-05-14T09:45:48.016877900Z",
                 "category": [
                     "authentication"
                 ],
                 "type": [
                     "info"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -982,19 +1032,21 @@
                 "executable": "/bin/su"
             },
             "@timestamp": "2017-03-16T04:02:57.805Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824650775Z",
-                "original": "type=USER_ACCT msg=audit(1489636977.805:19623808): user pid=28395 uid=0 auid=700 ses=12286 msg='op=PAM:accounting acct=\"root\" exe=\"/bin/su\" hostname=? addr=? terminal=pts/0 res=success'",
-                "kind": "event",
                 "action": [
                     "was-authorized"
                 ],
+                "ingested": "2021-05-14T09:45:48.016888800Z",
                 "category": [
                     "authentication"
                 ],
                 "type": [
                     "info"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -1025,19 +1077,21 @@
                 "executable": "/usr/lib/systemd/systemd"
             },
             "@timestamp": "2016-12-07T02:16:23.864Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824652792Z",
-                "original": "type=SERVICE_START msg=audit(1481076983.864:6): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='unit=auditd comm=\"systemd\" exe=\"/usr/lib/systemd/systemd\" hostname=? addr=? terminal=? res=success'",
-                "kind": "event",
                 "action": [
                     "started-service"
                 ],
+                "ingested": "2021-05-14T09:45:48.016899800Z",
                 "category": [
                     "process"
                 ],
                 "type": [
                     "start"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -1063,19 +1117,21 @@
                 "executable": "/usr/lib/systemd/systemd"
             },
             "@timestamp": "2016-12-07T02:16:24.534Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824654847Z",
-                "original": "type=SERVICE_STOP msg=audit(1481076984.534:16): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='unit=irqbalance comm=\"systemd\" exe=\"/usr/lib/systemd/systemd\" hostname=? addr=? terminal=? res=success'",
-                "kind": "event",
                 "action": [
                     "stopped-service"
                 ],
+                "ingested": "2021-05-14T09:45:48.016910800Z",
                 "category": [
                     "process"
                 ],
                 "type": [
                     "stop"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -1096,12 +1152,14 @@
         },
         {
             "@timestamp": "2016-12-07T02:16:24.827Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
                 "action": [
                     "loaded-firewall-rule-to"
                 ],
-                "ingested": "2021-04-23T12:52:53.824656995Z",
-                "original": "type=NETFILTER_CFG msg=audit(1481076984.827:17): table=filter family=2 entries=0",
+                "ingested": "2021-05-14T09:45:48.016922Z",
                 "category": [
                     "configuration"
                 ],
@@ -1126,13 +1184,14 @@
                 "executable": "/usr/sbin/groupadd"
             },
             "@timestamp": "2016-12-07T02:16:32.414Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824659013Z",
-                "original": "type=ADD_GROUP msg=audit(1481076992.414:385): pid=1235 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:unconfined_service_t:s0 msg='op=add-group id=1000 exe=\"/usr/sbin/groupadd\" hostname=? addr=? terminal=? res=success'",
-                "kind": "event",
                 "action": [
                     "added-group-account-to"
                 ],
+                "ingested": "2021-05-14T09:45:48.016933Z",
                 "category": [
                     "iam"
                 ],
@@ -1140,6 +1199,7 @@
                     "group",
                     "creation"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -1172,13 +1232,14 @@
                 "executable": "/usr/sbin/groupadd"
             },
             "@timestamp": "2016-12-07T02:16:32.419Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824661173Z",
-                "original": "type=GRP_MGMT msg=audit(1481076992.419:386): pid=1235 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:unconfined_service_t:s0 msg='op=add-shadow-group id=1000 exe=\"/usr/sbin/groupadd\" hostname=? addr=? terminal=? res=success'",
-                "kind": "event",
                 "action": [
                     "modified-group-account"
                 ],
+                "ingested": "2021-05-14T09:45:48.016944100Z",
                 "category": [
                     "iam"
                 ],
@@ -1186,6 +1247,7 @@
                     "group",
                     "change"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -1218,13 +1280,14 @@
                 "executable": "/usr/sbin/useradd"
             },
             "@timestamp": "2016-12-07T02:16:32.488Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824663194Z",
-                "original": "type=ADD_USER msg=audit(1481076992.488:389): pid=1264 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:unconfined_service_t:s0 msg='op=add-user id=1000 exe=\"/usr/sbin/useradd\" hostname=? addr=? terminal=? res=success'",
-                "kind": "event",
                 "action": [
                     "added-user-account"
                 ],
+                "ingested": "2021-05-14T09:45:48.016955100Z",
                 "category": [
                     "iam"
                 ],
@@ -1232,6 +1295,7 @@
                     "user",
                     "creation"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -1265,19 +1329,21 @@
                 "executable": "/usr/lib/systemd/systemd-update-utmp"
             },
             "@timestamp": "2016-12-07T02:16:32.492Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824665224Z",
-                "original": "type=SYSTEM_RUNLEVEL msg=audit(1481076992.492:390): pid=1279 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='old-level=N new-level=3 comm=\"systemd-update-utmp\" exe=\"/usr/lib/systemd/systemd-update-utmp\" hostname=? addr=? terminal=? res=success'",
-                "kind": "event",
                 "action": [
                     "changed-to-runlevel"
                 ],
+                "ingested": "2021-05-14T09:45:48.016964700Z",
                 "category": [
                     "host"
                 ],
                 "type": [
                     "change"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -1303,13 +1369,14 @@
                 "executable": "/usr/sbin/useradd"
             },
             "@timestamp": "2016-12-07T02:16:32.521Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824669644Z",
-                "original": "type=USER_MGMT msg=audit(1481076992.521:393): pid=1264 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:unconfined_service_t:s0 msg='op=add-home-dir id=1000 exe=\"/usr/sbin/useradd\" hostname=? addr=? terminal=? res=success'",
-                "kind": "event",
                 "action": [
                     "modified-user-account"
                 ],
+                "ingested": "2021-05-14T09:45:48.016969Z",
                 "category": [
                     "iam"
                 ],
@@ -1317,6 +1384,7 @@
                     "user",
                     "change"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -1349,19 +1417,21 @@
                 "executable": "/usr/sbin/hwclock"
             },
             "@timestamp": "2016-12-07T02:16:33.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824671923Z",
-                "original": "type=USYS_CONFIG msg=audit(1481076993.000:402): pid=1232 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:unconfined_service_t:s0 msg='changing system time exe=\"/usr/sbin/hwclock\" hostname=? addr=? terminal=? res=success'",
-                "kind": "event",
                 "action": [
                     "changed-configuration"
                 ],
+                "ingested": "2021-05-14T09:45:48.016978900Z",
                 "category": [
                     "configuration"
                 ],
                 "type": [
                     "change"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -1385,6 +1455,9 @@
                 "executable": "/usr/sbin/sshd"
             },
             "@timestamp": "2016-12-07T02:17:23.140Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "source": {
                 "geo": {
                     "continent_name": "North America",
@@ -1411,8 +1484,7 @@
                 "action": [
                     "changed-role-to"
                 ],
-                "ingested": "2021-04-23T12:52:53.824674004Z",
-                "original": "type=USER_ROLE_CHANGE msg=audit(1481077043.140:415): pid=1298 uid=0 auid=1000 ses=1 subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 msg='pam: default-context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 selected-context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 exe=\"/usr/sbin/sshd\" hostname=pool-96-241-146-97.washdc.fios.verizon.net addr=96.241.146.97 terminal=ssh res=success'",
+                "ingested": "2021-05-14T09:45:48.016990700Z",
                 "kind": "event",
                 "outcome": "success"
             },
@@ -1441,6 +1513,9 @@
                 "executable": "/usr/sbin/sshd"
             },
             "@timestamp": "2016-12-07T02:17:23.193Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "source": {
                 "geo": {
                     "continent_name": "North America",
@@ -1464,18 +1539,17 @@
                 "ip": "96.241.146.97"
             },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824676024Z",
-                "original": "type=USER_LOGIN msg=audit(1481077043.193:421): pid=1298 uid=0 auid=1000 ses=1 subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 msg='op=login id=1000 exe=\"/usr/sbin/sshd\" hostname=pool-96-241-146-97.washdc.fios.verizon.net addr=96.241.146.97 terminal=/dev/pts/0 res=success'",
-                "kind": "event",
                 "action": [
                     "logged-in"
                 ],
+                "ingested": "2021-05-14T09:45:48.017001800Z",
                 "category": [
                     "authentication"
                 ],
                 "type": [
                     "start"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -1507,19 +1581,21 @@
                 "executable": "/usr/sbin/sshd"
             },
             "@timestamp": "2016-12-07T02:17:29.033Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824678060Z",
-                "original": "type=USER_LOGOUT msg=audit(1481077049.033:424): pid=1298 uid=0 auid=1000 ses=1 subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 msg='op=login id=1000 exe=\"/usr/sbin/sshd\" hostname=? addr=? terminal=/dev/pts/0 res=success'",
-                "kind": "event",
                 "action": [
                     "logged-out"
                 ],
+                "ingested": "2021-05-14T09:45:48.017013Z",
                 "category": [
                     "authentication"
                 ],
                 "type": [
                     "end"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -1546,13 +1622,14 @@
         },
         {
             "@timestamp": "2016-12-07T02:20:31.371Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824680122Z",
-                "original": "type=CONFIG_CHANGE msg=audit(1481077231.371:478): auid=1000 ses=3 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 op=\"add_rule\" key=(null) list=4 res=1",
-                "kind": "event",
                 "action": [
                     "changed-audit-configuration"
                 ],
+                "ingested": "2021-05-14T09:45:48.017024100Z",
                 "category": [
                     "process",
                     "configuration"
@@ -1560,6 +1637,7 @@
                 "type": [
                     "change"
                 ],
+                "kind": "event",
                 "outcome": "1"
             },
             "auditd": {
@@ -1583,10 +1661,12 @@
                 "working_directory": "/home/some_user"
             },
             "@timestamp": "2016-12-07T02:20:31.371Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
                 "action": "cwd",
-                "ingested": "2021-04-23T12:52:53.824682147Z",
-                "original": "type=CWD msg=audit(1481077231.371:479):  cwd=\"/home/some_user\"",
+                "ingested": "2021-05-14T09:45:48.017035100Z",
                 "kind": "event"
             },
             "auditd": {
@@ -1597,10 +1677,12 @@
         },
         {
             "@timestamp": "2016-12-07T02:20:31.371Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
                 "action": "path",
-                "ingested": "2021-04-23T12:52:53.824684188Z",
-                "original": "type=PATH msg=audit(1481077231.371:479): item=0 name=\"/sbin/auditctl\" inode=17367907 dev=08:01 mode=0100750 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:auditctl_exec_t:s0 objtype=NORMAL",
+                "ingested": "2021-05-14T09:45:48.017046100Z",
                 "kind": "event"
             },
             "auditd": {
@@ -1626,10 +1708,12 @@
             }
         },
         {
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
                 "action": "unknown[1329]",
-                "ingested": "2021-04-23T12:52:53.824686198Z",
-                "original": "type=UNKNOWN[1329] msg=g\u0005",
+                "ingested": "2021-05-14T09:45:48.017056900Z",
                 "kind": "event"
             },
             "auditd": {
@@ -1639,10 +1723,12 @@
         },
         {
             "@timestamp": "2016-12-07T02:21:48.360Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
                 "action": "bprm_fcaps",
-                "ingested": "2021-04-23T12:52:53.824688716Z",
-                "original": "type=BPRM_FCAPS msg=audit(1481077308.360:529): fver=0 fp=0000000000000000 fi=0000000000000000 fe=0 old_pp=0000000000000000 old_pi=0000000000000000 old_pe=0000000000000000 new_pp=0000001fffffffff new_pi=0000000000000000 new_pe=0000001fffffffff",
+                "ingested": "2021-05-14T09:45:48.017071800Z",
                 "kind": "event"
             },
             "auditd": {
@@ -1663,10 +1749,12 @@
         },
         {
             "@timestamp": "2016-12-07T02:40:24.953Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
                 "action": "sockaddr",
-                "ingested": "2021-04-23T12:52:53.824690903Z",
-                "original": "type=SOCKADDR msg=audit(1481078424.953:688): saddr=02000050A9FEA9FE0000000000000000",
+                "ingested": "2021-05-14T09:45:48.017083200Z",
                 "kind": "event"
             },
             "auditd": {
@@ -1678,10 +1766,12 @@
         },
         {
             "@timestamp": "2016-12-07T02:42:33.346Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
                 "action": "ckaddr",
-                "ingested": "2021-04-23T12:52:53.824693044Z",
-                "original": "type=CKADDR msg=audit(1481078553.346:737): saddr=02000050A9FEA9FE0000000000000000",
+                "ingested": "2021-05-14T09:45:48.017094500Z",
                 "kind": "event"
             },
             "auditd": {
@@ -1693,19 +1783,21 @@
         },
         {
             "@timestamp": "2016-12-07T02:44:57.892Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "event": {
-                "ingested": "2021-04-23T12:52:53.824695108Z",
-                "original": "type=DAEMON_END msg=audit(1481078697.892:7799): auditd normal halt, sending auid=? pid=? subj=? res=success",
-                "kind": "event",
                 "action": [
                     "shutdown-audit"
                 ],
+                "ingested": "2021-05-14T09:45:48.017105500Z",
                 "category": [
                     "process"
                 ],
                 "type": [
                     "stop"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {

--- a/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-useradd.log-expected.json
+++ b/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-useradd.log-expected.json
@@ -6,17 +6,18 @@
                 "executable": "/usr/sbin/groupadd"
             },
             "@timestamp": "2021-01-17T17:12:33.686Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "source": {
                 "address": "127.0.0.1",
                 "ip": "127.0.0.1"
             },
             "event": {
-                "ingested": "2021-04-23T12:52:54.749045516Z",
-                "original": "type=ADD_GROUP msg=audit(1610903553.686:584): pid=2940 uid=0 auid=1000 ses=14 msg='op=adding group to /etc/group id=1004 exe=\"/usr/sbin/groupadd\" hostname=ubuntu-bionic addr=127.0.0.1 terminal=pts/2 res=success'",
-                "kind": "event",
                 "action": [
                     "added-group-account-to"
                 ],
+                "ingested": "2021-05-14T09:45:49.161706500Z",
                 "category": [
                     "iam"
                 ],
@@ -24,6 +25,7 @@
                     "group",
                     "creation"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -57,17 +59,18 @@
                 "executable": "/usr/sbin/groupadd"
             },
             "@timestamp": "2021-01-17T17:12:33.710Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "source": {
                 "address": "127.0.0.1",
                 "ip": "127.0.0.1"
             },
             "event": {
-                "ingested": "2021-04-23T12:52:54.749056502Z",
-                "original": "type=ADD_GROUP msg=audit(1610903553.710:586): pid=2940 uid=0 auid=1000 ses=14 msg='op=adding group to /etc/gshadow id=1004 exe=\"/usr/sbin/groupadd\" hostname=ubuntu-bionic addr=127.0.0.1 terminal=pts/2 res=success'",
-                "kind": "event",
                 "action": [
                     "added-group-account-to"
                 ],
+                "ingested": "2021-05-14T09:45:49.161722100Z",
                 "category": [
                     "iam"
                 ],
@@ -75,6 +78,7 @@
                     "group",
                     "creation"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -108,17 +112,18 @@
                 "executable": "/usr/sbin/groupadd"
             },
             "@timestamp": "2021-01-17T17:12:33.710Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "source": {
                 "address": "127.0.0.1",
                 "ip": "127.0.0.1"
             },
             "event": {
-                "ingested": "2021-04-23T12:52:54.749058427Z",
-                "original": "type=ADD_GROUP msg=audit(1610903553.710:587): pid=2940 uid=0 auid=1000 ses=14 msg='op= id=1004 exe=\"/usr/sbin/groupadd\" hostname=ubuntu-bionic addr=127.0.0.1 terminal=pts/2 res=success'",
-                "kind": "event",
                 "action": [
                     "added-group-account-to"
                 ],
+                "ingested": "2021-05-14T09:45:49.161732100Z",
                 "category": [
                     "iam"
                 ],
@@ -126,6 +131,7 @@
                     "group",
                     "creation"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -158,17 +164,18 @@
                 "executable": "/usr/sbin/useradd"
             },
             "@timestamp": "2021-01-17T17:12:33.730Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "source": {
                 "address": "127.0.0.1",
                 "ip": "127.0.0.1"
             },
             "event": {
-                "ingested": "2021-04-23T12:52:54.749060058Z",
-                "original": "type=ADD_USER msg=audit(1610903553.730:591): pid=2945 uid=0 auid=1000 ses=14 msg='op=adding user id=1004 exe=\"/usr/sbin/useradd\" hostname=ubuntu-bionic addr=127.0.0.1 terminal=pts/2 res=success'",
-                "kind": "event",
                 "action": [
                     "added-user-account"
                 ],
+                "ingested": "2021-05-14T09:45:49.161741600Z",
                 "category": [
                     "iam"
                 ],
@@ -176,6 +183,7 @@
                     "user",
                     "creation"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -209,23 +217,25 @@
                 "executable": "/sbin/pam_tally2"
             },
             "@timestamp": "2021-01-17T17:12:33.814Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "source": {
                 "address": "127.0.0.1",
                 "ip": "127.0.0.1"
             },
             "event": {
-                "ingested": "2021-04-23T12:52:54.749061593Z",
-                "original": "type=USER_ACCT msg=audit(1610903553.814:593): pid=2948 uid=0 auid=1000 ses=14 msg='pam_tally2 uid=1004 reset=0 exe=\"/sbin/pam_tally2\" hostname=localhost addr=127.0.0.1 terminal=/dev/pts/2 res=success'",
-                "kind": "event",
                 "action": [
                     "was-authorized"
                 ],
+                "ingested": "2021-05-14T09:45:49.161751Z",
                 "category": [
                     "authentication"
                 ],
                 "type": [
                     "info"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -255,17 +265,18 @@
                 "executable": "/usr/bin/passwd"
             },
             "@timestamp": "2021-01-17T17:12:38.174Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "source": {
                 "address": "127.0.0.1",
                 "ip": "127.0.0.1"
             },
             "event": {
-                "ingested": "2021-04-23T12:52:54.749063122Z",
-                "original": "type=USER_CHAUTHTOK msg=audit(1610903558.174:594): pid=2953 uid=0 auid=1000 ses=14 msg='op=PAM:chauthtok acct=\"charlie\" exe=\"/usr/bin/passwd\" hostname=ubuntu-bionic addr=127.0.0.1 terminal=pts/2 res=success'",
-                "kind": "event",
                 "action": [
                     "changed-password"
                 ],
+                "ingested": "2021-05-14T09:45:49.161760300Z",
                 "category": [
                     "iam"
                 ],
@@ -273,6 +284,7 @@
                     "user",
                     "change"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -306,23 +318,25 @@
                 "executable": "/usr/bin/chfn"
             },
             "@timestamp": "2021-01-17T17:12:38.178Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "source": {
                 "address": "127.0.0.1",
                 "ip": "127.0.0.1"
             },
             "event": {
-                "ingested": "2021-04-23T12:52:54.749064635Z",
-                "original": "type=USER_AUTH msg=audit(1610903558.178:595): pid=2954 uid=0 auid=1000 ses=14 msg='op=PAM:authentication acct=\"root\" exe=\"/usr/bin/chfn\" hostname=ubuntu-bionic addr=127.0.0.1 terminal=pts/2 res=success'",
-                "kind": "event",
                 "action": [
                     "authenticated"
                 ],
+                "ingested": "2021-05-14T09:45:49.161769900Z",
                 "category": [
                     "authentication"
                 ],
                 "type": [
                     "info"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -353,23 +367,25 @@
                 "executable": "/usr/bin/chfn"
             },
             "@timestamp": "2021-01-17T17:12:38.178Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "source": {
                 "address": "127.0.0.1",
                 "ip": "127.0.0.1"
             },
             "event": {
-                "ingested": "2021-04-23T12:52:54.749066130Z",
-                "original": "type=USER_ACCT msg=audit(1610903558.178:596): pid=2954 uid=0 auid=1000 ses=14 msg='op=PAM:accounting acct=\"root\" exe=\"/usr/bin/chfn\" hostname=ubuntu-bionic addr=127.0.0.1 terminal=pts/2 res=success'",
-                "kind": "event",
                 "action": [
                     "was-authorized"
                 ],
+                "ingested": "2021-05-14T09:45:49.161777800Z",
                 "category": [
                     "authentication"
                 ],
                 "type": [
                     "info"
                 ],
+                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {

--- a/packages/auditd/data_stream/log/agent/stream/log.yml.hbs
+++ b/packages/auditd/data_stream/log/agent/stream/log.yml.hbs
@@ -3,8 +3,7 @@ paths:
  - {{path}}
 {{/each}}
 exclude_files: [".gz$"]
-processors:
-  - add_fields:
-      target: ''
-      fields:
-        ecs.version: 1.9.0
+tags:
+{{#if preserve_original_event}}
+- preserve_original_event
+{{/if}}

--- a/packages/auditd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/auditd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -4,8 +4,15 @@ processors:
 - set:
     field: event.ingested
     value: '{{_ingest.timestamp}}'
-- grok:
+- set:
+    field: ecs.version
+    value: 1.9.0
+- rename:
     field: message
+    target_field: event.original
+    ignore_failure: true
+- grok:
+    field: event.original
     pattern_definitions:
       AUDIT_TYPE: "type=%{NOTSPACE:auditd.log.record_type}"
       AUDIT_NODE: "node=%{IPORHOST:auditd.log.node} "
@@ -31,10 +38,6 @@ processors:
     value_split: "="
     target_field: auditd.log
     ignore_missing: true
-- rename:
-    field: message
-    target_field: event.original
-    ignore_failure: true
 - date:
     field: auditd.log.epoch
     target_field: "@timestamp"
@@ -2157,6 +2160,11 @@ processors:
       - auditd.log.sub_kv
       - auditd.log.epoch
       - auditd.log.copy
+    ignore_failure: true
+    ignore_missing: true
+- remove:
+    field: event.original
+    if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"
     ignore_failure: true
     ignore_missing: true
 on_failure:

--- a/packages/auditd/data_stream/log/fields/base-fields.yml
+++ b/packages/auditd/data_stream/log/fields/base-fields.yml
@@ -10,3 +10,8 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: tags
+  description: List of keywords used to tag each event.
+  example: '["production", "env2"]'
+  ignore_above: 1024
+  type: keyword

--- a/packages/auditd/data_stream/log/manifest.yml
+++ b/packages/auditd/data_stream/log/manifest.yml
@@ -12,6 +12,14 @@ streams:
         show_user: true
         default:
           - /var/log/audit/audit.log*
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
     template_path: log.yml.hbs
     title: Auditd logs
     description: Collect Auditd logs using log input

--- a/packages/auditd/docs/README.md
+++ b/packages/auditd/docs/README.md
@@ -198,13 +198,14 @@ An example event for `log` looks as following:
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
 | source.ip | IP address of the source (IPv4 or IPv6). | ip |
+| tags | List of keywords used to tag each event. | keyword |
 | user.audit.group.id | Unique identifier for the group on the system/platform. | keyword |
 | user.audit.group.name | Name of the group. | keyword |
 | user.audit.id | One or multiple unique identifiers of the user. | keyword |
 | user.audit.name | Short name or login of the user. | keyword |
 | user.effective.group.id | Unique identifier for the group on the system/platform. | keyword |
 | user.effective.group.name | Name of the group. | keyword |
-| user.effective.id | One or multiple unique identifiers of the user. | keyword |
+| user.effective.id | Unique identifier of the user. | keyword |
 | user.effective.name | Short name or login of the user. | keyword |
 | user.filesystem.group.id | Unique identifier for the group on the system/platform. | keyword |
 | user.filesystem.group.name | Name of the group. | keyword |

--- a/packages/auditd/manifest.yml
+++ b/packages/auditd/manifest.yml
@@ -1,6 +1,6 @@
 name: auditd
 title: Auditd
-version: 0.1.1
+version: 0.1.2
 release: experimental
 description: Auditd Integration
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Moves remaining edge processing to the ingest pipeline and make `event.original` optional
## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.


## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
![image](https://user-images.githubusercontent.com/15213755/118253725-898b9b80-b4aa-11eb-8b78-fc99732f443e.png)
