### PR TITLE
[system] Make event.original optional for application, security, and system ata streams

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.12.5"
+  changes:
+    - description: Make event.original optional for application, security, and system data streams.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/990
 - version: "0.12.4"
   changes:
     - description: Fix inconsistent dashboard IDs

--- a/packages/system/data_stream/application/agent/stream/httpjson.yml.hbs
+++ b/packages/system/data_stream/application/agent/stream/httpjson.yml.hbs
@@ -33,6 +33,9 @@ tags:
 {{#each tags as |tag i|}}
   - {{tag}}
 {{/each}}
+{{#if preserve_original_event}}
+  - preserve_original_event
+{{/if}}
 {{#contains tags "forwarded"}}
 publisher_pipeline.disable_host: true
 {{/contains}}

--- a/packages/system/data_stream/application/agent/stream/winlog.yml.hbs
+++ b/packages/system/data_stream/application/agent/stream/winlog.yml.hbs
@@ -1,3 +1,7 @@
 name: Application
 condition: ${host.platform} == 'windows'
 ignore_older: 72h
+tags:
+{{#if preserve_original_event}}
+  - preserve_original_event
+{{/if}}

--- a/packages/system/data_stream/application/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/application/elasticsearch/ingest_pipeline/default.yml
@@ -4,6 +4,11 @@
       - set:
           field: event.ingested
           value: '{{_ingest.timestamp}}'
+      - remove:
+          field: event.original
+          if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"
+          ignore_failure: true
+          ignore_missing: true
     on_failure:
       - set:
           field: "error.message"

--- a/packages/system/data_stream/security/agent/stream/httpjson.yml.hbs
+++ b/packages/system/data_stream/security/agent/stream/httpjson.yml.hbs
@@ -33,6 +33,9 @@ tags:
 {{#each tags as |tag i|}}
   - {{tag}}
 {{/each}}
+{{#if preserve_original_event}}
+  - preserve_original_event
+{{/if}}
 {{#contains tags "forwarded"}}
 publisher_pipeline.disable_host: true
 {{/contains}}

--- a/packages/system/data_stream/security/agent/stream/winlog.yml.hbs
+++ b/packages/system/data_stream/security/agent/stream/winlog.yml.hbs
@@ -1,2 +1,6 @@
 name: Security
 condition: ${host.platform} == 'windows'
+tags:
+{{#if preserve_original_event}}
+  - preserve_original_event
+{{/if}}

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
@@ -3170,6 +3170,12 @@ processors:
       ignore_failure: true
       if: ctx?.winlog?.time_created != null
 
+  - remove:
+      field: event.original
+      if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"
+      ignore_failure: true
+      ignore_missing: true
+
 on_failure:
   - set:
       field: error.message

--- a/packages/system/data_stream/system/agent/stream/httpjson.yml.hbs
+++ b/packages/system/data_stream/system/agent/stream/httpjson.yml.hbs
@@ -33,6 +33,9 @@ tags:
 {{#each tags as |tag i|}}
   - {{tag}}
 {{/each}}
+{{#if preserve_original_event}}
+  - preserve_original_event
+{{/if}}
 {{#contains tags "forwarded"}}
 publisher_pipeline.disable_host: true
 {{/contains}}

--- a/packages/system/data_stream/system/agent/stream/winlog.yml.hbs
+++ b/packages/system/data_stream/system/agent/stream/winlog.yml.hbs
@@ -1,2 +1,6 @@
 name: System
 condition: ${host.platform} == 'windows'
+tags:
+{{#if preserve_original_event}}
+  - preserve_original_event
+{{/if}}

--- a/packages/system/data_stream/system/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/system/elasticsearch/ingest_pipeline/default.yml
@@ -4,6 +4,11 @@ processors:
   - set:
       field: event.ingested
       value: '{{_ingest.timestamp}}'
+  - remove:
+      field: event.original
+      if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"
+      ignore_failure: true
+      ignore_missing: true
 on_failure:
   - set:
       field: "error.message"

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 0.12.4
+version: 0.12.5
 license: basic
 description: System Integration
 type: integration
@@ -36,6 +36,15 @@ policy_templates:
       - type: winlog
         title: 'Collect events from the Windows event log'
         description: 'Collecting events from Windows event log'
+        vars:
+          - name: preserve_original_event
+            required: true
+            show_user: true
+            title: Preserve original event
+            description: Preserves a raw copy of the original event, added to the field `event.original`
+            type: bool
+            multi: false
+            default: false
       - type: system/metrics
         title: Collect metrics from System instances
         description: Collecting System core, CPU, diskio, entropy, filesystem, fsstat, load, memory, network, Network Summary, process, Process Summary, raid, service, socket, Socket Summary, uptime and users metrics
@@ -68,6 +77,14 @@ policy_templates:
             title: Splunk REST API Password
             required: true
             show_user: true
+          - name: preserve_original_event
+            required: true
+            show_user: true
+            title: Preserve original event
+            description: Preserves a raw copy of the original event, added to the field `event.original`
+            type: bool
+            multi: false
+            default: false
           - name: ssl
             type: yaml
             title: SSL Configuration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Makes event.original optional for application, security, and system data streams.

NOTE: In this case, `event.original` is already present from the winlog and httpjson inputs.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/777

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->

![image](https://user-images.githubusercontent.com/15213755/118262187-cfe5f800-b4b4-11eb-9092-a02cdea449d9.png)

![image](https://user-images.githubusercontent.com/15213755/118262215-dd02e700-b4b4-11eb-8a9c-988a9dda20da.png)
