### PR TITLE
set kibana version to ^7.13.0 for aws package

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,6 +3,7 @@
   changes:
     - description: Fix stack compatability
       type: bugfix
+      link: https://github.com/elastic/integrations/pull/1000
 - version: "0.5.5"
   changes:
     - description: Allow role_arn work with access keys for AWS

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,8 @@
 # newer versions go on top
+- version: "0.5.6"
+  changes:
+    - description: Fix stack compatability
+      type: bugfix
 - version: "0.5.5"
   changes:
     - description: Allow role_arn work with access keys for AWS

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 0.5.5
+version: 0.5.6
 license: basic
 description: AWS Integration
 type: integration
@@ -12,7 +12,7 @@ categories:
   - security
 release: beta
 conditions:
-  kibana.version: "^7.12.0"
+  kibana.version: "^7.13.0"
 screenshots:
   - src: /img/filebeat-aws-cloudtrail.png
     title: filebeat aws cloudtrail


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR is to set Kibana version to ^7.13.0 for aws package.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.