### PR TITLE
Updating Kibana version condition to 7.13.0

### DIFF
--- a/packages/traefik/changelog.yml
+++ b/packages/traefik/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.2"
+  changes:
+    - description: setting minimum Kibana version required to 7.13.0
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1003
 - version: "0.1.1"
   changes:
     - description: parse either commonlog- or json-formatted logs

--- a/packages/traefik/manifest.yml
+++ b/packages/traefik/manifest.yml
@@ -15,7 +15,7 @@ categories:
   - web
   - security
 conditions:
-  kibana.version: ^7.12.0
+  kibana.version: ^7.13.0
 screenshots:
   - src: /img/kibana-traefik.png
     title: kibana traefik

--- a/packages/traefik/manifest.yml
+++ b/packages/traefik/manifest.yml
@@ -1,6 +1,6 @@
 name: traefik
 title: Traefik
-version: 0.1.1
+version: 0.1.2
 release: experimental
 description: Traefik Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?

Updates the minimum version of Kibana required for the `traefik-0.1.2` package to `7.13.0`.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
