### PR TITLE
[netflow] Add pipeline tests and move ecs.version to ingest pipeline

### DIFF
--- a/packages/netflow/changelog.yml
+++ b/packages/netflow/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.9"
+  changes:
+    - description: add pipeline tests and move ecs.version set the to ingest pipeline
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1006
 - version: "0.3.8"
   changes:
     - description: update to ECS 1.9.0

--- a/packages/netflow/data_stream/log/_dev/test/pipeline/test-netflow-log-events.json
+++ b/packages/netflow/data_stream/log/_dev/test/pipeline/test-netflow-log-events.json
@@ -1,0 +1,3020 @@
+{
+    "events": [
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "network": {
+                "iana_number": 6,
+                "bytes": 719,
+                "packets": 5,
+                "direction": "unknown",
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "agent": {
+                "version": "8.0.0",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local",
+                "type": "filebeat"
+            },
+            "client": {
+                "bytes": 719,
+                "packets": 5
+            },
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "netflow": {
+                "art_network_time_sum": 0,
+                "flow_end_sys_up_time": 564184158,
+                "responder_octets": 0,
+                "art_count_responses": 0,
+                "initiator_octets": 719,
+                "art_server_response_time_maximum": 0,
+                "ingress_vrfid": 0,
+                "art_count_late_responses": 0,
+                "art_server_response_time_sum": 0,
+                "responder_packets": 0,
+                "waasoptimization_segment": 16,
+                "initiator_packets": 5,
+                "art_response_time_sum": 0,
+                "application_id": [
+                    3,
+                    0,
+                    0,
+                    80
+                ],
+                "connection_sum_duration_seconds": 0,
+                "protocol_identifier": 6,
+                "art_total_transaction_time_sum": 0,
+                "art_total_response_time_sum": 0,
+                "type": "netflow_flow",
+                "vlan_id": 0,
+                "biflow_direction": 1,
+                "ingress_interface": 10,
+                "art_client_network_time_sum": 0,
+                "art_count_transactions": 0,
+                "new_connection_delta_count": 1,
+                "flow_start_sys_up_time": 564184140,
+                "egress_interface": 13,
+                "art_server_network_time_sum": 0,
+                "art_count_retransmissions": 0,
+                "ip_ttl": 49,
+                "exporter": {
+                    "timestamp": "2018-07-03T10:47:00.000Z",
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10
+                },
+                "ip_diff_serv_code_point": 0
+            },
+            "server": {
+                "packets": 0,
+                "bytes": 0
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "event": {
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event",
+                "category": "network_session",
+                "action": "netflow_flow",
+                "type": [
+                    "connection"
+                ]
+            },
+            "source": {
+                "packets": 5,
+                "bytes": 719
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 0
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "event": {
+                "action": "netflow_flow",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event",
+                "category": "network_session"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "destination": {
+                "packets": 0,
+                "bytes": 0
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "agent": {
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "server": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "netflow": {
+                "new_connection_delta_count": 1,
+                "art_count_transactions": 0,
+                "application_id": [
+                    3,
+                    0,
+                    0,
+                    80
+                ],
+                "art_server_network_time_sum": 0,
+                "art_response_time_sum": 0,
+                "initiator_packets": 6,
+                "type": "netflow_flow",
+                "ingress_interface": 10,
+                "art_count_retransmissions": 0,
+                "art_client_network_time_sum": 0,
+                "vlan_id": 0,
+                "connection_sum_duration_seconds": 0,
+                "protocol_identifier": 6,
+                "initiator_octets": 1477,
+                "art_count_responses": 0,
+                "responder_octets": 0,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "flow_end_sys_up_time": 564184154,
+                "ip_ttl": 49,
+                "biflow_direction": 1,
+                "ip_diff_serv_code_point": 0,
+                "art_total_transaction_time_sum": 0,
+                "art_count_late_responses": 0,
+                "egress_interface": 13,
+                "art_server_response_time_maximum": 0,
+                "responder_packets": 0,
+                "art_total_response_time_sum": 0,
+                "art_network_time_sum": 0,
+                "waasoptimization_segment": 16,
+                "art_server_response_time_sum": 0,
+                "ingress_vrfid": 0,
+                "flow_start_sys_up_time": 564184140
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 1477,
+                "packets": 6
+            },
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "source": {
+                "bytes": 1477,
+                "packets": 6
+            },
+            "network": {
+                "transport": "tcp",
+                "iana_number": 6,
+                "bytes": 1477,
+                "packets": 6,
+                "direction": "unknown",
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0="
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "network": {
+                "transport": "tcp",
+                "iana_number": 6,
+                "bytes": 1,
+                "packets": 2,
+                "direction": "unknown",
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0="
+            },
+            "agent": {
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "destination": {
+                "packets": 1,
+                "bytes": 0
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "server": {
+                "bytes": 0,
+                "packets": 1
+            },
+            "source": {
+                "packets": 1,
+                "bytes": 1
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "netflow": {
+                "biflow_direction": 1,
+                "waasoptimization_segment": 16,
+                "art_count_responses": 0,
+                "responder_octets": 0,
+                "ingress_vrfid": 0,
+                "initiator_packets": 1,
+                "art_count_late_responses": 0,
+                "ip_ttl": 125,
+                "art_server_response_time_sum": 0,
+                "art_count_transactions": 0,
+                "protocol_identifier": 6,
+                "flow_end_sys_up_time": 564184144,
+                "type": "netflow_flow",
+                "art_server_response_time_maximum": 0,
+                "responder_packets": 1,
+                "ip_diff_serv_code_point": 0,
+                "art_network_time_sum": 0,
+                "connection_sum_duration_seconds": 89,
+                "art_total_response_time_sum": 0,
+                "egress_interface": 10,
+                "flow_start_sys_up_time": 564184142,
+                "art_response_time_sum": 0,
+                "exporter": {
+                    "timestamp": "2018-07-03T10:47:00.000Z",
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10
+                },
+                "new_connection_delta_count": 0,
+                "ingress_interface": 13,
+                "vlan_id": 290,
+                "art_client_network_time_sum": 0,
+                "art_total_transaction_time_sum": 0,
+                "art_count_retransmissions": 1,
+                "initiator_octets": 1,
+                "art_server_network_time_sum": 0,
+                "application_id": [
+                    13,
+                    0,
+                    2,
+                    8
+                ]
+            },
+            "event": {
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event",
+                "category": "network_session",
+                "action": "netflow_flow",
+                "type": [
+                    "connection"
+                ]
+            },
+            "client": {
+                "bytes": 1,
+                "packets": 1
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "ecs": {
+                "version": "1.8.0"
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "agent": {
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "server": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "destination": {
+                "packets": 0,
+                "bytes": 0
+            },
+            "netflow": {
+                "art_count_late_responses": 0,
+                "connection_sum_duration_seconds": 0,
+                "art_total_transaction_time_sum": 0,
+                "art_count_transactions": 0,
+                "biflow_direction": 1,
+                "waasoptimization_segment": 16,
+                "responder_packets": 0,
+                "art_response_time_sum": 0,
+                "flow_end_sys_up_time": 564184216,
+                "art_server_network_time_sum": 0,
+                "art_server_response_time_maximum": 0,
+                "ingress_interface": 10,
+                "protocol_identifier": 6,
+                "art_total_response_time_sum": 0,
+                "egress_interface": 13,
+                "initiator_octets": 108580,
+                "new_connection_delta_count": 1,
+                "exporter": {
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z",
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512
+                },
+                "vlan_id": 0,
+                "flow_start_sys_up_time": 564184131,
+                "initiator_packets": 79,
+                "art_network_time_sum": 0,
+                "art_client_network_time_sum": 0,
+                "ingress_vrfid": 0,
+                "ip_ttl": 49,
+                "type": "netflow_flow",
+                "application_id": [
+                    3,
+                    0,
+                    0,
+                    80
+                ],
+                "art_count_retransmissions": 2,
+                "art_count_responses": 0,
+                "ip_diff_serv_code_point": 0,
+                "responder_octets": 0,
+                "art_server_response_time_sum": 0
+            },
+            "event": {
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event",
+                "category": "network_session",
+                "action": "netflow_flow",
+                "type": [
+                    "connection"
+                ]
+            },
+            "client": {
+                "packets": 79,
+                "bytes": 108580
+            },
+            "source": {
+                "bytes": 108580,
+                "packets": 79
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "network": {
+                "transport": "tcp",
+                "iana_number": 6,
+                "bytes": 108580,
+                "packets": 79,
+                "direction": "unknown",
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0="
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "server": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "event": {
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event",
+                "category": "network_session",
+                "action": "netflow_flow",
+                "type": [
+                    "connection"
+                ]
+            },
+            "client": {
+                "bytes": 342,
+                "packets": 5
+            },
+            "source": {
+                "packets": 5,
+                "bytes": 342
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "network": {
+                "direction": "unknown",
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "iana_number": 6,
+                "bytes": 342,
+                "packets": 5
+            },
+            "netflow": {
+                "protocol_identifier": 6,
+                "art_total_response_time_sum": 0,
+                "type": "netflow_flow",
+                "ingress_interface": 10,
+                "waasoptimization_segment": 16,
+                "art_count_retransmissions": 0,
+                "biflow_direction": 1,
+                "art_server_response_time_sum": 0,
+                "application_id": [
+                    3,
+                    0,
+                    0,
+                    80
+                ],
+                "art_count_transactions": 0,
+                "responder_octets": 0,
+                "art_server_network_time_sum": 0,
+                "initiator_packets": 5,
+                "art_count_late_responses": 0,
+                "ingress_vrfid": 0,
+                "flow_end_sys_up_time": 564184208,
+                "art_client_network_time_sum": 0,
+                "art_total_transaction_time_sum": 0,
+                "new_connection_delta_count": 1,
+                "initiator_octets": 342,
+                "ip_ttl": 49,
+                "art_count_responses": 0,
+                "art_response_time_sum": 0,
+                "egress_interface": 13,
+                "responder_packets": 0,
+                "connection_sum_duration_seconds": 0,
+                "art_server_response_time_maximum": 0,
+                "art_network_time_sum": 0,
+                "vlan_id": 0,
+                "flow_start_sys_up_time": 564184176,
+                "ip_diff_serv_code_point": 0,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                }
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "agent": {
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local",
+                "type": "filebeat",
+                "version": "8.0.0"
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "client": {
+                "bytes": 1851,
+                "packets": 17
+            },
+            "source": {
+                "bytes": 1851,
+                "packets": 17
+            },
+            "netflow": {
+                "initiator_packets": 17,
+                "initiator_octets": 1851,
+                "type": "netflow_flow",
+                "responder_packets": 18,
+                "biflow_direction": 1,
+                "waasoptimization_segment": 16,
+                "art_count_retransmissions": 0,
+                "protocol_identifier": 6,
+                "art_server_response_time_sum": 13,
+                "exporter": {
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z",
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512
+                },
+                "art_client_network_time_sum": 2,
+                "ingress_vrfid": 0,
+                "art_total_transaction_time_sum": 100,
+                "art_response_time_sum": 153,
+                "new_connection_delta_count": 2,
+                "art_count_responses": 3,
+                "ip_diff_serv_code_point": 0,
+                "vlan_id": 290,
+                "application_id": [
+                    13,
+                    0,
+                    1,
+                    197
+                ],
+                "art_server_network_time_sum": 95,
+                "art_count_late_responses": 0,
+                "art_total_response_time_sum": 156,
+                "ip_ttl": 125,
+                "art_server_response_time_maximum": 8,
+                "connection_sum_duration_seconds": 24,
+                "art_network_time_sum": 97,
+                "flow_end_sys_up_time": 564197394,
+                "art_count_transactions": 2,
+                "flow_start_sys_up_time": 564184067,
+                "ingress_interface": 13,
+                "egress_interface": 10,
+                "responder_octets": 9437
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "agent": {
+                "version": "8.0.0",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local",
+                "type": "filebeat"
+            },
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "server": {
+                "bytes": 9437,
+                "packets": 18
+            },
+            "event": {
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event",
+                "category": "network_session",
+                "action": "netflow_flow"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "destination": {
+                "bytes": 9437,
+                "packets": 18
+            },
+            "network": {
+                "bytes": 11288,
+                "packets": 35,
+                "direction": "unknown",
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "iana_number": 6
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "source": {
+                "bytes": 51480,
+                "packets": 39
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "netflow": {
+                "flow_start_sys_up_time": 564184182,
+                "ip_diff_serv_code_point": 0,
+                "application_id": [
+                    3,
+                    0,
+                    0,
+                    80
+                ],
+                "waasoptimization_segment": 16,
+                "art_network_time_sum": 0,
+                "art_count_late_responses": 0,
+                "art_count_responses": 0,
+                "type": "netflow_flow",
+                "art_server_response_time_maximum": 0,
+                "ingress_vrfid": 0,
+                "responder_packets": 0,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "art_count_retransmissions": 0,
+                "responder_octets": 0,
+                "ip_ttl": 49,
+                "art_total_response_time_sum": 0,
+                "initiator_packets": 39,
+                "ingress_interface": 10,
+                "art_server_response_time_sum": 0,
+                "initiator_octets": 51480,
+                "egress_interface": 13,
+                "art_server_network_time_sum": 0,
+                "art_client_network_time_sum": 0,
+                "new_connection_delta_count": 1,
+                "art_response_time_sum": 0,
+                "vlan_id": 0,
+                "protocol_identifier": 6,
+                "connection_sum_duration_seconds": 0,
+                "art_total_transaction_time_sum": 0,
+                "biflow_direction": 1,
+                "art_count_transactions": 0,
+                "flow_end_sys_up_time": 564184216
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "agent": {
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "event": {
+                "category": "network_session",
+                "action": "netflow_flow",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event"
+            },
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "server": {
+                "packets": 0,
+                "bytes": 0
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 51480,
+                "packets": 39
+            },
+            "network": {
+                "transport": "tcp",
+                "iana_number": 6,
+                "bytes": 51480,
+                "packets": 39,
+                "direction": "unknown",
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0="
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "destination": {
+                "bytes": 36894,
+                "packets": 47
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "iana_number": 6,
+                "bytes": 42029,
+                "packets": 102,
+                "direction": "unknown"
+            },
+            "server": {
+                "bytes": 36894,
+                "packets": 47
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "netflow": {
+                "responder_packets": 47,
+                "egress_interface": 10,
+                "art_client_network_time_sum": 10,
+                "art_response_time_sum": 516,
+                "ip_diff_serv_code_point": 0,
+                "art_count_late_responses": 0,
+                "art_count_transactions": 14,
+                "ip_ttl": 126,
+                "art_count_responses": 15,
+                "responder_octets": 36894,
+                "connection_sum_duration_seconds": 35,
+                "protocol_identifier": 6,
+                "new_connection_delta_count": 6,
+                "art_server_response_time_maximum": 27,
+                "art_server_response_time_sum": 117,
+                "art_server_network_time_sum": 364,
+                "art_total_response_time_sum": 541,
+                "art_total_transaction_time_sum": 512,
+                "biflow_direction": 1,
+                "art_count_retransmissions": 0,
+                "ingress_interface": 13,
+                "initiator_packets": 55,
+                "ingress_vrfid": 0,
+                "vlan_id": 290,
+                "type": "netflow_flow",
+                "initiator_octets": 5135,
+                "art_network_time_sum": 374,
+                "application_id": [
+                    13,
+                    0,
+                    1,
+                    197
+                ],
+                "exporter": {
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z",
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809"
+                },
+                "flow_end_sys_up_time": 564203810,
+                "flow_start_sys_up_time": 564184040,
+                "waasoptimization_segment": 16
+            },
+            "client": {
+                "bytes": 5135,
+                "packets": 55
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "agent": {
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local",
+                "type": "filebeat",
+                "version": "8.0.0",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c"
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "event": {
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event",
+                "category": "network_session",
+                "action": "netflow_flow",
+                "type": [
+                    "connection"
+                ]
+            },
+            "source": {
+                "packets": 55,
+                "bytes": 5135
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "client": {
+                "bytes": 6533,
+                "packets": 14
+            },
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "server": {
+                "bytes": 6400,
+                "packets": 20
+            },
+            "agent": {
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "source": {
+                "packets": 14,
+                "bytes": 6533
+            },
+            "destination": {
+                "bytes": 6400,
+                "packets": 20
+            },
+            "network": {
+                "iana_number": 6,
+                "bytes": 12933,
+                "packets": 34,
+                "direction": "unknown",
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp"
+            },
+            "netflow": {
+                "responder_packets": 14,
+                "art_count_responses": 6,
+                "vlan_id": 0,
+                "new_connection_delta_count": 2,
+                "ingress_interface": 10,
+                "art_total_response_time_sum": 138,
+                "art_server_response_time_maximum": 31,
+                "ip_diff_serv_code_point": 0,
+                "art_server_response_time_sum": 78,
+                "art_count_retransmissions": 1,
+                "art_total_transaction_time_sum": 123,
+                "initiator_packets": 20,
+                "ip_ttl": 61,
+                "type": "netflow_flow",
+                "ingress_vrfid": 0,
+                "protocol_identifier": 6,
+                "art_server_network_time_sum": 18,
+                "art_count_transactions": 6,
+                "flow_start_sys_up_time": 564184163,
+                "exporter": {
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z",
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512
+                },
+                "art_network_time_sum": 23,
+                "egress_interface": 13,
+                "responder_octets": 6533,
+                "application_id": [
+                    13,
+                    0,
+                    2,
+                    99
+                ],
+                "biflow_direction": 2,
+                "waasoptimization_segment": 16,
+                "initiator_octets": 6400,
+                "flow_end_sys_up_time": 564200378,
+                "connection_sum_duration_seconds": 64,
+                "art_count_late_responses": 0,
+                "art_response_time_sum": 123,
+                "art_client_network_time_sum": 5
+            },
+            "event": {
+                "category": "network_session",
+                "action": "netflow_flow",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "event": {
+                "kind": "event",
+                "category": "network_session",
+                "action": "netflow_flow",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z"
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "server": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "source": {
+                "bytes": 5684,
+                "packets": 491
+            },
+            "network": {
+                "packets": 491,
+                "direction": "unknown",
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "iana_number": 6,
+                "bytes": 5684
+            },
+            "netflow": {
+                "new_connection_delta_count": 0,
+                "art_count_retransmissions": 0,
+                "vlan_id": 290,
+                "exporter": {
+                    "timestamp": "2018-07-03T10:47:00.000Z",
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10
+                },
+                "art_server_response_time_sum": 0,
+                "biflow_direction": 1,
+                "art_count_responses": 0,
+                "art_total_transaction_time_sum": 0,
+                "art_response_time_sum": 0,
+                "initiator_octets": 5684,
+                "ingress_vrfid": 0,
+                "responder_packets": 0,
+                "application_id": [
+                    13,
+                    0,
+                    0,
+                    49
+                ],
+                "connection_sum_duration_seconds": 109,
+                "art_total_response_time_sum": 0,
+                "type": "netflow_flow",
+                "flow_start_sys_up_time": 564184196,
+                "egress_interface": 10,
+                "ingress_interface": 13,
+                "art_server_network_time_sum": 0,
+                "ip_diff_serv_code_point": 0,
+                "initiator_packets": 491,
+                "ip_ttl": 125,
+                "responder_octets": 0,
+                "waasoptimization_segment": 16,
+                "art_network_time_sum": 0,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 0,
+                "art_count_late_responses": 0,
+                "art_client_network_time_sum": 0,
+                "flow_end_sys_up_time": 564185840,
+                "art_count_transactions": 0
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 5684,
+                "packets": 491
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "agent": {
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local",
+                "type": "filebeat",
+                "version": "8.0.0"
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "client": {
+                "bytes": 4965,
+                "packets": 13
+            },
+            "server": {
+                "packets": 0,
+                "bytes": 0
+            },
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "event": {
+                "category": "network_session",
+                "action": "netflow_flow",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "source": {
+                "bytes": 4965,
+                "packets": 13
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 0,
+                "new_connection_delta_count": 1,
+                "exporter": {
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z",
+                    "uptime_millis": 0
+                },
+                "type": "netflow_flow",
+                "art_count_responses": 0,
+                "art_server_network_time_sum": 0,
+                "responder_packets": 0,
+                "ingress_interface": 13,
+                "biflow_direction": 1,
+                "ip_diff_serv_code_point": 0,
+                "initiator_packets": 13,
+                "ingress_vrfid": 0,
+                "art_count_transactions": 0,
+                "art_response_time_sum": 0,
+                "art_total_transaction_time_sum": 0,
+                "connection_sum_duration_seconds": 0,
+                "flow_end_sys_up_time": 564184254,
+                "vlan_id": 290,
+                "initiator_octets": 4965,
+                "waasoptimization_segment": 16,
+                "responder_octets": 0,
+                "art_count_late_responses": 0,
+                "art_total_response_time_sum": 0,
+                "application_id": [
+                    13,
+                    0,
+                    1,
+                    197
+                ],
+                "art_server_response_time_sum": 0,
+                "flow_start_sys_up_time": 564184154,
+                "ip_ttl": 125,
+                "art_count_retransmissions": 0,
+                "art_network_time_sum": 0,
+                "egress_interface": 10,
+                "art_client_network_time_sum": 0
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "agent": {
+                "name": "mbp.local",
+                "type": "filebeat",
+                "version": "8.0.0",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75"
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "iana_number": 6,
+                "bytes": 4965,
+                "packets": 13,
+                "direction": "unknown"
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "server": {
+                "packets": 2,
+                "bytes": 0
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "agent": {
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local",
+                "type": "filebeat",
+                "version": "8.0.0",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c"
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 2
+            },
+            "event": {
+                "category": "network_session",
+                "action": "netflow_flow",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event"
+            },
+            "client": {
+                "bytes": 138,
+                "packets": 4
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "iana_number": 6,
+                "bytes": 138,
+                "packets": 6,
+                "direction": "unknown"
+            },
+            "netflow": {
+                "protocol_identifier": 6,
+                "ingress_interface": 10,
+                "vlan_id": 0,
+                "exporter": {
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z",
+                    "uptime_millis": 0
+                },
+                "art_server_network_time_sum": 0,
+                "art_server_response_time_maximum": 0,
+                "art_count_responses": 0,
+                "art_total_response_time_sum": 0,
+                "connection_sum_duration_seconds": 239,
+                "responder_octets": 138,
+                "art_count_retransmissions": 0,
+                "ingress_vrfid": 0,
+                "initiator_packets": 2,
+                "new_connection_delta_count": 0,
+                "application_id": [
+                    13,
+                    0,
+                    2,
+                    99
+                ],
+                "art_client_network_time_sum": 0,
+                "flow_start_sys_up_time": 564184214,
+                "biflow_direction": 2,
+                "art_network_time_sum": 0,
+                "type": "netflow_flow",
+                "art_count_late_responses": 0,
+                "art_count_transactions": 2,
+                "flow_end_sys_up_time": 564184362,
+                "egress_interface": 13,
+                "ip_diff_serv_code_point": 0,
+                "responder_packets": 4,
+                "art_response_time_sum": 0,
+                "art_total_transaction_time_sum": 119878,
+                "initiator_octets": 0,
+                "art_server_response_time_sum": 0,
+                "ip_ttl": 61,
+                "waasoptimization_segment": 16
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "source": {
+                "bytes": 138,
+                "packets": 4
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "netflow": {
+                "waasoptimization_segment": 16,
+                "art_total_transaction_time_sum": 0,
+                "art_server_response_time_sum": 0,
+                "art_total_response_time_sum": 0,
+                "art_count_responses": 0,
+                "ingress_interface": 13,
+                "art_server_network_time_sum": 0,
+                "art_client_network_time_sum": 0,
+                "flow_end_sys_up_time": 564184220,
+                "ingress_vrfid": 0,
+                "biflow_direction": 1,
+                "ip_ttl": 125,
+                "initiator_packets": 1,
+                "vlan_id": 290,
+                "ip_diff_serv_code_point": 0,
+                "art_count_retransmissions": 1,
+                "egress_interface": 10,
+                "art_response_time_sum": 0,
+                "art_count_transactions": 0,
+                "art_network_time_sum": 0,
+                "exporter": {
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z",
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809"
+                },
+                "type": "netflow_flow",
+                "responder_octets": 0,
+                "responder_packets": 0,
+                "connection_sum_duration_seconds": 44,
+                "art_count_late_responses": 0,
+                "flow_start_sys_up_time": 564184220,
+                "protocol_identifier": 6,
+                "application_id": [
+                    13,
+                    0,
+                    2,
+                    8
+                ],
+                "initiator_octets": 1,
+                "new_connection_delta_count": 0,
+                "art_server_response_time_maximum": 0
+            },
+            "event": {
+                "category": "network_session",
+                "action": "netflow_flow",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "agent": {
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "server": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "source": {
+                "packets": 1,
+                "bytes": 1
+            },
+            "network": {
+                "transport": "tcp",
+                "iana_number": 6,
+                "bytes": 1,
+                "packets": 1,
+                "direction": "unknown",
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0="
+            },
+            "client": {
+                "packets": 1,
+                "bytes": 1
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "input": {
+                "type": "netflow"
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "netflow": {
+                "art_count_responses": 3,
+                "egress_interface": 13,
+                "initiator_octets": 1571,
+                "ingress_vrfid": 0,
+                "connection_sum_duration_seconds": 62,
+                "art_server_network_time_sum": 146,
+                "art_client_network_time_sum": 3,
+                "application_id": [
+                    13,
+                    0,
+                    1,
+                    197
+                ],
+                "art_count_late_responses": 0,
+                "art_server_response_time_maximum": 3,
+                "art_total_response_time_sum": 453,
+                "type": "netflow_flow",
+                "ip_diff_serv_code_point": 0,
+                "exporter": {
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z",
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809"
+                },
+                "protocol_identifier": 6,
+                "ip_ttl": 220,
+                "waasoptimization_segment": 16,
+                "responder_octets": 6079,
+                "vlan_id": 0,
+                "art_server_response_time_sum": 6,
+                "initiator_packets": 13,
+                "art_count_retransmissions": 0,
+                "flow_end_sys_up_time": 564215068,
+                "responder_packets": 10,
+                "flow_start_sys_up_time": 564184067,
+                "ingress_interface": 10,
+                "art_response_time_sum": 444,
+                "biflow_direction": 2,
+                "art_network_time_sum": 149,
+                "art_count_transactions": 2,
+                "new_connection_delta_count": 1,
+                "art_total_transaction_time_sum": 296
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "client": {
+                "packets": 10,
+                "bytes": 6079
+            },
+            "network": {
+                "direction": "unknown",
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "iana_number": 6,
+                "bytes": 7650,
+                "packets": 23
+            },
+            "server": {
+                "bytes": 1571,
+                "packets": 13
+            },
+            "source": {
+                "bytes": 6079,
+                "packets": 10
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "agent": {
+                "type": "filebeat",
+                "version": "8.0.0",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local"
+            },
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "destination": {
+                "bytes": 1571,
+                "packets": 13
+            },
+            "event": {
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event",
+                "category": "network_session",
+                "action": "netflow_flow",
+                "type": [
+                    "connection"
+                ]
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "client": {
+                "packets": 6,
+                "bytes": 2807
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "event": {
+                "action": "netflow_flow",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event",
+                "category": "network_session"
+            },
+            "network": {
+                "packets": 6,
+                "direction": "unknown",
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "iana_number": 6,
+                "bytes": 2807
+            },
+            "source": {
+                "packets": 6,
+                "bytes": 2807
+            },
+            "netflow": {
+                "biflow_direction": 1,
+                "art_response_time_sum": 0,
+                "responder_packets": 0,
+                "waasoptimization_segment": 16,
+                "egress_interface": 13,
+                "art_count_responses": 0,
+                "ingress_vrfid": 0,
+                "connection_sum_duration_seconds": 0,
+                "exporter": {
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z",
+                    "uptime_millis": 0
+                },
+                "vlan_id": 0,
+                "art_count_late_responses": 0,
+                "type": "netflow_flow",
+                "ip_diff_serv_code_point": 0,
+                "flow_start_sys_up_time": 564183878,
+                "art_server_response_time_sum": 0,
+                "art_total_transaction_time_sum": 0,
+                "art_server_network_time_sum": 0,
+                "art_count_transactions": 0,
+                "responder_octets": 0,
+                "art_client_network_time_sum": 0,
+                "protocol_identifier": 6,
+                "initiator_packets": 6,
+                "initiator_octets": 2807,
+                "art_server_response_time_maximum": 0,
+                "art_network_time_sum": 0,
+                "art_total_response_time_sum": 0,
+                "flow_end_sys_up_time": 564184252,
+                "ip_ttl": 61,
+                "new_connection_delta_count": 1,
+                "ingress_interface": 10,
+                "application_id": [
+                    13,
+                    0,
+                    1,
+                    197
+                ],
+                "art_count_retransmissions": 0
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "agent": {
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "server": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "event": {
+                "kind": "event",
+                "category": "network_session",
+                "action": "netflow_flow",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "network": {
+                "packets": 1,
+                "direction": "unknown",
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "iana_number": 6,
+                "bytes": 0
+            },
+            "source": {
+                "bytes": 0,
+                "packets": 1
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "ip_diff_serv_code_point": 0,
+                "new_connection_delta_count": 0,
+                "art_server_network_time_sum": 0,
+                "protocol_identifier": 6,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "initiator_packets": 1,
+                "ingress_vrfid": 0,
+                "art_response_time_sum": 0,
+                "art_total_transaction_time_sum": 0,
+                "ingress_interface": 1,
+                "vlan_id": 0,
+                "type": "netflow_flow",
+                "art_count_responses": 0,
+                "art_client_network_time_sum": 0,
+                "art_server_response_time_sum": 0,
+                "waasoptimization_segment": 16,
+                "initiator_octets": 0,
+                "art_count_transactions": 0,
+                "responder_packets": 0,
+                "art_total_response_time_sum": 0,
+                "ip_ttl": 124,
+                "biflow_direction": 1,
+                "flow_end_sys_up_time": 564184248,
+                "egress_interface": 4,
+                "responder_octets": 0,
+                "art_network_time_sum": 0,
+                "connection_sum_duration_seconds": 59,
+                "flow_start_sys_up_time": 564184248,
+                "art_count_retransmissions": 0,
+                "art_server_response_time_maximum": 0,
+                "art_count_late_responses": 0,
+                "application_id": [
+                    13,
+                    0,
+                    0,
+                    1
+                ]
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "agent": {
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "server": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "client": {
+                "bytes": 0,
+                "packets": 1
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 0
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "network": {
+                "packets": 18,
+                "direction": "unknown",
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "iana_number": 6,
+                "bytes": 5286
+            },
+            "client": {
+                "bytes": 1877,
+                "packets": 11
+            },
+            "destination": {
+                "bytes": 3409,
+                "packets": 7
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "event": {
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event",
+                "category": "network_session",
+                "action": "netflow_flow",
+                "type": [
+                    "connection"
+                ]
+            },
+            "server": {
+                "bytes": 3409,
+                "packets": 7
+            },
+            "source": {
+                "bytes": 1877,
+                "packets": 11
+            },
+            "agent": {
+                "name": "mbp.local",
+                "type": "filebeat",
+                "version": "8.0.0",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75"
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "responder_packets": 7,
+                "ingress_interface": 13,
+                "art_server_response_time_sum": 7,
+                "ip_ttl": 125,
+                "initiator_packets": 11,
+                "exporter": {
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z",
+                    "uptime_millis": 0
+                },
+                "ingress_vrfid": 0,
+                "biflow_direction": 1,
+                "art_count_transactions": 4,
+                "art_server_network_time_sum": 4,
+                "art_count_responses": 4,
+                "type": "netflow_flow",
+                "art_total_transaction_time_sum": 23,
+                "ip_diff_serv_code_point": 0,
+                "application_id": [
+                    13,
+                    0,
+                    1,
+                    197
+                ],
+                "flow_end_sys_up_time": 564200378,
+                "art_count_late_responses": 0,
+                "art_count_retransmissions": 0,
+                "vlan_id": 290,
+                "initiator_octets": 1877,
+                "responder_octets": 3409,
+                "flow_start_sys_up_time": 564184251,
+                "egress_interface": 10,
+                "art_server_response_time_maximum": 3,
+                "waasoptimization_segment": 16,
+                "connection_sum_duration_seconds": 32,
+                "art_network_time_sum": 6,
+                "new_connection_delta_count": 1,
+                "art_client_network_time_sum": 2,
+                "art_response_time_sum": 23,
+                "art_total_response_time_sum": 31,
+                "protocol_identifier": 6
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "destination": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "iana_number": 6,
+                "bytes": 2255,
+                "packets": 7,
+                "direction": "unknown"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "source": {
+                "bytes": 2255,
+                "packets": 7
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "client": {
+                "bytes": 2255,
+                "packets": 7
+            },
+            "server": {
+                "packets": 0,
+                "bytes": 0
+            },
+            "event": {
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event",
+                "category": "network_session",
+                "action": "netflow_flow",
+                "type": [
+                    "connection"
+                ]
+            },
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "agent": {
+                "version": "8.0.0",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local",
+                "type": "filebeat"
+            },
+            "netflow": {
+                "ip_ttl": 61,
+                "art_network_time_sum": 0,
+                "responder_octets": 0,
+                "responder_packets": 0,
+                "art_count_retransmissions": 0,
+                "egress_interface": 13,
+                "biflow_direction": 1,
+                "vlan_id": 0,
+                "art_server_response_time_sum": 0,
+                "art_total_response_time_sum": 0,
+                "application_id": [
+                    13,
+                    0,
+                    1,
+                    197
+                ],
+                "new_connection_delta_count": 1,
+                "connection_sum_duration_seconds": 0,
+                "type": "netflow_flow",
+                "art_count_late_responses": 0,
+                "flow_start_sys_up_time": 564184040,
+                "art_response_time_sum": 0,
+                "exporter": {
+                    "timestamp": "2018-07-03T10:47:00.000Z",
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10
+                },
+                "art_client_network_time_sum": 0,
+                "protocol_identifier": 6,
+                "art_count_responses": 0,
+                "art_server_network_time_sum": 0,
+                "ingress_vrfid": 0,
+                "ingress_interface": 10,
+                "waasoptimization_segment": 16,
+                "initiator_packets": 7,
+                "art_server_response_time_maximum": 0,
+                "art_count_transactions": 0,
+                "ip_diff_serv_code_point": 0,
+                "art_total_transaction_time_sum": 0,
+                "initiator_octets": 2255,
+                "flow_end_sys_up_time": 564184286
+            },
+            "ecs": {
+                "version": "1.8.0"
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "source": {
+                "packets": 5,
+                "bytes": 538
+            },
+            "netflow": {
+                "initiator_packets": 5,
+                "waasoptimization_segment": 16,
+                "art_total_transaction_time_sum": 0,
+                "vlan_id": 0,
+                "new_connection_delta_count": 1,
+                "protocol_identifier": 6,
+                "flow_start_sys_up_time": 564184284,
+                "ingress_interface": 10,
+                "connection_sum_duration_seconds": 0,
+                "biflow_direction": 1,
+                "art_server_response_time_sum": 0,
+                "responder_packets": 0,
+                "art_count_responses": 0,
+                "art_count_retransmissions": 0,
+                "art_network_time_sum": 0,
+                "responder_octets": 0,
+                "art_client_network_time_sum": 0,
+                "ingress_vrfid": 0,
+                "art_count_late_responses": 0,
+                "ip_ttl": 49,
+                "art_server_response_time_maximum": 0,
+                "type": "netflow_flow",
+                "ip_diff_serv_code_point": 0,
+                "exporter": {
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z",
+                    "uptime_millis": 0
+                },
+                "art_server_network_time_sum": 0,
+                "art_response_time_sum": 0,
+                "art_total_response_time_sum": 0,
+                "egress_interface": 13,
+                "application_id": [
+                    3,
+                    0,
+                    0,
+                    80
+                ],
+                "initiator_octets": 538,
+                "art_count_transactions": 0,
+                "flow_end_sys_up_time": 564184314
+            },
+            "event": {
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event",
+                "category": "network_session",
+                "action": "netflow_flow"
+            },
+            "client": {
+                "packets": 5,
+                "bytes": 538
+            },
+            "server": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "agent": {
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "network": {
+                "transport": "tcp",
+                "iana_number": 6,
+                "bytes": 538,
+                "packets": 5,
+                "direction": "unknown",
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0="
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 0
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "network": {
+                "packets": 36,
+                "direction": "unknown",
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "iana_number": 6,
+                "bytes": 7792
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "event": {
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.939Z",
+                "kind": "event",
+                "category": "network_session",
+                "action": "netflow_flow"
+            },
+            "source": {
+                "bytes": 1487,
+                "packets": 21
+            },
+            "netflow": {
+                "art_server_response_time_maximum": 25,
+                "art_network_time_sum": 9,
+                "ip_diff_serv_code_point": 0,
+                "art_total_transaction_time_sum": 59870,
+                "art_count_late_responses": 0,
+                "responder_octets": 6305,
+                "art_total_response_time_sum": 77,
+                "flow_start_sys_up_time": 564184296,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "biflow_direction": 1,
+                "art_server_response_time_sum": 55,
+                "connection_sum_duration_seconds": 181,
+                "art_count_retransmissions": 0,
+                "waasoptimization_segment": 16,
+                "egress_interface": 10,
+                "new_connection_delta_count": 2,
+                "flow_end_sys_up_time": 564214304,
+                "initiator_packets": 21,
+                "vlan_id": 290,
+                "art_count_transactions": 5,
+                "art_server_network_time_sum": 7,
+                "ip_ttl": 125,
+                "application_id": [
+                    13,
+                    0,
+                    2,
+                    102
+                ],
+                "art_client_network_time_sum": 2,
+                "ingress_vrfid": 0,
+                "initiator_octets": 1487,
+                "art_count_responses": 5,
+                "art_response_time_sum": 72,
+                "responder_packets": 15,
+                "ingress_interface": 13,
+                "type": "netflow_flow",
+                "protocol_identifier": 6
+            },
+            "destination": {
+                "bytes": 6305,
+                "packets": 15
+            },
+            "server": {
+                "bytes": 6305,
+                "packets": 15
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "agent": {
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "client": {
+                "bytes": 1487,
+                "packets": 21
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "server": {
+                "bytes": 1973,
+                "packets": 10
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "netflow": {
+                "art_server_response_time_maximum": 14,
+                "exporter": {
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z",
+                    "uptime_millis": 0
+                },
+                "vlan_id": 0,
+                "art_client_network_time_sum": 2,
+                "responder_packets": 7,
+                "initiator_octets": 1973,
+                "application_id": [
+                    13,
+                    0,
+                    2,
+                    99
+                ],
+                "flow_end_sys_up_time": 564200376,
+                "art_total_transaction_time_sum": 39,
+                "biflow_direction": 2,
+                "art_count_retransmissions": 0,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "ingress_interface": 10,
+                "art_server_response_time_sum": 15,
+                "initiator_packets": 10,
+                "art_count_responses": 3,
+                "art_server_network_time_sum": 10,
+                "connection_sum_duration_seconds": 32,
+                "art_response_time_sum": 39,
+                "protocol_identifier": 6,
+                "flow_start_sys_up_time": 564184268,
+                "egress_interface": 13,
+                "art_count_transactions": 3,
+                "art_network_time_sum": 12,
+                "art_count_late_responses": 0,
+                "type": "netflow_flow",
+                "new_connection_delta_count": 1,
+                "responder_octets": 3110,
+                "ingress_vrfid": 0,
+                "ip_ttl": 61,
+                "art_total_response_time_sum": 45
+            },
+            "client": {
+                "bytes": 3110,
+                "packets": 7
+            },
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "source": {
+                "bytes": 3110,
+                "packets": 7
+            },
+            "event": {
+                "category": "network_session",
+                "action": "netflow_flow",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.939Z",
+                "kind": "event"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "agent": {
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "destination": {
+                "packets": 10,
+                "bytes": 1973
+            },
+            "network": {
+                "transport": "tcp",
+                "iana_number": 6,
+                "bytes": 5083,
+                "packets": 17,
+                "direction": "unknown",
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0="
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "server": {
+                "bytes": 2,
+                "packets": 4
+            },
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "destination": {
+                "bytes": 2,
+                "packets": 4
+            },
+            "client": {
+                "packets": 4,
+                "bytes": 2
+            },
+            "event": {
+                "created": "2021-05-19T09:08:51.939Z",
+                "kind": "event",
+                "category": "network_session",
+                "action": "netflow_flow",
+                "type": [
+                    "connection"
+                ]
+            },
+            "source": {
+                "bytes": 2,
+                "packets": 4
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "network": {
+                "bytes": 4,
+                "packets": 8,
+                "direction": "unknown",
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "iana_number": 6
+            },
+            "netflow": {
+                "art_count_responses": 0,
+                "flow_start_sys_up_time": 564184300,
+                "flow_end_sys_up_time": 564214242,
+                "waasoptimization_segment": 16,
+                "art_response_time_sum": 0,
+                "art_client_network_time_sum": 0,
+                "initiator_octets": 2,
+                "initiator_packets": 4,
+                "ip_diff_serv_code_point": 0,
+                "art_total_response_time_sum": 0,
+                "ip_ttl": 124,
+                "art_count_retransmissions": 2,
+                "protocol_identifier": 6,
+                "responder_packets": 4,
+                "type": "netflow_flow",
+                "application_id": [
+                    3,
+                    0,
+                    5,
+                    153
+                ],
+                "art_count_transactions": 0,
+                "art_network_time_sum": 0,
+                "egress_interface": 13,
+                "ingress_interface": 10,
+                "vlan_id": 0,
+                "art_count_late_responses": 0,
+                "new_connection_delta_count": 0,
+                "art_total_transaction_time_sum": 0,
+                "art_server_network_time_sum": 0,
+                "biflow_direction": 2,
+                "art_server_response_time_maximum": 0,
+                "responder_octets": 2,
+                "ingress_vrfid": 0,
+                "exporter": {
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z",
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512
+                },
+                "art_server_response_time_sum": 0,
+                "connection_sum_duration_seconds": 119
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "agent": {
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local",
+                "type": "filebeat",
+                "version": "8.0.0",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c"
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "network": {
+                "packets": 4,
+                "direction": "unknown",
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "iana_number": 6,
+                "bytes": 2
+            },
+            "netflow": {
+                "flow_start_sys_up_time": 564184306,
+                "art_network_time_sum": 0,
+                "art_total_response_time_sum": 0,
+                "flow_end_sys_up_time": 564184580,
+                "application_id": [
+                    3,
+                    0,
+                    0,
+                    80
+                ],
+                "new_connection_delta_count": 0,
+                "biflow_direction": 1,
+                "waasoptimization_segment": 16,
+                "exporter": {
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z",
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809"
+                },
+                "vlan_id": 290,
+                "art_total_transaction_time_sum": 0,
+                "initiator_packets": 2,
+                "art_server_network_time_sum": 0,
+                "egress_interface": 10,
+                "ip_diff_serv_code_point": 0,
+                "protocol_identifier": 6,
+                "art_response_time_sum": 0,
+                "ip_ttl": 125,
+                "art_count_responses": 0,
+                "initiator_octets": 2,
+                "art_server_response_time_maximum": 0,
+                "type": "netflow_flow",
+                "responder_packets": 2,
+                "art_server_response_time_sum": 0,
+                "art_client_network_time_sum": 0,
+                "art_count_late_responses": 0,
+                "connection_sum_duration_seconds": 179,
+                "art_count_transactions": 0,
+                "ingress_interface": 13,
+                "ingress_vrfid": 0,
+                "art_count_retransmissions": 2,
+                "responder_octets": 0
+            },
+            "source": {
+                "bytes": 2,
+                "packets": 2
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "server": {
+                "packets": 2,
+                "bytes": 0
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 2
+            },
+            "event": {
+                "kind": "event",
+                "category": "network_session",
+                "action": "netflow_flow",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.939Z"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "client": {
+                "bytes": 2,
+                "packets": 2
+            },
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "agent": {
+                "type": "filebeat",
+                "version": "8.0.0",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local"
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "agent": {
+                "version": "8.0.0",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local",
+                "type": "filebeat"
+            },
+            "server": {
+                "bytes": 0,
+                "packets": 2
+            },
+            "event": {
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.939Z",
+                "kind": "event",
+                "category": "network_session",
+                "action": "netflow_flow"
+            },
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "source": {
+                "bytes": 0,
+                "packets": 4
+            },
+            "network": {
+                "packets": 6,
+                "direction": "unknown",
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "iana_number": 6,
+                "bytes": 0
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "client": {
+                "bytes": 0,
+                "packets": 4
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 2
+            },
+            "netflow": {
+                "art_server_response_time_sum": 0,
+                "art_server_network_time_sum": 0,
+                "ip_diff_serv_code_point": 0,
+                "art_response_time_sum": 0,
+                "flow_start_sys_up_time": 564184326,
+                "application_id": [
+                    13,
+                    0,
+                    1,
+                    197
+                ],
+                "biflow_direction": 1,
+                "ip_ttl": 125,
+                "responder_packets": 2,
+                "responder_octets": 0,
+                "art_server_response_time_maximum": 0,
+                "initiator_packets": 4,
+                "type": "netflow_flow",
+                "art_total_transaction_time_sum": 18,
+                "egress_interface": 10,
+                "flow_end_sys_up_time": 564184326,
+                "art_total_response_time_sum": 0,
+                "vlan_id": 290,
+                "waasoptimization_segment": 16,
+                "ingress_interface": 13,
+                "exporter": {
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z",
+                    "uptime_millis": 0
+                },
+                "initiator_octets": 0,
+                "art_client_network_time_sum": 0,
+                "connection_sum_duration_seconds": 119,
+                "art_network_time_sum": 0,
+                "art_count_retransmissions": 0,
+                "art_count_late_responses": 0,
+                "art_count_transactions": 2,
+                "ingress_vrfid": 0,
+                "protocol_identifier": 6,
+                "new_connection_delta_count": 0,
+                "art_count_responses": 0
+            },
+            "host": {
+                "name": "mbp.local"
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "network": {
+                "transport": "tcp",
+                "iana_number": 6,
+                "bytes": 1179,
+                "packets": 7,
+                "direction": "unknown",
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0="
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "server": {
+                "bytes": 174,
+                "packets": 3
+            },
+            "destination": {
+                "bytes": 174,
+                "packets": 3
+            },
+            "netflow": {
+                "waasoptimization_segment": 16,
+                "initiator_packets": 4,
+                "art_count_retransmissions": 1,
+                "flow_start_sys_up_time": 564184326,
+                "connection_sum_duration_seconds": 119,
+                "initiator_octets": 1005,
+                "application_id": [
+                    3,
+                    0,
+                    5,
+                    153
+                ],
+                "ingress_interface": 13,
+                "art_server_response_time_sum": 5,
+                "responder_packets": 3,
+                "ip_ttl": 125,
+                "art_client_network_time_sum": 0,
+                "art_count_transactions": 1,
+                "art_total_transaction_time_sum": 12,
+                "protocol_identifier": 6,
+                "art_network_time_sum": 0,
+                "new_connection_delta_count": 0,
+                "art_server_response_time_maximum": 5,
+                "art_response_time_sum": 5,
+                "type": "netflow_flow",
+                "responder_octets": 174,
+                "art_server_network_time_sum": 0,
+                "art_count_responses": 1,
+                "egress_interface": 10,
+                "flow_end_sys_up_time": 564214476,
+                "biflow_direction": 1,
+                "ingress_vrfid": 0,
+                "art_total_response_time_sum": 8,
+                "exporter": {
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z",
+                    "uptime_millis": 0
+                },
+                "ip_diff_serv_code_point": 0,
+                "vlan_id": 290,
+                "art_count_late_responses": 0
+            },
+            "event": {
+                "kind": "event",
+                "category": "network_session",
+                "action": "netflow_flow",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.939Z"
+            },
+            "client": {
+                "bytes": 1005,
+                "packets": 4
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "agent": {
+                "name": "mbp.local",
+                "type": "filebeat",
+                "version": "8.0.0",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75"
+            },
+            "source": {
+                "bytes": 1005,
+                "packets": 4
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "agent": {
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "netflow": {
+                "art_server_network_time_sum": 0,
+                "vlan_id": 0,
+                "art_count_transactions": 2,
+                "responder_packets": 4,
+                "type": "netflow_flow",
+                "ingress_interface": 10,
+                "flow_end_sys_up_time": 564184490,
+                "protocol_identifier": 6,
+                "ingress_vrfid": 0,
+                "initiator_octets": 0,
+                "exporter": {
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z",
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512
+                },
+                "art_total_transaction_time_sum": 119644,
+                "art_response_time_sum": 0,
+                "responder_octets": 138,
+                "art_client_network_time_sum": 0,
+                "initiator_packets": 2,
+                "flow_start_sys_up_time": 564184336,
+                "ip_diff_serv_code_point": 0,
+                "connection_sum_duration_seconds": 238,
+                "egress_interface": 13,
+                "art_total_response_time_sum": 0,
+                "waasoptimization_segment": 16,
+                "art_network_time_sum": 0,
+                "art_server_response_time_sum": 0,
+                "art_server_response_time_maximum": 0,
+                "art_count_late_responses": 0,
+                "art_count_retransmissions": 0,
+                "biflow_direction": 2,
+                "art_count_responses": 0,
+                "application_id": [
+                    13,
+                    0,
+                    1,
+                    197
+                ],
+                "new_connection_delta_count": 0,
+                "ip_ttl": 61
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "iana_number": 6,
+                "bytes": 138,
+                "packets": 6,
+                "direction": "unknown"
+            },
+            "source": {
+                "packets": 4,
+                "bytes": 138
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "server": {
+                "bytes": 0,
+                "packets": 2
+            },
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 2
+            },
+            "event": {
+                "action": "netflow_flow",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.939Z",
+                "kind": "event",
+                "category": "network_session"
+            },
+            "client": {
+                "bytes": 138,
+                "packets": 4
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "host": {
+                "name": "mbp.local"
+            },
+            "agent": {
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "netflow": {
+                "art_total_response_time_sum": 0,
+                "initiator_octets": 0,
+                "flow_end_sys_up_time": 564184350,
+                "art_network_time_sum": 0,
+                "ingress_interface": 10,
+                "responder_octets": 31,
+                "art_server_response_time_sum": 0,
+                "art_count_transactions": 1,
+                "ingress_vrfid": 0,
+                "vlan_id": 0,
+                "application_id": [
+                    13,
+                    0,
+                    1,
+                    197
+                ],
+                "biflow_direction": 2,
+                "new_connection_delta_count": 0,
+                "initiator_packets": 1,
+                "art_client_network_time_sum": 0,
+                "exporter": {
+                    "timestamp": "2018-07-03T10:47:00.000Z",
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10
+                },
+                "art_response_time_sum": 0,
+                "type": "netflow_flow",
+                "art_count_responses": 0,
+                "waasoptimization_segment": 16,
+                "art_count_retransmissions": 0,
+                "ip_diff_serv_code_point": 0,
+                "ip_ttl": 43,
+                "art_count_late_responses": 0,
+                "art_total_transaction_time_sum": 59790,
+                "protocol_identifier": 6,
+                "flow_start_sys_up_time": 564184348,
+                "responder_packets": 2,
+                "art_server_response_time_maximum": 0,
+                "art_server_network_time_sum": 0,
+                "connection_sum_duration_seconds": 119,
+                "egress_interface": 13
+            },
+            "network": {
+                "iana_number": 6,
+                "bytes": 31,
+                "packets": 3,
+                "direction": "unknown",
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "client": {
+                "bytes": 31,
+                "packets": 2
+            },
+            "source": {
+                "bytes": 31,
+                "packets": 2
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "server": {
+                "packets": 1,
+                "bytes": 0
+            },
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "event": {
+                "category": "network_session",
+                "action": "netflow_flow",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.939Z",
+                "kind": "event"
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 1
+            },
+            "input": {
+                "type": "netflow"
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "event": {
+                "category": "network_session",
+                "action": "netflow_flow",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.939Z",
+                "kind": "event"
+            },
+            "flow": {
+                "id": "Vhs9T5k296w",
+                "locality": "internal"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "agent": {
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "client": {
+                "bytes": 13482,
+                "packets": 17
+            },
+            "destination": {
+                "bytes": 8989,
+                "packets": 19
+            },
+            "server": {
+                "bytes": 8989,
+                "packets": 19
+            },
+            "source": {
+                "bytes": 13482,
+                "packets": 17
+            },
+            "network": {
+                "packets": 36,
+                "direction": "unknown",
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "iana_number": 6,
+                "bytes": 22471
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "netflow": {
+                "application_id": [
+                    13,
+                    0,
+                    1,
+                    197
+                ],
+                "responder_packets": 17,
+                "new_connection_delta_count": 1,
+                "art_count_retransmissions": 0,
+                "art_count_transactions": 6,
+                "exporter": {
+                    "timestamp": "2018-07-03T10:47:00.000Z",
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10
+                },
+                "art_count_responses": 6,
+                "art_server_response_time_sum": 33,
+                "flow_end_sys_up_time": 564184586,
+                "art_total_transaction_time_sum": 43,
+                "egress_interface": 13,
+                "flow_start_sys_up_time": 564184356,
+                "art_network_time_sum": 3,
+                "initiator_packets": 19,
+                "type": "netflow_flow",
+                "art_response_time_sum": 33,
+                "ingress_interface": 10,
+                "art_server_network_time_sum": 0,
+                "waasoptimization_segment": 16,
+                "ingress_vrfid": 0,
+                "art_client_network_time_sum": 3,
+                "protocol_identifier": 6,
+                "responder_octets": 13482,
+                "ip_diff_serv_code_point": 0,
+                "art_total_response_time_sum": 51,
+                "art_count_late_responses": 0,
+                "ip_ttl": 124,
+                "art_server_response_time_maximum": 28,
+                "vlan_id": 0,
+                "biflow_direction": 2,
+                "initiator_octets": 8989,
+                "connection_sum_duration_seconds": 0
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            }
+        },
+        {
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "iana_number": 6,
+                "bytes": 261718,
+                "packets": 369,
+                "direction": "unknown"
+            },
+            "netflow": {
+                "ip_diff_serv_code_point": 0,
+                "connection_sum_duration_seconds": 116,
+                "art_count_transactions": 25,
+                "egress_interface": 13,
+                "new_connection_delta_count": 8,
+                "vlan_id": 0,
+                "biflow_direction": 2,
+                "art_response_time_sum": 301,
+                "art_total_response_time_sum": 363,
+                "art_network_time_sum": 58,
+                "art_server_network_time_sum": 38,
+                "type": "netflow_flow",
+                "flow_end_sys_up_time": 564215336,
+                "art_server_response_time_maximum": 31,
+                "art_server_response_time_sum": 168,
+                "ip_ttl": 61,
+                "art_total_transaction_time_sum": 332,
+                "responder_octets": 28373,
+                "protocol_identifier": 6,
+                "ingress_interface": 10,
+                "application_id": [
+                    13,
+                    0,
+                    2,
+                    99
+                ],
+                "responder_packets": 133,
+                "art_count_responses": 25,
+                "art_count_late_responses": 0,
+                "flow_start_sys_up_time": 564184380,
+                "ingress_vrfid": 0,
+                "waasoptimization_segment": 16,
+                "art_count_retransmissions": 4,
+                "exporter": {
+                    "timestamp": "2018-07-03T10:47:00.000Z",
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10
+                },
+                "initiator_octets": 233345,
+                "initiator_packets": 236,
+                "art_client_network_time_sum": 20
+            },
+            "client": {
+                "bytes": 28373,
+                "packets": 133
+            },
+            "server": {
+                "bytes": 233345,
+                "packets": 236
+            },
+            "source": {
+                "bytes": 28373,
+                "packets": 133
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "agent": {
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "name": "mbp.local",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            },
+            "destination": {
+                "packets": 236,
+                "bytes": 233345
+            },
+            "event": {
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.939Z",
+                "kind": "event",
+                "category": "network_session",
+                "action": "netflow_flow"
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            }
+        }
+    ]
+}

--- a/packages/netflow/data_stream/log/_dev/test/pipeline/test-netflow-log-events.json-config.yml
+++ b/packages/netflow/data_stream/log/_dev/test/pipeline/test-netflow-log-events.json-config.yml
@@ -1,0 +1,2 @@
+dynamic_fields:
+  event.ingested: "^.*$"

--- a/packages/netflow/data_stream/log/_dev/test/pipeline/test-netflow-log-events.json-expected.json
+++ b/packages/netflow/data_stream/log/_dev/test/pipeline/test-netflow-log-events.json-expected.json
@@ -1,0 +1,3049 @@
+{
+    "expected": [
+        {
+            "server": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "source": {
+                "bytes": 719,
+                "packets": 5
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 719,
+                "iana_number": "6",
+                "packets": 5,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 0,
+                "vlan_id": 0,
+                "responder_packets": 0,
+                "biflow_direction": 1,
+                "art_total_transaction_time_sum": 0,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 0,
+                "art_count_late_responses": 0,
+                "ip_ttl": 49,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 0,
+                "art_server_network_time_sum": 0,
+                "initiator_packets": 5,
+                "responder_octets": 0,
+                "art_response_time_sum": 0,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 0,
+                "flow_start_sys_up_time": 564184140,
+                "egress_interface": 13,
+                "initiator_octets": 719,
+                "art_server_response_time_sum": 0,
+                "application_id": [
+                    3,
+                    0,
+                    0,
+                    80
+                ],
+                "new_connection_delta_count": 1,
+                "art_client_network_time_sum": 0,
+                "art_count_responses": 0,
+                "connection_sum_duration_seconds": 0,
+                "art_count_retransmissions": 0,
+                "ingress_interface": 10,
+                "flow_end_sys_up_time": 564184158
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 719,
+                "packets": 5
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635402Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "source": {
+                "bytes": 1477,
+                "packets": 6
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 1477,
+                "iana_number": "6",
+                "packets": 6,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 0,
+                "vlan_id": 0,
+                "responder_packets": 0,
+                "biflow_direction": 1,
+                "art_total_transaction_time_sum": 0,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 0,
+                "art_count_late_responses": 0,
+                "ip_ttl": 49,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 0,
+                "art_server_network_time_sum": 0,
+                "initiator_packets": 6,
+                "responder_octets": 0,
+                "art_response_time_sum": 0,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 0,
+                "flow_start_sys_up_time": 564184140,
+                "egress_interface": 13,
+                "initiator_octets": 1477,
+                "art_server_response_time_sum": 0,
+                "application_id": [
+                    3,
+                    0,
+                    0,
+                    80
+                ],
+                "new_connection_delta_count": 1,
+                "art_client_network_time_sum": 0,
+                "art_count_responses": 0,
+                "connection_sum_duration_seconds": 0,
+                "art_count_retransmissions": 0,
+                "ingress_interface": 10,
+                "flow_end_sys_up_time": 564184154
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 1477,
+                "packets": 6
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635416600Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 0,
+                "packets": 1
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 1
+            },
+            "source": {
+                "bytes": 1,
+                "packets": 1
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 1,
+                "iana_number": "6",
+                "packets": 2,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 0,
+                "vlan_id": 290,
+                "responder_packets": 1,
+                "biflow_direction": 1,
+                "art_total_transaction_time_sum": 0,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 0,
+                "art_count_late_responses": 0,
+                "ip_ttl": 125,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 0,
+                "art_server_network_time_sum": 0,
+                "initiator_packets": 1,
+                "responder_octets": 0,
+                "art_response_time_sum": 0,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 0,
+                "flow_start_sys_up_time": 564184142,
+                "egress_interface": 10,
+                "initiator_octets": 1,
+                "art_server_response_time_sum": 0,
+                "application_id": [
+                    13,
+                    0,
+                    2,
+                    8
+                ],
+                "new_connection_delta_count": 0,
+                "art_client_network_time_sum": 0,
+                "art_count_responses": 0,
+                "connection_sum_duration_seconds": 89,
+                "art_count_retransmissions": 1,
+                "ingress_interface": 13,
+                "flow_end_sys_up_time": 564184144
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 1,
+                "packets": 1
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635425200Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "source": {
+                "bytes": 108580,
+                "packets": 79
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 108580,
+                "iana_number": "6",
+                "packets": 79,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 0,
+                "vlan_id": 0,
+                "responder_packets": 0,
+                "biflow_direction": 1,
+                "art_total_transaction_time_sum": 0,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 0,
+                "art_count_late_responses": 0,
+                "ip_ttl": 49,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 0,
+                "art_server_network_time_sum": 0,
+                "initiator_packets": 79,
+                "responder_octets": 0,
+                "art_response_time_sum": 0,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 0,
+                "flow_start_sys_up_time": 564184131,
+                "egress_interface": 13,
+                "initiator_octets": 108580,
+                "art_server_response_time_sum": 0,
+                "application_id": [
+                    3,
+                    0,
+                    0,
+                    80
+                ],
+                "new_connection_delta_count": 1,
+                "art_client_network_time_sum": 0,
+                "art_count_responses": 0,
+                "connection_sum_duration_seconds": 0,
+                "art_count_retransmissions": 2,
+                "ingress_interface": 10,
+                "flow_end_sys_up_time": 564184216
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 108580,
+                "packets": 79
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635429800Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "source": {
+                "bytes": 342,
+                "packets": 5
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 342,
+                "iana_number": "6",
+                "packets": 5,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 0,
+                "vlan_id": 0,
+                "responder_packets": 0,
+                "biflow_direction": 1,
+                "art_total_transaction_time_sum": 0,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 0,
+                "art_count_late_responses": 0,
+                "ip_ttl": 49,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 0,
+                "art_server_network_time_sum": 0,
+                "initiator_packets": 5,
+                "responder_octets": 0,
+                "art_response_time_sum": 0,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 0,
+                "flow_start_sys_up_time": 564184176,
+                "egress_interface": 13,
+                "initiator_octets": 342,
+                "art_server_response_time_sum": 0,
+                "application_id": [
+                    3,
+                    0,
+                    0,
+                    80
+                ],
+                "new_connection_delta_count": 1,
+                "art_client_network_time_sum": 0,
+                "art_count_responses": 0,
+                "connection_sum_duration_seconds": 0,
+                "art_count_retransmissions": 0,
+                "ingress_interface": 10,
+                "flow_end_sys_up_time": 564184208
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 342,
+                "packets": 5
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635438300Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 9437,
+                "packets": 18
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 9437,
+                "packets": 18
+            },
+            "source": {
+                "bytes": 1851,
+                "packets": 17
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 11288,
+                "iana_number": "6",
+                "packets": 35,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 97,
+                "vlan_id": 290,
+                "responder_packets": 18,
+                "biflow_direction": 1,
+                "art_total_transaction_time_sum": 100,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 156,
+                "art_count_late_responses": 0,
+                "ip_ttl": 125,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 2,
+                "art_server_network_time_sum": 95,
+                "initiator_packets": 17,
+                "responder_octets": 9437,
+                "art_response_time_sum": 153,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 8,
+                "flow_start_sys_up_time": 564184067,
+                "egress_interface": 10,
+                "initiator_octets": 1851,
+                "art_server_response_time_sum": 13,
+                "application_id": [
+                    13,
+                    0,
+                    1,
+                    197
+                ],
+                "new_connection_delta_count": 2,
+                "art_client_network_time_sum": 2,
+                "art_count_responses": 3,
+                "connection_sum_duration_seconds": 24,
+                "art_count_retransmissions": 0,
+                "ingress_interface": 13,
+                "flow_end_sys_up_time": 564197394
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 1851,
+                "packets": 17
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635447800Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "source": {
+                "bytes": 51480,
+                "packets": 39
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 51480,
+                "iana_number": "6",
+                "packets": 39,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 0,
+                "vlan_id": 0,
+                "responder_packets": 0,
+                "biflow_direction": 1,
+                "art_total_transaction_time_sum": 0,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 0,
+                "art_count_late_responses": 0,
+                "ip_ttl": 49,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 0,
+                "art_server_network_time_sum": 0,
+                "initiator_packets": 39,
+                "responder_octets": 0,
+                "art_response_time_sum": 0,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 0,
+                "flow_start_sys_up_time": 564184182,
+                "egress_interface": 13,
+                "initiator_octets": 51480,
+                "art_server_response_time_sum": 0,
+                "application_id": [
+                    3,
+                    0,
+                    0,
+                    80
+                ],
+                "new_connection_delta_count": 1,
+                "art_client_network_time_sum": 0,
+                "art_count_responses": 0,
+                "connection_sum_duration_seconds": 0,
+                "art_count_retransmissions": 0,
+                "ingress_interface": 10,
+                "flow_end_sys_up_time": 564184216
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 51480,
+                "packets": 39
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635457100Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 36894,
+                "packets": 47
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 36894,
+                "packets": 47
+            },
+            "source": {
+                "bytes": 5135,
+                "packets": 55
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 42029,
+                "iana_number": "6",
+                "packets": 102,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 374,
+                "vlan_id": 290,
+                "responder_packets": 47,
+                "biflow_direction": 1,
+                "art_total_transaction_time_sum": 512,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 541,
+                "art_count_late_responses": 0,
+                "ip_ttl": 126,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 14,
+                "art_server_network_time_sum": 364,
+                "initiator_packets": 55,
+                "responder_octets": 36894,
+                "art_response_time_sum": 516,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 27,
+                "flow_start_sys_up_time": 564184040,
+                "egress_interface": 10,
+                "initiator_octets": 5135,
+                "art_server_response_time_sum": 117,
+                "application_id": [
+                    13,
+                    0,
+                    1,
+                    197
+                ],
+                "new_connection_delta_count": 6,
+                "art_client_network_time_sum": 10,
+                "art_count_responses": 15,
+                "connection_sum_duration_seconds": 35,
+                "art_count_retransmissions": 0,
+                "ingress_interface": 13,
+                "flow_end_sys_up_time": 564203810
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 5135,
+                "packets": 55
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635469400Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 6400,
+                "packets": 20
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 6400,
+                "packets": 20
+            },
+            "source": {
+                "bytes": 6533,
+                "packets": 14
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 12933,
+                "iana_number": "6",
+                "packets": 34,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 23,
+                "vlan_id": 0,
+                "responder_packets": 14,
+                "biflow_direction": 2,
+                "art_total_transaction_time_sum": 123,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 138,
+                "art_count_late_responses": 0,
+                "ip_ttl": 61,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 6,
+                "art_server_network_time_sum": 18,
+                "initiator_packets": 20,
+                "responder_octets": 6533,
+                "art_response_time_sum": 123,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 31,
+                "flow_start_sys_up_time": 564184163,
+                "egress_interface": 13,
+                "initiator_octets": 6400,
+                "art_server_response_time_sum": 78,
+                "application_id": [
+                    13,
+                    0,
+                    2,
+                    99
+                ],
+                "new_connection_delta_count": 2,
+                "art_client_network_time_sum": 5,
+                "art_count_responses": 6,
+                "connection_sum_duration_seconds": 64,
+                "art_count_retransmissions": 1,
+                "ingress_interface": 10,
+                "flow_end_sys_up_time": 564200378
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 6533,
+                "packets": 14
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635480900Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "source": {
+                "bytes": 5684,
+                "packets": 491
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 5684,
+                "iana_number": "6",
+                "packets": 491,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 0,
+                "vlan_id": 290,
+                "responder_packets": 0,
+                "biflow_direction": 1,
+                "art_total_transaction_time_sum": 0,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 0,
+                "art_count_late_responses": 0,
+                "ip_ttl": 125,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 0,
+                "art_server_network_time_sum": 0,
+                "initiator_packets": 491,
+                "responder_octets": 0,
+                "art_response_time_sum": 0,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 0,
+                "flow_start_sys_up_time": 564184196,
+                "egress_interface": 10,
+                "initiator_octets": 5684,
+                "art_server_response_time_sum": 0,
+                "application_id": [
+                    13,
+                    0,
+                    0,
+                    49
+                ],
+                "new_connection_delta_count": 0,
+                "art_client_network_time_sum": 0,
+                "art_count_responses": 0,
+                "connection_sum_duration_seconds": 109,
+                "art_count_retransmissions": 0,
+                "ingress_interface": 13,
+                "flow_end_sys_up_time": 564185840
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 5684,
+                "packets": 491
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635492800Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "source": {
+                "bytes": 4965,
+                "packets": 13
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 4965,
+                "iana_number": "6",
+                "packets": 13,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 0,
+                "vlan_id": 290,
+                "responder_packets": 0,
+                "biflow_direction": 1,
+                "art_total_transaction_time_sum": 0,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 0,
+                "art_count_late_responses": 0,
+                "ip_ttl": 125,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 0,
+                "art_server_network_time_sum": 0,
+                "initiator_packets": 13,
+                "responder_octets": 0,
+                "art_response_time_sum": 0,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 0,
+                "flow_start_sys_up_time": 564184154,
+                "egress_interface": 10,
+                "initiator_octets": 4965,
+                "art_server_response_time_sum": 0,
+                "application_id": [
+                    13,
+                    0,
+                    1,
+                    197
+                ],
+                "new_connection_delta_count": 1,
+                "art_client_network_time_sum": 0,
+                "art_count_responses": 0,
+                "connection_sum_duration_seconds": 0,
+                "art_count_retransmissions": 0,
+                "ingress_interface": 13,
+                "flow_end_sys_up_time": 564184254
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 4965,
+                "packets": 13
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635504300Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 0,
+                "packets": 2
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 2
+            },
+            "source": {
+                "bytes": 138,
+                "packets": 4
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 138,
+                "iana_number": "6",
+                "packets": 6,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 0,
+                "vlan_id": 0,
+                "responder_packets": 4,
+                "biflow_direction": 2,
+                "art_total_transaction_time_sum": 119878,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 0,
+                "art_count_late_responses": 0,
+                "ip_ttl": 61,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 2,
+                "art_server_network_time_sum": 0,
+                "initiator_packets": 2,
+                "responder_octets": 138,
+                "art_response_time_sum": 0,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 0,
+                "flow_start_sys_up_time": 564184214,
+                "egress_interface": 13,
+                "initiator_octets": 0,
+                "art_server_response_time_sum": 0,
+                "application_id": [
+                    13,
+                    0,
+                    2,
+                    99
+                ],
+                "new_connection_delta_count": 0,
+                "art_client_network_time_sum": 0,
+                "art_count_responses": 0,
+                "connection_sum_duration_seconds": 239,
+                "art_count_retransmissions": 0,
+                "ingress_interface": 10,
+                "flow_end_sys_up_time": 564184362
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 138,
+                "packets": 4
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635516400Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "source": {
+                "bytes": 1,
+                "packets": 1
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 1,
+                "iana_number": "6",
+                "packets": 1,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 0,
+                "vlan_id": 290,
+                "responder_packets": 0,
+                "biflow_direction": 1,
+                "art_total_transaction_time_sum": 0,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 0,
+                "art_count_late_responses": 0,
+                "ip_ttl": 125,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 0,
+                "art_server_network_time_sum": 0,
+                "initiator_packets": 1,
+                "responder_octets": 0,
+                "art_response_time_sum": 0,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 0,
+                "flow_start_sys_up_time": 564184220,
+                "egress_interface": 10,
+                "initiator_octets": 1,
+                "art_server_response_time_sum": 0,
+                "application_id": [
+                    13,
+                    0,
+                    2,
+                    8
+                ],
+                "new_connection_delta_count": 0,
+                "art_client_network_time_sum": 0,
+                "art_count_responses": 0,
+                "connection_sum_duration_seconds": 44,
+                "art_count_retransmissions": 1,
+                "ingress_interface": 13,
+                "flow_end_sys_up_time": 564184220
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 1,
+                "packets": 1
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635526100Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 1571,
+                "packets": 13
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 1571,
+                "packets": 13
+            },
+            "source": {
+                "bytes": 6079,
+                "packets": 10
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 7650,
+                "iana_number": "6",
+                "packets": 23,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 149,
+                "vlan_id": 0,
+                "responder_packets": 10,
+                "biflow_direction": 2,
+                "art_total_transaction_time_sum": 296,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 453,
+                "art_count_late_responses": 0,
+                "ip_ttl": 220,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 2,
+                "art_server_network_time_sum": 146,
+                "initiator_packets": 13,
+                "responder_octets": 6079,
+                "art_response_time_sum": 444,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 3,
+                "flow_start_sys_up_time": 564184067,
+                "egress_interface": 13,
+                "initiator_octets": 1571,
+                "art_server_response_time_sum": 6,
+                "application_id": [
+                    13,
+                    0,
+                    1,
+                    197
+                ],
+                "new_connection_delta_count": 1,
+                "art_client_network_time_sum": 3,
+                "art_count_responses": 3,
+                "connection_sum_duration_seconds": 62,
+                "art_count_retransmissions": 0,
+                "ingress_interface": 10,
+                "flow_end_sys_up_time": 564215068
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 6079,
+                "packets": 10
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635533600Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "source": {
+                "bytes": 2807,
+                "packets": 6
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 2807,
+                "iana_number": "6",
+                "packets": 6,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 0,
+                "vlan_id": 0,
+                "responder_packets": 0,
+                "biflow_direction": 1,
+                "art_total_transaction_time_sum": 0,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 0,
+                "art_count_late_responses": 0,
+                "ip_ttl": 61,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 0,
+                "art_server_network_time_sum": 0,
+                "initiator_packets": 6,
+                "responder_octets": 0,
+                "art_response_time_sum": 0,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 0,
+                "flow_start_sys_up_time": 564183878,
+                "egress_interface": 13,
+                "initiator_octets": 2807,
+                "art_server_response_time_sum": 0,
+                "application_id": [
+                    13,
+                    0,
+                    1,
+                    197
+                ],
+                "new_connection_delta_count": 1,
+                "art_client_network_time_sum": 0,
+                "art_count_responses": 0,
+                "connection_sum_duration_seconds": 0,
+                "art_count_retransmissions": 0,
+                "ingress_interface": 10,
+                "flow_end_sys_up_time": 564184252
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 2807,
+                "packets": 6
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635538Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "source": {
+                "bytes": 0,
+                "packets": 1
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 0,
+                "iana_number": "6",
+                "packets": 1,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 0,
+                "vlan_id": 0,
+                "responder_packets": 0,
+                "biflow_direction": 1,
+                "art_total_transaction_time_sum": 0,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 0,
+                "art_count_late_responses": 0,
+                "ip_ttl": 124,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 0,
+                "art_server_network_time_sum": 0,
+                "initiator_packets": 1,
+                "responder_octets": 0,
+                "art_response_time_sum": 0,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 0,
+                "flow_start_sys_up_time": 564184248,
+                "egress_interface": 4,
+                "initiator_octets": 0,
+                "art_server_response_time_sum": 0,
+                "application_id": [
+                    13,
+                    0,
+                    0,
+                    1
+                ],
+                "new_connection_delta_count": 0,
+                "art_client_network_time_sum": 0,
+                "art_count_responses": 0,
+                "connection_sum_duration_seconds": 59,
+                "art_count_retransmissions": 0,
+                "ingress_interface": 1,
+                "flow_end_sys_up_time": 564184248
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 0,
+                "packets": 1
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635546Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 3409,
+                "packets": 7
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 3409,
+                "packets": 7
+            },
+            "source": {
+                "bytes": 1877,
+                "packets": 11
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 5286,
+                "iana_number": "6",
+                "packets": 18,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 6,
+                "vlan_id": 290,
+                "responder_packets": 7,
+                "biflow_direction": 1,
+                "art_total_transaction_time_sum": 23,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 31,
+                "art_count_late_responses": 0,
+                "ip_ttl": 125,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 4,
+                "art_server_network_time_sum": 4,
+                "initiator_packets": 11,
+                "responder_octets": 3409,
+                "art_response_time_sum": 23,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 3,
+                "flow_start_sys_up_time": 564184251,
+                "egress_interface": 10,
+                "initiator_octets": 1877,
+                "art_server_response_time_sum": 7,
+                "application_id": [
+                    13,
+                    0,
+                    1,
+                    197
+                ],
+                "new_connection_delta_count": 1,
+                "art_client_network_time_sum": 2,
+                "art_count_responses": 4,
+                "connection_sum_duration_seconds": 32,
+                "art_count_retransmissions": 0,
+                "ingress_interface": 13,
+                "flow_end_sys_up_time": 564200378
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 1877,
+                "packets": 11
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635558800Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "source": {
+                "bytes": 2255,
+                "packets": 7
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 2255,
+                "iana_number": "6",
+                "packets": 7,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 0,
+                "vlan_id": 0,
+                "responder_packets": 0,
+                "biflow_direction": 1,
+                "art_total_transaction_time_sum": 0,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 0,
+                "art_count_late_responses": 0,
+                "ip_ttl": 61,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 0,
+                "art_server_network_time_sum": 0,
+                "initiator_packets": 7,
+                "responder_octets": 0,
+                "art_response_time_sum": 0,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 0,
+                "flow_start_sys_up_time": 564184040,
+                "egress_interface": 13,
+                "initiator_octets": 2255,
+                "art_server_response_time_sum": 0,
+                "application_id": [
+                    13,
+                    0,
+                    1,
+                    197
+                ],
+                "new_connection_delta_count": 1,
+                "art_client_network_time_sum": 0,
+                "art_count_responses": 0,
+                "connection_sum_duration_seconds": 0,
+                "art_count_retransmissions": 0,
+                "ingress_interface": 10,
+                "flow_end_sys_up_time": 564184286
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 2255,
+                "packets": 7
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635570800Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 0
+            },
+            "source": {
+                "bytes": 538,
+                "packets": 5
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 538,
+                "iana_number": "6",
+                "packets": 5,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 0,
+                "vlan_id": 0,
+                "responder_packets": 0,
+                "biflow_direction": 1,
+                "art_total_transaction_time_sum": 0,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 0,
+                "art_count_late_responses": 0,
+                "ip_ttl": 49,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 0,
+                "art_server_network_time_sum": 0,
+                "initiator_packets": 5,
+                "responder_octets": 0,
+                "art_response_time_sum": 0,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 0,
+                "flow_start_sys_up_time": 564184284,
+                "egress_interface": 13,
+                "initiator_octets": 538,
+                "art_server_response_time_sum": 0,
+                "application_id": [
+                    3,
+                    0,
+                    0,
+                    80
+                ],
+                "new_connection_delta_count": 1,
+                "art_client_network_time_sum": 0,
+                "art_count_responses": 0,
+                "connection_sum_duration_seconds": 0,
+                "art_count_retransmissions": 0,
+                "ingress_interface": 10,
+                "flow_end_sys_up_time": 564184314
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 538,
+                "packets": 5
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635580400Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.938Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 6305,
+                "packets": 15
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 6305,
+                "packets": 15
+            },
+            "source": {
+                "bytes": 1487,
+                "packets": 21
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 7792,
+                "iana_number": "6",
+                "packets": 36,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 9,
+                "vlan_id": 290,
+                "responder_packets": 15,
+                "biflow_direction": 1,
+                "art_total_transaction_time_sum": 59870,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 77,
+                "art_count_late_responses": 0,
+                "ip_ttl": 125,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 5,
+                "art_server_network_time_sum": 7,
+                "initiator_packets": 21,
+                "responder_octets": 6305,
+                "art_response_time_sum": 72,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 25,
+                "flow_start_sys_up_time": 564184296,
+                "egress_interface": 10,
+                "initiator_octets": 1487,
+                "art_server_response_time_sum": 55,
+                "application_id": [
+                    13,
+                    0,
+                    2,
+                    102
+                ],
+                "new_connection_delta_count": 2,
+                "art_client_network_time_sum": 2,
+                "art_count_responses": 5,
+                "connection_sum_duration_seconds": 181,
+                "art_count_retransmissions": 0,
+                "ingress_interface": 13,
+                "flow_end_sys_up_time": 564214304
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 1487,
+                "packets": 21
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635585600Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.939Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 1973,
+                "packets": 10
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 1973,
+                "packets": 10
+            },
+            "source": {
+                "bytes": 3110,
+                "packets": 7
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 5083,
+                "iana_number": "6",
+                "packets": 17,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 12,
+                "vlan_id": 0,
+                "responder_packets": 7,
+                "biflow_direction": 2,
+                "art_total_transaction_time_sum": 39,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 45,
+                "art_count_late_responses": 0,
+                "ip_ttl": 61,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 3,
+                "art_server_network_time_sum": 10,
+                "initiator_packets": 10,
+                "responder_octets": 3110,
+                "art_response_time_sum": 39,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 14,
+                "flow_start_sys_up_time": 564184268,
+                "egress_interface": 13,
+                "initiator_octets": 1973,
+                "art_server_response_time_sum": 15,
+                "application_id": [
+                    13,
+                    0,
+                    2,
+                    99
+                ],
+                "new_connection_delta_count": 1,
+                "art_client_network_time_sum": 2,
+                "art_count_responses": 3,
+                "connection_sum_duration_seconds": 32,
+                "art_count_retransmissions": 0,
+                "ingress_interface": 10,
+                "flow_end_sys_up_time": 564200376
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 3110,
+                "packets": 7
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635590400Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.939Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 2,
+                "packets": 4
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 2,
+                "packets": 4
+            },
+            "source": {
+                "bytes": 2,
+                "packets": 4
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 4,
+                "iana_number": "6",
+                "packets": 8,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 0,
+                "vlan_id": 0,
+                "responder_packets": 4,
+                "biflow_direction": 2,
+                "art_total_transaction_time_sum": 0,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 0,
+                "art_count_late_responses": 0,
+                "ip_ttl": 124,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 0,
+                "art_server_network_time_sum": 0,
+                "initiator_packets": 4,
+                "responder_octets": 2,
+                "art_response_time_sum": 0,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 0,
+                "flow_start_sys_up_time": 564184300,
+                "egress_interface": 13,
+                "initiator_octets": 2,
+                "art_server_response_time_sum": 0,
+                "application_id": [
+                    3,
+                    0,
+                    5,
+                    153
+                ],
+                "new_connection_delta_count": 0,
+                "art_client_network_time_sum": 0,
+                "art_count_responses": 0,
+                "connection_sum_duration_seconds": 119,
+                "art_count_retransmissions": 2,
+                "ingress_interface": 10,
+                "flow_end_sys_up_time": 564214242
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 2,
+                "packets": 4
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635594400Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.939Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 0,
+                "packets": 2
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 2
+            },
+            "source": {
+                "bytes": 2,
+                "packets": 2
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 2,
+                "iana_number": "6",
+                "packets": 4,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 0,
+                "vlan_id": 290,
+                "responder_packets": 2,
+                "biflow_direction": 1,
+                "art_total_transaction_time_sum": 0,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 0,
+                "art_count_late_responses": 0,
+                "ip_ttl": 125,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 0,
+                "art_server_network_time_sum": 0,
+                "initiator_packets": 2,
+                "responder_octets": 0,
+                "art_response_time_sum": 0,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 0,
+                "flow_start_sys_up_time": 564184306,
+                "egress_interface": 10,
+                "initiator_octets": 2,
+                "art_server_response_time_sum": 0,
+                "application_id": [
+                    3,
+                    0,
+                    0,
+                    80
+                ],
+                "new_connection_delta_count": 0,
+                "art_client_network_time_sum": 0,
+                "art_count_responses": 0,
+                "connection_sum_duration_seconds": 179,
+                "art_count_retransmissions": 2,
+                "ingress_interface": 13,
+                "flow_end_sys_up_time": 564184580
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 2,
+                "packets": 2
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635601700Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.939Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 0,
+                "packets": 2
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 2
+            },
+            "source": {
+                "bytes": 0,
+                "packets": 4
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 0,
+                "iana_number": "6",
+                "packets": 6,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 0,
+                "vlan_id": 290,
+                "responder_packets": 2,
+                "biflow_direction": 1,
+                "art_total_transaction_time_sum": 18,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 0,
+                "art_count_late_responses": 0,
+                "ip_ttl": 125,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 2,
+                "art_server_network_time_sum": 0,
+                "initiator_packets": 4,
+                "responder_octets": 0,
+                "art_response_time_sum": 0,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 0,
+                "flow_start_sys_up_time": 564184326,
+                "egress_interface": 10,
+                "initiator_octets": 0,
+                "art_server_response_time_sum": 0,
+                "application_id": [
+                    13,
+                    0,
+                    1,
+                    197
+                ],
+                "new_connection_delta_count": 0,
+                "art_client_network_time_sum": 0,
+                "art_count_responses": 0,
+                "connection_sum_duration_seconds": 119,
+                "art_count_retransmissions": 0,
+                "ingress_interface": 13,
+                "flow_end_sys_up_time": 564184326
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 0,
+                "packets": 4
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635610300Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.939Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 174,
+                "packets": 3
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 174,
+                "packets": 3
+            },
+            "source": {
+                "bytes": 1005,
+                "packets": 4
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 1179,
+                "iana_number": "6",
+                "packets": 7,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 0,
+                "vlan_id": 290,
+                "responder_packets": 3,
+                "biflow_direction": 1,
+                "art_total_transaction_time_sum": 12,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 8,
+                "art_count_late_responses": 0,
+                "ip_ttl": 125,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 1,
+                "art_server_network_time_sum": 0,
+                "initiator_packets": 4,
+                "responder_octets": 174,
+                "art_response_time_sum": 5,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 5,
+                "flow_start_sys_up_time": 564184326,
+                "egress_interface": 10,
+                "initiator_octets": 1005,
+                "art_server_response_time_sum": 5,
+                "application_id": [
+                    3,
+                    0,
+                    5,
+                    153
+                ],
+                "new_connection_delta_count": 0,
+                "art_client_network_time_sum": 0,
+                "art_count_responses": 1,
+                "connection_sum_duration_seconds": 119,
+                "art_count_retransmissions": 1,
+                "ingress_interface": 13,
+                "flow_end_sys_up_time": 564214476
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 1005,
+                "packets": 4
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635622600Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.939Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 0,
+                "packets": 2
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 2
+            },
+            "source": {
+                "bytes": 138,
+                "packets": 4
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 138,
+                "iana_number": "6",
+                "packets": 6,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 0,
+                "vlan_id": 0,
+                "responder_packets": 4,
+                "biflow_direction": 2,
+                "art_total_transaction_time_sum": 119644,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 0,
+                "art_count_late_responses": 0,
+                "ip_ttl": 61,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 2,
+                "art_server_network_time_sum": 0,
+                "initiator_packets": 2,
+                "responder_octets": 138,
+                "art_response_time_sum": 0,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 0,
+                "flow_start_sys_up_time": 564184336,
+                "egress_interface": 13,
+                "initiator_octets": 0,
+                "art_server_response_time_sum": 0,
+                "application_id": [
+                    13,
+                    0,
+                    1,
+                    197
+                ],
+                "new_connection_delta_count": 0,
+                "art_client_network_time_sum": 0,
+                "art_count_responses": 0,
+                "connection_sum_duration_seconds": 238,
+                "art_count_retransmissions": 0,
+                "ingress_interface": 10,
+                "flow_end_sys_up_time": 564184490
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 138,
+                "packets": 4
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635635Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.939Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 0,
+                "packets": 1
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 0,
+                "packets": 1
+            },
+            "source": {
+                "bytes": 31,
+                "packets": 2
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 31,
+                "iana_number": "6",
+                "packets": 3,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 0,
+                "vlan_id": 0,
+                "responder_packets": 2,
+                "biflow_direction": 2,
+                "art_total_transaction_time_sum": 59790,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 0,
+                "art_count_late_responses": 0,
+                "ip_ttl": 43,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 1,
+                "art_server_network_time_sum": 0,
+                "initiator_packets": 1,
+                "responder_octets": 31,
+                "art_response_time_sum": 0,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 0,
+                "flow_start_sys_up_time": 564184348,
+                "egress_interface": 13,
+                "initiator_octets": 0,
+                "art_server_response_time_sum": 0,
+                "application_id": [
+                    13,
+                    0,
+                    1,
+                    197
+                ],
+                "new_connection_delta_count": 0,
+                "art_client_network_time_sum": 0,
+                "art_count_responses": 0,
+                "connection_sum_duration_seconds": 119,
+                "art_count_retransmissions": 0,
+                "ingress_interface": 10,
+                "flow_end_sys_up_time": 564184350
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 31,
+                "packets": 2
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635644200Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.939Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 8989,
+                "packets": 19
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 8989,
+                "packets": 19
+            },
+            "source": {
+                "bytes": 13482,
+                "packets": 17
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 22471,
+                "iana_number": "6",
+                "packets": 36,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 3,
+                "vlan_id": 0,
+                "responder_packets": 17,
+                "biflow_direction": 2,
+                "art_total_transaction_time_sum": 43,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 51,
+                "art_count_late_responses": 0,
+                "ip_ttl": 124,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 6,
+                "art_server_network_time_sum": 0,
+                "initiator_packets": 19,
+                "responder_octets": 13482,
+                "art_response_time_sum": 33,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 28,
+                "flow_start_sys_up_time": 564184356,
+                "egress_interface": 13,
+                "initiator_octets": 8989,
+                "art_server_response_time_sum": 33,
+                "application_id": [
+                    13,
+                    0,
+                    1,
+                    197
+                ],
+                "new_connection_delta_count": 1,
+                "art_client_network_time_sum": 3,
+                "art_count_responses": 6,
+                "connection_sum_duration_seconds": 0,
+                "art_count_retransmissions": 0,
+                "ingress_interface": 10,
+                "flow_end_sys_up_time": 564184586
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 13482,
+                "packets": 17
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635695900Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.939Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        },
+        {
+            "server": {
+                "bytes": 233345,
+                "packets": 236
+            },
+            "agent": {
+                "name": "mbp.local",
+                "id": "508165af-d28d-4de1-bbb3-e81aafd32d75",
+                "ephemeral_id": "0a75cedf-6ef5-4932-8d1b-43b0d1b4739c",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "destination": {
+                "bytes": 233345,
+                "packets": 236
+            },
+            "source": {
+                "bytes": 28373,
+                "packets": 133
+            },
+            "network": {
+                "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
+                "transport": "tcp",
+                "bytes": 261718,
+                "iana_number": "6",
+                "packets": 369,
+                "direction": "unknown"
+            },
+            "input": {
+                "type": "netflow"
+            },
+            "observer": {
+                "ip": "127.0.0.1"
+            },
+            "netflow": {
+                "art_network_time_sum": 58,
+                "vlan_id": 0,
+                "responder_packets": 133,
+                "biflow_direction": 2,
+                "art_total_transaction_time_sum": 332,
+                "waasoptimization_segment": 16,
+                "ip_diff_serv_code_point": 0,
+                "type": "netflow_flow",
+                "art_total_response_time_sum": 363,
+                "art_count_late_responses": 0,
+                "ip_ttl": 61,
+                "exporter": {
+                    "uptime_millis": 0,
+                    "address": "127.0.0.1:62809",
+                    "source_id": 512,
+                    "version": 10,
+                    "timestamp": "2018-07-03T10:47:00.000Z"
+                },
+                "ingress_vrfid": 0,
+                "art_count_transactions": 25,
+                "art_server_network_time_sum": 38,
+                "initiator_packets": 236,
+                "responder_octets": 28373,
+                "art_response_time_sum": 301,
+                "protocol_identifier": 6,
+                "art_server_response_time_maximum": 31,
+                "flow_start_sys_up_time": 564184380,
+                "egress_interface": 13,
+                "initiator_octets": 233345,
+                "art_server_response_time_sum": 168,
+                "application_id": [
+                    13,
+                    0,
+                    2,
+                    99
+                ],
+                "new_connection_delta_count": 8,
+                "art_client_network_time_sum": 20,
+                "art_count_responses": 25,
+                "connection_sum_duration_seconds": 116,
+                "art_count_retransmissions": 4,
+                "ingress_interface": 10,
+                "flow_end_sys_up_time": 564215336
+            },
+            "@timestamp": "2018-07-03T10:47:00.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "host": {
+                "name": "mbp.local"
+            },
+            "client": {
+                "bytes": 28373,
+                "packets": 133
+            },
+            "event": {
+                "action": "netflow_flow",
+                "ingested": "2021-05-19T09:26:13.635705500Z",
+                "category": "network_session",
+                "type": [
+                    "connection"
+                ],
+                "created": "2021-05-19T09:08:51.939Z",
+                "kind": "event"
+            },
+            "flow": {
+                "locality": "internal",
+                "id": "Vhs9T5k296w"
+            }
+        }
+    ]
+}

--- a/packages/netflow/data_stream/log/agent/stream/netflow.yml.hbs
+++ b/packages/netflow/data_stream/log/agent/stream/netflow.yml.hbs
@@ -25,9 +25,3 @@ tags:
 {{#contains tags "forwarded"}}
 publisher_pipeline.disable_host: true
 {{/contains}}
-
-processors:
-  - add_fields:
-      target: ''
-      fields:
-        ecs.version: 1.9.0

--- a/packages/netflow/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/netflow/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -6,6 +6,16 @@ processors:
       field: event.ingested
       value: '{{_ingest.timestamp}}'
 
+  - set:
+      field: ecs.version
+      value: 1.9.0
+
+  - convert:
+      field: network.iana_number
+      type: string
+      ignore_missing: true
+      ignore_failure: true
+
   # IP Geolocation Lookup
   - geoip:
         if: ctx.source?.geo == null
@@ -16,7 +26,7 @@ processors:
         if: ctx.destination?.geo == null
         field: destination.ip
         target_field: destination.geo
-        ignore_missing: true
+        ignore_missing: true 
 
   # IP Autonomous System (AS) Lookup
   - geoip:

--- a/packages/netflow/manifest.yml
+++ b/packages/netflow/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: netflow
 title: NetFlow
-version: 0.3.8
+version: 0.3.9
 license: basic
 description: NetFlow Integration
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Moves ecs.version to the ingest pipeline and add pipeline tests.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #961 

