### PR TITLE
Fix broken Cisco package

### DIFF
--- a/packages/cisco/changelog.yml
+++ b/packages/cisco/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: fix broken package
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/TODO
+      link: https://github.com/elastic/integrations/pull/1011
 - version: "0.9.0"
   changes:
     - description: parse additional log types

--- a/packages/cisco/changelog.yml
+++ b/packages/cisco/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.9.1"
+  changes:
+    - description: fix broken package
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/TODO
 - version: "0.9.0"
   changes:
     - description: parse additional log types

--- a/packages/cisco/manifest.yml
+++ b/packages/cisco/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco
 title: Cisco
-version: 0.9.0
+version: 0.9.1
 license: basic
 description: Cisco Integration
 type: integration
@@ -28,13 +28,10 @@ policy_templates:
     inputs:
       - type: udp
         title: Collect logs from Cisco via UDP
-        description: Collecting logs from Cisco ASA, FTD, Nexus and Meraki via UDP
-      - type: syslog
-        title: Collect logs from Cisco via syslog
-        description: Collecting logs from Cisco IOS via syslog
+        description: Collecting logs from Cisco via UDP
       - type: logfile
         title: Collect logs from Cisco via file
-        description: Collecting logs from Cisco ASA, FTD, IOS, Nexus and Meraki via file
+        description: Collecting logs from Cisco via file
       - type: tcp
         title: Collect logs from Cisco Nexus via TCP
         description: Collecting syslog from Cisco Nexus and Meraki via TCP


### PR DESCRIPTION
## What does this PR do?

Fixes the Cisco package being broken (not-installable).

It would cause the following error in Kibana when trying to configure it:

```
kbn-ui-shared-deps.js:382 TypeError: Root value is not flatten-able, received undefined
    at getFlattenedObject (:9243/39457/bundles/plugin/fleet/fleet.chunk.0.js:3)
    at countValidationErrors (:9243/39457/bundles/plugin/fleet/fleet.chunk.2.js:39)
    at :9243/39457/bundles/plugin/fleet/fleet.chunk.2.js:39
    [...]
```

Due to an input defined in the main manifest.yml that was not used by any data stream.

The package seem to have been broken for a long time.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Related issues

- Closes https://github.com/elastic/kibana/issues/100340
