### PR TITLE
[Synthetics] bump version to 0.1.0 for 7.13.0 release

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: bump version to 0.1.0 for 7.13.0 release
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/1016
 - version: "0.0.6"
   changes:
     - description: update README

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Monitor services availability.
-version: 0.0.6
+version: 0.1.0
 categories: ["custom"]
 release: beta
 type: integration


### PR DESCRIPTION
This PR bumps the version to 0.1.0 for the 7.13.0 release.