### PR TITLE
[google_workspace] Use fingerprint of id object as document id

### DIFF
--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: add fingerprint processor to avoid duplicated events.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1019
 - version: "0.3.0"
   changes:
     - description: move edge processing to ingest pipelines

--- a/packages/google_workspace/data_stream/admin/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/admin/elasticsearch/ingest_pipeline/default.yml
@@ -31,6 +31,13 @@ processors:
       field: json.events.name
       target_field: event.action
       ignore_missing: true
+  - fingerprint:
+      description: Hashes the ID object and uses it as the document id to avoid duplicate events.
+      fields:
+        - json.id
+      target_field: _id
+      ignore_missing: true
+      ignore_failure: true
   - rename: 
       field: json.id.applicationName
       target_field: event.provider

--- a/packages/google_workspace/data_stream/drive/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/drive/elasticsearch/ingest_pipeline/default.yml
@@ -31,6 +31,13 @@ processors:
       field: json.events.name
       target_field: event.action
       ignore_missing: true
+  - fingerprint:
+      description: Hashes the ID object and uses it as the document id to avoid duplicate events.
+      fields:
+        - json.id
+      target_field: _id
+      ignore_missing: true
+      ignore_failure: true
   - rename:
       field: json.id.applicationName
       target_field: event.provider

--- a/packages/google_workspace/data_stream/groups/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/groups/elasticsearch/ingest_pipeline/default.yml
@@ -34,6 +34,13 @@ processors:
       field: json.events.name
       target_field: event.action
       ignore_missing: true
+  - fingerprint:
+      description: Hashes the ID object and uses it as the document id to avoid duplicate events.
+      fields:
+        - json.id
+      target_field: _id
+      ignore_missing: true
+      ignore_failure: true
   - rename:
       field: json.id.applicationName
       target_field: event.provider

--- a/packages/google_workspace/data_stream/login/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/login/elasticsearch/ingest_pipeline/default.yml
@@ -31,6 +31,13 @@ processors:
       field: json.events.name
       target_field: event.action
       ignore_missing: true
+  - fingerprint:
+      description: Hashes the ID object and uses it as the document id to avoid duplicate events.
+      fields:
+        - json.id
+      target_field: _id
+      ignore_missing: true
+      ignore_failure: true
   - rename:
       field: json.id.applicationName
       target_field: event.provider

--- a/packages/google_workspace/data_stream/saml/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/saml/elasticsearch/ingest_pipeline/default.yml
@@ -37,6 +37,13 @@ processors:
       field: json.events.name
       target_field: event.action
       ignore_missing: true
+  - fingerprint:
+      description: Hashes the ID object and uses it as the document id to avoid duplicate events.
+      fields:
+        - json.id
+      target_field: _id
+      ignore_missing: true
+      ignore_failure: true
   - rename:
       field: json.id.applicationName
       target_field: event.provider

--- a/packages/google_workspace/data_stream/user_accounts/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/user_accounts/elasticsearch/ingest_pipeline/default.yml
@@ -37,6 +37,13 @@ processors:
       field: json.events.name
       target_field: event.action
       ignore_missing: true
+  - fingerprint:
+      description: Hashes the ID object and uses it as the document id to avoid duplicate events.
+      fields:
+        - json.id
+      target_field: _id
+      ignore_missing: true
+      ignore_failure: true
   - rename:
       field: json.id.applicationName
       target_field: event.provider

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: 0.3.0
+version: 0.3.1
 release: experimental
 description: Google Workspace Integration
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Adds a fingerprint processor for the `json.id` object, and uses it as the document id to prevent duplicated events in case of re processing.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~
