### PR TITLE
Update dependency on elastic-package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/elastic/elastic-package v0.0.0-20210526153026-29dd7eb6f647
+	github.com/elastic/elastic-package v0.0.0-20210528113559-07bfa0124100
 	github.com/elastic/package-registry v0.17.0
 	github.com/magefile/mage v1.11.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,8 @@ github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5m
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
-github.com/elastic/elastic-package v0.0.0-20210526153026-29dd7eb6f647 h1:DFaBoZSA8HHmLq0KqKS1aLIOsiLYYUfFi+vbXdnQTYQ=
-github.com/elastic/elastic-package v0.0.0-20210526153026-29dd7eb6f647/go.mod h1:JSY1uUBxJbo4N533uJhuGP3+9fmXasp+VmL5sjqGfaI=
+github.com/elastic/elastic-package v0.0.0-20210528113559-07bfa0124100 h1:O+pXFQGVCVNx/HEb0kvQsNQuS2i4lPTO12KL2Hz3cFo=
+github.com/elastic/elastic-package v0.0.0-20210528113559-07bfa0124100/go.mod h1:JSY1uUBxJbo4N533uJhuGP3+9fmXasp+VmL5sjqGfaI=
 github.com/elastic/go-elasticsearch/v7 v7.9.0 h1:UEau+a1MiiE/F+UrDj60kqIHFWdzU1M2y/YtBU2NC2M=
 github.com/elastic/go-elasticsearch/v7 v7.9.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/go-licenser v0.3.1/go.mod h1:D8eNQk70FOCVBl3smCGQt/lv7meBeQno2eI1S5apiHQ=

--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.0"
+  changes:
+    - description: Render units and metric types in exported fields table
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1028
 - version: "0.5.1"
   changes:
     - description: Move ecs.version to the ingest pipeline and make event.original optional

--- a/packages/apache/docs/README.md
+++ b/packages/apache/docs/README.md
@@ -16,85 +16,85 @@ Access logs collects the Apache access logs.
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| apache.access.ssl.cipher | SSL cipher name. | keyword |
-| apache.access.ssl.protocol | SSL protocol version. | keyword |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| destination.domain | Destination domain | keyword |
-| ecs.version | ECS version | keyword |
-| event.category | Event category. This contains high-level information about the contents of the event. It is more generic than `event.action`, in the sense that typically a category contains multiple actions. Warning: In future versions of ECS, we plan to provide a list of acceptable values for this field, please use with caution. | keyword |
-| event.created | event.created contains the date/time when the event was first read by an agent, or by your pipeline. This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event. In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source. In case the two timestamps are identical, @timestamp should be used. | date |
-| event.kind | The kind of the event. This gives information about what type of information the event contains, without being specific to the contents of the event.  Examples are `event`, `state`, `alarm`. Warning: In future versions of ECS, we plan to provide a list of acceptable values for this field, please use with caution. | keyword |
-| event.outcome | The outcome of the event. If the event describes an action, this fields contains the outcome of that action. Examples outcomes are `success` and `failure`. Warning: In future versions of ECS, we plan to provide a list of acceptable values for this field, please use with caution. | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| http.request.method | HTTP request method. Prior to ECS 1.6.0 the following guidance was provided: "The field value must be normalized to lowercase for querying." As of ECS 1.6.0, the guidance is deprecated because the original case of the method may be useful in anomaly detection.  Original case will be mandated in ECS 2.0.0 | keyword |
-| http.request.referrer | Referrer for this HTTP request. | keyword |
-| http.response.body.bytes | Size in bytes of the response body. | long |
-| http.response.status_code | HTTP response status code. | long |
-| http.version | HTTP version. | keyword |
-| input.type | Input type | keyword |
-| log.file.path | Log path | keyword |
-| log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
-| log.offset | Log offset | long |
-| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
-| process.pid | Process id. | long |
-| process.thread.id | Thread ID. | long |
-| source.address | Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
-| source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | keyword |
-| source.domain | Source domain | keyword |
-| source.geo.city_name | City name. | keyword |
-| source.geo.continent_name | Name of the continent. | keyword |
-| source.geo.country_iso_code | Country ISO code. | keyword |
-| source.geo.country_name | Country name. | keyword |
-| source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.region_iso_code | Region ISO code. | keyword |
-| source.geo.region_name | Region name. | keyword |
-| source.ip | IP address of the source | ip |
-| tls.cipher | String indicating the cipher used during the current connection. | keyword |
-| tls.version | Numeric part of the version parsed from the original string. | keyword |
-| tls.version_protocol | Normalized lowercase protocol name parsed from original string. | keyword |
-| url.original | Unmodified original url as seen in the event source. Note that in network monitoring, the observed URL may be a full URL, whereas in access logs, the URL is often just represented as a path. This field is meant to represent the URL as it was observed, complete or not. | keyword |
-| user.name | Short name or login of the user. | keyword |
-| user_agent.device.name | Name of the device. | keyword |
-| user_agent.name | Name of the user agent. | keyword |
-| user_agent.original | Unparsed user_agent string. | keyword |
-| user_agent.os.full | Operating system name, including the version or code name. | keyword |
-| user_agent.os.name | Operating system name, without the version. | keyword |
-| user_agent.os.version | Operating system version as a raw string | keyword |
-| user_agent.version | Version of the user agent | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| apache.access.ssl.cipher | SSL cipher name. | keyword |  |  |
+| apache.access.ssl.protocol | SSL protocol version. | keyword |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| destination.domain | Destination domain | keyword |  |  |
+| ecs.version | ECS version | keyword |  |  |
+| event.category | Event category. This contains high-level information about the contents of the event. It is more generic than `event.action`, in the sense that typically a category contains multiple actions. Warning: In future versions of ECS, we plan to provide a list of acceptable values for this field, please use with caution. | keyword |  |  |
+| event.created | event.created contains the date/time when the event was first read by an agent, or by your pipeline. This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event. In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source. In case the two timestamps are identical, @timestamp should be used. | date |  |  |
+| event.kind | The kind of the event. This gives information about what type of information the event contains, without being specific to the contents of the event.  Examples are `event`, `state`, `alarm`. Warning: In future versions of ECS, we plan to provide a list of acceptable values for this field, please use with caution. | keyword |  |  |
+| event.outcome | The outcome of the event. If the event describes an action, this fields contains the outcome of that action. Examples outcomes are `success` and `failure`. Warning: In future versions of ECS, we plan to provide a list of acceptable values for this field, please use with caution. | keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| http.request.method | HTTP request method. Prior to ECS 1.6.0 the following guidance was provided: "The field value must be normalized to lowercase for querying." As of ECS 1.6.0, the guidance is deprecated because the original case of the method may be useful in anomaly detection.  Original case will be mandated in ECS 2.0.0 | keyword |  |  |
+| http.request.referrer | Referrer for this HTTP request. | keyword |  |  |
+| http.response.body.bytes | Size in bytes of the response body. | long | byte | gauge |
+| http.response.status_code | HTTP response status code. | long |  |  |
+| http.version | HTTP version. | keyword |  |  |
+| input.type | Input type | keyword |  |  |
+| log.file.path | Log path | keyword |  |  |
+| log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |  |  |
+| log.offset | Log offset | long |  |  |
+| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |  |  |
+| process.pid | Process id. | long |  |  |
+| process.thread.id | Thread ID. | long |  |  |
+| source.address | Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |  |  |
+| source.as.number | Unique number allocated to the autonomous system. | long |  |  |
+| source.as.organization.name | Organization name. | keyword |  |  |
+| source.domain | Source domain | keyword |  |  |
+| source.geo.city_name | City name. | keyword |  |  |
+| source.geo.continent_name | Name of the continent. | keyword |  |  |
+| source.geo.country_iso_code | Country ISO code. | keyword |  |  |
+| source.geo.country_name | Country name. | keyword |  |  |
+| source.geo.location | Longitude and latitude. | geo_point |  |  |
+| source.geo.region_iso_code | Region ISO code. | keyword |  |  |
+| source.geo.region_name | Region name. | keyword |  |  |
+| source.ip | IP address of the source | ip |  |  |
+| tls.cipher | String indicating the cipher used during the current connection. | keyword |  |  |
+| tls.version | Numeric part of the version parsed from the original string. | keyword |  |  |
+| tls.version_protocol | Normalized lowercase protocol name parsed from original string. | keyword |  |  |
+| url.original | Unmodified original url as seen in the event source. Note that in network monitoring, the observed URL may be a full URL, whereas in access logs, the URL is often just represented as a path. This field is meant to represent the URL as it was observed, complete or not. | keyword |  |  |
+| user.name | Short name or login of the user. | keyword |  |  |
+| user_agent.device.name | Name of the device. | keyword |  |  |
+| user_agent.name | Name of the user agent. | keyword |  |  |
+| user_agent.original | Unparsed user_agent string. | keyword |  |  |
+| user_agent.os.full | Operating system name, including the version or code name. | keyword |  |  |
+| user_agent.os.name | Operating system name, without the version. | keyword |  |  |
+| user_agent.os.version | Operating system version as a raw string | keyword |  |  |
+| user_agent.version | Version of the user agent | keyword |  |  |
 
 
 ### Error Logs
@@ -103,78 +103,78 @@ Error logs collects the Apache error logs.
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| apache.error.module | The module producing the logged message. | keyword |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version | keyword |
-| event.category | Event category. This contains high-level information about the contents of the event. It is more generic than `event.action`, in the sense that typically a category contains multiple actions. Warning: In future versions of ECS, we plan to provide a list of acceptable values for this field, please use with caution. | keyword |
-| event.kind | The kind of the event. This gives information about what type of information the event contains, without being specific to the contents of the event.  Examples are `event`, `state`, `alarm`. Warning: In future versions of ECS, we plan to provide a list of acceptable values for this field, please use with caution. | keyword |
-| event.timezone | This field should be populated when the event's timestamp does not include timezone information already (e.g. default Syslog timestamps). It's optional otherwise. Acceptable timezone formats are: a canonical ID (e.g. "Europe/Amsterdam"), abbreviated (e.g. "EST") or an HH:mm differential (e.g. "-05:00"). | keyword |
-| event.type | Reserved for future usage. Please avoid using this field for user data. | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| http.request.method | HTTP request method. Prior to ECS 1.6.0 the following guidance was provided: "The field value must be normalized to lowercase for querying." As of ECS 1.6.0, the guidance is deprecated because the original case of the method may be useful in anomaly detection.  Original case will be mandated in ECS 2.0.0 | keyword |
-| http.request.referrer | Referrer for this HTTP request. | keyword |
-| http.response.body.bytes | Size in bytes of the response body. | long |
-| http.response.status_code | HTTP response status code. | long |
-| http.version | HTTP version. | keyword |
-| input.type | Input type | keyword |
-| log.file.path | Log path | keyword |
-| log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
-| log.offset | Log offset | long |
-| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
-| process.pid | Process id. | long |
-| process.thread.id | Thread ID. | long |
-| source.address | Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
-| source.as.number | Unique number allocated to the autonomous system. | long |
-| source.as.organization.name | Organization name. | keyword |
-| source.geo.city_name | City name. | keyword |
-| source.geo.continent_name | Name of the continent. | keyword |
-| source.geo.country_iso_code | Country ISO code. | keyword |
-| source.geo.country_name | Country name. | keyword |
-| source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.region_iso_code | Region ISO code. | keyword |
-| source.geo.region_name | Region name. | keyword |
-| source.ip | Source IP address. | ip |
-| source.port | Source port. | long |
-| tags | List of keywords used to tag each event. | keyword |
-| url.original | Unmodified original url as seen in the event source. Note that in network monitoring, the observed URL may be a full URL, whereas in access logs, the URL is often just represented as a path. This field is meant to represent the URL as it was observed, complete or not. | keyword |
-| user.name | Short name or login of the user. | keyword |
-| user_agent.device.name | Name of the device. | keyword |
-| user_agent.name | Name of the user agent. | keyword |
-| user_agent.original | Unparsed user_agent string. | keyword |
-| user_agent.os.name | Operating system name, without the version. | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| apache.error.module | The module producing the logged message. | keyword |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| ecs.version | ECS version | keyword |  |  |
+| event.category | Event category. This contains high-level information about the contents of the event. It is more generic than `event.action`, in the sense that typically a category contains multiple actions. Warning: In future versions of ECS, we plan to provide a list of acceptable values for this field, please use with caution. | keyword |  |  |
+| event.kind | The kind of the event. This gives information about what type of information the event contains, without being specific to the contents of the event.  Examples are `event`, `state`, `alarm`. Warning: In future versions of ECS, we plan to provide a list of acceptable values for this field, please use with caution. | keyword |  |  |
+| event.timezone | This field should be populated when the event's timestamp does not include timezone information already (e.g. default Syslog timestamps). It's optional otherwise. Acceptable timezone formats are: a canonical ID (e.g. "Europe/Amsterdam"), abbreviated (e.g. "EST") or an HH:mm differential (e.g. "-05:00"). | keyword |  |  |
+| event.type | Reserved for future usage. Please avoid using this field for user data. | keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| http.request.method | HTTP request method. Prior to ECS 1.6.0 the following guidance was provided: "The field value must be normalized to lowercase for querying." As of ECS 1.6.0, the guidance is deprecated because the original case of the method may be useful in anomaly detection.  Original case will be mandated in ECS 2.0.0 | keyword |  |  |
+| http.request.referrer | Referrer for this HTTP request. | keyword |  |  |
+| http.response.body.bytes | Size in bytes of the response body. | long | byte | gauge |
+| http.response.status_code | HTTP response status code. | long |  |  |
+| http.version | HTTP version. | keyword |  |  |
+| input.type | Input type | keyword |  |  |
+| log.file.path | Log path | keyword |  |  |
+| log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |  |  |
+| log.offset | Log offset | long |  |  |
+| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |  |  |
+| process.pid | Process id. | long |  |  |
+| process.thread.id | Thread ID. | long |  |  |
+| source.address | Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |  |  |
+| source.as.number | Unique number allocated to the autonomous system. | long |  |  |
+| source.as.organization.name | Organization name. | keyword |  |  |
+| source.geo.city_name | City name. | keyword |  |  |
+| source.geo.continent_name | Name of the continent. | keyword |  |  |
+| source.geo.country_iso_code | Country ISO code. | keyword |  |  |
+| source.geo.country_name | Country name. | keyword |  |  |
+| source.geo.location | Longitude and latitude. | geo_point |  |  |
+| source.geo.region_iso_code | Region ISO code. | keyword |  |  |
+| source.geo.region_name | Region name. | keyword |  |  |
+| source.ip | Source IP address. | ip |  |  |
+| source.port | Source port. | long |  |  |
+| tags | List of keywords used to tag each event. | keyword |  |  |
+| url.original | Unmodified original url as seen in the event source. Note that in network monitoring, the observed URL may be a full URL, whereas in access logs, the URL is often just represented as a path. This field is meant to represent the URL as it was observed, complete or not. | keyword |  |  |
+| user.name | Short name or login of the user. | keyword |  |  |
+| user_agent.device.name | Name of the device. | keyword |  |  |
+| user_agent.name | Name of the user agent. | keyword |  |  |
+| user_agent.original | Unparsed user_agent string. | keyword |  |  |
+| user_agent.os.name | Operating system name, without the version. | keyword |  |  |
 
 
 ## Metrics
@@ -292,75 +292,75 @@ An example event for `status` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| apache.status.bytes_per_request | Bytes per request. | scaled_float |
-| apache.status.bytes_per_sec | Bytes per second. | scaled_float |
-| apache.status.connections.async.closing | Async closed connections. | long |
-| apache.status.connections.async.keep_alive | Async keeped alive connections. | long |
-| apache.status.connections.async.writing | Async connection writing. | long |
-| apache.status.connections.total | Total connections. | long |
-| apache.status.cpu.children_system | CPU of children system. | scaled_float |
-| apache.status.cpu.children_user | CPU of children user. | scaled_float |
-| apache.status.cpu.load | CPU Load. | scaled_float |
-| apache.status.cpu.system | System cpu. | scaled_float |
-| apache.status.cpu.user | CPU user load. | scaled_float |
-| apache.status.load.1 | Load average for the last minute. | scaled_float |
-| apache.status.load.15 | Load average for the last 15 minutes. | scaled_float |
-| apache.status.load.5 | Load average for the last 5 minutes. | scaled_float |
-| apache.status.requests_per_sec | Requests per second. | scaled_float |
-| apache.status.scoreboard.closing_connection | Closing connections. | long |
-| apache.status.scoreboard.dns_lookup | Dns Lookups. | long |
-| apache.status.scoreboard.gracefully_finishing | Gracefully finishing. | long |
-| apache.status.scoreboard.idle_cleanup | Idle cleanups. | long |
-| apache.status.scoreboard.keepalive | Keep alive. | long |
-| apache.status.scoreboard.logging | Logging | long |
-| apache.status.scoreboard.open_slot | Open slots. | long |
-| apache.status.scoreboard.reading_request | Reading requests. | long |
-| apache.status.scoreboard.sending_reply | Sending Reply. | long |
-| apache.status.scoreboard.starting_up | Starting up. | long |
-| apache.status.scoreboard.total | Total. | long |
-| apache.status.scoreboard.waiting_for_connection | Waiting for connections. | long |
-| apache.status.total_accesses | Total number of access requests. | long |
-| apache.status.total_bytes | Total number of bytes served. | long |
-| apache.status.uptime.server_uptime | Server uptime in seconds. | long |
-| apache.status.uptime.uptime | Server uptime. | long |
-| apache.status.workers.busy | Number of busy workers. | long |
-| apache.status.workers.idle | Number of idle workers. | long |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| apache.status.bytes_per_request | Bytes per request. | scaled_float |  | gauge |
+| apache.status.bytes_per_sec | Bytes per second. | scaled_float |  | gauge |
+| apache.status.connections.async.closing | Async closed connections. | long |  | gauge |
+| apache.status.connections.async.keep_alive | Async keeped alive connections. | long |  | gauge |
+| apache.status.connections.async.writing | Async connection writing. | long |  | gauge |
+| apache.status.connections.total | Total connections. | long |  | counter |
+| apache.status.cpu.children_system | CPU of children system. | scaled_float |  | gauge |
+| apache.status.cpu.children_user | CPU of children user. | scaled_float |  | gauge |
+| apache.status.cpu.load | CPU Load. | scaled_float |  | gauge |
+| apache.status.cpu.system | System cpu. | scaled_float |  | gauge |
+| apache.status.cpu.user | CPU user load. | scaled_float |  | gauge |
+| apache.status.load.1 | Load average for the last minute. | scaled_float |  | gauge |
+| apache.status.load.15 | Load average for the last 15 minutes. | scaled_float |  | gauge |
+| apache.status.load.5 | Load average for the last 5 minutes. | scaled_float |  | gauge |
+| apache.status.requests_per_sec | Requests per second. | scaled_float |  | gauge |
+| apache.status.scoreboard.closing_connection | Closing connections. | long |  | gauge |
+| apache.status.scoreboard.dns_lookup | Dns Lookups. | long |  | gauge |
+| apache.status.scoreboard.gracefully_finishing | Gracefully finishing. | long |  | gauge |
+| apache.status.scoreboard.idle_cleanup | Idle cleanups. | long |  | gauge |
+| apache.status.scoreboard.keepalive | Keep alive. | long |  | gauge |
+| apache.status.scoreboard.logging | Logging | long |  | gauge |
+| apache.status.scoreboard.open_slot | Open slots. | long |  | gauge |
+| apache.status.scoreboard.reading_request | Reading requests. | long |  | gauge |
+| apache.status.scoreboard.sending_reply | Sending Reply. | long |  | gauge |
+| apache.status.scoreboard.starting_up | Starting up. | long |  | gauge |
+| apache.status.scoreboard.total | Total. | long |  | gauge |
+| apache.status.scoreboard.waiting_for_connection | Waiting for connections. | long |  | gauge |
+| apache.status.total_accesses | Total number of access requests. | long |  | counter |
+| apache.status.total_bytes | Total number of bytes served. | long | byte | counter |
+| apache.status.uptime.server_uptime | Server uptime in seconds. | long |  | counter |
+| apache.status.uptime.uptime | Server uptime. | long |  | counter |
+| apache.status.workers.busy | Number of busy workers. | long |  | gauge |
+| apache.status.workers.idle | Number of idle workers. | long |  | gauge |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| ecs.version | ECS version | keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| service.address | Service address | keyword |  |  |
+| service.type | Service type | keyword |  |  |
 

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: apache
 title: Apache
-version: 0.5.1
+version: 0.6.0
 license: basic
 description: Apache Integration
 type: integration

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -9,7 +9,7 @@ categories:
   - web
 release: experimental
 conditions:
-  kibana.version: "^7.13.0"
+  kibana.version: "^7.14.0"
 screenshots:
   - src: /img/apache-metrics-overview.png
     title: Apache metrics overview

--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.0"
+  changes:
+    - description: Render units and metric types in exported fields table
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1028
 - version: "0.1.1"
   changes:
     - description: Fix compatibility with Kibana

--- a/packages/docker/docs/README.md
+++ b/packages/docker/docs/README.md
@@ -39,38 +39,38 @@ running Docker containers.
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.name | Container name. | keyword |
-| container.runtime | Container runtime. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| docker.container.command | Command that was executed in the Docker container. | keyword |
-| docker.container.created | Date when the container was created. | date |
-| docker.container.ip_addresses | Container IP addresses. | ip |
-| docker.container.labels.* | Container labels | object |
-| docker.container.size.root_fs | Total size of all the files in the container. | long |
-| docker.container.size.rw | Size of the files that have been created or changed since creation. | long |
-| docker.container.status | Container status. | keyword |
-| docker.container.tags | Image tags. | keyword |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.ip | Host ip address. | ip |
-| host.mac | Host mac address. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.full | Operating system name, including the version or code name. | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Metric Type |
+|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |
+| container.id | Unique container id. | keyword |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |
+| container.name | Container name. | keyword |  |
+| container.runtime | Container runtime. | keyword |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |
+| data_stream.type | Data stream type. | constant_keyword |  |
+| docker.container.command | Command that was executed in the Docker container. | keyword |  |
+| docker.container.created | Date when the container was created. | date |  |
+| docker.container.ip_addresses | Container IP addresses. | ip |  |
+| docker.container.labels.* | Container labels | object |  |
+| docker.container.size.root_fs | Total size of all the files in the container. | long | gauge |
+| docker.container.size.rw | Size of the files that have been created or changed since creation. | long | gauge |
+| docker.container.status | Container status. | keyword |  |
+| docker.container.tags | Image tags. | keyword |  |
+| ecs.version | ECS version | keyword |  |
+| host.architecture | Operating system architecture. | keyword |  |
+| host.ip | Host ip address. | ip |  |
+| host.mac | Host mac address. | keyword |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |
+| host.os.full | Operating system name, including the version or code name. | keyword |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |
+| host.os.name | Operating system name, without the version. | keyword |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |
+| host.type | Type of host. | keyword |  |
+| service.address | Service address | keyword |  |
+| service.type | Service type | keyword |  |
 
 
 An example event for `container` looks as following:
@@ -143,45 +143,45 @@ The Docker `cpu` data stream collects runtime CPU metrics.
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.name | Container name. | keyword |
-| container.runtime | Container runtime. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| docker.container.labels.* | Container labels | object |
-| docker.cpu.core.*.norm.pct | Percentage of CPU time in this core, normalized by the number of CPU cores. | object |
-| docker.cpu.core.*.pct | Percentage of CPU time in this core. | object |
-| docker.cpu.core.*.ticks | Number of CPU ticks in this core. | object |
-| docker.cpu.kernel.norm.pct | Percentage of time in kernel space normalized by the number of CPU cores. | scaled_float |
-| docker.cpu.kernel.pct | Percentage of time in kernel space. | scaled_float |
-| docker.cpu.kernel.ticks | CPU ticks in kernel space. | long |
-| docker.cpu.system.norm.pct | Percentage of total CPU time in the system normalized by the number of CPU cores. | scaled_float |
-| docker.cpu.system.pct | Percentage of total CPU time in the system. | scaled_float |
-| docker.cpu.system.ticks | CPU system ticks. | long |
-| docker.cpu.total.norm.pct | Total CPU usage normalized by the number of CPU cores. | scaled_float |
-| docker.cpu.total.pct | Total CPU usage. | scaled_float |
-| docker.cpu.user.norm.pct | Percentage of time in user space normalized by the number of CPU cores. | scaled_float |
-| docker.cpu.user.pct | Percentage of time in user space. | scaled_float |
-| docker.cpu.user.ticks | CPU ticks in user space. | long |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.ip | Host ip address. | ip |
-| host.mac | Host mac address. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.full | Operating system name, including the version or code name. | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.name | Container name. | keyword |  |  |
+| container.runtime | Container runtime. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| docker.container.labels.* | Container labels | object |  |  |
+| docker.cpu.core.*.norm.pct | Percentage of CPU time in this core, normalized by the number of CPU cores. | object | percent | gauge |
+| docker.cpu.core.*.pct | Percentage of CPU time in this core. | object | percent | gauge |
+| docker.cpu.core.*.ticks | Number of CPU ticks in this core. | object |  |  |
+| docker.cpu.kernel.norm.pct | Percentage of time in kernel space normalized by the number of CPU cores. | scaled_float | percent | gauge |
+| docker.cpu.kernel.pct | Percentage of time in kernel space. | scaled_float | percent | gauge |
+| docker.cpu.kernel.ticks | CPU ticks in kernel space. | long |  | counter |
+| docker.cpu.system.norm.pct | Percentage of total CPU time in the system normalized by the number of CPU cores. | scaled_float | percent | gauge |
+| docker.cpu.system.pct | Percentage of total CPU time in the system. | scaled_float | percent | gauge |
+| docker.cpu.system.ticks | CPU system ticks. | long |  | counter |
+| docker.cpu.total.norm.pct | Total CPU usage normalized by the number of CPU cores. | scaled_float | percent | gauge |
+| docker.cpu.total.pct | Total CPU usage. | scaled_float | percent | gauge |
+| docker.cpu.user.norm.pct | Percentage of time in user space normalized by the number of CPU cores. | scaled_float | percent | gauge |
+| docker.cpu.user.pct | Percentage of time in user space. | scaled_float | percent | gauge |
+| docker.cpu.user.ticks | CPU ticks in user space. | long |  | counter |
+| ecs.version | ECS version | keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.ip | Host ip address. | ip |  |  |
+| host.mac | Host mac address. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.full | Operating system name, including the version or code name. | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. | keyword |  |  |
+| service.address | Service address | keyword |  |  |
+| service.type | Service type | keyword |  |  |
 
 
 An example event for `cpu` looks as following:
@@ -317,52 +317,52 @@ The Docker `diskio` data stream collects disk I/O metrics.
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.name | Container name. | keyword |
-| container.runtime | Container runtime. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| docker.container.labels.* | Container labels | object |
-| docker.diskio.read.bytes | Bytes read during the life of the container | long |
-| docker.diskio.read.ops | Number of reads during the life of the container | long |
-| docker.diskio.read.queued | Total number of queued requests | long |
-| docker.diskio.read.rate | Number of current reads per second | long |
-| docker.diskio.read.service_time | Total time to service IO requests, in nanoseconds | long |
-| docker.diskio.read.wait_time | Total time requests spent waiting in queues for service, in nanoseconds | long |
-| docker.diskio.reads | Number of current reads per second | scaled_float |
-| docker.diskio.summary.bytes | Bytes read and written during the life of the container | long |
-| docker.diskio.summary.ops | Number of I/O operations during the life of the container | long |
-| docker.diskio.summary.queued | Total number of queued requests | long |
-| docker.diskio.summary.rate | Number of current operations per second | long |
-| docker.diskio.summary.service_time | Total time to service IO requests, in nanoseconds | long |
-| docker.diskio.summary.wait_time | Total time requests spent waiting in queues for service, in nanoseconds | long |
-| docker.diskio.total | Number of reads and writes per second | scaled_float |
-| docker.diskio.write.bytes | Bytes written during the life of the container | long |
-| docker.diskio.write.ops | Number of writes during the life of the container | long |
-| docker.diskio.write.queued | Total number of queued requests | long |
-| docker.diskio.write.rate | Number of current writes per second | long |
-| docker.diskio.write.service_time | Total time to service IO requests, in nanoseconds | long |
-| docker.diskio.write.wait_time | Total time requests spent waiting in queues for service, in nanoseconds | long |
-| docker.diskio.writes | Number of current writes per second | scaled_float |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.ip | Host ip address. | ip |
-| host.mac | Host mac address. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.full | Operating system name, including the version or code name. | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.name | Container name. | keyword |  |  |
+| container.runtime | Container runtime. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| docker.container.labels.* | Container labels | object |  |  |
+| docker.diskio.read.bytes | Bytes read during the life of the container | long |  | counter |
+| docker.diskio.read.ops | Number of reads during the life of the container | long |  |  |
+| docker.diskio.read.queued | Total number of queued requests | long |  | gauge |
+| docker.diskio.read.rate | Number of current reads per second | long |  | gauge |
+| docker.diskio.read.service_time | Total time to service IO requests, in nanoseconds | long |  | counter |
+| docker.diskio.read.wait_time | Total time requests spent waiting in queues for service, in nanoseconds | long |  | counter |
+| docker.diskio.reads | Number of current reads per second | scaled_float |  | gauge |
+| docker.diskio.summary.bytes | Bytes read and written during the life of the container | long | byte | counter |
+| docker.diskio.summary.ops | Number of I/O operations during the life of the container | long |  | counter |
+| docker.diskio.summary.queued | Total number of queued requests | long |  | counter |
+| docker.diskio.summary.rate | Number of current operations per second | long |  | gauge |
+| docker.diskio.summary.service_time | Total time to service IO requests, in nanoseconds | long |  | counter |
+| docker.diskio.summary.wait_time | Total time requests spent waiting in queues for service, in nanoseconds | long |  | counter |
+| docker.diskio.total | Number of reads and writes per second | scaled_float |  | gauge |
+| docker.diskio.write.bytes | Bytes written during the life of the container | long | byte | counter |
+| docker.diskio.write.ops | Number of writes during the life of the container | long |  | counter |
+| docker.diskio.write.queued | Total number of queued requests | long |  | counter |
+| docker.diskio.write.rate | Number of current writes per second | long |  | gauge |
+| docker.diskio.write.service_time | Total time to service IO requests, in nanoseconds | long |  | counter |
+| docker.diskio.write.wait_time | Total time requests spent waiting in queues for service, in nanoseconds | long |  | counter |
+| docker.diskio.writes | Number of current writes per second | scaled_float |  | gauge |
+| ecs.version | ECS version | keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.ip | Host ip address. | ip |  |  |
+| host.mac | Host mac address. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.full | Operating system name, including the version or code name. | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. | keyword |  |  |
+| service.address | Service address | keyword |  |  |
+| service.type | Service type | keyword |  |  |
 
 
 An example event for `diskio` looks as following:
@@ -509,37 +509,37 @@ docker `HEALTHCHECK` instruction has been used to build the docker image.
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.name | Container name. | keyword |
-| container.runtime | Container runtime. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| docker.container.labels.* | Container labels | object |
-| docker.healthcheck.event.end_date | Healthcheck end date | date |
-| docker.healthcheck.event.exit_code | Healthcheck status code | integer |
-| docker.healthcheck.event.output | Healthcheck output | keyword |
-| docker.healthcheck.event.start_date | Healthcheck start date | date |
-| docker.healthcheck.failingstreak | concurent failed check | integer |
-| docker.healthcheck.status | Healthcheck status code | keyword |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.ip | Host ip address. | ip |
-| host.mac | Host mac address. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.full | Operating system name, including the version or code name. | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Metric Type |
+|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |
+| container.id | Unique container id. | keyword |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |
+| container.name | Container name. | keyword |  |
+| container.runtime | Container runtime. | keyword |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |
+| data_stream.type | Data stream type. | constant_keyword |  |
+| docker.container.labels.* | Container labels | object |  |
+| docker.healthcheck.event.end_date | Healthcheck end date | date |  |
+| docker.healthcheck.event.exit_code | Healthcheck status code | integer |  |
+| docker.healthcheck.event.output | Healthcheck output | keyword |  |
+| docker.healthcheck.event.start_date | Healthcheck start date | date |  |
+| docker.healthcheck.failingstreak | concurent failed check | integer | counter |
+| docker.healthcheck.status | Healthcheck status code | keyword |  |
+| ecs.version | ECS version | keyword |  |
+| host.architecture | Operating system architecture. | keyword |  |
+| host.ip | Host ip address. | ip |  |
+| host.mac | Host mac address. | keyword |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |
+| host.os.full | Operating system name, including the version or code name. | keyword |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |
+| host.os.name | Operating system name, without the version. | keyword |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |
+| host.type | Type of host. | keyword |  |
+| service.address | Service address | keyword |  |
+| service.type | Service type | keyword |  |
 
 
 An example event for `healthcheck` looks as following:
@@ -612,37 +612,37 @@ The Docker `image` data stream collects metrics on docker images
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.name | Container name. | keyword |
-| container.runtime | Container runtime. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| docker.image.created | Date and time when the image was created. | date |
-| docker.image.id.current | Unique image identifier given upon its creation. | keyword |
-| docker.image.id.parent | Identifier of the image, if it exists, from which the current image directly descends. | keyword |
-| docker.image.labels.* | Image labels. | object |
-| docker.image.size.regular | Total size of the all cached images associated to the current image. | long |
-| docker.image.size.virtual | Size of the image. | long |
-| docker.image.tags | Image tags. | keyword |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.ip | Host ip address. | ip |
-| host.mac | Host mac address. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.full | Operating system name, including the version or code name. | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Metric Type |
+|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |
+| container.id | Unique container id. | keyword |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |
+| container.name | Container name. | keyword |  |
+| container.runtime | Container runtime. | keyword |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |
+| data_stream.type | Data stream type. | constant_keyword |  |
+| docker.image.created | Date and time when the image was created. | date |  |
+| docker.image.id.current | Unique image identifier given upon its creation. | keyword |  |
+| docker.image.id.parent | Identifier of the image, if it exists, from which the current image directly descends. | keyword |  |
+| docker.image.labels.* | Image labels. | object |  |
+| docker.image.size.regular | Total size of the all cached images associated to the current image. | long | counter |
+| docker.image.size.virtual | Size of the image. | long | gauge |
+| docker.image.tags | Image tags. | keyword |  |
+| ecs.version | ECS version | keyword |  |
+| host.architecture | Operating system architecture. | keyword |  |
+| host.ip | Host ip address. | ip |  |
+| host.mac | Host mac address. | keyword |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |
+| host.os.full | Operating system name, including the version or code name. | keyword |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |
+| host.os.name | Operating system name, without the version. | keyword |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |
+| host.type | Type of host. | keyword |  |
+| service.address | Service address | keyword |  |
+| service.type | Service type | keyword |  |
 
 
 An example event for `image` looks as following:
@@ -699,36 +699,36 @@ https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/#/display-s
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.name | Container name. | keyword |
-| container.runtime | Container runtime. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| docker.info.containers.paused | Total number of paused containers. | long |
-| docker.info.containers.running | Total number of running containers. | long |
-| docker.info.containers.stopped | Total number of stopped containers. | long |
-| docker.info.containers.total | Total number of existing containers. | long |
-| docker.info.id | Unique Docker host identifier. | keyword |
-| docker.info.images | Total number of existing images. | long |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.ip | Host ip address. | ip |
-| host.mac | Host mac address. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.full | Operating system name, including the version or code name. | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Metric Type |
+|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |
+| container.id | Unique container id. | keyword |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |
+| container.name | Container name. | keyword |  |
+| container.runtime | Container runtime. | keyword |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |
+| data_stream.type | Data stream type. | constant_keyword |  |
+| docker.info.containers.paused | Total number of paused containers. | long | counter |
+| docker.info.containers.running | Total number of running containers. | long | counter |
+| docker.info.containers.stopped | Total number of stopped containers. | long | counter |
+| docker.info.containers.total | Total number of existing containers. | long | counter |
+| docker.info.id | Unique Docker host identifier. | keyword |  |
+| docker.info.images | Total number of existing images. | long | counter |
+| ecs.version | ECS version | keyword |  |
+| host.architecture | Operating system architecture. | keyword |  |
+| host.ip | Host ip address. | ip |  |
+| host.mac | Host mac address. | keyword |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |
+| host.os.full | Operating system name, including the version or code name. | keyword |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |
+| host.os.name | Operating system name, without the version. | keyword |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |
+| host.type | Type of host. | keyword |  |
+| service.address | Service address | keyword |  |
+| service.type | Service type | keyword |  |
 
 
 An example event for `info` looks as following:
@@ -770,42 +770,42 @@ The Docker `memory` data stream collects memory metrics from docker.
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.name | Container name. | keyword |
-| container.runtime | Container runtime. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| docker.container.labels.* | Container labels | object |
-| docker.memory.commit.peak | Peak committed bytes on Windows | long |
-| docker.memory.commit.total | Total bytes | long |
-| docker.memory.fail.count | Fail counter. | scaled_float |
-| docker.memory.limit | Memory limit. | long |
-| docker.memory.private_working_set.total | private working sets on Windows | long |
-| docker.memory.rss.pct | Memory resident set size percentage. | scaled_float |
-| docker.memory.rss.total | Total memory resident set size. | long |
-| docker.memory.stats.* | Raw memory stats from the cgroups memory.stat interface | object |
-| docker.memory.usage.max | Max memory usage. | long |
-| docker.memory.usage.pct | Memory usage percentage. | scaled_float |
-| docker.memory.usage.total | Total memory usage. | long |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.ip | Host ip address. | ip |
-| host.mac | Host mac address. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.full | Operating system name, including the version or code name. | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.name | Container name. | keyword |  |  |
+| container.runtime | Container runtime. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| docker.container.labels.* | Container labels | object |  |  |
+| docker.memory.commit.peak | Peak committed bytes on Windows | long | byte | gauge |
+| docker.memory.commit.total | Total bytes | long | byte | counter |
+| docker.memory.fail.count | Fail counter. | scaled_float |  | counter |
+| docker.memory.limit | Memory limit. | long | byte | gauge |
+| docker.memory.private_working_set.total | private working sets on Windows | long | byte | gauge |
+| docker.memory.rss.pct | Memory resident set size percentage. | scaled_float | percent | gauge |
+| docker.memory.rss.total | Total memory resident set size. | long | byte | gauge |
+| docker.memory.stats.* | Raw memory stats from the cgroups memory.stat interface | object |  |  |
+| docker.memory.usage.max | Max memory usage. | long | byte | gauge |
+| docker.memory.usage.pct | Memory usage percentage. | scaled_float | percent | gauge |
+| docker.memory.usage.total | Total memory usage. | long | byte | gauge |
+| ecs.version | ECS version | keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.ip | Host ip address. | ip |  |  |
+| host.mac | Host mac address. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.full | Operating system name, including the version or code name. | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. | keyword |  |  |
+| service.address | Service address | keyword |  |  |
+| service.type | Service type | keyword |  |  |
 
 
 An example event for `memory` looks as following:
@@ -894,48 +894,48 @@ The Docker `network` data stream collects network metrics.
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.name | Container name. | keyword |
-| container.runtime | Container runtime. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| docker.container.labels.* | Container labels | object |
-| docker.network.in.bytes | Total number of incoming bytes. | long |
-| docker.network.in.dropped | Total number of dropped incoming packets. | scaled_float |
-| docker.network.in.errors | Total errors on incoming packets. | long |
-| docker.network.in.packets | Total number of incoming packets. | long |
-| docker.network.inbound.bytes | Total number of incoming bytes. | long |
-| docker.network.inbound.dropped | Total number of dropped incoming packets. | long |
-| docker.network.inbound.errors | Total errors on incoming packets. | long |
-| docker.network.inbound.packets | Total number of incoming packets. | long |
-| docker.network.interface | Network interface name. | keyword |
-| docker.network.out.bytes | Total number of outgoing bytes. | long |
-| docker.network.out.dropped | Total number of dropped outgoing packets. | scaled_float |
-| docker.network.out.errors | Total errors on outgoing packets. | long |
-| docker.network.out.packets | Total number of outgoing packets. | long |
-| docker.network.outbound.bytes | Total number of outgoing bytes. | long |
-| docker.network.outbound.dropped | Total number of dropped outgoing packets. | long |
-| docker.network.outbound.errors | Total errors on outgoing packets. | long |
-| docker.network.outbound.packets | Total number of outgoing packets. | long |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.ip | Host ip address. | ip |
-| host.mac | Host mac address. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.full | Operating system name, including the version or code name. | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Metric Type |
+|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |
+| container.id | Unique container id. | keyword |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |
+| container.name | Container name. | keyword |  |
+| container.runtime | Container runtime. | keyword |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |
+| data_stream.type | Data stream type. | constant_keyword |  |
+| docker.container.labels.* | Container labels | object |  |
+| docker.network.in.bytes | Total number of incoming bytes. | long | counter |
+| docker.network.in.dropped | Total number of dropped incoming packets. | scaled_float | counter |
+| docker.network.in.errors | Total errors on incoming packets. | long | counter |
+| docker.network.in.packets | Total number of incoming packets. | long | counter |
+| docker.network.inbound.bytes | Total number of incoming bytes. | long | counter |
+| docker.network.inbound.dropped | Total number of dropped incoming packets. | long | counter |
+| docker.network.inbound.errors | Total errors on incoming packets. | long | counter |
+| docker.network.inbound.packets | Total number of incoming packets. | long | counter |
+| docker.network.interface | Network interface name. | keyword |  |
+| docker.network.out.bytes | Total number of outgoing bytes. | long | counter |
+| docker.network.out.dropped | Total number of dropped outgoing packets. | scaled_float | counter |
+| docker.network.out.errors | Total errors on outgoing packets. | long | counter |
+| docker.network.out.packets | Total number of outgoing packets. | long | counter |
+| docker.network.outbound.bytes | Total number of outgoing bytes. | long | counter |
+| docker.network.outbound.dropped | Total number of dropped outgoing packets. | long | counter |
+| docker.network.outbound.errors | Total errors on outgoing packets. | long | counter |
+| docker.network.outbound.packets | Total number of outgoing packets. | long | counter |
+| ecs.version | ECS version | keyword |  |
+| host.architecture | Operating system architecture. | keyword |  |
+| host.ip | Host ip address. | ip |  |
+| host.mac | Host mac address. | keyword |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |
+| host.os.full | Operating system name, including the version or code name. | keyword |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |
+| host.os.name | Operating system name, without the version. | keyword |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |
+| host.type | Type of host. | keyword |  |
+| service.address | Service address | keyword |  |
+| service.type | Service type | keyword |  |
 
 
 An example event for `network` looks as following:

--- a/packages/docker/manifest.yml
+++ b/packages/docker/manifest.yml
@@ -1,6 +1,6 @@
 name: docker
 title: Docker
-version: 0.1.1
+version: 0.2.0
 release: beta
 description: Docker Integration
 type: integration

--- a/packages/docker/manifest.yml
+++ b/packages/docker/manifest.yml
@@ -20,7 +20,7 @@ categories:
   - containers
   - os_system
 conditions:
-  kibana.version: ^7.11.0
+  kibana.version: ^7.14.0
 policy_templates:
   - name: docker
     title: Docker metrics

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.13.0"
+  changes:
+    - description: Render units and metric types in exported fields table
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1028
 - version: "0.12.6"
   changes:
     - description: Report system_summary properly.

--- a/packages/system/docs/README.md
+++ b/packages/system/docs/README.md
@@ -897,59 +897,59 @@ This dataset is available on:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip address. | ip |
-| host.mac | Host mac address. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.full | Operating system name, including the version or code name. | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. | keyword |
-| system.core.id | CPU Core number. | keyword |
-| system.core.idle.pct | The percentage of CPU time spent idle. | scaled_float |
-| system.core.idle.ticks | The amount of CPU time spent idle. | long |
-| system.core.iowait.pct | The percentage of CPU time spent in wait (on disk). | scaled_float |
-| system.core.iowait.ticks | The amount of CPU time spent in wait (on disk). | long |
-| system.core.irq.pct | The percentage of CPU time spent servicing and handling hardware interrupts. | scaled_float |
-| system.core.irq.ticks | The amount of CPU time spent servicing and handling hardware interrupts. | long |
-| system.core.nice.pct | The percentage of CPU time spent on low-priority processes. | scaled_float |
-| system.core.nice.ticks | The amount of CPU time spent on low-priority processes. | long |
-| system.core.softirq.pct | The percentage of CPU time spent servicing and handling software interrupts. | scaled_float |
-| system.core.softirq.ticks | The amount of CPU time spent servicing and handling software interrupts. | long |
-| system.core.steal.pct | The percentage of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix. | scaled_float |
-| system.core.steal.ticks | The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix. | long |
-| system.core.system.pct | The percentage of CPU time spent in kernel space. | scaled_float |
-| system.core.system.ticks | The amount of CPU time spent in kernel space. | long |
-| system.core.user.pct | The percentage of CPU time spent in user space. | scaled_float |
-| system.core.user.ticks | The amount of CPU time spent in user space. | long |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip address. | ip |  |  |
+| host.mac | Host mac address. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.full | Operating system name, including the version or code name. | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. | keyword |  |  |
+| system.core.id | CPU Core number. | keyword |  |  |
+| system.core.idle.pct | The percentage of CPU time spent idle. | scaled_float | percent | gauge |
+| system.core.idle.ticks | The amount of CPU time spent idle. | long |  | counter |
+| system.core.iowait.pct | The percentage of CPU time spent in wait (on disk). | scaled_float | percent | gauge |
+| system.core.iowait.ticks | The amount of CPU time spent in wait (on disk). | long |  | counter |
+| system.core.irq.pct | The percentage of CPU time spent servicing and handling hardware interrupts. | scaled_float | percent | gauge |
+| system.core.irq.ticks | The amount of CPU time spent servicing and handling hardware interrupts. | long |  | counter |
+| system.core.nice.pct | The percentage of CPU time spent on low-priority processes. | scaled_float | percent | gauge |
+| system.core.nice.ticks | The amount of CPU time spent on low-priority processes. | long |  | counter |
+| system.core.softirq.pct | The percentage of CPU time spent servicing and handling software interrupts. | scaled_float | percent | gauge |
+| system.core.softirq.ticks | The amount of CPU time spent servicing and handling software interrupts. | long |  | counter |
+| system.core.steal.pct | The percentage of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix. | scaled_float | percent | gauge |
+| system.core.steal.ticks | The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix. | long |  | counter |
+| system.core.system.pct | The percentage of CPU time spent in kernel space. | scaled_float | percent | gauge |
+| system.core.system.ticks | The amount of CPU time spent in kernel space. | long |  | counter |
+| system.core.user.pct | The percentage of CPU time spent in user space. | scaled_float | percent | gauge |
+| system.core.user.ticks | The amount of CPU time spent in user space. | long |  | counter |
 
 
 ### CPU
@@ -966,70 +966,70 @@ This dataset is available on:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.cpu.pct | Percent CPU used. This value is normalized by the number of CPU cores and it ranges from 0 to 1. | scaled_float |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip address. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.full | Operating system name, including the version or code name. | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| system.cpu.cores | The number of CPU cores present on the host. The non-normalized percentages will have a maximum value of `100% * cores`. The normalized percentages already take this value into account and have a maximum value of 100%. | long |
-| system.cpu.idle.norm.pct | The percentage of CPU time spent idle. | scaled_float |
-| system.cpu.idle.pct | The percentage of CPU time spent idle. | scaled_float |
-| system.cpu.idle.ticks | The amount of CPU time spent idle. | long |
-| system.cpu.iowait.norm.pct | The percentage of CPU time spent in wait (on disk). | scaled_float |
-| system.cpu.iowait.pct | The percentage of CPU time spent in wait (on disk). | scaled_float |
-| system.cpu.iowait.ticks | The amount of CPU time spent in wait (on disk). | long |
-| system.cpu.irq.norm.pct | The percentage of CPU time spent servicing and handling hardware interrupts. | scaled_float |
-| system.cpu.irq.pct | The percentage of CPU time spent servicing and handling hardware interrupts. | scaled_float |
-| system.cpu.irq.ticks | The amount of CPU time spent servicing and handling hardware interrupts. | long |
-| system.cpu.nice.norm.pct | The percentage of CPU time spent on low-priority processes. | scaled_float |
-| system.cpu.nice.pct | The percentage of CPU time spent on low-priority processes. | scaled_float |
-| system.cpu.nice.ticks | The amount of CPU time spent on low-priority processes. | long |
-| system.cpu.softirq.norm.pct | The percentage of CPU time spent servicing and handling software interrupts. | scaled_float |
-| system.cpu.softirq.pct | The percentage of CPU time spent servicing and handling software interrupts. | scaled_float |
-| system.cpu.softirq.ticks | The amount of CPU time spent servicing and handling software interrupts. | long |
-| system.cpu.steal.norm.pct | The percentage of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix. | scaled_float |
-| system.cpu.steal.pct | The percentage of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix. | scaled_float |
-| system.cpu.steal.ticks | The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix. | long |
-| system.cpu.system.norm.pct | The percentage of CPU time spent in kernel space. | scaled_float |
-| system.cpu.system.pct | The percentage of CPU time spent in kernel space. | scaled_float |
-| system.cpu.system.ticks | The amount of CPU time spent in kernel space. | long |
-| system.cpu.total.norm.pct | The percentage of CPU time in states other than Idle and IOWait, normalised by the number of cores. | scaled_float |
-| system.cpu.total.pct | The percentage of CPU time spent in states other than Idle and IOWait. | scaled_float |
-| system.cpu.user.norm.pct | The percentage of CPU time spent in user space. | scaled_float |
-| system.cpu.user.pct | The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%. For example, if 3 cores are at 60% use, then the `system.cpu.user.pct` will be 180%. | scaled_float |
-| system.cpu.user.ticks | The amount of CPU time spent in user space. | long |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.cpu.pct | Percent CPU used. This value is normalized by the number of CPU cores and it ranges from 0 to 1. | scaled_float | percent | gauge |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip address. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.full | Operating system name, including the version or code name. | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| system.cpu.cores | The number of CPU cores present on the host. The non-normalized percentages will have a maximum value of `100% * cores`. The normalized percentages already take this value into account and have a maximum value of 100%. | long |  | gauge |
+| system.cpu.idle.norm.pct | The percentage of CPU time spent idle. | scaled_float | percent | gauge |
+| system.cpu.idle.pct | The percentage of CPU time spent idle. | scaled_float | percent | gauge |
+| system.cpu.idle.ticks | The amount of CPU time spent idle. | long |  | counter |
+| system.cpu.iowait.norm.pct | The percentage of CPU time spent in wait (on disk). | scaled_float | percent | gauge |
+| system.cpu.iowait.pct | The percentage of CPU time spent in wait (on disk). | scaled_float | percent | gauge |
+| system.cpu.iowait.ticks | The amount of CPU time spent in wait (on disk). | long |  | counter |
+| system.cpu.irq.norm.pct | The percentage of CPU time spent servicing and handling hardware interrupts. | scaled_float | percent | gauge |
+| system.cpu.irq.pct | The percentage of CPU time spent servicing and handling hardware interrupts. | scaled_float | percent | gauge |
+| system.cpu.irq.ticks | The amount of CPU time spent servicing and handling hardware interrupts. | long |  | counter |
+| system.cpu.nice.norm.pct | The percentage of CPU time spent on low-priority processes. | scaled_float | percent | gauge |
+| system.cpu.nice.pct | The percentage of CPU time spent on low-priority processes. | scaled_float | percent | gauge |
+| system.cpu.nice.ticks | The amount of CPU time spent on low-priority processes. | long |  | counter |
+| system.cpu.softirq.norm.pct | The percentage of CPU time spent servicing and handling software interrupts. | scaled_float | percent | gauge |
+| system.cpu.softirq.pct | The percentage of CPU time spent servicing and handling software interrupts. | scaled_float | percent | gauge |
+| system.cpu.softirq.ticks | The amount of CPU time spent servicing and handling software interrupts. | long |  | counter |
+| system.cpu.steal.norm.pct | The percentage of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix. | scaled_float | percent | gauge |
+| system.cpu.steal.pct | The percentage of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix. | scaled_float | percent | gauge |
+| system.cpu.steal.ticks | The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix. | long |  | counter |
+| system.cpu.system.norm.pct | The percentage of CPU time spent in kernel space. | scaled_float | percent | gauge |
+| system.cpu.system.pct | The percentage of CPU time spent in kernel space. | scaled_float | percent | gauge |
+| system.cpu.system.ticks | The amount of CPU time spent in kernel space. | long |  |  |
+| system.cpu.total.norm.pct | The percentage of CPU time in states other than Idle and IOWait, normalised by the number of cores. | scaled_float | percent | gauge |
+| system.cpu.total.pct | The percentage of CPU time spent in states other than Idle and IOWait. | scaled_float | percent | gauge |
+| system.cpu.user.norm.pct | The percentage of CPU time spent in user space. | scaled_float | percent | gauge |
+| system.cpu.user.pct | The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%. For example, if 3 cores are at 60% use, then the `system.cpu.user.pct` will be 180%. | scaled_float | percent | gauge |
+| system.cpu.user.ticks | The amount of CPU time spent in user space. | long |  | counter |
 
 
 ### Disk IO
@@ -1046,66 +1046,66 @@ This dataset is available on:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.disk.read.bytes | The total number of bytes read successfully in a given period of time. | scaled_float |
-| host.disk.write.bytes | The total number of bytes write successfully in a given period of time. | scaled_float |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.full | Operating system name, including the version or code name. | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| system.diskio.io.time | The total number of of milliseconds spent doing I/Os. | long |
-| system.diskio.iostat.await | The average time spent for requests issued to the device to be served. | float |
-| system.diskio.iostat.busy | Percentage of CPU time during which I/O requests were issued to the device (bandwidth utilization for the device). Device saturation occurs when this value is close to 100%. | float |
-| system.diskio.iostat.queue.avg_size | The average queue length of the requests that were issued to the device. | float |
-| system.diskio.iostat.read.await | The average time spent for read requests issued to the device to be served. | float |
-| system.diskio.iostat.read.per_sec.bytes | The number of Bytes read from the device per second. | float |
-| system.diskio.iostat.read.request.merges_per_sec | The number of read requests merged per second that were queued to the device. | float |
-| system.diskio.iostat.read.request.per_sec | The number of read requests that were issued to the device per second | float |
-| system.diskio.iostat.request.avg_size | The average size (in bytes) of the requests that were issued to the device. | float |
-| system.diskio.iostat.service_time | The average service time (in milliseconds) for I/O requests that were issued to the device. | float |
-| system.diskio.iostat.write.await | The average time spent for write requests issued to the device to be served. | float |
-| system.diskio.iostat.write.per_sec.bytes | The number of Bytes write from the device per second. | float |
-| system.diskio.iostat.write.request.merges_per_sec | The number of write requests merged per second that were queued to the device. | float |
-| system.diskio.iostat.write.request.per_sec | The number of write requests that were issued to the device per second | float |
-| system.diskio.name | The disk name. | keyword |
-| system.diskio.read.bytes | The total number of bytes read successfully. On Linux this is the number of sectors read multiplied by an assumed sector size of 512. | long |
-| system.diskio.read.count | The total number of reads completed successfully. | long |
-| system.diskio.read.time | The total number of milliseconds spent by all reads. | long |
-| system.diskio.serial_number | The disk's serial number. This may not be provided by all operating systems. | keyword |
-| system.diskio.write.bytes | The total number of bytes written successfully. On Linux this is the number of sectors written multiplied by an assumed sector size of 512. | long |
-| system.diskio.write.count | The total number of writes completed successfully. | long |
-| system.diskio.write.time | The total number of milliseconds spent by all writes. | long |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.disk.read.bytes | The total number of bytes read successfully in a given period of time. | scaled_float | byte | gauge |
+| host.disk.write.bytes | The total number of bytes write successfully in a given period of time. | scaled_float | byte | gauge |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.full | Operating system name, including the version or code name. | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| system.diskio.io.time | The total number of of milliseconds spent doing I/Os. | long |  | counter |
+| system.diskio.iostat.await | The average time spent for requests issued to the device to be served. | float |  | gauge |
+| system.diskio.iostat.busy | Percentage of CPU time during which I/O requests were issued to the device (bandwidth utilization for the device). Device saturation occurs when this value is close to 100%. | float |  | gauge |
+| system.diskio.iostat.queue.avg_size | The average queue length of the requests that were issued to the device. | float | byte | gauge |
+| system.diskio.iostat.read.await | The average time spent for read requests issued to the device to be served. | float |  | gauge |
+| system.diskio.iostat.read.per_sec.bytes | The number of Bytes read from the device per second. | float |  | gauge |
+| system.diskio.iostat.read.request.merges_per_sec | The number of read requests merged per second that were queued to the device. | float |  | gauge |
+| system.diskio.iostat.read.request.per_sec | The number of read requests that were issued to the device per second | float |  | gauge |
+| system.diskio.iostat.request.avg_size | The average size (in bytes) of the requests that were issued to the device. | float | byte | gauge |
+| system.diskio.iostat.service_time | The average service time (in milliseconds) for I/O requests that were issued to the device. | float | ms | gauge |
+| system.diskio.iostat.write.await | The average time spent for write requests issued to the device to be served. | float |  | gauge |
+| system.diskio.iostat.write.per_sec.bytes | The number of Bytes write from the device per second. | float |  | gauge |
+| system.diskio.iostat.write.request.merges_per_sec | The number of write requests merged per second that were queued to the device. | float |  | gauge |
+| system.diskio.iostat.write.request.per_sec | The number of write requests that were issued to the device per second | float |  | gauge |
+| system.diskio.name | The disk name. | keyword |  |  |
+| system.diskio.read.bytes | The total number of bytes read successfully. On Linux this is the number of sectors read multiplied by an assumed sector size of 512. | long | byte | counter |
+| system.diskio.read.count | The total number of reads completed successfully. | long |  | counter |
+| system.diskio.read.time | The total number of milliseconds spent by all reads. | long |  | counter |
+| system.diskio.serial_number | The disk's serial number. This may not be provided by all operating systems. | keyword |  |  |
+| system.diskio.write.bytes | The total number of bytes written successfully. On Linux this is the number of sectors written multiplied by an assumed sector size of 512. | long | byte | counter |
+| system.diskio.write.count | The total number of writes completed successfully. | long |  | counter |
+| system.diskio.write.time | The total number of milliseconds spent by all writes. | long |  | counter |
 
 
 ### Filesystem
@@ -1123,51 +1123,51 @@ This dataset is available on:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| system.filesystem.available | The disk space available to an unprivileged user in bytes. | long |
-| system.filesystem.device_name | The disk name. For example: `/dev/disk1` | keyword |
-| system.filesystem.files | The total number of file nodes in the file system. | long |
-| system.filesystem.free | The disk space available in bytes. | long |
-| system.filesystem.free_files | The number of free file nodes in the file system. | long |
-| system.filesystem.mount_point | The mounting point. For example: `/` | keyword |
-| system.filesystem.total | The total disk space in bytes. | long |
-| system.filesystem.type | The disk type. For example: `ext4` | keyword |
-| system.filesystem.used.bytes | The used disk space in bytes. | long |
-| system.filesystem.used.pct | The percentage of used disk space. | scaled_float |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| system.filesystem.available | The disk space available to an unprivileged user in bytes. | long | byte | gauge |
+| system.filesystem.device_name | The disk name. For example: `/dev/disk1` | keyword |  |  |
+| system.filesystem.files | The total number of file nodes in the file system. | long |  | gauge |
+| system.filesystem.free | The disk space available in bytes. | long | byte | gauge |
+| system.filesystem.free_files | The number of free file nodes in the file system. | long |  | gauge |
+| system.filesystem.mount_point | The mounting point. For example: `/` | keyword |  |  |
+| system.filesystem.total | The total disk space in bytes. | long | byte | gauge |
+| system.filesystem.type | The disk type. For example: `ext4` | keyword |  |  |
+| system.filesystem.used.bytes | The used disk space in bytes. | long | byte | gauge |
+| system.filesystem.used.pct | The percentage of used disk space. | scaled_float | percent | gauge |
 
 
 ### Fsstat
@@ -1184,47 +1184,47 @@ This dataset is available on:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.full | Operating system name, including the version or code name. | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. | keyword |
-| system.fsstat.count | Number of file systems found. | long |
-| system.fsstat.total_files | Total number of files. | long |
-| system.fsstat.total_size.free | Total free space. | long |
-| system.fsstat.total_size.total | Total space (used plus free). | long |
-| system.fsstat.total_size.used | Total used space. | long |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.full | Operating system name, including the version or code name. | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. | keyword |  |  |
+| system.fsstat.count | Number of file systems found. | long |  | gauge |
+| system.fsstat.total_files | Total number of files. | long |  | gauge |
+| system.fsstat.total_size.free | Total free space. | long | byte | gauge |
+| system.fsstat.total_size.total | Total space (used plus free). | long | byte | gauge |
+| system.fsstat.total_size.used | Total used space. | long | byte | gauge |
 
 
 ### Load
@@ -1240,49 +1240,49 @@ This dataset is available on:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac address. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.full | Operating system name, including the version or code name. | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. | keyword |
-| system.load.1 | Load average for the last minute. | scaled_float |
-| system.load.15 | Load average for the last 15 minutes. | scaled_float |
-| system.load.5 | Load average for the last 5 minutes. | scaled_float |
-| system.load.cores | The number of CPU cores present on the host. | long |
-| system.load.norm.1 | Load for the last minute divided by the number of cores. | scaled_float |
-| system.load.norm.15 | Load for the last 15 minutes divided by the number of cores. | scaled_float |
-| system.load.norm.5 | Load for the last 5 minutes divided by the number of cores. | scaled_float |
+| Field | Description | Type | Metric Type |
+|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |
+| cloud.region | Region in which this host is running. | keyword |  |
+| container.id | Unique container id. | keyword |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |
+| container.labels | Image labels. | object |  |
+| container.name | Container name. | keyword |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |
+| data_stream.type | Data stream type. | constant_keyword |  |
+| host.architecture | Operating system architecture. | keyword |  |
+| host.containerized | If the host is a container. | boolean |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |
+| host.ip | Host ip addresses. | ip |  |
+| host.mac | Host mac address. | keyword |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |
+| host.os.build | OS build information. | keyword |  |
+| host.os.codename | OS codename, if any. | keyword |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |
+| host.os.full | Operating system name, including the version or code name. | keyword |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |
+| host.os.name | Operating system name, without the version. | keyword |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |
+| host.type | Type of host. | keyword |  |
+| system.load.1 | Load average for the last minute. | scaled_float | gauge |
+| system.load.15 | Load average for the last 15 minutes. | scaled_float | gauge |
+| system.load.5 | Load average for the last 5 minutes. | scaled_float | gauge |
+| system.load.cores | The number of CPU cores present on the host. | long | gauge |
+| system.load.norm.1 | Load for the last minute divided by the number of cores. | scaled_float | gauge |
+| system.load.norm.15 | Load for the last 15 minutes divided by the number of cores. | scaled_float | gauge |
+| system.load.norm.5 | Load for the last 5 minutes divided by the number of cores. | scaled_float | gauge |
 
 
 ### Memory
@@ -1299,73 +1299,73 @@ This dataset is available on:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip address. | ip |
-| host.mac | Host mac address. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.full | Operating system name, including the version or code name. | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| system.memory.actual.free | Actual free memory in bytes. It is calculated based on the OS. On Linux this value will be MemAvailable from /proc/meminfo,  or calculated from free memory plus caches and buffers if /proc/meminfo is not available. On OSX it is a sum of free memory and the inactive memory. On Windows, it is equal to `system.memory.free`. | long |
-| system.memory.actual.used.bytes | Actual used memory in bytes. It represents the difference between the total and the available memory. The available memory depends on the OS. For more details, please check `system.actual.free`. | long |
-| system.memory.actual.used.pct | The percentage of actual used memory. | scaled_float |
-| system.memory.free | The total amount of free memory in bytes. This value does not include memory consumed by system caches and buffers (see system.memory.actual.free). | long |
-| system.memory.hugepages.default_size | Default size for huge pages. | long |
-| system.memory.hugepages.free | Number of available huge pages in the pool. | long |
-| system.memory.hugepages.reserved | Number of reserved but not allocated huge pages in the pool. | long |
-| system.memory.hugepages.surplus | Number of overcommited huge pages. | long |
-| system.memory.hugepages.swap.out.fallback | Count of huge pages that must be split before swapout | long |
-| system.memory.hugepages.swap.out.pages | pages swapped out | long |
-| system.memory.hugepages.total | Number of huge pages in the pool. | long |
-| system.memory.hugepages.used.bytes | Memory used in allocated huge pages. | long |
-| system.memory.hugepages.used.pct | Percentage of huge pages used. | long |
-| system.memory.page_stats.direct_efficiency.pct | direct reclaim efficiency percentage. A lower percentage indicates the system is struggling to reclaim memory. | scaled_float |
-| system.memory.page_stats.kswapd_efficiency.pct | kswapd reclaim efficiency percentage. A lower percentage indicates the system is struggling to reclaim memory. | scaled_float |
-| system.memory.page_stats.pgfree.pages | pages freed by the system | long |
-| system.memory.page_stats.pgscan_direct.pages | pages scanned directly | long |
-| system.memory.page_stats.pgscan_kswapd.pages | pages scanned by kswapd | long |
-| system.memory.page_stats.pgsteal_direct.pages | number of pages reclaimed directly | long |
-| system.memory.page_stats.pgsteal_kswapd.pages | number of pages reclaimed by kswapd | long |
-| system.memory.swap.free | Available swap memory. | long |
-| system.memory.swap.in.pages | count of pages swapped in | long |
-| system.memory.swap.out.pages | count of pages swapped out | long |
-| system.memory.swap.readahead.cached | swap readahead cache hits | long |
-| system.memory.swap.readahead.pages | swap readahead pages | long |
-| system.memory.swap.total | Total swap memory. | long |
-| system.memory.swap.used.bytes | Used swap memory. | long |
-| system.memory.swap.used.pct | The percentage of used swap memory. | scaled_float |
-| system.memory.total | Total memory. | long |
-| system.memory.used.bytes | Used memory. | long |
-| system.memory.used.pct | The percentage of used memory. | scaled_float |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip address. | ip |  |  |
+| host.mac | Host mac address. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.full | Operating system name, including the version or code name. | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| system.memory.actual.free | Actual free memory in bytes. It is calculated based on the OS. On Linux this value will be MemAvailable from /proc/meminfo,  or calculated from free memory plus caches and buffers if /proc/meminfo is not available. On OSX it is a sum of free memory and the inactive memory. On Windows, it is equal to `system.memory.free`. | long | byte | gauge |
+| system.memory.actual.used.bytes | Actual used memory in bytes. It represents the difference between the total and the available memory. The available memory depends on the OS. For more details, please check `system.actual.free`. | long | byte | gauge |
+| system.memory.actual.used.pct | The percentage of actual used memory. | scaled_float | percent | gauge |
+| system.memory.free | The total amount of free memory in bytes. This value does not include memory consumed by system caches and buffers (see system.memory.actual.free). | long | byte | gauge |
+| system.memory.hugepages.default_size | Default size for huge pages. | long |  | gauge |
+| system.memory.hugepages.free | Number of available huge pages in the pool. | long |  | gauge |
+| system.memory.hugepages.reserved | Number of reserved but not allocated huge pages in the pool. | long |  | gauge |
+| system.memory.hugepages.surplus | Number of overcommited huge pages. | long |  | gauge |
+| system.memory.hugepages.swap.out.fallback | Count of huge pages that must be split before swapout | long |  | gauge |
+| system.memory.hugepages.swap.out.pages | pages swapped out | long |  | gauge |
+| system.memory.hugepages.total | Number of huge pages in the pool. | long |  | gauge |
+| system.memory.hugepages.used.bytes | Memory used in allocated huge pages. | long | byte | gauge |
+| system.memory.hugepages.used.pct | Percentage of huge pages used. | long | percent | gauge |
+| system.memory.page_stats.direct_efficiency.pct | direct reclaim efficiency percentage. A lower percentage indicates the system is struggling to reclaim memory. | scaled_float | percent | gauge |
+| system.memory.page_stats.kswapd_efficiency.pct | kswapd reclaim efficiency percentage. A lower percentage indicates the system is struggling to reclaim memory. | scaled_float | percent | gauge |
+| system.memory.page_stats.pgfree.pages | pages freed by the system | long |  | counter |
+| system.memory.page_stats.pgscan_direct.pages | pages scanned directly | long |  | counter |
+| system.memory.page_stats.pgscan_kswapd.pages | pages scanned by kswapd | long |  | counter |
+| system.memory.page_stats.pgsteal_direct.pages | number of pages reclaimed directly | long |  | counter |
+| system.memory.page_stats.pgsteal_kswapd.pages | number of pages reclaimed by kswapd | long |  | counter |
+| system.memory.swap.free | Available swap memory. | long | byte | gauge |
+| system.memory.swap.in.pages | count of pages swapped in | long |  | gauge |
+| system.memory.swap.out.pages | count of pages swapped out | long |  | counter |
+| system.memory.swap.readahead.cached | swap readahead cache hits | long |  |  |
+| system.memory.swap.readahead.pages | swap readahead pages | long |  | counter |
+| system.memory.swap.total | Total swap memory. | long | byte | gauge |
+| system.memory.swap.used.bytes | Used swap memory. | long | byte | gauge |
+| system.memory.swap.used.pct | The percentage of used swap memory. | scaled_float | percent | gauge |
+| system.memory.total | Total memory. | long | byte | gauge |
+| system.memory.used.bytes | Used memory. | long | byte | gauge |
+| system.memory.used.pct | The percentage of used memory. | scaled_float | percent | gauge |
 
 
 ### Network
@@ -1382,69 +1382,69 @@ This dataset is available on:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Date/time when the event originated. This is the date/time extracted from the event, typically representing when the event was generated by the source. If the event source has no original timestamp, this value is typically populated by the first time the event was received by the pipeline. Required field for all events. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| group.id | Unique identifier for the group on the system/platform. | keyword |
-| group.name | Name of the group. | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.network.in.bytes | The number of bytes received on all network interfaces by the host in a given period of time. | scaled_float |
-| host.network.in.packets | The number of packets received on all network interfaces by the host in a given period of time. | long |
-| host.network.out.bytes | The number of bytes sent out on all network interfaces by the host in a given period of time. | scaled_float |
-| host.network.out.packets | The number of packets sent out on all network interfaces by the host in a given period of time. | long |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
-| process.name | Process name. Sometimes called program name or similar. | keyword |
-| process.pid | Process id. | long |
-| source.geo.city_name | City name. | keyword |
-| source.geo.continent_name | Name of the continent. | keyword |
-| source.geo.country_iso_code | Country ISO code. | keyword |
-| source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.region_iso_code | Region ISO code. | keyword |
-| source.geo.region_name | Region name. | keyword |
-| source.ip | IP address of the source (IPv4 or IPv6). | ip |
-| source.port | Port of the source. | long |
-| system.network.in.bytes | The number of bytes received. | long |
-| system.network.in.dropped | The number of incoming packets that were dropped. | long |
-| system.network.in.errors | The number of errors while receiving. | long |
-| system.network.in.packets | The number or packets received. | long |
-| system.network.name | The network interface name. | keyword |
-| system.network.out.bytes | The number of bytes sent. | long |
-| system.network.out.dropped | The number of outgoing packets that were dropped. This value is always 0 on Darwin and BSD because it is not reported by the operating system. | long |
-| system.network.out.errors | The number of errors while sending. | long |
-| system.network.out.packets | The number of packets sent. | long |
-| user.id | Unique identifier of the user. | keyword |
-| user.name | Short name or login of the user. | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Date/time when the event originated. This is the date/time extracted from the event, typically representing when the event was generated by the source. If the event source has no original timestamp, this value is typically populated by the first time the event was received by the pipeline. Required field for all events. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| group.id | Unique identifier for the group on the system/platform. | keyword |  |  |
+| group.name | Name of the group. | keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.network.in.bytes | The number of bytes received on all network interfaces by the host in a given period of time. | scaled_float | byte | counter |
+| host.network.in.packets | The number of packets received on all network interfaces by the host in a given period of time. | long |  |  |
+| host.network.out.bytes | The number of bytes sent out on all network interfaces by the host in a given period of time. | scaled_float | byte | counter |
+| host.network.out.packets | The number of packets sent out on all network interfaces by the host in a given period of time. | long |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |  |  |
+| process.name | Process name. Sometimes called program name or similar. | keyword |  |  |
+| process.pid | Process id. | long |  |  |
+| source.geo.city_name | City name. | keyword |  |  |
+| source.geo.continent_name | Name of the continent. | keyword |  |  |
+| source.geo.country_iso_code | Country ISO code. | keyword |  |  |
+| source.geo.location | Longitude and latitude. | geo_point |  |  |
+| source.geo.region_iso_code | Region ISO code. | keyword |  |  |
+| source.geo.region_name | Region name. | keyword |  |  |
+| source.ip | IP address of the source (IPv4 or IPv6). | ip |  |  |
+| source.port | Port of the source. | long |  |  |
+| system.network.in.bytes | The number of bytes received. | long | byte | counter |
+| system.network.in.dropped | The number of incoming packets that were dropped. | long |  | counter |
+| system.network.in.errors | The number of errors while receiving. | long |  | counter |
+| system.network.in.packets | The number or packets received. | long |  | counter |
+| system.network.name | The network interface name. | keyword |  |  |
+| system.network.out.bytes | The number of bytes sent. | long | byte | counter |
+| system.network.out.dropped | The number of outgoing packets that were dropped. This value is always 0 on Darwin and BSD because it is not reported by the operating system. | long |  | counter |
+| system.network.out.errors | The number of errors while sending. | long |  | counter |
+| system.network.out.packets | The number of packets sent. | long |  | counter |
+| user.id | Unique identifier of the user. | keyword |  |  |
+| user.name | Short name or login of the user. | keyword |  |  |
 
 
 ### Process
@@ -1461,125 +1461,125 @@ This dataset is available on:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip address. | ip |
-| host.mac | Host mac address. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.full | Operating system name, including the version or code name. | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| process.cpu.pct | The percentage of CPU time spent by the process since the last event. This value is normalized by the number of CPU cores and it ranges from 0 to 1. | scaled_float |
-| process.cpu.start_time | The time when the process was started. | date |
-| process.memory.pct | The percentage of memory the process occupied in main memory (RAM). | scaled_float |
-| process.name | Process name. Sometimes called program name or similar. | keyword |
-| process.pgid | Identifier of the group of processes the process belongs to. | long |
-| process.pid | Process id. | long |
-| process.ppid | Parent process' pid. | long |
-| process.state | The process state. For example: "running". | keyword |
-| process.working_directory | The working directory of the process. | keyword |
-| system.process.cgroup.blkio.id | ID of the cgroup. | keyword |
-| system.process.cgroup.blkio.path | Path to the cgroup relative to the cgroup subsystems mountpoint. | keyword |
-| system.process.cgroup.blkio.total.bytes | Total number of bytes transferred to and from all block devices by processes in the cgroup. | long |
-| system.process.cgroup.blkio.total.ios | Total number of I/O operations performed on all devices by processes in the cgroup as seen by the throttling policy. | long |
-| system.process.cgroup.cpu.cfs.period.us | Period of time in microseconds for how regularly a cgroup's access to CPU resources should be reallocated. | long |
-| system.process.cgroup.cpu.cfs.quota.us | Total amount of time in microseconds for which all tasks in a cgroup can run during one period (as defined by cfs.period.us). | long |
-| system.process.cgroup.cpu.cfs.shares | An integer value that specifies a relative share of CPU time available to the tasks in a cgroup. The value specified in the cpu.shares file must be 2 or higher. | long |
-| system.process.cgroup.cpu.id | ID of the cgroup. | keyword |
-| system.process.cgroup.cpu.path | Path to the cgroup relative to the cgroup subsystem's mountpoint. | keyword |
-| system.process.cgroup.cpu.rt.period.us | Period of time in microseconds for how regularly a cgroup's access to CPU resources is reallocated. | long |
-| system.process.cgroup.cpu.rt.runtime.us | Period of time in microseconds for the longest continuous period in which the tasks in a cgroup have access to CPU resources. | long |
-| system.process.cgroup.cpu.stats.periods | Number of period intervals (as specified in cpu.cfs.period.us) that have elapsed. | long |
-| system.process.cgroup.cpu.stats.throttled.ns | The total time duration (in nanoseconds) for which tasks in a cgroup have been throttled. | long |
-| system.process.cgroup.cpu.stats.throttled.periods | Number of times tasks in a cgroup have been throttled (that is, not allowed to run because they have exhausted all of the available time as specified by their quota). | long |
-| system.process.cgroup.cpuacct.id | ID of the cgroup. | keyword |
-| system.process.cgroup.cpuacct.path | Path to the cgroup relative to the cgroup subsystem's mountpoint. | keyword |
-| system.process.cgroup.cpuacct.percpu | CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup. | object |
-| system.process.cgroup.cpuacct.stats.system.ns | CPU time consumed by tasks in user (kernel) mode. | long |
-| system.process.cgroup.cpuacct.stats.user.ns | CPU time consumed by tasks in user mode. | long |
-| system.process.cgroup.cpuacct.total.ns | Total CPU time in nanoseconds consumed by all tasks in the cgroup. | long |
-| system.process.cgroup.id | The ID common to all cgroups associated with this task. If there isn't a common ID used by all cgroups this field will be absent. | keyword |
-| system.process.cgroup.memory.id | ID of the cgroup. | keyword |
-| system.process.cgroup.memory.kmem.failures | The number of times that the memory limit (kmem.limit.bytes) was reached. | long |
-| system.process.cgroup.memory.kmem.limit.bytes | The maximum amount of kernel memory that tasks in the cgroup are allowed to use. | long |
-| system.process.cgroup.memory.kmem.usage.bytes | Total kernel memory usage by processes in the cgroup (in bytes). | long |
-| system.process.cgroup.memory.kmem.usage.max.bytes | The maximum kernel memory used by processes in the cgroup (in bytes). | long |
-| system.process.cgroup.memory.kmem_tcp.failures | The number of times that the memory limit (kmem_tcp.limit.bytes) was reached. | long |
-| system.process.cgroup.memory.kmem_tcp.limit.bytes | The maximum amount of memory for TCP buffers that tasks in the cgroup are allowed to use. | long |
-| system.process.cgroup.memory.kmem_tcp.usage.bytes | Total memory usage for TCP buffers in bytes. | long |
-| system.process.cgroup.memory.kmem_tcp.usage.max.bytes | The maximum memory used for TCP buffers by processes in the cgroup (in bytes). | long |
-| system.process.cgroup.memory.mem.failures | The number of times that the memory limit (mem.limit.bytes) was reached. | long |
-| system.process.cgroup.memory.mem.limit.bytes | The maximum amount of user memory in bytes (including file cache) that tasks in the cgroup are allowed to use. | long |
-| system.process.cgroup.memory.mem.usage.bytes | Total memory usage by processes in the cgroup (in bytes). | long |
-| system.process.cgroup.memory.mem.usage.max.bytes | The maximum memory used by processes in the cgroup (in bytes). | long |
-| system.process.cgroup.memory.memsw.failures | The number of times that the memory plus swap space limit (memsw.limit.bytes) was reached. | long |
-| system.process.cgroup.memory.memsw.limit.bytes | The maximum amount for the sum of memory and swap usage that tasks in the cgroup are allowed to use. | long |
-| system.process.cgroup.memory.memsw.usage.bytes | The sum of current memory usage plus swap space used by processes in the cgroup (in bytes). | long |
-| system.process.cgroup.memory.memsw.usage.max.bytes | The maximum amount of memory and swap space used by processes in the cgroup (in bytes). | long |
-| system.process.cgroup.memory.path | Path to the cgroup relative to the cgroup subsystem's mountpoint. | keyword |
-| system.process.cgroup.memory.stats.active_anon.bytes | Anonymous and swap cache on active least-recently-used (LRU) list, including tmpfs (shmem), in bytes. | long |
-| system.process.cgroup.memory.stats.active_file.bytes | File-backed memory on active LRU list, in bytes. | long |
-| system.process.cgroup.memory.stats.cache.bytes | Page cache, including tmpfs (shmem), in bytes. | long |
-| system.process.cgroup.memory.stats.hierarchical_memory_limit.bytes | Memory limit for the hierarchy that contains the memory cgroup, in bytes. | long |
-| system.process.cgroup.memory.stats.hierarchical_memsw_limit.bytes | Memory plus swap limit for the hierarchy that contains the memory cgroup, in bytes. | long |
-| system.process.cgroup.memory.stats.inactive_anon.bytes | Anonymous and swap cache on inactive LRU list, including tmpfs (shmem), in bytes | long |
-| system.process.cgroup.memory.stats.inactive_file.bytes | File-backed memory on inactive LRU list, in bytes. | long |
-| system.process.cgroup.memory.stats.major_page_faults | Number of times that a process in the cgroup triggered a major fault. "Major" faults happen when the kernel actually has to read the data from disk. | long |
-| system.process.cgroup.memory.stats.mapped_file.bytes | Size of memory-mapped mapped files, including tmpfs (shmem), in bytes. | long |
-| system.process.cgroup.memory.stats.page_faults | Number of times that a process in the cgroup triggered a page fault. | long |
-| system.process.cgroup.memory.stats.pages_in | Number of pages paged into memory. This is a counter. | long |
-| system.process.cgroup.memory.stats.pages_out | Number of pages paged out of memory. This is a counter. | long |
-| system.process.cgroup.memory.stats.rss.bytes | Anonymous and swap cache (includes transparent hugepages), not including tmpfs (shmem), in bytes. | long |
-| system.process.cgroup.memory.stats.rss_huge.bytes | Number of bytes of anonymous transparent hugepages. | long |
-| system.process.cgroup.memory.stats.swap.bytes | Swap usage, in bytes. | long |
-| system.process.cgroup.memory.stats.unevictable.bytes | Memory that cannot be reclaimed, in bytes. | long |
-| system.process.cgroup.path | The path to the cgroup relative to the cgroup subsystem's mountpoint. If there isn't a common path used by all cgroups this field will be absent. | keyword |
-| system.process.cmdline | The full command-line used to start the process, including the arguments separated by space. | keyword |
-| system.process.cpu.start_time | The time when the process was started. | date |
-| system.process.cpu.system.ticks | The amount of CPU time the process spent in kernel space. | long |
-| system.process.cpu.total.norm.pct | The percentage of CPU time spent by the process since the last event. This value is normalized by the number of CPU cores and it ranges from 0 to 100%. | scaled_float |
-| system.process.cpu.total.pct | The percentage of CPU time spent by the process since the last update. Its value is similar to the %CPU value of the process displayed by the top command on Unix systems. | scaled_float |
-| system.process.cpu.total.ticks | The total CPU time spent by the process. | long |
-| system.process.cpu.total.value | The value of CPU usage since starting the process. | long |
-| system.process.cpu.user.ticks | The amount of CPU time the process spent in user space. | long |
-| system.process.env | The environment variables used to start the process. The data is available on FreeBSD, Linux, and OS X. | object |
-| system.process.fd.limit.hard | The hard limit on the number of file descriptors opened by the process. The hard limit can only be raised by root. | long |
-| system.process.fd.limit.soft | The soft limit on the number of file descriptors opened by the process. The soft limit can be changed by the process at any time. | long |
-| system.process.fd.open | The number of file descriptors open by the process. | long |
-| system.process.memory.rss.bytes | The Resident Set Size. The amount of memory the process occupied in main memory (RAM). On Windows this represents the current working set size, in bytes. | long |
-| system.process.memory.rss.pct | The percentage of memory the process occupied in main memory (RAM). | scaled_float |
-| system.process.memory.share | The shared memory the process uses. | long |
-| system.process.memory.size | The total virtual memory the process has. On Windows this represents the Commit Charge (the total amount of memory that the memory manager has committed for a running process) value in bytes for this process. | long |
-| system.process.state | The process state. For example: "running". | keyword |
-| user.name | Short name or login of the user. | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip address. | ip |  |  |
+| host.mac | Host mac address. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.full | Operating system name, including the version or code name. | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| process.cpu.pct | The percentage of CPU time spent by the process since the last event. This value is normalized by the number of CPU cores and it ranges from 0 to 1. | scaled_float |  |  |
+| process.cpu.start_time | The time when the process was started. | date |  |  |
+| process.memory.pct | The percentage of memory the process occupied in main memory (RAM). | scaled_float |  |  |
+| process.name | Process name. Sometimes called program name or similar. | keyword |  |  |
+| process.pgid | Identifier of the group of processes the process belongs to. | long |  |  |
+| process.pid | Process id. | long |  |  |
+| process.ppid | Parent process' pid. | long |  |  |
+| process.state | The process state. For example: "running". | keyword |  |  |
+| process.working_directory | The working directory of the process. | keyword |  |  |
+| system.process.cgroup.blkio.id | ID of the cgroup. | keyword |  |  |
+| system.process.cgroup.blkio.path | Path to the cgroup relative to the cgroup subsystems mountpoint. | keyword |  |  |
+| system.process.cgroup.blkio.total.bytes | Total number of bytes transferred to and from all block devices by processes in the cgroup. | long | byte | gauge |
+| system.process.cgroup.blkio.total.ios | Total number of I/O operations performed on all devices by processes in the cgroup as seen by the throttling policy. | long |  | counter |
+| system.process.cgroup.cpu.cfs.period.us | Period of time in microseconds for how regularly a cgroup's access to CPU resources should be reallocated. | long | micros |  |
+| system.process.cgroup.cpu.cfs.quota.us | Total amount of time in microseconds for which all tasks in a cgroup can run during one period (as defined by cfs.period.us). | long | micros |  |
+| system.process.cgroup.cpu.cfs.shares | An integer value that specifies a relative share of CPU time available to the tasks in a cgroup. The value specified in the cpu.shares file must be 2 or higher. | long |  |  |
+| system.process.cgroup.cpu.id | ID of the cgroup. | keyword |  |  |
+| system.process.cgroup.cpu.path | Path to the cgroup relative to the cgroup subsystem's mountpoint. | keyword |  |  |
+| system.process.cgroup.cpu.rt.period.us | Period of time in microseconds for how regularly a cgroup's access to CPU resources is reallocated. | long | micros |  |
+| system.process.cgroup.cpu.rt.runtime.us | Period of time in microseconds for the longest continuous period in which the tasks in a cgroup have access to CPU resources. | long | micros |  |
+| system.process.cgroup.cpu.stats.periods | Number of period intervals (as specified in cpu.cfs.period.us) that have elapsed. | long |  | counter |
+| system.process.cgroup.cpu.stats.throttled.ns | The total time duration (in nanoseconds) for which tasks in a cgroup have been throttled. | long | nanos | counter |
+| system.process.cgroup.cpu.stats.throttled.periods | Number of times tasks in a cgroup have been throttled (that is, not allowed to run because they have exhausted all of the available time as specified by their quota). | long |  | counter |
+| system.process.cgroup.cpuacct.id | ID of the cgroup. | keyword |  |  |
+| system.process.cgroup.cpuacct.path | Path to the cgroup relative to the cgroup subsystem's mountpoint. | keyword |  |  |
+| system.process.cgroup.cpuacct.percpu | CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup. | object |  |  |
+| system.process.cgroup.cpuacct.stats.system.ns | CPU time consumed by tasks in user (kernel) mode. | long | nanos | counter |
+| system.process.cgroup.cpuacct.stats.user.ns | CPU time consumed by tasks in user mode. | long | nanos | counter |
+| system.process.cgroup.cpuacct.total.ns | Total CPU time in nanoseconds consumed by all tasks in the cgroup. | long | nanos | counter |
+| system.process.cgroup.id | The ID common to all cgroups associated with this task. If there isn't a common ID used by all cgroups this field will be absent. | keyword |  |  |
+| system.process.cgroup.memory.id | ID of the cgroup. | keyword |  |  |
+| system.process.cgroup.memory.kmem.failures | The number of times that the memory limit (kmem.limit.bytes) was reached. | long |  | counter |
+| system.process.cgroup.memory.kmem.limit.bytes | The maximum amount of kernel memory that tasks in the cgroup are allowed to use. | long | byte | gauge |
+| system.process.cgroup.memory.kmem.usage.bytes | Total kernel memory usage by processes in the cgroup (in bytes). | long | byte | gauge |
+| system.process.cgroup.memory.kmem.usage.max.bytes | The maximum kernel memory used by processes in the cgroup (in bytes). | long | byte | gauge |
+| system.process.cgroup.memory.kmem_tcp.failures | The number of times that the memory limit (kmem_tcp.limit.bytes) was reached. | long |  | counter |
+| system.process.cgroup.memory.kmem_tcp.limit.bytes | The maximum amount of memory for TCP buffers that tasks in the cgroup are allowed to use. | long | byte | gauge |
+| system.process.cgroup.memory.kmem_tcp.usage.bytes | Total memory usage for TCP buffers in bytes. | long | byte | gauge |
+| system.process.cgroup.memory.kmem_tcp.usage.max.bytes | The maximum memory used for TCP buffers by processes in the cgroup (in bytes). | long | byte | gauge |
+| system.process.cgroup.memory.mem.failures | The number of times that the memory limit (mem.limit.bytes) was reached. | long |  |  |
+| system.process.cgroup.memory.mem.limit.bytes | The maximum amount of user memory in bytes (including file cache) that tasks in the cgroup are allowed to use. | long | byte | gauge |
+| system.process.cgroup.memory.mem.usage.bytes | Total memory usage by processes in the cgroup (in bytes). | long | byte | gauge |
+| system.process.cgroup.memory.mem.usage.max.bytes | The maximum memory used by processes in the cgroup (in bytes). | long | byte | gauge |
+| system.process.cgroup.memory.memsw.failures | The number of times that the memory plus swap space limit (memsw.limit.bytes) was reached. | long | byte | gauge |
+| system.process.cgroup.memory.memsw.limit.bytes | The maximum amount for the sum of memory and swap usage that tasks in the cgroup are allowed to use. | long | byte | gauge |
+| system.process.cgroup.memory.memsw.usage.bytes | The sum of current memory usage plus swap space used by processes in the cgroup (in bytes). | long | byte | gauge |
+| system.process.cgroup.memory.memsw.usage.max.bytes | The maximum amount of memory and swap space used by processes in the cgroup (in bytes). | long | byte | gauge |
+| system.process.cgroup.memory.path | Path to the cgroup relative to the cgroup subsystem's mountpoint. | keyword |  |  |
+| system.process.cgroup.memory.stats.active_anon.bytes | Anonymous and swap cache on active least-recently-used (LRU) list, including tmpfs (shmem), in bytes. | long | byte | gauge |
+| system.process.cgroup.memory.stats.active_file.bytes | File-backed memory on active LRU list, in bytes. | long | byte | gauge |
+| system.process.cgroup.memory.stats.cache.bytes | Page cache, including tmpfs (shmem), in bytes. | long | byte | gauge |
+| system.process.cgroup.memory.stats.hierarchical_memory_limit.bytes | Memory limit for the hierarchy that contains the memory cgroup, in bytes. | long | byte | gauge |
+| system.process.cgroup.memory.stats.hierarchical_memsw_limit.bytes | Memory plus swap limit for the hierarchy that contains the memory cgroup, in bytes. | long | byte | gauge |
+| system.process.cgroup.memory.stats.inactive_anon.bytes | Anonymous and swap cache on inactive LRU list, including tmpfs (shmem), in bytes | long | byte | gauge |
+| system.process.cgroup.memory.stats.inactive_file.bytes | File-backed memory on inactive LRU list, in bytes. | long | byte | gauge |
+| system.process.cgroup.memory.stats.major_page_faults | Number of times that a process in the cgroup triggered a major fault. "Major" faults happen when the kernel actually has to read the data from disk. | long |  | counter |
+| system.process.cgroup.memory.stats.mapped_file.bytes | Size of memory-mapped mapped files, including tmpfs (shmem), in bytes. | long | byte | gauge |
+| system.process.cgroup.memory.stats.page_faults | Number of times that a process in the cgroup triggered a page fault. | long |  | counter |
+| system.process.cgroup.memory.stats.pages_in | Number of pages paged into memory. This is a counter. | long |  | counter |
+| system.process.cgroup.memory.stats.pages_out | Number of pages paged out of memory. This is a counter. | long |  | counter |
+| system.process.cgroup.memory.stats.rss.bytes | Anonymous and swap cache (includes transparent hugepages), not including tmpfs (shmem), in bytes. | long | byte | gauge |
+| system.process.cgroup.memory.stats.rss_huge.bytes | Number of bytes of anonymous transparent hugepages. | long | byte | gauge |
+| system.process.cgroup.memory.stats.swap.bytes | Swap usage, in bytes. | long | byte | gauge |
+| system.process.cgroup.memory.stats.unevictable.bytes | Memory that cannot be reclaimed, in bytes. | long | byte | gauge |
+| system.process.cgroup.path | The path to the cgroup relative to the cgroup subsystem's mountpoint. If there isn't a common path used by all cgroups this field will be absent. | keyword |  |  |
+| system.process.cmdline | The full command-line used to start the process, including the arguments separated by space. | keyword |  |  |
+| system.process.cpu.start_time | The time when the process was started. | date |  |  |
+| system.process.cpu.system.ticks | The amount of CPU time the process spent in kernel space. | long |  | counter |
+| system.process.cpu.total.norm.pct | The percentage of CPU time spent by the process since the last event. This value is normalized by the number of CPU cores and it ranges from 0 to 100%. | scaled_float | percent | gauge |
+| system.process.cpu.total.pct | The percentage of CPU time spent by the process since the last update. Its value is similar to the %CPU value of the process displayed by the top command on Unix systems. | scaled_float | percent | gauge |
+| system.process.cpu.total.ticks | The total CPU time spent by the process. | long |  | counter |
+| system.process.cpu.total.value | The value of CPU usage since starting the process. | long |  | counter |
+| system.process.cpu.user.ticks | The amount of CPU time the process spent in user space. | long |  | counter |
+| system.process.env | The environment variables used to start the process. The data is available on FreeBSD, Linux, and OS X. | object |  |  |
+| system.process.fd.limit.hard | The hard limit on the number of file descriptors opened by the process. The hard limit can only be raised by root. | long |  | gauge |
+| system.process.fd.limit.soft | The soft limit on the number of file descriptors opened by the process. The soft limit can be changed by the process at any time. | long |  | gauge |
+| system.process.fd.open | The number of file descriptors open by the process. | long |  | gauge |
+| system.process.memory.rss.bytes | The Resident Set Size. The amount of memory the process occupied in main memory (RAM). On Windows this represents the current working set size, in bytes. | long | byte | gauge |
+| system.process.memory.rss.pct | The percentage of memory the process occupied in main memory (RAM). | scaled_float | percent | gauge |
+| system.process.memory.share | The shared memory the process uses. | long | byte | gauge |
+| system.process.memory.size | The total virtual memory the process has. On Windows this represents the Commit Charge (the total amount of memory that the memory manager has committed for a running process) value in bytes for this process. | long | byte | gauge |
+| system.process.state | The process state. For example: "running". | keyword |  |  |
+| user.name | Short name or login of the user. | keyword |  |  |
 
 
 ### Process summary
@@ -1596,64 +1596,64 @@ This dataset is available on:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| group.id | Unique identifier for the group on the system/platform. | keyword |
-| group.name | Name of the group. | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
-| process.name | Process name. Sometimes called program name or similar. | keyword |
-| process.pid | Process id. | long |
-| source.geo.city_name | City name. | keyword |
-| source.geo.continent_name | Name of the continent. | keyword |
-| source.geo.country_iso_code | Country ISO code. | keyword |
-| source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.region_iso_code | Region ISO code. | keyword |
-| source.geo.region_name | Region name. | keyword |
-| source.ip | IP address of the source (IPv4 or IPv6). | ip |
-| source.port | Port of the source. | long |
-| system.process.summary.dead | Number of dead processes on this host. It's very unlikely that it will appear but in some special situations it may happen. | long |
-| system.process.summary.idle | Number of idle processes on this host. | long |
-| system.process.summary.running | Number of running processes on this host. | long |
-| system.process.summary.sleeping | Number of sleeping processes on this host. | long |
-| system.process.summary.stopped | Number of stopped processes on this host. | long |
-| system.process.summary.total | Total number of processes on this host. | long |
-| system.process.summary.unknown | Number of processes for which the state couldn't be retrieved or is unknown. | long |
-| system.process.summary.zombie | Number of zombie processes on this host. | long |
-| user.id | Unique identifier of the user. | keyword |
-| user.name | Short name or login of the user. | keyword |
+| Field | Description | Type | Metric Type |
+|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |
+| cloud.region | Region in which this host is running. | keyword |  |
+| container.id | Unique container id. | keyword |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |
+| container.labels | Image labels. | object |  |
+| container.name | Container name. | keyword |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |
+| data_stream.type | Data stream type. | constant_keyword |  |
+| group.id | Unique identifier for the group on the system/platform. | keyword |  |
+| group.name | Name of the group. | keyword |  |
+| host.architecture | Operating system architecture. | keyword |  |
+| host.containerized | If the host is a container. | boolean |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |
+| host.ip | Host ip addresses. | ip |  |
+| host.mac | Host mac addresses. | keyword |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |
+| host.os.build | OS build information. | keyword |  |
+| host.os.codename | OS codename, if any. | keyword |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |
+| host.os.name | Operating system name, without the version. | keyword |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
+| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |  |
+| process.name | Process name. Sometimes called program name or similar. | keyword |  |
+| process.pid | Process id. | long |  |
+| source.geo.city_name | City name. | keyword |  |
+| source.geo.continent_name | Name of the continent. | keyword |  |
+| source.geo.country_iso_code | Country ISO code. | keyword |  |
+| source.geo.location | Longitude and latitude. | geo_point |  |
+| source.geo.region_iso_code | Region ISO code. | keyword |  |
+| source.geo.region_name | Region name. | keyword |  |
+| source.ip | IP address of the source (IPv4 or IPv6). | ip |  |
+| source.port | Port of the source. | long |  |
+| system.process.summary.dead | Number of dead processes on this host. It's very unlikely that it will appear but in some special situations it may happen. | long | gauge |
+| system.process.summary.idle | Number of idle processes on this host. | long | gauge |
+| system.process.summary.running | Number of running processes on this host. | long | gauge |
+| system.process.summary.sleeping | Number of sleeping processes on this host. | long | gauge |
+| system.process.summary.stopped | Number of stopped processes on this host. | long | gauge |
+| system.process.summary.total | Total number of processes on this host. | long | gauge |
+| system.process.summary.unknown | Number of processes for which the state couldn't be retrieved or is unknown. | long | gauge |
+| system.process.summary.zombie | Number of zombie processes on this host. | long | gauge |
+| user.id | Unique identifier of the user. | keyword |  |
+| user.name | Short name or login of the user. | keyword |  |
 
 
 ### Socket summary
@@ -1673,73 +1673,73 @@ This dataset is available on:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| group.id | Unique identifier for the group on the system/platform. | keyword |
-| group.name | Name of the group. | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
-| process.name | Process name. Sometimes called program name or similar. | keyword |
-| process.pid | Process id. | long |
-| source.geo.city_name | City name. | keyword |
-| source.geo.continent_name | Name of the continent. | keyword |
-| source.geo.country_iso_code | Country ISO code. | keyword |
-| source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.region_iso_code | Region ISO code. | keyword |
-| source.geo.region_name | Region name. | keyword |
-| source.ip | IP address of the source (IPv4 or IPv6). | ip |
-| source.port | Port of the source. | long |
-| system.socket.summary.all.count | All open connections | integer |
-| system.socket.summary.all.listening | All listening ports | integer |
-| system.socket.summary.tcp.all.close_wait | Number of TCP connections in _close_wait_ state | integer |
-| system.socket.summary.tcp.all.closing | Number of TCP connections in _closing_ state | integer |
-| system.socket.summary.tcp.all.count | All open TCP connections | integer |
-| system.socket.summary.tcp.all.established | Number of established TCP connections | integer |
-| system.socket.summary.tcp.all.fin_wait1 | Number of TCP connections in _fin_wait1_ state | integer |
-| system.socket.summary.tcp.all.fin_wait2 | Number of TCP connections in _fin_wait2_ state | integer |
-| system.socket.summary.tcp.all.last_ack | Number of TCP connections in _last_ack_ state | integer |
-| system.socket.summary.tcp.all.listening | All TCP listening ports | integer |
-| system.socket.summary.tcp.all.orphan | A count of all orphaned tcp sockets. Only available on Linux. | integer |
-| system.socket.summary.tcp.all.syn_recv | Number of TCP connections in _syn_recv_ state | integer |
-| system.socket.summary.tcp.all.syn_sent | Number of TCP connections in _syn_sent_ state | integer |
-| system.socket.summary.tcp.all.time_wait | Number of TCP connections in _time_wait_ state | integer |
-| system.socket.summary.tcp.memory | Memory used by TCP sockets in bytes, based on number of allocated pages and system page size. Corresponds to limits set in /proc/sys/net/ipv4/tcp_mem. Only available on Linux. | integer |
-| system.socket.summary.udp.all.count | All open UDP connections | integer |
-| system.socket.summary.udp.memory | Memory used by UDP sockets in bytes, based on number of allocated pages and system page size. Corresponds to limits set in /proc/sys/net/ipv4/udp_mem. Only available on Linux. | integer |
-| user.id | Unique identifier of the user. | keyword |
-| user.name | Short name or login of the user. | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| group.id | Unique identifier for the group on the system/platform. | keyword |  |  |
+| group.name | Name of the group. | keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |  |  |
+| process.name | Process name. Sometimes called program name or similar. | keyword |  |  |
+| process.pid | Process id. | long |  |  |
+| source.geo.city_name | City name. | keyword |  |  |
+| source.geo.continent_name | Name of the continent. | keyword |  |  |
+| source.geo.country_iso_code | Country ISO code. | keyword |  |  |
+| source.geo.location | Longitude and latitude. | geo_point |  |  |
+| source.geo.region_iso_code | Region ISO code. | keyword |  |  |
+| source.geo.region_name | Region name. | keyword |  |  |
+| source.ip | IP address of the source (IPv4 or IPv6). | ip |  |  |
+| source.port | Port of the source. | long |  |  |
+| system.socket.summary.all.count | All open connections | integer |  | gauge |
+| system.socket.summary.all.listening | All listening ports | integer |  | gauge |
+| system.socket.summary.tcp.all.close_wait | Number of TCP connections in _close_wait_ state | integer |  | gauge |
+| system.socket.summary.tcp.all.closing | Number of TCP connections in _closing_ state | integer |  | gauge |
+| system.socket.summary.tcp.all.count | All open TCP connections | integer |  | gauge |
+| system.socket.summary.tcp.all.established | Number of established TCP connections | integer |  | gauge |
+| system.socket.summary.tcp.all.fin_wait1 | Number of TCP connections in _fin_wait1_ state | integer |  | gauge |
+| system.socket.summary.tcp.all.fin_wait2 | Number of TCP connections in _fin_wait2_ state | integer |  | gauge |
+| system.socket.summary.tcp.all.last_ack | Number of TCP connections in _last_ack_ state | integer |  | gauge |
+| system.socket.summary.tcp.all.listening | All TCP listening ports | integer |  | gauge |
+| system.socket.summary.tcp.all.orphan | A count of all orphaned tcp sockets. Only available on Linux. | integer |  | gauge |
+| system.socket.summary.tcp.all.syn_recv | Number of TCP connections in _syn_recv_ state | integer |  | gauge |
+| system.socket.summary.tcp.all.syn_sent | Number of TCP connections in _syn_sent_ state | integer |  | gauge |
+| system.socket.summary.tcp.all.time_wait | Number of TCP connections in _time_wait_ state | integer |  | gauge |
+| system.socket.summary.tcp.memory | Memory used by TCP sockets in bytes, based on number of allocated pages and system page size. Corresponds to limits set in /proc/sys/net/ipv4/tcp_mem. Only available on Linux. | integer | byte | gauge |
+| system.socket.summary.udp.all.count | All open UDP connections | integer |  | gauge |
+| system.socket.summary.udp.memory | Memory used by UDP sockets in bytes, based on number of allocated pages and system page size. Corresponds to limits set in /proc/sys/net/ipv4/udp_mem. Only available on Linux. | integer | byte | gauge |
+| user.id | Unique identifier of the user. | keyword |  |  |
+| user.name | Short name or login of the user. | keyword |  |  |
 
 
 ### Uptime
@@ -1756,40 +1756,40 @@ This dataset is available on:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| system.uptime.duration.ms | The OS uptime in milliseconds. | long |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| system.uptime.duration.ms | The OS uptime in milliseconds. | long | ms | counter |
 

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -10,7 +10,7 @@ categories:
   - security
 release: beta
 conditions:
-  kibana.version: '^7.13.0'
+  kibana.version: '^7.14.0'
 screenshots:
   - src: /img/kibana-system.png
     title: kibana system

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 0.12.6
+version: 0.13.0
 license: basic
 description: System Integration
 type: integration


### PR DESCRIPTION
This PR updates dependency on elastic-package to include changes around rendering of units and metric types for exported fields table.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).
