### PR TITLE
[Auditd] updating auditd package to ECS 1.10

### DIFF
--- a/packages/auditd/changelog.yml
+++ b/packages/auditd/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.0.0"
+- version: "0.2.0"
   changes:
     - description: update to ECS 1.10.0 and apply changes to prepare for package GA
       type: enhancement

--- a/packages/auditd/changelog.yml
+++ b/packages/auditd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.3"
+  changes:
+    - description: set version in the ingest pipeline and make event.original optional
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1031
 - version: "0.1.2"
   changes:
     - description: set version in the ingest pipeline and make event.original optional

--- a/packages/auditd/changelog.yml
+++ b/packages/auditd/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "0.1.3"
   changes:
-    - description: set version in the ingest pipeline and make event.original optional
+    - description: update to ECS 1.10.0
       type: enhancement
       link: https://github.com/elastic/integrations/pull/1031
 - version: "0.1.2"

--- a/packages/auditd/changelog.yml
+++ b/packages/auditd/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
-- version: "0.1.3"
+- version: "1.0.0"
   changes:
-    - description: update to ECS 1.10.0
+    - description: update to ECS 1.10.0 and apply changes to prepare for package GA
       type: enhancement
       link: https://github.com/elastic/integrations/pull/1031
 - version: "0.1.2"

--- a/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-raw.log-config.yml
+++ b/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-raw.log-config.yml
@@ -1,2 +1,0 @@
-dynamic_fields:
-  event.ingested: ".*"

--- a/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-raw.log-expected.json
+++ b/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-raw.log-expected.json
@@ -14,7 +14,7 @@
             },
             "event": {
                 "action": "mac_ipsec_event",
-                "ingested": "2021-06-02T08:11:46.790120300Z",
+                "ingested": "2021-06-09T07:23:18.784310600Z",
                 "original": "type=MAC_IPSEC_EVENT msg=audit(1485893834.891:18877201): op=SPD-delete auid=4294967295 ses=4294967295 res=1 src=192.168.2.0 src_prefixlen=24 dst=192.168.0.0 dst_prefixlen=16",
                 "kind": "event",
                 "outcome": "1"
@@ -54,7 +54,7 @@
             },
             "event": {
                 "action": "syscall",
-                "ingested": "2021-06-02T08:11:46.790159Z",
+                "ingested": "2021-06-09T07:23:18.784333500Z",
                 "original": "type=SYSCALL msg=audit(1485893834.891:18877199): arch=c000003e syscall=44 success=yes exit=184 a0=9 items=0 ppid=1240 pid=1281 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=\"charon\" exe=2F7573722F6C6962657865632F7374726F6E677377616E2F636861726F6E202864656C6574656429 key=(null)",
                 "category": [
                     "process"
@@ -125,7 +125,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790166500Z",
+                "ingested": "2021-06-09T07:23:18.784340400Z",
                 "original": "type=USER_CMD msg=audit(1489519256.192:19600329): user pid=4151 uid=497 auid=700 ses=11988 msg='cwd=\"/\" cmd=2F7573722F6C696236342F6E6167696F732F706C7567696E732F636865636B5F617374657269736B5F7369705F7065657273202D7020323032 terminal=? res=success'",
                 "kind": "event",
                 "action": [
@@ -188,7 +188,7 @@
                 "ip": "96.241.146.97"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790193Z",
+                "ingested": "2021-06-09T07:23:18.784346200Z",
                 "original": "type=CRYPTO_SESSION msg=audit(1481077041.515:406): pid=1298 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 msg='op=start direction=from-server cipher=chacha20-poly1305@openssh.com ksize=512 mac= pfs=curve25519-sha256@libssh.org spid=1299 suid=74 rport=63927 laddr=10.142.0.2 lport=22  exe=\"/usr/sbin/sshd\" hostname=? addr=96.241.146.97 terminal=? res=success'",
                 "kind": "event",
                 "action": [
@@ -245,7 +245,7 @@
                 "action": [
                     "typed"
                 ],
-                "ingested": "2021-06-02T08:11:46.790199300Z",
+                "ingested": "2021-06-09T07:23:18.784354100Z",
                 "original": "type=TTY msg=audit(1491924063.550:1065565): tty pid=27930 uid=1000 auid=1000 ses=762 major=136 minor=0 comm=\"bash\" data=65687F7F6563686F20746573740D76696D202F6574632F70616D2E642F70617373776F72642D617574682D61630D6D616E2070616D5F7474795F61756469740D6D616E2070616D2E640D76696D202F657463017375646F20052F70616D642E73797F7F7F7F7F2E7F6D2E642F7379092D6109617F2D61090D6D616E2070616D0D747F67726570207379737F7F7F2F7661722F6C6F09672F6D65097309207C20677265702070616D5F7474790D677265702070616D5F747479202F7661722F6C6F672F6D6573090D1B5B41017375646F200D7375646F2073750D",
                 "kind": "event"
             },
@@ -276,7 +276,7 @@
             },
             "event": {
                 "action": "proctitle",
-                "ingested": "2021-06-02T08:11:46.790204400Z",
+                "ingested": "2021-06-09T07:23:18.784359700Z",
                 "original": "type=PROCTITLE msg=audit(1451781471.394:194438): proctitle=\"bash\"",
                 "kind": "event"
             },
@@ -297,7 +297,7 @@
             },
             "event": {
                 "action": "proctitle",
-                "ingested": "2021-06-02T08:11:46.790209200Z",
+                "ingested": "2021-06-09T07:23:18.784365Z",
                 "original": "type=PROCTITLE msg=audit(1451781471.394:194440): proctitle=737368643A206275726E205B707269765D",
                 "kind": "event"
             },
@@ -322,7 +322,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790214300Z",
+                "ingested": "2021-06-09T07:23:18.784370100Z",
                 "original": "type=SOFTWARE_UPDATE msg=audit(1573844484.309:785): pid=3157 uid=0 auid=1000 ses=3 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='sw=\"gcc-4.8.5-39.el7.x86_64\" sw_type=rpm key_enforce=0 gpg_res=1 root_dir=\"/\" comm=\"yum\" exe=\"/usr/bin/python2.7\" hostname=? addr=? terminal=? res=success'",
                 "kind": "event",
                 "action": [
@@ -370,7 +370,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790218800Z",
+                "ingested": "2021-06-09T07:23:18.784375500Z",
                 "original": "type=SYSTEM_BOOT msg=audit(1573844456.144:5): pid=678 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg=' comm=\"systemd-update-utmp\" exe=\"/usr/lib/systemd/systemd-update-utmp\" hostname=? addr=? terminal=? res=success'",
                 "kind": "event",
                 "action": [
@@ -409,7 +409,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790223300Z",
+                "ingested": "2021-06-09T07:23:18.784380400Z",
                 "original": "type=SYSTEM_SHUTDOWN msg=audit(1573844517.054:1163): pid=4440 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg=' comm=\"systemd-update-utmp\" exe=\"/usr/lib/systemd/systemd-update-utmp\" hostname=? addr=? terminal=? res=success'",
                 "kind": "event",
                 "action": [
@@ -447,7 +447,7 @@
             },
             "event": {
                 "action": "execve",
-                "ingested": "2021-06-02T08:11:46.790228700Z",
+                "ingested": "2021-06-09T07:23:18.784386200Z",
                 "original": "type=EXECVE msg=audit(1581371984.206:579393): argc=1 a0=top",
                 "kind": "event"
             },
@@ -470,7 +470,7 @@
                 "action": [
                     "loaded-kernel-module"
                 ],
-                "ingested": "2021-06-02T08:11:46.790233100Z",
+                "ingested": "2021-06-09T07:23:18.784391500Z",
                 "original": "type=KERN_MODULE msg=audit(1581371984.206:579397): name=mymodule",
                 "category": [
                     "driver"
@@ -501,7 +501,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790237600Z",
+                "ingested": "2021-06-09T07:23:18.784396500Z",
                 "original": "type=VIRT_CONTROL msg=audit(1513507481.075:145): pid=1431 uid=0 auid=100 ses=3 subj=system_u:system_r:container_runtime_t:s0 msg='user=root reason=api op=create vm=? vm-pid=? hostname=? exe=\"/usr/bin/dockerd-current\" addr=? terminal=? res=success'",
                 "kind": "event",
                 "action": [
@@ -546,7 +546,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790241900Z",
+                "ingested": "2021-06-09T07:23:18.784401300Z",
                 "original": "type=VIRT_MACHINE_ID msg=audit(1481903143.572:23118): pid=5637 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:virtd_t:s0-s0:c0.c1023 msg='virt=kvm vm=\"rhel-work3\" uuid=5501263b-181d-47ed-ab03-a6066f3d26bf vm-ctx=system_u:system_r:svirt_t:s0:c444,c977 img-ctx=system_u:object_r:svirt_image_t:s0:c444,c977 model=selinux exe=\"/usr/sbin/libvirtd\" hostname=? addr=? terminal=? res=success'",
                 "kind": "event",
                 "action": [
@@ -589,7 +589,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790246200Z",
+                "ingested": "2021-06-09T07:23:18.784406Z",
                 "original": "node=localhost.localdomain type=DAEMON_START msg=audit(1594053514.588:4686): op=start ver=2.8.5 format=raw kernel=3.10.0-1062.9.1.el7.x86_64 auid=4294967295 pid=1643 uid=0 ses=4294967295 subj=system_u:system_r:auditd_t:s0 res=success",
                 "kind": "event",
                 "action": [
@@ -632,7 +632,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790250500Z",
+                "ingested": "2021-06-09T07:23:18.784410700Z",
                 "original": "node=localhost.localdomain type=CONFIG_CHANGE msg=audit(1594053514.707:5): audit_failure=1 old=1 auid=4294967295 ses=4294967295 subj=system_u:system_r:unconfined_service_t:s0 res=1",
                 "kind": "event",
                 "action": [
@@ -678,7 +678,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790254900Z",
+                "ingested": "2021-06-09T07:23:18.784415700Z",
                 "original": "node=localhost.localdomain type=SERVICE_START msg=audit(1594053514.709:6): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='unit=auditd comm=\"systemd\" exe=\"/usr/lib/systemd/systemd\" hostname=? addr=? terminal=? res=success'",
                 "kind": "event",
                 "action": [
@@ -723,7 +723,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790259200Z",
+                "ingested": "2021-06-09T07:23:18.784420400Z",
                 "original": "node=localhost.localdomain type=SYSTEM_BOOT msg=audit(1594053514.725:7): pid=1667 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg=' comm=\"systemd-update-utmp\" exe=\"/usr/lib/systemd/systemd-update-utmp\" hostname=? addr=? terminal=? res=success'",
                 "kind": "event",
                 "action": [
@@ -762,7 +762,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790263500Z",
+                "ingested": "2021-06-09T07:23:18.784425100Z",
                 "original": "type=USER_END msg=audit(1489519230.178:19600327): user pid=4121 uid=0 auid=700 ses=11988 msg='op=PAM:session_close acct=\"root\" exe=\"/usr/bin/sudo\" hostname=? addr=? terminal=? res=success'",
                 "kind": "event",
                 "action": [
@@ -809,7 +809,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790268Z",
+                "ingested": "2021-06-09T07:23:18.784429900Z",
                 "original": "type=CRED_DISP msg=audit(1489519230.178:19600328): user pid=4121 uid=0 auid=700 ses=11988 msg='op=PAM:setcred acct=\"root\" exe=\"/usr/bin/sudo\" hostname=? addr=? terminal=? res=success'",
                 "kind": "event",
                 "action": [
@@ -856,7 +856,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790278700Z",
+                "ingested": "2021-06-09T07:23:18.784434800Z",
                 "original": "type=CRED_ACQ msg=audit(1489519256.193:19600330): user pid=4151 uid=0 auid=700 ses=11988 msg='op=PAM:setcred acct=\"root\" exe=\"/usr/bin/sudo\" hostname=? addr=? terminal=? res=success'",
                 "kind": "event",
                 "action": [
@@ -903,7 +903,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790282800Z",
+                "ingested": "2021-06-09T07:23:18.784439900Z",
                 "original": "type=USER_START msg=audit(1489519256.193:19600331): user pid=4151 uid=0 auid=700 ses=11988 msg='op=PAM:session_open acct=\"root\" exe=\"/usr/bin/sudo\" hostname=? addr=? terminal=? res=success'",
                 "kind": "event",
                 "action": [
@@ -952,7 +952,7 @@
                 "action": [
                     "changed-login-id-to"
                 ],
-                "ingested": "2021-06-02T08:11:46.790287500Z",
+                "ingested": "2021-06-09T07:23:18.784444600Z",
                 "original": "type=LOGIN msg=audit(1489636960.072:19623791): pid=28281 uid=0 old auid=700 new auid=700 old ses=6793 new ses=12286",
                 "category": [
                     "authentication"
@@ -1015,7 +1015,7 @@
                 "ip": "96.241.146.97"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790291900Z",
+                "ingested": "2021-06-09T07:23:18.784449700Z",
                 "original": "type=CRYPTO_KEY_USER msg=audit(1489636960.070:19623788): user pid=28281 uid=0 auid=700 ses=6793 msg='op=destroy kind=session fp=? direction=both spid=28282 suid=74 rport=58994 laddr=107.170.139.210 lport=50022  exe=\"/usr/sbin/sshd\" hostname=? addr=96.241.146.97 terminal=? res=success'",
                 "kind": "event",
                 "action": [
@@ -1088,7 +1088,7 @@
                 "ip": "96.241.146.97"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790296100Z",
+                "ingested": "2021-06-09T07:23:18.784455500Z",
                 "original": "type=USER_AUTH msg=audit(1489636960.072:19623789): user pid=28281 uid=0 auid=700 ses=6793 msg='op=success acct=\"admin\" exe=\"/usr/sbin/sshd\" hostname=? addr=96.241.146.97 terminal=ssh res=success'",
                 "kind": "event",
                 "action": [
@@ -1136,7 +1136,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790300400Z",
+                "ingested": "2021-06-09T07:23:18.784460400Z",
                 "original": "type=USER_ACCT msg=audit(1489636977.805:19623808): user pid=28395 uid=0 auid=700 ses=12286 msg='op=PAM:accounting acct=\"root\" exe=\"/bin/su\" hostname=? addr=? terminal=pts/0 res=success'",
                 "kind": "event",
                 "action": [
@@ -1185,7 +1185,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790304600Z",
+                "ingested": "2021-06-09T07:23:18.784465500Z",
                 "original": "type=SERVICE_START msg=audit(1481076983.864:6): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='unit=auditd comm=\"systemd\" exe=\"/usr/lib/systemd/systemd\" hostname=? addr=? terminal=? res=success'",
                 "kind": "event",
                 "action": [
@@ -1229,7 +1229,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790308900Z",
+                "ingested": "2021-06-09T07:23:18.784470400Z",
                 "original": "type=SERVICE_STOP msg=audit(1481076984.534:16): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='unit=irqbalance comm=\"systemd\" exe=\"/usr/lib/systemd/systemd\" hostname=? addr=? terminal=? res=success'",
                 "kind": "event",
                 "action": [
@@ -1271,7 +1271,7 @@
                 "action": [
                     "loaded-firewall-rule-to"
                 ],
-                "ingested": "2021-06-02T08:11:46.790316800Z",
+                "ingested": "2021-06-09T07:23:18.784475500Z",
                 "original": "type=NETFILTER_CFG msg=audit(1481076984.827:17): table=filter family=2 entries=0",
                 "category": [
                     "configuration"
@@ -1304,7 +1304,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790320800Z",
+                "ingested": "2021-06-09T07:23:18.784481800Z",
                 "original": "type=ADD_GROUP msg=audit(1481076992.414:385): pid=1235 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:unconfined_service_t:s0 msg='op=add-group id=1000 exe=\"/usr/sbin/groupadd\" hostname=? addr=? terminal=? res=success'",
                 "kind": "event",
                 "action": [
@@ -1356,7 +1356,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790324500Z",
+                "ingested": "2021-06-09T07:23:18.784486400Z",
                 "original": "type=GRP_MGMT msg=audit(1481076992.419:386): pid=1235 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:unconfined_service_t:s0 msg='op=add-shadow-group id=1000 exe=\"/usr/sbin/groupadd\" hostname=? addr=? terminal=? res=success'",
                 "kind": "event",
                 "action": [
@@ -1408,7 +1408,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790328700Z",
+                "ingested": "2021-06-09T07:23:18.784491100Z",
                 "original": "type=ADD_USER msg=audit(1481076992.488:389): pid=1264 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:unconfined_service_t:s0 msg='op=add-user id=1000 exe=\"/usr/sbin/useradd\" hostname=? addr=? terminal=? res=success'",
                 "kind": "event",
                 "action": [
@@ -1461,7 +1461,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790332300Z",
+                "ingested": "2021-06-09T07:23:18.784496500Z",
                 "original": "type=SYSTEM_RUNLEVEL msg=audit(1481076992.492:390): pid=1279 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='old-level=N new-level=3 comm=\"systemd-update-utmp\" exe=\"/usr/lib/systemd/systemd-update-utmp\" hostname=? addr=? terminal=? res=success'",
                 "kind": "event",
                 "action": [
@@ -1505,7 +1505,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790335800Z",
+                "ingested": "2021-06-09T07:23:18.784502400Z",
                 "original": "type=USER_MGMT msg=audit(1481076992.521:393): pid=1264 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:unconfined_service_t:s0 msg='op=add-home-dir id=1000 exe=\"/usr/sbin/useradd\" hostname=? addr=? terminal=? res=success'",
                 "kind": "event",
                 "action": [
@@ -1557,7 +1557,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790341800Z",
+                "ingested": "2021-06-09T07:23:18.784507200Z",
                 "original": "type=USYS_CONFIG msg=audit(1481076993.000:402): pid=1232 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:unconfined_service_t:s0 msg='changing system time exe=\"/usr/sbin/hwclock\" hostname=? addr=? terminal=? res=success'",
                 "kind": "event",
                 "action": [
@@ -1624,7 +1624,7 @@
                 "action": [
                     "changed-role-to"
                 ],
-                "ingested": "2021-06-02T08:11:46.790345700Z",
+                "ingested": "2021-06-09T07:23:18.784514100Z",
                 "original": "type=USER_ROLE_CHANGE msg=audit(1481077043.140:415): pid=1298 uid=0 auid=1000 ses=1 subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 msg='pam: default-context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 selected-context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 exe=\"/usr/sbin/sshd\" hostname=pool-96-241-146-97.washdc.fios.verizon.net addr=96.241.146.97 terminal=ssh res=success'",
                 "kind": "event",
                 "outcome": "success"
@@ -1683,7 +1683,7 @@
                 "ip": "96.241.146.97"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790349200Z",
+                "ingested": "2021-06-09T07:23:18.784518900Z",
                 "original": "type=USER_LOGIN msg=audit(1481077043.193:421): pid=1298 uid=0 auid=1000 ses=1 subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 msg='op=login id=1000 exe=\"/usr/sbin/sshd\" hostname=pool-96-241-146-97.washdc.fios.verizon.net addr=96.241.146.97 terminal=/dev/pts/0 res=success'",
                 "kind": "event",
                 "action": [
@@ -1733,7 +1733,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790352900Z",
+                "ingested": "2021-06-09T07:23:18.784523900Z",
                 "original": "type=USER_LOGOUT msg=audit(1481077049.033:424): pid=1298 uid=0 auid=1000 ses=1 subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 msg='op=login id=1000 exe=\"/usr/sbin/sshd\" hostname=? addr=? terminal=/dev/pts/0 res=success'",
                 "kind": "event",
                 "action": [
@@ -1778,7 +1778,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790356500Z",
+                "ingested": "2021-06-09T07:23:18.784528400Z",
                 "original": "type=CONFIG_CHANGE msg=audit(1481077231.371:478): auid=1000 ses=3 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 op=\"add_rule\" key=(null) list=4 res=1",
                 "kind": "event",
                 "action": [
@@ -1822,7 +1822,7 @@
             },
             "event": {
                 "action": "cwd",
-                "ingested": "2021-06-02T08:11:46.790359800Z",
+                "ingested": "2021-06-09T07:23:18.784533200Z",
                 "original": "type=CWD msg=audit(1481077231.371:479):  cwd=\"/home/some_user\"",
                 "kind": "event"
             },
@@ -1842,7 +1842,7 @@
             },
             "event": {
                 "action": "path",
-                "ingested": "2021-06-02T08:11:46.790363300Z",
+                "ingested": "2021-06-09T07:23:18.784537800Z",
                 "original": "type=PATH msg=audit(1481077231.371:479): item=0 name=\"/sbin/auditctl\" inode=17367907 dev=08:01 mode=0100750 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:auditctl_exec_t:s0 objtype=NORMAL",
                 "kind": "event"
             },
@@ -1877,7 +1877,7 @@
             },
             "event": {
                 "action": "unknown[1329]",
-                "ingested": "2021-06-02T08:11:46.790366900Z",
+                "ingested": "2021-06-09T07:23:18.784542400Z",
                 "original": "type=UNKNOWN[1329] msg=g\u0005",
                 "kind": "event"
             },
@@ -1896,7 +1896,7 @@
             },
             "event": {
                 "action": "bprm_fcaps",
-                "ingested": "2021-06-02T08:11:46.790371Z",
+                "ingested": "2021-06-09T07:23:18.784547200Z",
                 "original": "type=BPRM_FCAPS msg=audit(1481077308.360:529): fver=0 fp=0000000000000000 fi=0000000000000000 fe=0 old_pp=0000000000000000 old_pi=0000000000000000 old_pe=0000000000000000 new_pp=0000001fffffffff new_pi=0000000000000000 new_pe=0000001fffffffff",
                 "kind": "event"
             },
@@ -1926,7 +1926,7 @@
             },
             "event": {
                 "action": "sockaddr",
-                "ingested": "2021-06-02T08:11:46.790374800Z",
+                "ingested": "2021-06-09T07:23:18.784552Z",
                 "original": "type=SOCKADDR msg=audit(1481078424.953:688): saddr=02000050A9FEA9FE0000000000000000",
                 "kind": "event"
             },
@@ -1947,7 +1947,7 @@
             },
             "event": {
                 "action": "ckaddr",
-                "ingested": "2021-06-02T08:11:46.790378300Z",
+                "ingested": "2021-06-09T07:23:18.784556500Z",
                 "original": "type=CKADDR msg=audit(1481078553.346:737): saddr=02000050A9FEA9FE0000000000000000",
                 "kind": "event"
             },
@@ -1967,7 +1967,7 @@
                 "version": "1.10.0"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:46.790382200Z",
+                "ingested": "2021-06-09T07:23:18.784561200Z",
                 "original": "type=DAEMON_END msg=audit(1481078697.892:7799): auditd normal halt, sending auid=? pid=? subj=? res=success",
                 "kind": "event",
                 "action": [

--- a/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-raw.log-expected.json
+++ b/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-raw.log-expected.json
@@ -14,7 +14,7 @@
             },
             "event": {
                 "action": "mac_ipsec_event",
-                "ingested": "2021-05-31T08:35:47.194096900Z",
+                "ingested": "2021-05-31T11:38:06.470321Z",
                 "kind": "event",
                 "outcome": "1"
             },
@@ -50,7 +50,7 @@
             },
             "event": {
                 "action": "syscall",
-                "ingested": "2021-05-31T08:35:47.194123800Z",
+                "ingested": "2021-05-31T11:38:06.470345800Z",
                 "category": [
                     "process"
                 ],
@@ -120,7 +120,7 @@
                 "action": [
                     "ran-command"
                 ],
-                "ingested": "2021-05-31T08:35:47.194170100Z",
+                "ingested": "2021-05-31T11:38:06.470378100Z",
                 "category": [
                     "process"
                 ],
@@ -179,7 +179,7 @@
                 "action": [
                     "started-crypto-session"
                 ],
-                "ingested": "2021-05-31T08:35:47.194177500Z",
+                "ingested": "2021-05-31T11:38:06.470385200Z",
                 "category": [
                     "process"
                 ],
@@ -229,7 +229,7 @@
                 "action": [
                     "typed"
                 ],
-                "ingested": "2021-05-31T08:35:47.194183700Z",
+                "ingested": "2021-05-31T11:38:06.470391600Z",
                 "kind": "event"
             },
             "auditd": {
@@ -256,7 +256,7 @@
             },
             "event": {
                 "action": "proctitle",
-                "ingested": "2021-05-31T08:35:47.194190Z",
+                "ingested": "2021-05-31T11:38:06.470397600Z",
                 "kind": "event"
             },
             "auditd": {
@@ -273,7 +273,7 @@
             },
             "event": {
                 "action": "proctitle",
-                "ingested": "2021-05-31T08:35:47.194195700Z",
+                "ingested": "2021-05-31T11:38:06.470403200Z",
                 "kind": "event"
             },
             "auditd": {
@@ -297,7 +297,7 @@
                 "action": [
                     "package-updated"
                 ],
-                "ingested": "2021-05-31T08:35:47.194201Z",
+                "ingested": "2021-05-31T11:38:06.470408700Z",
                 "category": [
                     "package"
                 ],
@@ -341,7 +341,7 @@
                 "action": [
                     "booted-system"
                 ],
-                "ingested": "2021-05-31T08:35:47.194206300Z",
+                "ingested": "2021-05-31T11:38:06.470415Z",
                 "category": "host",
                 "type": "info",
                 "kind": "event",
@@ -376,7 +376,7 @@
                 "action": [
                     "shutdown-system"
                 ],
-                "ingested": "2021-05-31T08:35:47.194211400Z",
+                "ingested": "2021-05-31T11:38:06.470420700Z",
                 "category": "host",
                 "type": "info",
                 "kind": "event",
@@ -407,7 +407,7 @@
             },
             "event": {
                 "action": "execve",
-                "ingested": "2021-05-31T08:35:47.194217500Z",
+                "ingested": "2021-05-31T11:38:06.470427200Z",
                 "kind": "event"
             },
             "auditd": {
@@ -426,7 +426,7 @@
                 "action": [
                     "loaded-kernel-module"
                 ],
-                "ingested": "2021-05-31T08:35:47.194223500Z",
+                "ingested": "2021-05-31T11:38:06.470432900Z",
                 "category": [
                     "driver"
                 ],
@@ -456,7 +456,7 @@
                 "action": [
                     "issued-vm-control"
                 ],
-                "ingested": "2021-05-31T08:35:47.194228400Z",
+                "ingested": "2021-05-31T11:38:06.470438500Z",
                 "category": "host",
                 "type": "creation",
                 "kind": "event",
@@ -497,7 +497,7 @@
                 "action": [
                     "assigned-vm-id"
                 ],
-                "ingested": "2021-05-31T08:35:47.194239500Z",
+                "ingested": "2021-05-31T11:38:06.470443900Z",
                 "category": "host",
                 "type": "creation",
                 "kind": "event",
@@ -536,7 +536,7 @@
                 "action": [
                     "started-audit"
                 ],
-                "ingested": "2021-05-31T08:35:47.194254200Z",
+                "ingested": "2021-05-31T11:38:06.470449Z",
                 "category": [
                     "process"
                 ],
@@ -575,7 +575,7 @@
                 "action": [
                     "changed-audit-configuration"
                 ],
-                "ingested": "2021-05-31T08:35:47.194261800Z",
+                "ingested": "2021-05-31T11:38:06.470460300Z",
                 "category": [
                     "process",
                     "configuration"
@@ -617,7 +617,7 @@
                 "action": [
                     "started-service"
                 ],
-                "ingested": "2021-05-31T08:35:47.194267900Z",
+                "ingested": "2021-05-31T11:38:06.470465500Z",
                 "category": [
                     "process"
                 ],
@@ -658,7 +658,7 @@
                 "action": [
                     "booted-system"
                 ],
-                "ingested": "2021-05-31T08:35:47.194273400Z",
+                "ingested": "2021-05-31T11:38:06.470471900Z",
                 "category": "host",
                 "type": "info",
                 "kind": "event",
@@ -693,7 +693,7 @@
                 "action": [
                     "ended-session"
                 ],
-                "ingested": "2021-05-31T08:35:47.194278500Z",
+                "ingested": "2021-05-31T11:38:06.470477700Z",
                 "category": [
                     "session"
                 ],
@@ -736,7 +736,7 @@
                 "action": [
                     "disposed-credentials"
                 ],
-                "ingested": "2021-05-31T08:35:47.194283200Z",
+                "ingested": "2021-05-31T11:38:06.470482900Z",
                 "category": [
                     "authentication"
                 ],
@@ -779,7 +779,7 @@
                 "action": [
                     "acquired-credentials"
                 ],
-                "ingested": "2021-05-31T08:35:47.194288200Z",
+                "ingested": "2021-05-31T11:38:06.470488800Z",
                 "category": [
                     "authentication"
                 ],
@@ -822,7 +822,7 @@
                 "action": [
                     "started-session"
                 ],
-                "ingested": "2021-05-31T08:35:47.194311100Z",
+                "ingested": "2021-05-31T11:38:06.470498200Z",
                 "category": [
                     "session"
                 ],
@@ -864,7 +864,7 @@
                 "action": [
                     "changed-login-id-to"
                 ],
-                "ingested": "2021-05-31T08:35:47.194318600Z",
+                "ingested": "2021-05-31T11:38:06.470502900Z",
                 "category": [
                     "authentication"
                 ],
@@ -926,7 +926,7 @@
                 "action": [
                     "negotiated-crypto-key"
                 ],
-                "ingested": "2021-05-31T08:35:47.194324400Z",
+                "ingested": "2021-05-31T11:38:06.470508Z",
                 "category": [
                     "process"
                 ],
@@ -995,7 +995,7 @@
                 "action": [
                     "authenticated"
                 ],
-                "ingested": "2021-05-31T08:35:47.194329500Z",
+                "ingested": "2021-05-31T11:38:06.470512800Z",
                 "category": [
                     "authentication"
                 ],
@@ -1039,7 +1039,7 @@
                 "action": [
                     "was-authorized"
                 ],
-                "ingested": "2021-05-31T08:35:47.194334400Z",
+                "ingested": "2021-05-31T11:38:06.470517400Z",
                 "category": [
                     "authentication"
                 ],
@@ -1084,7 +1084,7 @@
                 "action": [
                     "started-service"
                 ],
-                "ingested": "2021-05-31T08:35:47.194339900Z",
+                "ingested": "2021-05-31T11:38:06.470522800Z",
                 "category": [
                     "process"
                 ],
@@ -1124,7 +1124,7 @@
                 "action": [
                     "stopped-service"
                 ],
-                "ingested": "2021-05-31T08:35:47.194344Z",
+                "ingested": "2021-05-31T11:38:06.470527700Z",
                 "category": [
                     "process"
                 ],
@@ -1159,7 +1159,7 @@
                 "action": [
                     "loaded-firewall-rule-to"
                 ],
-                "ingested": "2021-05-31T08:35:47.194348200Z",
+                "ingested": "2021-05-31T11:38:06.470532800Z",
                 "category": [
                     "configuration"
                 ],
@@ -1191,7 +1191,7 @@
                 "action": [
                     "added-group-account-to"
                 ],
-                "ingested": "2021-05-31T08:35:47.194352900Z",
+                "ingested": "2021-05-31T11:38:06.470538Z",
                 "category": [
                     "iam"
                 ],
@@ -1239,7 +1239,7 @@
                 "action": [
                     "modified-group-account"
                 ],
-                "ingested": "2021-05-31T08:35:47.194358Z",
+                "ingested": "2021-05-31T11:38:06.470542300Z",
                 "category": [
                     "iam"
                 ],
@@ -1287,7 +1287,7 @@
                 "action": [
                     "added-user-account"
                 ],
-                "ingested": "2021-05-31T08:35:47.194362400Z",
+                "ingested": "2021-05-31T11:38:06.470546600Z",
                 "category": [
                     "iam"
                 ],
@@ -1336,7 +1336,7 @@
                 "action": [
                     "changed-to-runlevel"
                 ],
-                "ingested": "2021-05-31T08:35:47.194368700Z",
+                "ingested": "2021-05-31T11:38:06.470553Z",
                 "category": [
                     "host"
                 ],
@@ -1376,7 +1376,7 @@
                 "action": [
                     "modified-user-account"
                 ],
-                "ingested": "2021-05-31T08:35:47.194373100Z",
+                "ingested": "2021-05-31T11:38:06.470561600Z",
                 "category": [
                     "iam"
                 ],
@@ -1424,7 +1424,7 @@
                 "action": [
                     "changed-configuration"
                 ],
-                "ingested": "2021-05-31T08:35:47.194382700Z",
+                "ingested": "2021-05-31T11:38:06.470566400Z",
                 "category": [
                     "configuration"
                 ],
@@ -1484,7 +1484,7 @@
                 "action": [
                     "changed-role-to"
                 ],
-                "ingested": "2021-05-31T08:35:47.194386900Z",
+                "ingested": "2021-05-31T11:38:06.470570800Z",
                 "kind": "event",
                 "outcome": "success"
             },
@@ -1542,7 +1542,7 @@
                 "action": [
                     "logged-in"
                 ],
-                "ingested": "2021-05-31T08:35:47.194390900Z",
+                "ingested": "2021-05-31T11:38:06.470575100Z",
                 "category": [
                     "authentication"
                 ],
@@ -1588,7 +1588,7 @@
                 "action": [
                     "logged-out"
                 ],
-                "ingested": "2021-05-31T08:35:47.194394600Z",
+                "ingested": "2021-05-31T11:38:06.470579500Z",
                 "category": [
                     "authentication"
                 ],
@@ -1629,7 +1629,7 @@
                 "action": [
                     "changed-audit-configuration"
                 ],
-                "ingested": "2021-05-31T08:35:47.194398400Z",
+                "ingested": "2021-05-31T11:38:06.470584100Z",
                 "category": [
                     "process",
                     "configuration"
@@ -1666,7 +1666,7 @@
             },
             "event": {
                 "action": "cwd",
-                "ingested": "2021-05-31T08:35:47.194402300Z",
+                "ingested": "2021-05-31T11:38:06.470588400Z",
                 "kind": "event"
             },
             "auditd": {
@@ -1682,7 +1682,7 @@
             },
             "event": {
                 "action": "path",
-                "ingested": "2021-05-31T08:35:47.194406Z",
+                "ingested": "2021-05-31T11:38:06.470592500Z",
                 "kind": "event"
             },
             "auditd": {
@@ -1713,7 +1713,7 @@
             },
             "event": {
                 "action": "unknown[1329]",
-                "ingested": "2021-05-31T08:35:47.194409800Z",
+                "ingested": "2021-05-31T11:38:06.470596700Z",
                 "kind": "event"
             },
             "auditd": {
@@ -1728,7 +1728,7 @@
             },
             "event": {
                 "action": "bprm_fcaps",
-                "ingested": "2021-05-31T08:35:47.194413800Z",
+                "ingested": "2021-05-31T11:38:06.470601800Z",
                 "kind": "event"
             },
             "auditd": {
@@ -1754,7 +1754,7 @@
             },
             "event": {
                 "action": "sockaddr",
-                "ingested": "2021-05-31T08:35:47.194417800Z",
+                "ingested": "2021-05-31T11:38:06.470606400Z",
                 "kind": "event"
             },
             "auditd": {
@@ -1771,7 +1771,7 @@
             },
             "event": {
                 "action": "ckaddr",
-                "ingested": "2021-05-31T08:35:47.194421400Z",
+                "ingested": "2021-05-31T11:38:06.470610600Z",
                 "kind": "event"
             },
             "auditd": {
@@ -1790,7 +1790,7 @@
                 "action": [
                     "shutdown-audit"
                 ],
-                "ingested": "2021-05-31T08:35:47.194425100Z",
+                "ingested": "2021-05-31T11:38:06.470614700Z",
                 "category": [
                     "process"
                 ],

--- a/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-raw.log-expected.json
+++ b/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-raw.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2017-01-31T20:17:14.891Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "destination": {
                 "address": "192.168.0.0"
@@ -14,7 +14,7 @@
             },
             "event": {
                 "action": "mac_ipsec_event",
-                "ingested": "2021-05-14T09:45:48.016589900Z",
+                "ingested": "2021-05-31T08:35:47.194096900Z",
                 "kind": "event",
                 "outcome": "1"
             },
@@ -43,14 +43,14 @@
             },
             "@timestamp": "2017-01-31T20:17:14.891Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "host": {
                 "architecture": "x86_64"
             },
             "event": {
                 "action": "syscall",
-                "ingested": "2021-05-14T09:45:48.016611300Z",
+                "ingested": "2021-05-31T08:35:47.194123800Z",
                 "category": [
                     "process"
                 ],
@@ -114,13 +114,13 @@
             },
             "@timestamp": "2017-03-14T19:20:56.192Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "ran-command"
                 ],
-                "ingested": "2021-05-14T09:45:48.016665700Z",
+                "ingested": "2021-05-31T08:35:47.194170100Z",
                 "category": [
                     "process"
                 ],
@@ -151,7 +151,7 @@
             },
             "@timestamp": "2016-12-07T02:17:21.515Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "source": {
                 "geo": {
@@ -179,7 +179,7 @@
                 "action": [
                     "started-crypto-session"
                 ],
-                "ingested": "2021-05-14T09:45:48.016674700Z",
+                "ingested": "2021-05-31T08:35:47.194177500Z",
                 "category": [
                     "process"
                 ],
@@ -223,13 +223,13 @@
             },
             "@timestamp": "2017-04-11T15:21:03.550Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "typed"
                 ],
-                "ingested": "2021-05-14T09:45:48.016678600Z",
+                "ingested": "2021-05-31T08:35:47.194183700Z",
                 "kind": "event"
             },
             "auditd": {
@@ -252,11 +252,11 @@
         {
             "@timestamp": "2016-01-03T00:37:51.394Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": "proctitle",
-                "ingested": "2021-05-14T09:45:48.016686100Z",
+                "ingested": "2021-05-31T08:35:47.194190Z",
                 "kind": "event"
             },
             "auditd": {
@@ -269,11 +269,11 @@
         {
             "@timestamp": "2016-01-03T00:37:51.394Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": "proctitle",
-                "ingested": "2021-05-14T09:45:48.016697800Z",
+                "ingested": "2021-05-31T08:35:47.194195700Z",
                 "kind": "event"
             },
             "auditd": {
@@ -291,13 +291,13 @@
             },
             "@timestamp": "2019-11-15T19:01:24.309Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "package-updated"
                 ],
-                "ingested": "2021-05-14T09:45:48.016708700Z",
+                "ingested": "2021-05-31T08:35:47.194201Z",
                 "category": [
                     "package"
                 ],
@@ -335,13 +335,13 @@
             },
             "@timestamp": "2019-11-15T19:00:56.144Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "booted-system"
                 ],
-                "ingested": "2021-05-14T09:45:48.016719800Z",
+                "ingested": "2021-05-31T08:35:47.194206300Z",
                 "category": "host",
                 "type": "info",
                 "kind": "event",
@@ -370,13 +370,13 @@
             },
             "@timestamp": "2019-11-15T19:01:57.054Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "shutdown-system"
                 ],
-                "ingested": "2021-05-14T09:45:48.016730600Z",
+                "ingested": "2021-05-31T08:35:47.194211400Z",
                 "category": "host",
                 "type": "info",
                 "kind": "event",
@@ -403,11 +403,11 @@
             },
             "@timestamp": "2020-02-10T21:59:44.206Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": "execve",
-                "ingested": "2021-05-14T09:45:48.016741400Z",
+                "ingested": "2021-05-31T08:35:47.194217500Z",
                 "kind": "event"
             },
             "auditd": {
@@ -420,13 +420,13 @@
         {
             "@timestamp": "2020-02-10T21:59:44.206Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "loaded-kernel-module"
                 ],
-                "ingested": "2021-05-14T09:45:48.016752700Z",
+                "ingested": "2021-05-31T08:35:47.194223500Z",
                 "category": [
                     "driver"
                 ],
@@ -450,13 +450,13 @@
             },
             "@timestamp": "2017-12-17T10:44:41.075Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "issued-vm-control"
                 ],
-                "ingested": "2021-05-14T09:45:48.016763900Z",
+                "ingested": "2021-05-31T08:35:47.194228400Z",
                 "category": "host",
                 "type": "creation",
                 "kind": "event",
@@ -491,13 +491,13 @@
             },
             "@timestamp": "2016-12-16T15:45:43.572Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "assigned-vm-id"
                 ],
-                "ingested": "2021-05-14T09:45:48.016775Z",
+                "ingested": "2021-05-31T08:35:47.194239500Z",
                 "category": "host",
                 "type": "creation",
                 "kind": "event",
@@ -530,13 +530,13 @@
             },
             "@timestamp": "2020-07-06T16:38:34.588Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "started-audit"
                 ],
-                "ingested": "2021-05-14T09:45:48.016785800Z",
+                "ingested": "2021-05-31T08:35:47.194254200Z",
                 "category": [
                     "process"
                 ],
@@ -569,13 +569,13 @@
         {
             "@timestamp": "2020-07-06T16:38:34.707Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "changed-audit-configuration"
                 ],
-                "ingested": "2021-05-14T09:45:48.016797Z",
+                "ingested": "2021-05-31T08:35:47.194261800Z",
                 "category": [
                     "process",
                     "configuration"
@@ -611,13 +611,13 @@
             },
             "@timestamp": "2020-07-06T16:38:34.709Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "started-service"
                 ],
-                "ingested": "2021-05-14T09:45:48.016808100Z",
+                "ingested": "2021-05-31T08:35:47.194267900Z",
                 "category": [
                     "process"
                 ],
@@ -652,13 +652,13 @@
             },
             "@timestamp": "2020-07-06T16:38:34.725Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "booted-system"
                 ],
-                "ingested": "2021-05-14T09:45:48.016817700Z",
+                "ingested": "2021-05-31T08:35:47.194273400Z",
                 "category": "host",
                 "type": "info",
                 "kind": "event",
@@ -687,13 +687,13 @@
             },
             "@timestamp": "2017-03-14T19:20:30.178Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "ended-session"
                 ],
-                "ingested": "2021-05-14T09:45:48.016822100Z",
+                "ingested": "2021-05-31T08:35:47.194278500Z",
                 "category": [
                     "session"
                 ],
@@ -730,13 +730,13 @@
             },
             "@timestamp": "2017-03-14T19:20:30.178Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "disposed-credentials"
                 ],
-                "ingested": "2021-05-14T09:45:48.016826Z",
+                "ingested": "2021-05-31T08:35:47.194283200Z",
                 "category": [
                     "authentication"
                 ],
@@ -773,13 +773,13 @@
             },
             "@timestamp": "2017-03-14T19:20:56.193Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "acquired-credentials"
                 ],
-                "ingested": "2021-05-14T09:45:48.016832900Z",
+                "ingested": "2021-05-31T08:35:47.194288200Z",
                 "category": [
                     "authentication"
                 ],
@@ -816,13 +816,13 @@
             },
             "@timestamp": "2017-03-14T19:20:56.193Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "started-session"
                 ],
-                "ingested": "2021-05-14T09:45:48.016844600Z",
+                "ingested": "2021-05-31T08:35:47.194311100Z",
                 "category": [
                     "session"
                 ],
@@ -858,13 +858,13 @@
             },
             "@timestamp": "2017-03-16T04:02:40.072Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "changed-login-id-to"
                 ],
-                "ingested": "2021-05-14T09:45:48.016855600Z",
+                "ingested": "2021-05-31T08:35:47.194318600Z",
                 "category": [
                     "authentication"
                 ],
@@ -898,7 +898,7 @@
             },
             "@timestamp": "2017-03-16T04:02:40.070Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "source": {
                 "geo": {
@@ -926,7 +926,7 @@
                 "action": [
                     "negotiated-crypto-key"
                 ],
-                "ingested": "2021-05-14T09:45:48.016866800Z",
+                "ingested": "2021-05-31T08:35:47.194324400Z",
                 "category": [
                     "process"
                 ],
@@ -967,7 +967,7 @@
             },
             "@timestamp": "2017-03-16T04:02:40.072Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "source": {
                 "geo": {
@@ -995,7 +995,7 @@
                 "action": [
                     "authenticated"
                 ],
-                "ingested": "2021-05-14T09:45:48.016877900Z",
+                "ingested": "2021-05-31T08:35:47.194329500Z",
                 "category": [
                     "authentication"
                 ],
@@ -1033,13 +1033,13 @@
             },
             "@timestamp": "2017-03-16T04:02:57.805Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "was-authorized"
                 ],
-                "ingested": "2021-05-14T09:45:48.016888800Z",
+                "ingested": "2021-05-31T08:35:47.194334400Z",
                 "category": [
                     "authentication"
                 ],
@@ -1078,13 +1078,13 @@
             },
             "@timestamp": "2016-12-07T02:16:23.864Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "started-service"
                 ],
-                "ingested": "2021-05-14T09:45:48.016899800Z",
+                "ingested": "2021-05-31T08:35:47.194339900Z",
                 "category": [
                     "process"
                 ],
@@ -1118,13 +1118,13 @@
             },
             "@timestamp": "2016-12-07T02:16:24.534Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "stopped-service"
                 ],
-                "ingested": "2021-05-14T09:45:48.016910800Z",
+                "ingested": "2021-05-31T08:35:47.194344Z",
                 "category": [
                     "process"
                 ],
@@ -1153,13 +1153,13 @@
         {
             "@timestamp": "2016-12-07T02:16:24.827Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "loaded-firewall-rule-to"
                 ],
-                "ingested": "2021-05-14T09:45:48.016922Z",
+                "ingested": "2021-05-31T08:35:47.194348200Z",
                 "category": [
                     "configuration"
                 ],
@@ -1185,13 +1185,13 @@
             },
             "@timestamp": "2016-12-07T02:16:32.414Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "added-group-account-to"
                 ],
-                "ingested": "2021-05-14T09:45:48.016933Z",
+                "ingested": "2021-05-31T08:35:47.194352900Z",
                 "category": [
                     "iam"
                 ],
@@ -1233,13 +1233,13 @@
             },
             "@timestamp": "2016-12-07T02:16:32.419Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "modified-group-account"
                 ],
-                "ingested": "2021-05-14T09:45:48.016944100Z",
+                "ingested": "2021-05-31T08:35:47.194358Z",
                 "category": [
                     "iam"
                 ],
@@ -1281,13 +1281,13 @@
             },
             "@timestamp": "2016-12-07T02:16:32.488Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "added-user-account"
                 ],
-                "ingested": "2021-05-14T09:45:48.016955100Z",
+                "ingested": "2021-05-31T08:35:47.194362400Z",
                 "category": [
                     "iam"
                 ],
@@ -1330,13 +1330,13 @@
             },
             "@timestamp": "2016-12-07T02:16:32.492Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "changed-to-runlevel"
                 ],
-                "ingested": "2021-05-14T09:45:48.016964700Z",
+                "ingested": "2021-05-31T08:35:47.194368700Z",
                 "category": [
                     "host"
                 ],
@@ -1370,13 +1370,13 @@
             },
             "@timestamp": "2016-12-07T02:16:32.521Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "modified-user-account"
                 ],
-                "ingested": "2021-05-14T09:45:48.016969Z",
+                "ingested": "2021-05-31T08:35:47.194373100Z",
                 "category": [
                     "iam"
                 ],
@@ -1418,13 +1418,13 @@
             },
             "@timestamp": "2016-12-07T02:16:33.000Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "changed-configuration"
                 ],
-                "ingested": "2021-05-14T09:45:48.016978900Z",
+                "ingested": "2021-05-31T08:35:47.194382700Z",
                 "category": [
                     "configuration"
                 ],
@@ -1456,7 +1456,7 @@
             },
             "@timestamp": "2016-12-07T02:17:23.140Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "source": {
                 "geo": {
@@ -1484,7 +1484,7 @@
                 "action": [
                     "changed-role-to"
                 ],
-                "ingested": "2021-05-14T09:45:48.016990700Z",
+                "ingested": "2021-05-31T08:35:47.194386900Z",
                 "kind": "event",
                 "outcome": "success"
             },
@@ -1514,7 +1514,7 @@
             },
             "@timestamp": "2016-12-07T02:17:23.193Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "source": {
                 "geo": {
@@ -1542,7 +1542,7 @@
                 "action": [
                     "logged-in"
                 ],
-                "ingested": "2021-05-14T09:45:48.017001800Z",
+                "ingested": "2021-05-31T08:35:47.194390900Z",
                 "category": [
                     "authentication"
                 ],
@@ -1582,13 +1582,13 @@
             },
             "@timestamp": "2016-12-07T02:17:29.033Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "logged-out"
                 ],
-                "ingested": "2021-05-14T09:45:48.017013Z",
+                "ingested": "2021-05-31T08:35:47.194394600Z",
                 "category": [
                     "authentication"
                 ],
@@ -1623,13 +1623,13 @@
         {
             "@timestamp": "2016-12-07T02:20:31.371Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "changed-audit-configuration"
                 ],
-                "ingested": "2021-05-14T09:45:48.017024100Z",
+                "ingested": "2021-05-31T08:35:47.194398400Z",
                 "category": [
                     "process",
                     "configuration"
@@ -1662,11 +1662,11 @@
             },
             "@timestamp": "2016-12-07T02:20:31.371Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": "cwd",
-                "ingested": "2021-05-14T09:45:48.017035100Z",
+                "ingested": "2021-05-31T08:35:47.194402300Z",
                 "kind": "event"
             },
             "auditd": {
@@ -1678,11 +1678,11 @@
         {
             "@timestamp": "2016-12-07T02:20:31.371Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": "path",
-                "ingested": "2021-05-14T09:45:48.017046100Z",
+                "ingested": "2021-05-31T08:35:47.194406Z",
                 "kind": "event"
             },
             "auditd": {
@@ -1709,11 +1709,11 @@
         },
         {
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": "unknown[1329]",
-                "ingested": "2021-05-14T09:45:48.017056900Z",
+                "ingested": "2021-05-31T08:35:47.194409800Z",
                 "kind": "event"
             },
             "auditd": {
@@ -1724,11 +1724,11 @@
         {
             "@timestamp": "2016-12-07T02:21:48.360Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": "bprm_fcaps",
-                "ingested": "2021-05-14T09:45:48.017071800Z",
+                "ingested": "2021-05-31T08:35:47.194413800Z",
                 "kind": "event"
             },
             "auditd": {
@@ -1750,11 +1750,11 @@
         {
             "@timestamp": "2016-12-07T02:40:24.953Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": "sockaddr",
-                "ingested": "2021-05-14T09:45:48.017083200Z",
+                "ingested": "2021-05-31T08:35:47.194417800Z",
                 "kind": "event"
             },
             "auditd": {
@@ -1767,11 +1767,11 @@
         {
             "@timestamp": "2016-12-07T02:42:33.346Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": "ckaddr",
-                "ingested": "2021-05-14T09:45:48.017094500Z",
+                "ingested": "2021-05-31T08:35:47.194421400Z",
                 "kind": "event"
             },
             "auditd": {
@@ -1784,13 +1784,13 @@
         {
             "@timestamp": "2016-12-07T02:44:57.892Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "event": {
                 "action": [
                     "shutdown-audit"
                 ],
-                "ingested": "2021-05-14T09:45:48.017105500Z",
+                "ingested": "2021-05-31T08:35:47.194425100Z",
                 "category": [
                     "process"
                 ],

--- a/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-raw.log-expected.json
+++ b/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-raw.log-expected.json
@@ -14,7 +14,8 @@
             },
             "event": {
                 "action": "mac_ipsec_event",
-                "ingested": "2021-05-31T11:38:06.470321Z",
+                "ingested": "2021-06-02T08:11:46.790120300Z",
+                "original": "type=MAC_IPSEC_EVENT msg=audit(1485893834.891:18877201): op=SPD-delete auid=4294967295 ses=4294967295 res=1 src=192.168.2.0 src_prefixlen=24 dst=192.168.0.0 dst_prefixlen=16",
                 "kind": "event",
                 "outcome": "1"
             },
@@ -31,7 +32,10 @@
                 "audit": {
                     "id": "4294967295"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -50,7 +54,8 @@
             },
             "event": {
                 "action": "syscall",
-                "ingested": "2021-05-31T11:38:06.470345800Z",
+                "ingested": "2021-06-02T08:11:46.790159Z",
+                "original": "type=SYSCALL msg=audit(1485893834.891:18877199): arch=c000003e syscall=44 success=yes exit=184 a0=9 items=0 ppid=1240 pid=1281 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=\"charon\" exe=2F7573722F6C6962657865632F7374726F6E677377616E2F636861726F6E202864656C6574656429 key=(null)",
                 "category": [
                     "process"
                 ],
@@ -97,6 +102,9 @@
                     "id": "0"
                 }
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "direction": "egress"
             }
@@ -117,17 +125,18 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790166500Z",
+                "original": "type=USER_CMD msg=audit(1489519256.192:19600329): user pid=4151 uid=497 auid=700 ses=11988 msg='cwd=\"/\" cmd=2F7573722F6C696236342F6E6167696F732F706C7567696E732F636865636B5F617374657269736B5F7369705F7065657273202D7020323032 terminal=? res=success'",
+                "kind": "event",
                 "action": [
                     "ran-command"
                 ],
-                "ingested": "2021-05-31T11:38:06.470378100Z",
                 "category": [
                     "process"
                 ],
                 "type": [
                     "start"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -142,7 +151,10 @@
                     "id": "700"
                 },
                 "id": "497"
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -176,17 +188,18 @@
                 "ip": "96.241.146.97"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790193Z",
+                "original": "type=CRYPTO_SESSION msg=audit(1481077041.515:406): pid=1298 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 msg='op=start direction=from-server cipher=chacha20-poly1305@openssh.com ksize=512 mac= pfs=curve25519-sha256@libssh.org spid=1299 suid=74 rport=63927 laddr=10.142.0.2 lport=22  exe=\"/usr/sbin/sshd\" hostname=? addr=96.241.146.97 terminal=? res=success'",
+                "kind": "event",
                 "action": [
                     "started-crypto-session"
                 ],
-                "ingested": "2021-05-31T11:38:06.470385200Z",
                 "category": [
                     "process"
                 ],
                 "type": [
                     "info"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -214,7 +227,10 @@
                     "id": "4294967295"
                 },
                 "id": "0"
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -229,7 +245,8 @@
                 "action": [
                     "typed"
                 ],
-                "ingested": "2021-05-31T11:38:06.470391600Z",
+                "ingested": "2021-06-02T08:11:46.790199300Z",
+                "original": "type=TTY msg=audit(1491924063.550:1065565): tty pid=27930 uid=1000 auid=1000 ses=762 major=136 minor=0 comm=\"bash\" data=65687F7F6563686F20746573740D76696D202F6574632F70616D2E642F70617373776F72642D617574682D61630D6D616E2070616D5F7474795F61756469740D6D616E2070616D2E640D76696D202F657463017375646F20052F70616D642E73797F7F7F7F7F2E7F6D2E642F7379092D6109617F2D61090D6D616E2070616D0D747F67726570207379737F7F7F2F7661722F6C6F09672F6D65097309207C20677265702070616D5F7474790D677265702070616D5F747479202F7661722F6C6F672F6D6573090D1B5B41017375646F200D7375646F2073750D",
                 "kind": "event"
             },
             "auditd": {
@@ -247,7 +264,10 @@
                     "id": "1000"
                 },
                 "id": "1000"
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "@timestamp": "2016-01-03T00:37:51.394Z",
@@ -256,7 +276,8 @@
             },
             "event": {
                 "action": "proctitle",
-                "ingested": "2021-05-31T11:38:06.470397600Z",
+                "ingested": "2021-06-02T08:11:46.790204400Z",
+                "original": "type=PROCTITLE msg=audit(1451781471.394:194438): proctitle=\"bash\"",
                 "kind": "event"
             },
             "auditd": {
@@ -264,7 +285,10 @@
                     "proctitle": "bash",
                     "sequence": 194438
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "@timestamp": "2016-01-03T00:37:51.394Z",
@@ -273,7 +297,8 @@
             },
             "event": {
                 "action": "proctitle",
-                "ingested": "2021-05-31T11:38:06.470403200Z",
+                "ingested": "2021-06-02T08:11:46.790209200Z",
+                "original": "type=PROCTITLE msg=audit(1451781471.394:194440): proctitle=737368643A206275726E205B707269765D",
                 "kind": "event"
             },
             "auditd": {
@@ -281,7 +306,10 @@
                     "proctitle": "sshd: burn [priv]",
                     "sequence": 194440
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -294,17 +322,18 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790214300Z",
+                "original": "type=SOFTWARE_UPDATE msg=audit(1573844484.309:785): pid=3157 uid=0 auid=1000 ses=3 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='sw=\"gcc-4.8.5-39.el7.x86_64\" sw_type=rpm key_enforce=0 gpg_res=1 root_dir=\"/\" comm=\"yum\" exe=\"/usr/bin/python2.7\" hostname=? addr=? terminal=? res=success'",
+                "kind": "event",
                 "action": [
                     "package-updated"
                 ],
-                "ingested": "2021-05-31T11:38:06.470408700Z",
                 "category": [
                     "package"
                 ],
                 "type": [
                     "info"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -325,7 +354,10 @@
                     "id": "1000"
                 },
                 "id": "0"
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -338,13 +370,14 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790218800Z",
+                "original": "type=SYSTEM_BOOT msg=audit(1573844456.144:5): pid=678 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg=' comm=\"systemd-update-utmp\" exe=\"/usr/lib/systemd/systemd-update-utmp\" hostname=? addr=? terminal=? res=success'",
+                "kind": "event",
                 "action": [
                     "booted-system"
                 ],
-                "ingested": "2021-05-31T11:38:06.470415Z",
                 "category": "host",
                 "type": "info",
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -360,7 +393,10 @@
                     "id": "4294967295"
                 },
                 "id": "0"
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -373,13 +409,14 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790223300Z",
+                "original": "type=SYSTEM_SHUTDOWN msg=audit(1573844517.054:1163): pid=4440 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg=' comm=\"systemd-update-utmp\" exe=\"/usr/lib/systemd/systemd-update-utmp\" hostname=? addr=? terminal=? res=success'",
+                "kind": "event",
                 "action": [
                     "shutdown-system"
                 ],
-                "ingested": "2021-05-31T11:38:06.470420700Z",
                 "category": "host",
                 "type": "info",
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -395,7 +432,10 @@
                     "id": "4294967295"
                 },
                 "id": "0"
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -407,7 +447,8 @@
             },
             "event": {
                 "action": "execve",
-                "ingested": "2021-05-31T11:38:06.470427200Z",
+                "ingested": "2021-06-02T08:11:46.790228700Z",
+                "original": "type=EXECVE msg=audit(1581371984.206:579393): argc=1 a0=top",
                 "kind": "event"
             },
             "auditd": {
@@ -415,7 +456,10 @@
                     "sequence": 579393,
                     "a0": "top"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "@timestamp": "2020-02-10T21:59:44.206Z",
@@ -426,7 +470,8 @@
                 "action": [
                     "loaded-kernel-module"
                 ],
-                "ingested": "2021-05-31T11:38:06.470432900Z",
+                "ingested": "2021-06-02T08:11:46.790233100Z",
+                "original": "type=KERN_MODULE msg=audit(1581371984.206:579397): name=mymodule",
                 "category": [
                     "driver"
                 ],
@@ -441,7 +486,10 @@
                     "sequence": 579397,
                     "record_type": "KERN_MODULE"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -453,13 +501,14 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790237600Z",
+                "original": "type=VIRT_CONTROL msg=audit(1513507481.075:145): pid=1431 uid=0 auid=100 ses=3 subj=system_u:system_r:container_runtime_t:s0 msg='user=root reason=api op=create vm=? vm-pid=? hostname=? exe=\"/usr/bin/dockerd-current\" addr=? terminal=? res=success'",
+                "kind": "event",
                 "action": [
                     "issued-vm-control"
                 ],
-                "ingested": "2021-05-31T11:38:06.470438500Z",
                 "category": "host",
                 "type": "creation",
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -478,7 +527,10 @@
                     "id": "100"
                 },
                 "id": "0"
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "container": {
@@ -494,13 +546,14 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790241900Z",
+                "original": "type=VIRT_MACHINE_ID msg=audit(1481903143.572:23118): pid=5637 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:virtd_t:s0-s0:c0.c1023 msg='virt=kvm vm=\"rhel-work3\" uuid=5501263b-181d-47ed-ab03-a6066f3d26bf vm-ctx=system_u:system_r:svirt_t:s0:c444,c977 img-ctx=system_u:object_r:svirt_image_t:s0:c444,c977 model=selinux exe=\"/usr/sbin/libvirtd\" hostname=? addr=? terminal=? res=success'",
+                "kind": "event",
                 "action": [
                     "assigned-vm-id"
                 ],
-                "ingested": "2021-05-31T11:38:06.470443900Z",
                 "category": "host",
                 "type": "creation",
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -522,7 +575,10 @@
                     "id": "4294967295"
                 },
                 "id": "0"
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -533,17 +589,18 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790246200Z",
+                "original": "node=localhost.localdomain type=DAEMON_START msg=audit(1594053514.588:4686): op=start ver=2.8.5 format=raw kernel=3.10.0-1062.9.1.el7.x86_64 auid=4294967295 pid=1643 uid=0 ses=4294967295 subj=system_u:system_r:auditd_t:s0 res=success",
+                "kind": "event",
                 "action": [
                     "started-audit"
                 ],
-                "ingested": "2021-05-31T11:38:06.470449Z",
                 "category": [
                     "process"
                 ],
                 "type": [
                     "start"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -564,7 +621,10 @@
                     "id": "4294967295"
                 },
                 "id": "0"
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "@timestamp": "2020-07-06T16:38:34.707Z",
@@ -572,10 +632,12 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790250500Z",
+                "original": "node=localhost.localdomain type=CONFIG_CHANGE msg=audit(1594053514.707:5): audit_failure=1 old=1 auid=4294967295 ses=4294967295 subj=system_u:system_r:unconfined_service_t:s0 res=1",
+                "kind": "event",
                 "action": [
                     "changed-audit-configuration"
                 ],
-                "ingested": "2021-05-31T11:38:06.470460300Z",
                 "category": [
                     "process",
                     "configuration"
@@ -583,7 +645,6 @@
                 "type": [
                     "change"
                 ],
-                "kind": "event",
                 "outcome": "1"
             },
             "auditd": {
@@ -601,7 +662,10 @@
                 "audit": {
                     "id": "4294967295"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -614,17 +678,18 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790254900Z",
+                "original": "node=localhost.localdomain type=SERVICE_START msg=audit(1594053514.709:6): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='unit=auditd comm=\"systemd\" exe=\"/usr/lib/systemd/systemd\" hostname=? addr=? terminal=? res=success'",
+                "kind": "event",
                 "action": [
                     "started-service"
                 ],
-                "ingested": "2021-05-31T11:38:06.470465500Z",
                 "category": [
                     "process"
                 ],
                 "type": [
                     "start"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -642,7 +707,10 @@
                     "id": "4294967295"
                 },
                 "id": "0"
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -655,13 +723,14 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790259200Z",
+                "original": "node=localhost.localdomain type=SYSTEM_BOOT msg=audit(1594053514.725:7): pid=1667 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg=' comm=\"systemd-update-utmp\" exe=\"/usr/lib/systemd/systemd-update-utmp\" hostname=? addr=? terminal=? res=success'",
+                "kind": "event",
                 "action": [
                     "booted-system"
                 ],
-                "ingested": "2021-05-31T11:38:06.470471900Z",
                 "category": "host",
                 "type": "info",
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -678,7 +747,10 @@
                     "id": "4294967295"
                 },
                 "id": "0"
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -690,17 +762,18 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790263500Z",
+                "original": "type=USER_END msg=audit(1489519230.178:19600327): user pid=4121 uid=0 auid=700 ses=11988 msg='op=PAM:session_close acct=\"root\" exe=\"/usr/bin/sudo\" hostname=? addr=? terminal=? res=success'",
+                "kind": "event",
                 "action": [
                     "ended-session"
                 ],
-                "ingested": "2021-05-31T11:38:06.470477700Z",
                 "category": [
                     "session"
                 ],
                 "type": [
                     "end"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -721,7 +794,10 @@
                 "audit": {
                     "id": "700"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -733,17 +809,18 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790268Z",
+                "original": "type=CRED_DISP msg=audit(1489519230.178:19600328): user pid=4121 uid=0 auid=700 ses=11988 msg='op=PAM:setcred acct=\"root\" exe=\"/usr/bin/sudo\" hostname=? addr=? terminal=? res=success'",
+                "kind": "event",
                 "action": [
                     "disposed-credentials"
                 ],
-                "ingested": "2021-05-31T11:38:06.470482900Z",
                 "category": [
                     "authentication"
                 ],
                 "type": [
                     "info"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -764,7 +841,10 @@
                 "audit": {
                     "id": "700"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -776,17 +856,18 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790278700Z",
+                "original": "type=CRED_ACQ msg=audit(1489519256.193:19600330): user pid=4151 uid=0 auid=700 ses=11988 msg='op=PAM:setcred acct=\"root\" exe=\"/usr/bin/sudo\" hostname=? addr=? terminal=? res=success'",
+                "kind": "event",
                 "action": [
                     "acquired-credentials"
                 ],
-                "ingested": "2021-05-31T11:38:06.470488800Z",
                 "category": [
                     "authentication"
                 ],
                 "type": [
                     "info"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -807,7 +888,10 @@
                 "audit": {
                     "id": "700"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -819,17 +903,18 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790282800Z",
+                "original": "type=USER_START msg=audit(1489519256.193:19600331): user pid=4151 uid=0 auid=700 ses=11988 msg='op=PAM:session_open acct=\"root\" exe=\"/usr/bin/sudo\" hostname=? addr=? terminal=? res=success'",
+                "kind": "event",
                 "action": [
                     "started-session"
                 ],
-                "ingested": "2021-05-31T11:38:06.470498200Z",
                 "category": [
                     "session"
                 ],
                 "type": [
                     "start"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -850,7 +935,10 @@
                 "audit": {
                     "id": "700"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -864,7 +952,8 @@
                 "action": [
                     "changed-login-id-to"
                 ],
-                "ingested": "2021-05-31T11:38:06.470502900Z",
+                "ingested": "2021-06-02T08:11:46.790287500Z",
+                "original": "type=LOGIN msg=audit(1489636960.072:19623791): pid=28281 uid=0 old auid=700 new auid=700 old ses=6793 new ses=12286",
                 "category": [
                     "authentication"
                 ],
@@ -889,7 +978,10 @@
                     "id": "700"
                 },
                 "id": "700"
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -923,17 +1015,18 @@
                 "ip": "96.241.146.97"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790291900Z",
+                "original": "type=CRYPTO_KEY_USER msg=audit(1489636960.070:19623788): user pid=28281 uid=0 auid=700 ses=6793 msg='op=destroy kind=session fp=? direction=both spid=28282 suid=74 rport=58994 laddr=107.170.139.210 lport=50022  exe=\"/usr/sbin/sshd\" hostname=? addr=96.241.146.97 terminal=? res=success'",
+                "kind": "event",
                 "action": [
                     "negotiated-crypto-key"
                 ],
-                "ingested": "2021-05-31T11:38:06.470508Z",
                 "category": [
                     "process"
                 ],
                 "type": [
                     "info"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -958,7 +1051,10 @@
                     "id": "700"
                 },
                 "id": "0"
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -992,17 +1088,18 @@
                 "ip": "96.241.146.97"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790296100Z",
+                "original": "type=USER_AUTH msg=audit(1489636960.072:19623789): user pid=28281 uid=0 auid=700 ses=6793 msg='op=success acct=\"admin\" exe=\"/usr/sbin/sshd\" hostname=? addr=96.241.146.97 terminal=ssh res=success'",
+                "kind": "event",
                 "action": [
                     "authenticated"
                 ],
-                "ingested": "2021-05-31T11:38:06.470512800Z",
                 "category": [
                     "authentication"
                 ],
                 "type": [
                     "info"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -1024,7 +1121,10 @@
                 "audit": {
                     "id": "700"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -1036,17 +1136,18 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790300400Z",
+                "original": "type=USER_ACCT msg=audit(1489636977.805:19623808): user pid=28395 uid=0 auid=700 ses=12286 msg='op=PAM:accounting acct=\"root\" exe=\"/bin/su\" hostname=? addr=? terminal=pts/0 res=success'",
+                "kind": "event",
                 "action": [
                     "was-authorized"
                 ],
-                "ingested": "2021-05-31T11:38:06.470517400Z",
                 "category": [
                     "authentication"
                 ],
                 "type": [
                     "info"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -1068,7 +1169,10 @@
                 "audit": {
                     "id": "700"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -1081,17 +1185,18 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790304600Z",
+                "original": "type=SERVICE_START msg=audit(1481076983.864:6): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='unit=auditd comm=\"systemd\" exe=\"/usr/lib/systemd/systemd\" hostname=? addr=? terminal=? res=success'",
+                "kind": "event",
                 "action": [
                     "started-service"
                 ],
-                "ingested": "2021-05-31T11:38:06.470522800Z",
                 "category": [
                     "process"
                 ],
                 "type": [
                     "start"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -1108,7 +1213,10 @@
                     "id": "4294967295"
                 },
                 "id": "0"
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -1121,17 +1229,18 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790308900Z",
+                "original": "type=SERVICE_STOP msg=audit(1481076984.534:16): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='unit=irqbalance comm=\"systemd\" exe=\"/usr/lib/systemd/systemd\" hostname=? addr=? terminal=? res=success'",
+                "kind": "event",
                 "action": [
                     "stopped-service"
                 ],
-                "ingested": "2021-05-31T11:38:06.470527700Z",
                 "category": [
                     "process"
                 ],
                 "type": [
                     "stop"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -1148,7 +1257,10 @@
                     "id": "4294967295"
                 },
                 "id": "0"
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "@timestamp": "2016-12-07T02:16:24.827Z",
@@ -1159,7 +1271,8 @@
                 "action": [
                     "loaded-firewall-rule-to"
                 ],
-                "ingested": "2021-05-31T11:38:06.470532800Z",
+                "ingested": "2021-06-02T08:11:46.790316800Z",
+                "original": "type=NETFILTER_CFG msg=audit(1481076984.827:17): table=filter family=2 entries=0",
                 "category": [
                     "configuration"
                 ],
@@ -1176,7 +1289,10 @@
                     "record_type": "NETFILTER_CFG",
                     "table": "filter"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -1188,10 +1304,12 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790320800Z",
+                "original": "type=ADD_GROUP msg=audit(1481076992.414:385): pid=1235 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:unconfined_service_t:s0 msg='op=add-group id=1000 exe=\"/usr/sbin/groupadd\" hostname=? addr=? terminal=? res=success'",
+                "kind": "event",
                 "action": [
                     "added-group-account-to"
                 ],
-                "ingested": "2021-05-31T11:38:06.470538Z",
                 "category": [
                     "iam"
                 ],
@@ -1199,7 +1317,6 @@
                     "group",
                     "creation"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -1222,6 +1339,9 @@
                 },
                 "id": "4294967295"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "group": {
                 "id": "1000"
             }
@@ -1236,10 +1356,12 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790324500Z",
+                "original": "type=GRP_MGMT msg=audit(1481076992.419:386): pid=1235 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:unconfined_service_t:s0 msg='op=add-shadow-group id=1000 exe=\"/usr/sbin/groupadd\" hostname=? addr=? terminal=? res=success'",
+                "kind": "event",
                 "action": [
                     "modified-group-account"
                 ],
-                "ingested": "2021-05-31T11:38:06.470542300Z",
                 "category": [
                     "iam"
                 ],
@@ -1247,7 +1369,6 @@
                     "group",
                     "change"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -1270,6 +1391,9 @@
                 },
                 "id": "4294967295"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "group": {
                 "id": "0"
             }
@@ -1284,10 +1408,12 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790328700Z",
+                "original": "type=ADD_USER msg=audit(1481076992.488:389): pid=1264 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:unconfined_service_t:s0 msg='op=add-user id=1000 exe=\"/usr/sbin/useradd\" hostname=? addr=? terminal=? res=success'",
+                "kind": "event",
                 "action": [
                     "added-user-account"
                 ],
-                "ingested": "2021-05-31T11:38:06.470546600Z",
                 "category": [
                     "iam"
                 ],
@@ -1295,7 +1421,6 @@
                     "user",
                     "creation"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -1320,7 +1445,10 @@
                 "target": {
                     "id": "1000"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -1333,17 +1461,18 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790332300Z",
+                "original": "type=SYSTEM_RUNLEVEL msg=audit(1481076992.492:390): pid=1279 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='old-level=N new-level=3 comm=\"systemd-update-utmp\" exe=\"/usr/lib/systemd/systemd-update-utmp\" hostname=? addr=? terminal=? res=success'",
+                "kind": "event",
                 "action": [
                     "changed-to-runlevel"
                 ],
-                "ingested": "2021-05-31T11:38:06.470553Z",
                 "category": [
                     "host"
                 ],
                 "type": [
                     "change"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -1361,7 +1490,10 @@
                     "id": "4294967295"
                 },
                 "id": "0"
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -1373,10 +1505,12 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790335800Z",
+                "original": "type=USER_MGMT msg=audit(1481076992.521:393): pid=1264 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:unconfined_service_t:s0 msg='op=add-home-dir id=1000 exe=\"/usr/sbin/useradd\" hostname=? addr=? terminal=? res=success'",
+                "kind": "event",
                 "action": [
                     "modified-user-account"
                 ],
-                "ingested": "2021-05-31T11:38:06.470561600Z",
                 "category": [
                     "iam"
                 ],
@@ -1384,7 +1518,6 @@
                     "user",
                     "change"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -1409,7 +1542,10 @@
                 "target": {
                     "id": "1000"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -1421,17 +1557,18 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790341800Z",
+                "original": "type=USYS_CONFIG msg=audit(1481076993.000:402): pid=1232 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:unconfined_service_t:s0 msg='changing system time exe=\"/usr/sbin/hwclock\" hostname=? addr=? terminal=? res=success'",
+                "kind": "event",
                 "action": [
                     "changed-configuration"
                 ],
-                "ingested": "2021-05-31T11:38:06.470566400Z",
                 "category": [
                     "configuration"
                 ],
                 "type": [
                     "change"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -1447,7 +1584,10 @@
                     "id": "4294967295"
                 },
                 "id": "0"
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -1484,7 +1624,8 @@
                 "action": [
                     "changed-role-to"
                 ],
-                "ingested": "2021-05-31T11:38:06.470570800Z",
+                "ingested": "2021-06-02T08:11:46.790345700Z",
+                "original": "type=USER_ROLE_CHANGE msg=audit(1481077043.140:415): pid=1298 uid=0 auid=1000 ses=1 subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 msg='pam: default-context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 selected-context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 exe=\"/usr/sbin/sshd\" hostname=pool-96-241-146-97.washdc.fios.verizon.net addr=96.241.146.97 terminal=ssh res=success'",
                 "kind": "event",
                 "outcome": "success"
             },
@@ -1505,7 +1646,10 @@
                 },
                 "id": "0",
                 "terminal": "ssh"
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -1539,17 +1683,18 @@
                 "ip": "96.241.146.97"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790349200Z",
+                "original": "type=USER_LOGIN msg=audit(1481077043.193:421): pid=1298 uid=0 auid=1000 ses=1 subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 msg='op=login id=1000 exe=\"/usr/sbin/sshd\" hostname=pool-96-241-146-97.washdc.fios.verizon.net addr=96.241.146.97 terminal=/dev/pts/0 res=success'",
+                "kind": "event",
                 "action": [
                     "logged-in"
                 ],
-                "ingested": "2021-05-31T11:38:06.470575100Z",
                 "category": [
                     "authentication"
                 ],
                 "type": [
                     "start"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -1573,7 +1718,10 @@
                 "audit": {
                     "id": "1000"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -1585,17 +1733,18 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790352900Z",
+                "original": "type=USER_LOGOUT msg=audit(1481077049.033:424): pid=1298 uid=0 auid=1000 ses=1 subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 msg='op=login id=1000 exe=\"/usr/sbin/sshd\" hostname=? addr=? terminal=/dev/pts/0 res=success'",
+                "kind": "event",
                 "action": [
                     "logged-out"
                 ],
-                "ingested": "2021-05-31T11:38:06.470579500Z",
                 "category": [
                     "authentication"
                 ],
                 "type": [
                     "end"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -1618,7 +1767,10 @@
                 "audit": {
                     "id": "1000"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "@timestamp": "2016-12-07T02:20:31.371Z",
@@ -1626,10 +1778,12 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790356500Z",
+                "original": "type=CONFIG_CHANGE msg=audit(1481077231.371:478): auid=1000 ses=3 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 op=\"add_rule\" key=(null) list=4 res=1",
+                "kind": "event",
                 "action": [
                     "changed-audit-configuration"
                 ],
-                "ingested": "2021-05-31T11:38:06.470584100Z",
                 "category": [
                     "process",
                     "configuration"
@@ -1637,7 +1791,6 @@
                 "type": [
                     "change"
                 ],
-                "kind": "event",
                 "outcome": "1"
             },
             "auditd": {
@@ -1654,7 +1807,10 @@
                 "audit": {
                     "id": "1000"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -1666,14 +1822,18 @@
             },
             "event": {
                 "action": "cwd",
-                "ingested": "2021-05-31T11:38:06.470588400Z",
+                "ingested": "2021-06-02T08:11:46.790359800Z",
+                "original": "type=CWD msg=audit(1481077231.371:479):  cwd=\"/home/some_user\"",
                 "kind": "event"
             },
             "auditd": {
                 "log": {
                     "sequence": 479
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "@timestamp": "2016-12-07T02:20:31.371Z",
@@ -1682,7 +1842,8 @@
             },
             "event": {
                 "action": "path",
-                "ingested": "2021-05-31T11:38:06.470592500Z",
+                "ingested": "2021-06-02T08:11:46.790363300Z",
+                "original": "type=PATH msg=audit(1481077231.371:479): item=0 name=\"/sbin/auditctl\" inode=17367907 dev=08:01 mode=0100750 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:auditctl_exec_t:s0 objtype=NORMAL",
                 "kind": "event"
             },
             "auditd": {
@@ -1705,7 +1866,10 @@
                         "id": "0"
                     }
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "ecs": {
@@ -1713,13 +1877,17 @@
             },
             "event": {
                 "action": "unknown[1329]",
-                "ingested": "2021-05-31T11:38:06.470596700Z",
+                "ingested": "2021-06-02T08:11:46.790366900Z",
+                "original": "type=UNKNOWN[1329] msg=g\u0005",
                 "kind": "event"
             },
             "auditd": {
                 "log": {}
             },
-            "message": "g\u0005"
+            "message": "g\u0005",
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "@timestamp": "2016-12-07T02:21:48.360Z",
@@ -1728,7 +1896,8 @@
             },
             "event": {
                 "action": "bprm_fcaps",
-                "ingested": "2021-05-31T11:38:06.470601800Z",
+                "ingested": "2021-06-02T08:11:46.790371Z",
+                "original": "type=BPRM_FCAPS msg=audit(1481077308.360:529): fver=0 fp=0000000000000000 fi=0000000000000000 fe=0 old_pp=0000000000000000 old_pi=0000000000000000 old_pe=0000000000000000 new_pp=0000001fffffffff new_pi=0000000000000000 new_pe=0000001fffffffff",
                 "kind": "event"
             },
             "auditd": {
@@ -1745,7 +1914,10 @@
                     "new_pe": "0000001fffffffff",
                     "fe": "0"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "@timestamp": "2016-12-07T02:40:24.953Z",
@@ -1754,7 +1926,8 @@
             },
             "event": {
                 "action": "sockaddr",
-                "ingested": "2021-05-31T11:38:06.470606400Z",
+                "ingested": "2021-06-02T08:11:46.790374800Z",
+                "original": "type=SOCKADDR msg=audit(1481078424.953:688): saddr=02000050A9FEA9FE0000000000000000",
                 "kind": "event"
             },
             "auditd": {
@@ -1762,7 +1935,10 @@
                     "sequence": 688,
                     "saddr": "02000050A9FEA9FE0000000000000000"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "@timestamp": "2016-12-07T02:42:33.346Z",
@@ -1771,7 +1947,8 @@
             },
             "event": {
                 "action": "ckaddr",
-                "ingested": "2021-05-31T11:38:06.470610600Z",
+                "ingested": "2021-06-02T08:11:46.790378300Z",
+                "original": "type=CKADDR msg=audit(1481078553.346:737): saddr=02000050A9FEA9FE0000000000000000",
                 "kind": "event"
             },
             "auditd": {
@@ -1779,7 +1956,10 @@
                     "sequence": 737,
                     "saddr": "02000050A9FEA9FE0000000000000000"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "@timestamp": "2016-12-07T02:44:57.892Z",
@@ -1787,17 +1967,18 @@
                 "version": "1.10.0"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:46.790382200Z",
+                "original": "type=DAEMON_END msg=audit(1481078697.892:7799): auditd normal halt, sending auid=? pid=? subj=? res=success",
+                "kind": "event",
                 "action": [
                     "shutdown-audit"
                 ],
-                "ingested": "2021-05-31T11:38:06.470614700Z",
                 "category": [
                     "process"
                 ],
                 "type": [
                     "stop"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -1805,7 +1986,10 @@
                     "sequence": 7799,
                     "record_type": "DAEMON_END"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-useradd.log-config.yml
+++ b/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-useradd.log-config.yml
@@ -1,2 +1,0 @@
-dynamic_fields:
-  event.ingested: ".*"

--- a/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-useradd.log-expected.json
+++ b/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-useradd.log-expected.json
@@ -17,7 +17,7 @@
                 "action": [
                     "added-group-account-to"
                 ],
-                "ingested": "2021-05-31T08:35:48.047089600Z",
+                "ingested": "2021-05-31T11:38:07.328798300Z",
                 "category": [
                     "iam"
                 ],
@@ -70,7 +70,7 @@
                 "action": [
                     "added-group-account-to"
                 ],
-                "ingested": "2021-05-31T08:35:48.047111100Z",
+                "ingested": "2021-05-31T11:38:07.328818300Z",
                 "category": [
                     "iam"
                 ],
@@ -123,7 +123,7 @@
                 "action": [
                     "added-group-account-to"
                 ],
-                "ingested": "2021-05-31T08:35:48.047116700Z",
+                "ingested": "2021-05-31T11:38:07.328824100Z",
                 "category": [
                     "iam"
                 ],
@@ -175,7 +175,7 @@
                 "action": [
                     "added-user-account"
                 ],
-                "ingested": "2021-05-31T08:35:48.047121500Z",
+                "ingested": "2021-05-31T11:38:07.328828700Z",
                 "category": [
                     "iam"
                 ],
@@ -228,7 +228,7 @@
                 "action": [
                     "was-authorized"
                 ],
-                "ingested": "2021-05-31T08:35:48.047125700Z",
+                "ingested": "2021-05-31T11:38:07.328832600Z",
                 "category": [
                     "authentication"
                 ],
@@ -276,7 +276,7 @@
                 "action": [
                     "changed-password"
                 ],
-                "ingested": "2021-05-31T08:35:48.047129400Z",
+                "ingested": "2021-05-31T11:38:07.328836400Z",
                 "category": [
                     "iam"
                 ],
@@ -329,7 +329,7 @@
                 "action": [
                     "authenticated"
                 ],
-                "ingested": "2021-05-31T08:35:48.047133300Z",
+                "ingested": "2021-05-31T11:38:07.328840200Z",
                 "category": [
                     "authentication"
                 ],
@@ -378,7 +378,7 @@
                 "action": [
                     "was-authorized"
                 ],
-                "ingested": "2021-05-31T08:35:48.047136800Z",
+                "ingested": "2021-05-31T11:38:07.328843700Z",
                 "category": [
                     "authentication"
                 ],

--- a/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-useradd.log-expected.json
+++ b/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-useradd.log-expected.json
@@ -7,7 +7,7 @@
             },
             "@timestamp": "2021-01-17T17:12:33.686Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "source": {
                 "address": "127.0.0.1",
@@ -17,7 +17,7 @@
                 "action": [
                     "added-group-account-to"
                 ],
-                "ingested": "2021-05-14T09:45:49.161706500Z",
+                "ingested": "2021-05-31T08:35:48.047089600Z",
                 "category": [
                     "iam"
                 ],
@@ -60,7 +60,7 @@
             },
             "@timestamp": "2021-01-17T17:12:33.710Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "source": {
                 "address": "127.0.0.1",
@@ -70,7 +70,7 @@
                 "action": [
                     "added-group-account-to"
                 ],
-                "ingested": "2021-05-14T09:45:49.161722100Z",
+                "ingested": "2021-05-31T08:35:48.047111100Z",
                 "category": [
                     "iam"
                 ],
@@ -113,7 +113,7 @@
             },
             "@timestamp": "2021-01-17T17:12:33.710Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "source": {
                 "address": "127.0.0.1",
@@ -123,7 +123,7 @@
                 "action": [
                     "added-group-account-to"
                 ],
-                "ingested": "2021-05-14T09:45:49.161732100Z",
+                "ingested": "2021-05-31T08:35:48.047116700Z",
                 "category": [
                     "iam"
                 ],
@@ -165,7 +165,7 @@
             },
             "@timestamp": "2021-01-17T17:12:33.730Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "source": {
                 "address": "127.0.0.1",
@@ -175,7 +175,7 @@
                 "action": [
                     "added-user-account"
                 ],
-                "ingested": "2021-05-14T09:45:49.161741600Z",
+                "ingested": "2021-05-31T08:35:48.047121500Z",
                 "category": [
                     "iam"
                 ],
@@ -218,7 +218,7 @@
             },
             "@timestamp": "2021-01-17T17:12:33.814Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "source": {
                 "address": "127.0.0.1",
@@ -228,7 +228,7 @@
                 "action": [
                     "was-authorized"
                 ],
-                "ingested": "2021-05-14T09:45:49.161751Z",
+                "ingested": "2021-05-31T08:35:48.047125700Z",
                 "category": [
                     "authentication"
                 ],
@@ -266,7 +266,7 @@
             },
             "@timestamp": "2021-01-17T17:12:38.174Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "source": {
                 "address": "127.0.0.1",
@@ -276,7 +276,7 @@
                 "action": [
                     "changed-password"
                 ],
-                "ingested": "2021-05-14T09:45:49.161760300Z",
+                "ingested": "2021-05-31T08:35:48.047129400Z",
                 "category": [
                     "iam"
                 ],
@@ -319,7 +319,7 @@
             },
             "@timestamp": "2021-01-17T17:12:38.178Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "source": {
                 "address": "127.0.0.1",
@@ -329,7 +329,7 @@
                 "action": [
                     "authenticated"
                 ],
-                "ingested": "2021-05-14T09:45:49.161769900Z",
+                "ingested": "2021-05-31T08:35:48.047133300Z",
                 "category": [
                     "authentication"
                 ],
@@ -368,7 +368,7 @@
             },
             "@timestamp": "2021-01-17T17:12:38.178Z",
             "ecs": {
-                "version": "1.9.0"
+                "version": "1.10.0"
             },
             "source": {
                 "address": "127.0.0.1",
@@ -378,7 +378,7 @@
                 "action": [
                     "was-authorized"
                 ],
-                "ingested": "2021-05-14T09:45:49.161777800Z",
+                "ingested": "2021-05-31T08:35:48.047136800Z",
                 "category": [
                     "authentication"
                 ],

--- a/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-useradd.log-expected.json
+++ b/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-useradd.log-expected.json
@@ -14,7 +14,7 @@
                 "ip": "127.0.0.1"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:47.723089100Z",
+                "ingested": "2021-06-09T07:23:19.616205600Z",
                 "original": "type=ADD_GROUP msg=audit(1610903553.686:584): pid=2940 uid=0 auid=1000 ses=14 msg='op=adding group to /etc/group id=1004 exe=\"/usr/sbin/groupadd\" hostname=ubuntu-bionic addr=127.0.0.1 terminal=pts/2 res=success'",
                 "kind": "event",
                 "action": [
@@ -71,7 +71,7 @@
                 "ip": "127.0.0.1"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:47.723109100Z",
+                "ingested": "2021-06-09T07:23:19.616222500Z",
                 "original": "type=ADD_GROUP msg=audit(1610903553.710:586): pid=2940 uid=0 auid=1000 ses=14 msg='op=adding group to /etc/gshadow id=1004 exe=\"/usr/sbin/groupadd\" hostname=ubuntu-bionic addr=127.0.0.1 terminal=pts/2 res=success'",
                 "kind": "event",
                 "action": [
@@ -128,7 +128,7 @@
                 "ip": "127.0.0.1"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:47.723115Z",
+                "ingested": "2021-06-09T07:23:19.616227900Z",
                 "original": "type=ADD_GROUP msg=audit(1610903553.710:587): pid=2940 uid=0 auid=1000 ses=14 msg='op= id=1004 exe=\"/usr/sbin/groupadd\" hostname=ubuntu-bionic addr=127.0.0.1 terminal=pts/2 res=success'",
                 "kind": "event",
                 "action": [
@@ -184,7 +184,7 @@
                 "ip": "127.0.0.1"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:47.723119700Z",
+                "ingested": "2021-06-09T07:23:19.616232100Z",
                 "original": "type=ADD_USER msg=audit(1610903553.730:591): pid=2945 uid=0 auid=1000 ses=14 msg='op=adding user id=1004 exe=\"/usr/sbin/useradd\" hostname=ubuntu-bionic addr=127.0.0.1 terminal=pts/2 res=success'",
                 "kind": "event",
                 "action": [
@@ -241,7 +241,7 @@
                 "ip": "127.0.0.1"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:47.723123800Z",
+                "ingested": "2021-06-09T07:23:19.616235900Z",
                 "original": "type=USER_ACCT msg=audit(1610903553.814:593): pid=2948 uid=0 auid=1000 ses=14 msg='pam_tally2 uid=1004 reset=0 exe=\"/sbin/pam_tally2\" hostname=localhost addr=127.0.0.1 terminal=/dev/pts/2 res=success'",
                 "kind": "event",
                 "action": [
@@ -293,7 +293,7 @@
                 "ip": "127.0.0.1"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:47.723127600Z",
+                "ingested": "2021-06-09T07:23:19.616239500Z",
                 "original": "type=USER_CHAUTHTOK msg=audit(1610903558.174:594): pid=2953 uid=0 auid=1000 ses=14 msg='op=PAM:chauthtok acct=\"charlie\" exe=\"/usr/bin/passwd\" hostname=ubuntu-bionic addr=127.0.0.1 terminal=pts/2 res=success'",
                 "kind": "event",
                 "action": [
@@ -350,7 +350,7 @@
                 "ip": "127.0.0.1"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:47.723131100Z",
+                "ingested": "2021-06-09T07:23:19.616243500Z",
                 "original": "type=USER_AUTH msg=audit(1610903558.178:595): pid=2954 uid=0 auid=1000 ses=14 msg='op=PAM:authentication acct=\"root\" exe=\"/usr/bin/chfn\" hostname=ubuntu-bionic addr=127.0.0.1 terminal=pts/2 res=success'",
                 "kind": "event",
                 "action": [
@@ -403,7 +403,7 @@
                 "ip": "127.0.0.1"
             },
             "event": {
-                "ingested": "2021-06-02T08:11:47.723134900Z",
+                "ingested": "2021-06-09T07:23:19.616247200Z",
                 "original": "type=USER_ACCT msg=audit(1610903558.178:596): pid=2954 uid=0 auid=1000 ses=14 msg='op=PAM:accounting acct=\"root\" exe=\"/usr/bin/chfn\" hostname=ubuntu-bionic addr=127.0.0.1 terminal=pts/2 res=success'",
                 "kind": "event",
                 "action": [

--- a/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-useradd.log-expected.json
+++ b/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-useradd.log-expected.json
@@ -14,10 +14,12 @@
                 "ip": "127.0.0.1"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:47.723089100Z",
+                "original": "type=ADD_GROUP msg=audit(1610903553.686:584): pid=2940 uid=0 auid=1000 ses=14 msg='op=adding group to /etc/group id=1004 exe=\"/usr/sbin/groupadd\" hostname=ubuntu-bionic addr=127.0.0.1 terminal=pts/2 res=success'",
+                "kind": "event",
                 "action": [
                     "added-group-account-to"
                 ],
-                "ingested": "2021-05-31T11:38:07.328798300Z",
                 "category": [
                     "iam"
                 ],
@@ -25,7 +27,6 @@
                     "group",
                     "creation"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -49,6 +50,9 @@
                     "id": "1000"
                 }
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "group": {
                 "id": "1004"
             }
@@ -67,10 +71,12 @@
                 "ip": "127.0.0.1"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:47.723109100Z",
+                "original": "type=ADD_GROUP msg=audit(1610903553.710:586): pid=2940 uid=0 auid=1000 ses=14 msg='op=adding group to /etc/gshadow id=1004 exe=\"/usr/sbin/groupadd\" hostname=ubuntu-bionic addr=127.0.0.1 terminal=pts/2 res=success'",
+                "kind": "event",
                 "action": [
                     "added-group-account-to"
                 ],
-                "ingested": "2021-05-31T11:38:07.328818300Z",
                 "category": [
                     "iam"
                 ],
@@ -78,7 +84,6 @@
                     "group",
                     "creation"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -102,6 +107,9 @@
                     "id": "1000"
                 }
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "group": {
                 "id": "1004"
             }
@@ -120,10 +128,12 @@
                 "ip": "127.0.0.1"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:47.723115Z",
+                "original": "type=ADD_GROUP msg=audit(1610903553.710:587): pid=2940 uid=0 auid=1000 ses=14 msg='op= id=1004 exe=\"/usr/sbin/groupadd\" hostname=ubuntu-bionic addr=127.0.0.1 terminal=pts/2 res=success'",
+                "kind": "event",
                 "action": [
                     "added-group-account-to"
                 ],
-                "ingested": "2021-05-31T11:38:07.328824100Z",
                 "category": [
                     "iam"
                 ],
@@ -131,7 +141,6 @@
                     "group",
                     "creation"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -154,6 +163,9 @@
                     "id": "1000"
                 }
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "group": {
                 "id": "1004"
             }
@@ -172,10 +184,12 @@
                 "ip": "127.0.0.1"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:47.723119700Z",
+                "original": "type=ADD_USER msg=audit(1610903553.730:591): pid=2945 uid=0 auid=1000 ses=14 msg='op=adding user id=1004 exe=\"/usr/sbin/useradd\" hostname=ubuntu-bionic addr=127.0.0.1 terminal=pts/2 res=success'",
+                "kind": "event",
                 "action": [
                     "added-user-account"
                 ],
-                "ingested": "2021-05-31T11:38:07.328828700Z",
                 "category": [
                     "iam"
                 ],
@@ -183,7 +197,6 @@
                     "user",
                     "creation"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -209,7 +222,10 @@
                 "target": {
                     "id": "1004"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -225,17 +241,18 @@
                 "ip": "127.0.0.1"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:47.723123800Z",
+                "original": "type=USER_ACCT msg=audit(1610903553.814:593): pid=2948 uid=0 auid=1000 ses=14 msg='pam_tally2 uid=1004 reset=0 exe=\"/sbin/pam_tally2\" hostname=localhost addr=127.0.0.1 terminal=/dev/pts/2 res=success'",
+                "kind": "event",
                 "action": [
                     "was-authorized"
                 ],
-                "ingested": "2021-05-31T11:38:07.328832600Z",
                 "category": [
                     "authentication"
                 ],
                 "type": [
                     "info"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -257,7 +274,10 @@
                 },
                 "id": "1000",
                 "terminal": "/dev/pts/2"
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -273,10 +293,12 @@
                 "ip": "127.0.0.1"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:47.723127600Z",
+                "original": "type=USER_CHAUTHTOK msg=audit(1610903558.174:594): pid=2953 uid=0 auid=1000 ses=14 msg='op=PAM:chauthtok acct=\"charlie\" exe=\"/usr/bin/passwd\" hostname=ubuntu-bionic addr=127.0.0.1 terminal=pts/2 res=success'",
+                "kind": "event",
                 "action": [
                     "changed-password"
                 ],
-                "ingested": "2021-05-31T11:38:07.328836400Z",
                 "category": [
                     "iam"
                 ],
@@ -284,7 +306,6 @@
                     "user",
                     "change"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -310,7 +331,10 @@
                 "target": {
                     "name": "charlie"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -326,17 +350,18 @@
                 "ip": "127.0.0.1"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:47.723131100Z",
+                "original": "type=USER_AUTH msg=audit(1610903558.178:595): pid=2954 uid=0 auid=1000 ses=14 msg='op=PAM:authentication acct=\"root\" exe=\"/usr/bin/chfn\" hostname=ubuntu-bionic addr=127.0.0.1 terminal=pts/2 res=success'",
+                "kind": "event",
                 "action": [
                     "authenticated"
                 ],
-                "ingested": "2021-05-31T11:38:07.328840200Z",
                 "category": [
                     "authentication"
                 ],
                 "type": [
                     "info"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -359,7 +384,10 @@
                 "audit": {
                     "id": "1000"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -375,17 +403,18 @@
                 "ip": "127.0.0.1"
             },
             "event": {
+                "ingested": "2021-06-02T08:11:47.723134900Z",
+                "original": "type=USER_ACCT msg=audit(1610903558.178:596): pid=2954 uid=0 auid=1000 ses=14 msg='op=PAM:accounting acct=\"root\" exe=\"/usr/bin/chfn\" hostname=ubuntu-bionic addr=127.0.0.1 terminal=pts/2 res=success'",
+                "kind": "event",
                 "action": [
                     "was-authorized"
                 ],
-                "ingested": "2021-05-31T11:38:07.328843700Z",
                 "category": [
                     "authentication"
                 ],
                 "type": [
                     "info"
                 ],
-                "kind": "event",
                 "outcome": "success"
             },
             "auditd": {
@@ -408,7 +437,10 @@
                 "audit": {
                     "id": "1000"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/auditd/data_stream/log/_dev/test/pipeline/test-common-config.yml
+++ b/packages/auditd/data_stream/log/_dev/test/pipeline/test-common-config.yml
@@ -1,0 +1,5 @@
+dynamic_fields:
+  event.ingested: ".*"
+fields:
+  tags:
+    - preserve_original_event

--- a/packages/auditd/data_stream/log/agent/stream/log.yml.hbs
+++ b/packages/auditd/data_stream/log/agent/stream/log.yml.hbs
@@ -13,5 +13,7 @@ tags:
 publisher_pipeline.disable_host: true
 {{/contains}}
 exclude_files: [".gz$"]
+{{#if processors}}
 processors:
 {{processors}}
+{{/if}}

--- a/packages/auditd/data_stream/log/agent/stream/log.yml.hbs
+++ b/packages/auditd/data_stream/log/agent/stream/log.yml.hbs
@@ -2,8 +2,16 @@ paths:
 {{#each paths as |path i|}}
  - {{path}}
 {{/each}}
-exclude_files: [".gz$"]
 tags:
 {{#if preserve_original_event}}
-- preserve_original_event
+  - preserve_original_event
 {{/if}}
+{{#each tags as |tag i|}}
+  - {{tag}}
+{{/each}}
+{{#contains tags "forwarded"}}
+publisher_pipeline.disable_host: true
+{{/contains}}
+exclude_files: [".gz$"]
+processors:
+{{processors}}

--- a/packages/auditd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/auditd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1,2173 +1,2173 @@
 ---
 description: Pipeline for parsing Linux auditd logs
 processors:
-- set:
-    field: event.ingested
-    value: '{{_ingest.timestamp}}'
-- set:
-    field: ecs.version
-    value: 1.10.0
-- rename:
-    field: message
-    target_field: event.original
-    ignore_failure: true
-- grok:
-    field: event.original
-    pattern_definitions:
-      AUDIT_TYPE: "type=%{NOTSPACE:auditd.log.record_type}"
-      AUDIT_NODE: "node=%{IPORHOST:auditd.log.node} "
-      AUDIT_PREFIX: "^(?:%{AUDIT_NODE})?%{AUDIT_TYPE} msg=audit\\(%{NUMBER:auditd.log.epoch}:%{NUMBER:auditd.log.sequence}\\):(%{DATA})?"
-      AUDIT_KEY_VALUES: "%{WORD}=%{GREEDYDATA}"
-      ANY: ".*"
-    patterns:
-    - "%{AUDIT_PREFIX} %{AUDIT_KEY_VALUES:auditd.log.kv} old auid=%{NUMBER:auditd.log.old_auid}
-      new auid=%{NUMBER:auditd.log.new_auid} old ses=%{NUMBER:auditd.log.old_ses}
-      new ses=%{NUMBER:auditd.log.new_ses}"
-    - "%{AUDIT_PREFIX} %{AUDIT_KEY_VALUES:auditd.log.kv} msg=['\"]([^=]*\\s)?%{ANY:auditd.log.sub_kv}['\"]"
-    - "%{AUDIT_PREFIX} %{AUDIT_KEY_VALUES:auditd.log.kv}"
-    - "%{AUDIT_PREFIX}"
-    - "%{AUDIT_TYPE} %{AUDIT_KEY_VALUES:auditd.log.kv}"
-- kv:
-    field: auditd.log.kv
-    field_split: "\\s+"
-    value_split: "="
-    target_field: auditd.log
-- kv:
-    field: auditd.log.sub_kv
-    field_split: "\\s+(?=[^\\s]+=)"
-    value_split: "="
-    target_field: auditd.log
-    ignore_missing: true
-- date:
-    field: auditd.log.epoch
-    target_field: "@timestamp"
-    formats:
-    - UNIX
-    ignore_failure: true
-- rename:
-    ignore_failure: true
-    field: auditd.log.old-auid
-    target_field: auditd.log.old_auid
-- rename:
-    ignore_failure: true
-    field: auditd.log.old-ses
-    target_field: auditd.log.old_ses
-- script:
-    lang: painless
-    source: |
-        String trimQuotes(def singleQuote, def doubleQuote, def v) {
-            if (v.startsWith(singleQuote) || v.startsWith(doubleQuote)) {
-                v = v.substring(1, v.length());
-            }
-            if (v.endsWith(singleQuote) || v.endsWith(doubleQuote)) {
-                v = v.substring(0, v.length()-1);
-            }
-            return v;
-        }
-
-        boolean isHexAscii(String v) {
-            def len = v.length();
-
-            if (len == 0 || len % 2 != 0) {
-                return false;
-            }
-
-            for (int i = 0 ; i < len ; i++) {
-                if (Character.digit(v.charAt(i), 16) == -1) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        String convertHexToString(String hex) {
-            StringBuilder sb = new StringBuilder();
-            boolean needed_encoding = false;
-
-            for (int i=0; i < hex.length() - 1; i+=2) {
-                int cp = Integer.parseInt(hex.substring(i, (i +2)), 16);
-                if (cp < 33 || cp == 34 || cp == 127) {
-                    needed_encoding = true;
-                }
-                if (cp < 32 || cp == 127) {
-                    sb.append('^');
-                    cp ^= 64;
-                }
-                sb.append((char)cp);
-            }
-            if (needed_encoding) {
-                return sb.toString();
-            }
-            return hex;
-        }
-
-        def possibleHexKeys = ["exe", "cmd", "data", "path", "comm", "file", "name", "watch", "cwd", "acct", "dir", "vm", "old-chardev", "new-chardev", "old-disk", "new-disk", "old-fs", "new-fs", "old-net", "new-net", "device", "cgroup", "apparmor", "operation", "denied_mask", "info", "profile", "requested_mask", "old-rng", "new-rng", "ocomm", "grp", "new_group", "invalid_context", "sw", "root_dir", "proctitle"];
-        def audit = ctx.auditd.get("log");
-        Iterator entries = audit.entrySet().iterator();
-
-        while (entries.hasNext()) {
-            def e = entries.next();
-            def k = e.getKey();
-            def v = e.getValue();
-
-            // Remove entries whose value is ?
-            if (v == "?" || v == "(null)" || v == "") {
-                entries.remove();
-                continue;
-            }
-
-            // Convert hex values to ASCII.
-            if (possibleHexKeys.contains(k) && isHexAscii(v)) {
-                v = convertHexToString(v);
-                audit.put(k, v);
-            }
-
-            // Trim quotes.
-            if (v instanceof String) {
-                v = trimQuotes(params.single_quote, params.double_quote, v);
-                audit.put(k, v);
-            }
-
-            // Convert arch.
-            if (k == "arch" && v == "c000003e") {
-                audit.put(k, "x86_64");
-            }
-        }
-    params:
-      single_quote: "'"
-      double_quote: "\""
-- convert:
-    field: auditd.log.sequence
-    type: long
-    ignore_missing: true
-- convert:
-    field: auditd.log.lport
-    type: long
-    ignore_missing: true
-- convert:
-    field: auditd.log.rport
-    type: long
-    ignore_missing: true
-- convert:
-    field: auditd.log.entries
-    type: long
-    ignore_missing: true
-- convert:
-    field: auditd.log.dst_prefixlen
-    type: long
-    ignore_missing: true
-- convert:
-    field: auditd.log.ksize
-    type: long
-    ignore_missing: true
-- convert:
-    field: auditd.log.size
-    type: long
-    ignore_missing: true
-- convert:
-    field: auditd.log.src_prefixlen
-    type: long
-    ignore_missing: true
-- set:
-    field: event.kind
-    value: event
-- script:
-    lang: painless
-    ignore_failure: true
-    # Auditd record type to ECS mappings
-    # AUTOGENERATED FROM go-libaudit v2.2.0, DO NOT EDIT
-    params:
-      syscalls:
-        '*':
-          - event:
-              category:
-                - process
-              type:
-                - info
-        accept:
-          - event:
-              action:
-                - accepted-connection-from
-              category:
-                - network
-              type:
-                - connection
-                - start
-        accept4:
-          - event:
-              action:
-                - accepted-connection-from
-              category:
-                - network
-              type:
-                - connection
-                - start
-        access:
-          - event:
-              action:
-                - checked-metadata-of
-              category:
-                - file
-              type:
-                - info
-        adjtimex:
-          - event:
-              action:
-                - changed-system-time
-              category:
-                - host
-              type:
-                - change
-        bind:
-          - event:
-              action:
-                - bound-socket
-              category:
-                - network
-              type:
-                - start
-        brk:
-          - event:
-              action:
-                - allocated-memory
-              category:
-                - process
-              type:
-                - info
-        chmod:
-          - event:
-              action:
-                - changed-file-permissions-of
-              category:
-                - file
-              type:
-                - change
-        chown:
-          - event:
-              action:
-                - changed-file-ownership-of
-              category:
-                - file
-              type:
-                - change
-        clock_settime:
-          - event:
-              action:
-                - changed-system-time
-              category:
-                - host
-              type:
-                - change
-        connect:
-          - event:
-              action:
-                - connected-to
-              category:
-                - network
-              type:
-                - connection
-                - start
-        creat:
-          - event:
-              action:
-                - opened-file
-              category:
-                - file
-              type:
-                - creation
-        delete_module:
-          - event:
-              action:
-                - unloaded-kernel-module
-              category:
-                - driver
-              type:
-                - end
-        execve:
-          - event:
-              action:
-                - executed
-              category:
-                - process
-              type:
-                - start
-        execveat:
-          - event:
-              action:
-                - executed
-              category:
-                - process
-              type:
-                - start
-        faccessat:
-          - event:
-              action:
-                - checked-metadata-of
-              category:
-                - file
-              type:
-                - info
-        fallocate:
-          - event:
-              action:
-                - opened-file
-              category:
-                - file
-              type:
-                - change
-        fchmod:
-          - event:
-              action:
-                - changed-file-permissions-of
-              category:
-                - file
-              type:
-                - change
-        fchmodat:
-          - event:
-              action:
-                - changed-file-permissions-of
-              category:
-                - file
-              type:
-                - change
-        fchown:
-          - event:
-              action:
-                - changed-file-ownership-of
-              category:
-                - file
-              type:
-                - change
-        fchownat:
-          - event:
-              action:
-                - changed-file-ownership-of
-              category:
-                - file
-              type:
-                - change
-        fgetxattr:
-          - event:
-              action:
-                - checked-metadata-of
-              category:
-                - file
-              type:
-                - info
-        finit_module:
-          - event:
-              action:
-                - loaded-kernel-module
-              category:
-                - driver
-              type:
-                - start
-        fremovexattr:
-          - event:
-              action:
-                - changed-file-attributes-of
-              category:
-                - file
-              type:
-                - change
-        fsetxattr:
-          - event:
-              action:
-                - changed-file-attributes-of
-              category:
-                - file
-              type:
-                - change
-        fstat:
-          - event:
-              action:
-                - checked-metadata-of
-              category:
-                - file
-              type:
-                - info
-        fstatat:
-          - event:
-              action:
-                - checked-metadata-of
-              category:
-                - file
-              type:
-                - info
-        fstatfs:
-          - event:
-              action:
-                - checked-filesystem-metadata-of
-              category:
-                - file
-              type:
-                - info
-        ftruncate:
-          - event:
-              action:
-                - opened-file
-              category:
-                - file
-              type:
-                - change
-        futimens:
-          - event:
-              action:
-                - changed-timestamp-of
-              category:
-                - file
-              type:
-                - info
-        futimesat:
-          - event:
-              action:
-                - changed-timestamp-of
-              category:
-                - file
-              type:
-                - info
-        getxattr:
-          - event:
-              action:
-                - checked-metadata-of
-              category:
-                - file
-              type:
-                - info
-        init_module:
-          - event:
-              action:
-                - loaded-kernel-module
-              category:
-                - driver
-              type:
-                - start
-        kill:
-          - event:
-              action:
-                - killed-pid
-              category:
-                - process
-              type:
-                - end
-        lchown:
-          - event:
-              action:
-                - changed-file-ownership-of
-              category:
-                - file
-              type:
-                - change
-        lgetxattr:
-          - event:
-              action:
-                - checked-metadata-of
-              category:
-                - file
-              type:
-                - info
-        listen:
-          - event:
-              action:
-                - listen-for-connections
-              category:
-                - network
-              type:
-                - start
-        lremovexattr:
-          - event:
-              action:
-                - changed-file-attributes-of
-              category:
-                - file
-              type:
-                - change
-        lsetxattr:
-          - event:
-              action:
-                - changed-file-attributes-of
-              category:
-                - file
-              type:
-                - change
-        lstat:
-          - event:
-              action:
-                - checked-metadata-of
-              category:
-                - file
-              type:
-                - info
-        mkdir:
-          - event:
-              action:
-                - created-directory
-              category:
-                - file
-              type:
-                - creation
-        mkdirat:
-          - event:
-              action:
-                - created-directory
-              category:
-                - file
-              type:
-                - creation
-        mknod:
-          - event:
-              action:
-                - make-device
-              category:
-                - file
-              type:
-                - creation
-        mknodat:
-          - event:
-              action:
-                - make-device
-              category:
-                - file
-              type:
-                - creation
-        mmap:
-          - event:
-              action:
-                - allocated-memory
-              category:
-                - process
-              type:
-                - info
-        mmap2:
-          - event:
-              action:
-                - allocated-memory
-              category:
-                - process
-              type:
-                - info
-        mount:
-          - event:
-              action:
-                - mounted
-              category:
-                - file
-              type:
-                - creation
-        newfstatat:
-          - event:
-              action:
-                - checked-metadata-of
-              category:
-                - file
-              type:
-                - info
-        open:
-          - event:
-              action:
-                - opened-file
-              category:
-                - file
-              type:
-                - info
-        openat:
-          - event:
-              action:
-                - opened-file
-              category:
-                - file
-              type:
-                - info
-        read:
-          - event:
-              action:
-                - read-file
-              category:
-                - file
-              type:
-                - info
-        readlink:
-          - event:
-              action:
-                - opened-file
-              category:
-                - file
-              type:
-                - info
-        readlinkat:
-          - event:
-              action:
-                - opened-file
-              category:
-                - file
-              type:
-                - info
-        recv:
-          - event:
-              action:
-                - received-from
-              category:
-                - network
-              type:
-                - connection
-                - info
-        recvfrom:
-          - event:
-              action:
-                - received-from
-              category:
-                - network
-              type:
-                - connection
-                - info
-        recvmmsg:
-          - event:
-              action:
-                - received-from
-              category:
-                - network
-              type:
-                - connection
-                - info
-        recvmsg:
-          - event:
-              action:
-                - received-from
-              category:
-                - network
-              type:
-                - connection
-                - info
-        removexattr:
-          - event:
-              action:
-                - changed-file-attributes-of
-              category:
-                - file
-              type:
-                - change
-        rename:
-          - event:
-              action:
-                - renamed
-              category:
-                - file
-              type:
-                - change
-        renameat:
-          - event:
-              action:
-                - renamed
-              category:
-                - file
-              type:
-                - change
-        renameat2:
-          - event:
-              action:
-                - renamed
-              category:
-                - file
-              type:
-                - change
-        rmdir:
-          - event:
-              action:
-                - deleted
-              category:
-                - file
-              type:
-                - deletion
-        sched_setattr:
-          - event:
-              action:
-                - adjusted-scheduling-policy-of
-              category:
-                - process
-              type:
-                - change
-        sched_setparam:
-          - event:
-              action:
-                - adjusted-scheduling-policy-of
-              category:
-                - process
-              type:
-                - change
-        sched_setscheduler:
-          - event:
-              action:
-                - adjusted-scheduling-policy-of
-              category:
-                - process
-              type:
-                - change
-        send:
-          - event:
-              action:
-                - sent-to
-              category:
-                - network
-              type:
-                - connection
-                - info
-        sendmmsg:
-          - event:
-              action:
-                - sent-to
-              category:
-                - network
-              type:
-                - connection
-                - info
-        sendmsg:
-          - event:
-              action:
-                - sent-to
-              category:
-                - network
-              type:
-                - connection
-                - info
-        sendto:
-          - event:
-              action:
-                - sent-to
-              category:
-                - network
-              type:
-                - connection
-                - info
-        setdomainname:
-          - event:
-              action:
-                - changed-system-name
-              category:
-                - host
-              type:
-                - change
-        setegid:
-          - event:
-              action:
-                - changed-identity-of
-              category:
-                - process
-              type:
-                - change
-        seteuid:
-          - event:
-              action:
-                - changed-identity-of
-              category:
-                - process
-              type:
-                - change
-        setfsgid:
-          - event:
-              action:
-                - changed-identity-of
-              category:
-                - process
-              type:
-                - change
-        setfsuid:
-          - event:
-              action:
-                - changed-identity-of
-              category:
-                - process
-              type:
-                - change
-        setgid:
-          - event:
-              action:
-                - changed-identity-of
-              category:
-                - process
-              type:
-                - change
-        sethostname:
-          - event:
-              action:
-                - changed-system-name
-              category:
-                - host
-              type:
-                - change
-        setregid:
-          - event:
-              action:
-                - changed-identity-of
-              category:
-                - process
-              type:
-                - change
-        setresgid:
-          - event:
-              action:
-                - changed-identity-of
-              category:
-                - process
-              type:
-                - change
-        setresuid:
-          - event:
-              action:
-                - changed-identity-of
-              category:
-                - process
-              type:
-                - change
-        setreuid:
-          - event:
-              action:
-                - changed-identity-of
-              category:
-                - process
-              type:
-                - change
-        settimeofday:
-          - event:
-              action:
-                - changed-system-time
-              category:
-                - host
-              type:
-                - change
-        setuid:
-          - event:
-              action:
-                - changed-identity-of
-              category:
-                - process
-              type:
-                - change
-        setxattr:
-          - event:
-              action:
-                - changed-file-attributes-of
-              category:
-                - file
-              type:
-                - change
-        stat:
-          - event:
-              action:
-                - checked-metadata-of
-              category:
-                - file
-              type:
-                - info
-        stat64:
-          - event:
-              action:
-                - checked-metadata-of
-              category:
-                - file
-              type:
-                - info
-        statfs:
-          - event:
-              action:
-                - checked-filesystem-metadata-of
-              category:
-                - file
-              type:
-                - info
-        stime:
-          - event:
-              action:
-                - changed-system-time
-              category:
-                - host
-              type:
-                - change
-        symlink:
-          - event:
-              action:
-                - symlinked
-              category:
-                - file
-              type:
-                - creation
-        symlinkat:
-          - event:
-              action:
-                - symlinked
-              category:
-                - file
-              type:
-                - creation
-        tgkill:
-          - event:
-              action:
-                - killed-pid
-              category:
-                - process
-              type:
-                - end
-        tkill:
-          - event:
-              action:
-                - killed-pid
-              category:
-                - process
-              type:
-                - end
-        truncate:
-          - event:
-              action:
-                - opened-file
-              category:
-                - file
-              type:
-                - change
-        umount:
-          - event:
-              action:
-                - unmounted
-              category:
-                - file
-              type:
-                - deletion
-        umount2:
-          - event:
-              action:
-                - unmounted
-              category:
-                - file
-              type:
-                - deletion
-        unlink:
-          - event:
-              action:
-                - deleted
-              category:
-                - file
-              type:
-                - deletion
-        unlinkat:
-          - event:
-              action:
-                - deleted
-              category:
-                - file
-              type:
-                - deletion
-        utime:
-          - event:
-              action:
-                - changed-timestamp-of
-              category:
-                - file
-              type:
-                - info
-        utimensat:
-          - event:
-              action:
-                - changed-timestamp-of
-              category:
-                - file
-              type:
-                - info
-        utimes:
-          - event:
-              action:
-                - changed-timestamp-of
-              category:
-                - file
-              type:
-                - info
-        write:
-          - event:
-              action:
-                - wrote-to-file
-              category:
-                - file
-              type:
-                - change
-      types:
-        ACCT_LOCK:
-          - event:
-              action:
-                - locked-account
-              category:
-                - iam
-              type:
-                - user
-                - info
-        ACCT_UNLOCK:
-          - event:
-              action:
-                - unlocked-account
-              category:
-                - iam
-              type:
-                - user
-                - info
-        ADD_GROUP:
-          - copy:
-              - from:
-                  - auid
-                to: user
-              - from:
-                  - uid
-                to: user.effective
-              - from:
-                  - id
-                  - acct
-                to: group
-            event:
-              action:
-                - added-group-account-to
-              category:
-                - iam
-              type:
-                - group
-                - creation
-        ADD_USER:
-          - copy:
-              - from:
-                  - auid
-                to: user
-              - from:
-                  - uid
-                to: user.effective
-              - from:
-                  - id
-                  - acct
-                to: user.target
-            event:
-              action:
-                - added-user-account
-              category:
-                - iam
-              type:
-                - user
-                - creation
-        ANOM_ABEND:
-          - event:
-              action:
-                - crashed-program
-              category:
-                - process
-              type:
-                - end
-        ANOM_EXEC:
-          - event:
-              action:
-                - attempted-execution-of-forbidden-program
-              category:
-                - process
-              type:
-                - start
-        ANOM_LINK:
-          - event:
-              action:
-                - used-suspicious-link
-        ANOM_LOGIN_FAILURES:
-          - event:
-              action:
-                - failed-log-in-too-many-times-to
-        ANOM_LOGIN_LOCATION:
-          - event:
-              action:
-                - attempted-log-in-from-unusual-place-to
-        ANOM_LOGIN_SESSIONS:
-          - event:
-              action:
-                - opened-too-many-sessions-to
-        ANOM_LOGIN_TIME:
-          - event:
-              action:
-                - attempted-log-in-during-unusual-hour-to
-        ANOM_PROMISCUOUS:
-          - event:
-              action:
-                - changed-promiscuous-mode-on-device
-        ANOM_RBAC_INTEGRITY_FAIL:
-          - event:
-              action:
-                - tested-file-system-integrity-of
-        AVC:
-          - event:
-              action:
-                - violated-selinux-policy
-            has_fields:
-              - seresult
-          - event:
-              action:
-                - violated-apparmor-policy
-            has_fields:
-              - apparmor
-        CHGRP_ID:
-          - event:
-              action:
-                - changed-group
-              category:
-                - process
-              type:
-                - change
-        CHUSER_ID:
-          - event:
-              action:
-                - changed-user-id
-              category:
-                - process
-              type:
-                - change
-        CONFIG_CHANGE:
-          - event:
-              action:
-                - changed-audit-configuration
-              category:
-                - process
-                - configuration
-              type:
-                - change
-        CRED_ACQ:
-          - copy:
-              - from:
-                  - auid
-                to: user
-              - from:
-                  - acct
-                  - id
-                  - uid
-                to: user.effective
-            event:
-              action:
-                - acquired-credentials
-              category:
-                - authentication
-              type:
-                - info
-        CRED_DISP:
-          - copy:
-              - from:
-                  - auid
-                to: user
-              - from:
-                  - acct
-                  - id
-                  - uid
-                to: user.effective
-            event:
-              action:
-                - disposed-credentials
-              category:
-                - authentication
-              type:
-                - info
-        CRED_REFR:
-          - copy:
-              - from:
-                  - auid
-                to: user
-              - from:
-                  - acct
-                  - id
-                  - uid
-                to: user.effective
-            event:
-              action:
-                - refreshed-credentials
-              category:
-                - authentication
-              type:
-                - info
-        CRYPTO_KEY_USER:
-          - event:
-              action:
-                - negotiated-crypto-key
-              category:
-                - process
-              type:
-                - info
-        CRYPTO_LOGIN:
-          - event:
-              action:
-                - crypto-officer-logged-in
-        CRYPTO_LOGOUT:
-          - event:
-              action:
-                - crypto-officer-logged-out
-              category:
-                - process
-              type:
-                - info
-        CRYPTO_SESSION:
-          - event:
-              action:
-                - started-crypto-session
-              category:
-                - process
-              type:
-                - info
-        DAC_CHECK:
-          - event:
-              action:
-                - access-result
-        DAEMON_ABORT:
-          - event:
-              action:
-                - aborted-auditd-startup
-              category:
-                - process
-              type:
-                - stop
-        DAEMON_ACCEPT:
-          - event:
-              action:
-                - remote-audit-connected
-              category:
-                - network
-              type:
-                - connection
-                - start
-        DAEMON_CLOSE:
-          - event:
-              action:
-                - remote-audit-disconnected
-              category:
-                - network
-              type:
-                - connection
-                - start
-        DAEMON_CONFIG:
-          - event:
-              action:
-                - changed-auditd-configuration
-              category:
-                - process
-                - configuration
-              type:
-                - change
-        DAEMON_END:
-          - event:
-              action:
-                - shutdown-audit
-              category:
-                - process
-              type:
-                - stop
-        DAEMON_ERR:
-          - event:
-              action:
-                - audit-error
-              category:
-                - process
-              type:
-                - info
-        DAEMON_RECONFIG:
-          - event:
-              action:
-                - reconfigured-auditd
-              category:
-                - process
-                - configuration
-              type:
-                - info
-        DAEMON_RESUME:
-          - event:
-              action:
-                - resumed-audit-logging
-              category:
-                - process
-              type:
-                - change
-        DAEMON_ROTATE:
-          - event:
-              action:
-                - rotated-audit-logs
-              category:
-                - process
-              type:
-                - change
-        DAEMON_START:
-          - event:
-              action:
-                - started-audit
-              category:
-                - process
-              type:
-                - start
-        DEL_GROUP:
-          - copy:
-              - from:
-                  - auid
-                to: user
-              - from:
-                  - uid
-                to: user.effective
-              - from:
-                  - id
-                  - acct
-                to: group
-            event:
-              action:
-                - deleted-group-account-from
-              category:
-                - iam
-              type:
-                - group
-                - deletion
-        DEL_USER:
-          - copy:
-              - from:
-                  - auid
-                to: user
-              - from:
-                  - uid
-                to: user.effective
-              - from:
-                  - id
-                  - acct
-                to: user.target
-            event:
-              action:
-                - deleted-user-account
-              category:
-                - iam
-              type:
-                - user
-                - deletion
-        FEATURE_CHANGE:
-          - event:
-              action:
-                - changed-audit-feature
-              category:
-                - configuration
-              type:
-                - change
-        FS_RELABEL:
-          - event:
-              action:
-                - relabeled-filesystem
-        GRP_AUTH:
-          - copy:
-              - from:
-                  - auid
-                to: user
-              - from:
-                  - uid
-                to: user.effective
-            event:
-              action:
-                - authenticated-to-group
-              category:
-                - authentication
-              type:
-                - info
-        GRP_CHAUTHTOK:
-          - copy:
-              - from:
-                  - auid
-                to: user
-              - from:
-                  - uid
-                to: user.effective
-              - from:
-                  - acct
-                  - id
-                  - uid
-                to: group
-            event:
-              action:
-                - changed-group-password
-              category:
-                - iam
-              type:
-                - group
-                - change
-        GRP_MGMT:
-          - copy:
-              - from:
-                  - auid
-                to: user
-              - from:
-                  - uid
-                to: group
-              - from:
-                  - uid
-                to: user.effective
-            event:
-              action:
-                - modified-group-account
-              category:
-                - iam
-              type:
-                - group
-                - change
-        KERNEL:
-          - event:
-              action:
-                - initialized-audit-subsystem
-              category:
-                - process
-              type:
-                - info
-        KERN_MODULE:
-          - event:
-              action:
-                - loaded-kernel-module
-              category:
-                - driver
-              type:
-                - start
-        LABEL_LEVEL_CHANGE:
-          - event:
-              action:
-                - modified-level-of
-        LABEL_OVERRIDE:
-          - event:
-              action:
-                - overrode-label-of
-        LOGIN:
-          - copy:
-              - from:
-                  - old_auid
-                  - old-auid
-                to: user
-              - from:
-                  - new-auid
-                  - new_auid
-                  - auid
-                to: user.effective
-            event:
-              action:
-                - changed-login-id-to
-              category:
-                - authentication
-              type:
-                - start
-        MAC_CHECK:
-          - event:
-              action:
-                - mac-permission
-        MAC_CONFIG_CHANGE:
-          - event:
-              action:
-                - changed-selinux-boolean
-              category:
-                - configuration
-              type:
-                - change
-        MAC_POLICY_LOAD:
-          - event:
-              action:
-                - loaded-selinux-policy
-              category:
-                - configuration
-              type:
-                - access
-        MAC_STATUS:
-          - event:
-              action:
-                - changed-selinux-enforcement
-              category:
-                - configuration
-              type:
-                - change
-        NETFILTER_CFG:
-          - event:
-              action:
-                - loaded-firewall-rule-to
-              category:
-                - configuration
-              type:
-                - change
-        ROLE_ASSIGN:
-          - event:
-              action:
-                - assigned-user-role-to
-              category:
-                - iam
-              type:
-                - user
-                - change
-        ROLE_MODIFY:
-          - event:
-              action:
-                - modified-role
-              category:
-                - iam
-              type:
-                - change
-        ROLE_REMOVE:
-          - event:
-              action:
-                - removed-user-role-from
-              category:
-                - iam
-              type:
-                - user
-                - change
-        SECCOMP:
-          - event:
-              action:
-                - violated-seccomp-policy
-        SELINUX_ERR:
-          - event:
-              action:
-                - caused-mac-policy-error
-        SERVICE_START:
-          - event:
-              action:
-                - started-service
-              category:
-                - process
-              type:
-                - start
-        SERVICE_STOP:
-          - event:
-              action:
-                - stopped-service
-              category:
-                - process
-              type:
-                - stop
-        SOFTWARE_UPDATE:
-          - event:
-              action:
-                - package-updated
-              category:
-                - package
-              type:
-                - info
-        SYSTEM_BOOT:
-          - event:
-              action:
-                - booted-system
-              category:
-                - host
-              type:
-                - start
-        SYSTEM_RUNLEVEL:
-          - event:
-              action:
-                - changed-to-runlevel
-              category:
-                - host
-              type:
-                - change
-        SYSTEM_SHUTDOWN:
-          - event:
-              action:
-                - shutdown-system
-              category:
-                - host
-              type:
-                - end
-        TEST:
-          - event:
-              action:
-                - sent-test
-              category:
-                - process
-              type:
-                - info
-        TRUSTED_APP:
-          - event:
-              action:
-                - unknown
-              category:
-                - process
-              type:
-                - info
-        TTY:
-          - event:
-              action:
-                - typed
-        USER:
-          - event:
-              action:
-                - sent-message
-        USER_ACCT:
-          - copy:
-              - from:
-                  - auid
-                to: user
-              - from:
-                  - acct
-                  - id
-                  - uid
-                to: user.effective
-            event:
-              action:
-                - was-authorized
-              category:
-                - authentication
-              type:
-                - info
-        USER_AUTH:
-          - copy:
-              - from:
-                  - auid
-                to: user
-              - from:
-                  - acct
-                  - id
-                  - uid
-                to: user.effective
-            event:
-              action:
-                - authenticated
-              category:
-                - authentication
-              type:
-                - info
-        USER_AVC:
-          - event:
-              action:
-                - access-permission
-        USER_CHAUTHTOK:
-          - copy:
-              - from:
-                  - auid
-                to: user
-              - from:
-                  - uid
-                to: user.effective
-              - from:
-                  - acct
-                  - id
-                  - uid
-                to: user.target
-            event:
-              action:
-                - changed-password
-              category:
-                - iam
-              type:
-                - user
-                - change
-        USER_CMD:
-          - event:
-              action:
-                - ran-command
-              category:
-                - process
-              type:
-                - start
-        USER_END:
-          - copy:
-              - from:
-                  - auid
-                to: user
-              - from:
-                  - acct
-                  - id
-                  - uid
-                to: user.effective
-            event:
-              action:
-                - ended-session
-              category:
-                - session
-              type:
-                - end
-        USER_ERR:
-          - copy:
-              - from:
-                  - auid
-                to: user
-              - from:
-                  - acct
-                  - id
-                  - uid
-                to: user.effective
-            event:
-              action:
-                - error
-              category:
-                - authentication
-              type:
-                - info
-        USER_LOGIN:
-          - copy:
-              - from:
-                  - auid
-                to: user
-              - from:
-                  - acct
-                  - id
-                  - uid
-                to: user.effective
-            event:
-              action:
-                - logged-in
-              category:
-                - authentication
-              type:
-                - start
-        USER_LOGOUT:
-          - copy:
-              - from:
-                  - auid
-                to: user
-              - from:
-                  - acct
-                  - id
-                  - uid
-                to: user.effective
-            event:
-              action:
-                - logged-out
-              category:
-                - authentication
-              type:
-                - end
-        USER_MAC_CONFIG_CHANGE:
-          - event:
-              action:
-                - changed-mac-configuration
-              category:
-                - configuration
-              type:
-                - change
-        USER_MAC_POLICY_LOAD:
-          - event:
-              action:
-                - loaded-mac-policy
-              category:
-                - configuration
-              type:
-                - access
-        USER_MGMT:
-          - copy:
-              - from:
-                  - auid
-                to: user
-              - from:
-                  - acct
-                  - id
-                  - uid
-                to: user.target
-              - from:
-                  - uid
-                to: user.effective
-            event:
-              action:
-                - modified-user-account
-              category:
-                - iam
-              type:
-                - user
-                - change
-        USER_ROLE_CHANGE:
-          - event:
-              action:
-                - changed-role-to
-        USER_SELINUX_ERR:
-          - event:
-              action:
-                - access-error
-        USER_START:
-          - copy:
-              - from:
-                  - auid
-                to: user
-              - from:
-                  - acct
-                  - id
-                  - uid
-                to: user.effective
-            event:
-              action:
-                - started-session
-              category:
-                - session
-              type:
-                - start
-        USER_TTY:
-          - event:
-              action:
-                - typed
-        USYS_CONFIG:
-          - event:
-              action:
-                - changed-configuration
-              category:
-                - configuration
-              type:
-                - change
-        VIRT_CONTROL:
-          - event:
-              action:
-                - issued-vm-control
-              category:
-                - host
-              type:
-                - info
-        VIRT_CREATE:
-          - event:
-              action:
-                - created-vm-image
-              category:
-                - host
-              type:
-                - info
-        VIRT_DESTROY:
-          - event:
-              action:
-                - deleted-vm-image
-              category:
-                - host
-              type:
-                - info
-        VIRT_INTEGRITY_CHECK:
-          - event:
-              action:
-                - checked-integrity-of
-              category:
-                - host
-              type:
-                - info
-        VIRT_MACHINE_ID:
-          - event:
-              action:
-                - assigned-vm-id
-              category:
-                - host
-              type:
-                - info
-        VIRT_MIGRATE_IN:
-          - event:
-              action:
-                - migrated-vm-from
-              category:
-                - host
-              type:
-                - info
-        VIRT_MIGRATE_OUT:
-          - event:
-              action:
-                - migrated-vm-to
-              category:
-                - host
-              type:
-                - info
-        VIRT_RESOURCE:
-          - event:
-              action:
-                - assigned-vm-resource
-              category:
-                - host
-              type:
-                - info
-    # END OF AUTOGENERATED
-    source: >-
-      boolean hasFields(HashMap base, def list) {
-        if (list == null) return true;
-        for (int i=0; i<list.length; i++)
-          if (base[list[i]] == null) return false;
-        return true;
-      }
-      if (ctx?.auditd?.log?.record_type == null) {
-        return;
-      }
-      HashMap base = ctx.auditd.log;
-      def acts = params.types.get(base.record_type);
-      if (acts == null && base.syscall != null) {
-        acts = params.syscalls.get(base?.syscall);
-        if (acts == null) acts = params.syscalls.get('*');
-      }
-      if (acts == null) return;
-      def act = null;
-      for (int i=0; act == null && i<acts.length; i++) {
-        if (hasFields(base, acts[i]["has_fields"])) act = acts[i];
-      }
-
-      if (act?.event != null) {
-        def hm = new HashMap(act.event);
-        hm.forEach((k, v) -> ctx.event[k] = v);
-      }
-      if (act?.copy != null) {
-        List lst = new ArrayList();
-        for(int i=0; i<act.copy.length; i++) {
-          def value;
-          def srcList = act.copy[i]["from"];
-          for (int j=0; value == null && j<srcList.length; j++) {
-            value = base[srcList[j]];
+  - set:
+      field: event.ingested
+      value: '{{_ingest.timestamp}}'
+  - set:
+      field: ecs.version
+      value: "1.10.0"
+  - rename:
+      field: message
+      target_field: event.original
+      ignore_failure: true
+  - grok:
+      field: event.original
+      pattern_definitions:
+        AUDIT_TYPE: "type=%{NOTSPACE:auditd.log.record_type}"
+        AUDIT_NODE: "node=%{IPORHOST:auditd.log.node} "
+        AUDIT_PREFIX: "^(?:%{AUDIT_NODE})?%{AUDIT_TYPE} msg=audit\\(%{NUMBER:auditd.log.epoch}:%{NUMBER:auditd.log.sequence}\\):(%{DATA})?"
+        AUDIT_KEY_VALUES: "%{WORD}=%{GREEDYDATA}"
+        ANY: ".*"
+      patterns:
+      - "%{AUDIT_PREFIX} %{AUDIT_KEY_VALUES:auditd.log.kv} old auid=%{NUMBER:auditd.log.old_auid}
+        new auid=%{NUMBER:auditd.log.new_auid} old ses=%{NUMBER:auditd.log.old_ses}
+        new ses=%{NUMBER:auditd.log.new_ses}"
+      - "%{AUDIT_PREFIX} %{AUDIT_KEY_VALUES:auditd.log.kv} msg=['\"]([^=]*\\s)?%{ANY:auditd.log.sub_kv}['\"]"
+      - "%{AUDIT_PREFIX} %{AUDIT_KEY_VALUES:auditd.log.kv}"
+      - "%{AUDIT_PREFIX}"
+      - "%{AUDIT_TYPE} %{AUDIT_KEY_VALUES:auditd.log.kv}"
+  - kv:
+      field: auditd.log.kv
+      field_split: "\\s+"
+      value_split: "="
+      target_field: auditd.log
+  - kv:
+      field: auditd.log.sub_kv
+      field_split: "\\s+(?=[^\\s]+=)"
+      value_split: "="
+      target_field: auditd.log
+      ignore_missing: true
+  - date:
+      field: auditd.log.epoch
+      target_field: "@timestamp"
+      formats:
+      - UNIX
+      ignore_failure: true
+  - rename:
+      ignore_failure: true
+      field: auditd.log.old-auid
+      target_field: auditd.log.old_auid
+  - rename:
+      ignore_failure: true
+      field: auditd.log.old-ses
+      target_field: auditd.log.old_ses
+  - script:
+      lang: painless
+      source: |
+          String trimQuotes(def singleQuote, def doubleQuote, def v) {
+              if (v.startsWith(singleQuote) || v.startsWith(doubleQuote)) {
+                  v = v.substring(1, v.length());
+              }
+              if (v.endsWith(singleQuote) || v.endsWith(doubleQuote)) {
+                  v = v.substring(0, v.length()-1);
+              }
+              return v;
           }
-          if (value != null && value instanceof String) {
-            String suffix = value ==~ /[0-9]+/? ".id" : ".name";
-            lst.add([
-              "target": act.copy[i]["to"] + suffix,
-              "value": value
-            ]);
+
+          boolean isHexAscii(String v) {
+              def len = v.length();
+
+              if (len == 0 || len % 2 != 0) {
+                  return false;
+              }
+
+              for (int i = 0 ; i < len ; i++) {
+                  if (Character.digit(v.charAt(i), 16) == -1) {
+                      return false;
+                  }
+              }
+              return true;
+          }
+
+          String convertHexToString(String hex) {
+              StringBuilder sb = new StringBuilder();
+              boolean needed_encoding = false;
+
+              for (int i=0; i < hex.length() - 1; i+=2) {
+                  int cp = Integer.parseInt(hex.substring(i, (i +2)), 16);
+                  if (cp < 33 || cp == 34 || cp == 127) {
+                      needed_encoding = true;
+                  }
+                  if (cp < 32 || cp == 127) {
+                      sb.append('^');
+                      cp ^= 64;
+                  }
+                  sb.append((char)cp);
+              }
+              if (needed_encoding) {
+                  return sb.toString();
+              }
+              return hex;
+          }
+
+          def possibleHexKeys = ["exe", "cmd", "data", "path", "comm", "file", "name", "watch", "cwd", "acct", "dir", "vm", "old-chardev", "new-chardev", "old-disk", "new-disk", "old-fs", "new-fs", "old-net", "new-net", "device", "cgroup", "apparmor", "operation", "denied_mask", "info", "profile", "requested_mask", "old-rng", "new-rng", "ocomm", "grp", "new_group", "invalid_context", "sw", "root_dir", "proctitle"];
+          def audit = ctx.auditd.get("log");
+          Iterator entries = audit.entrySet().iterator();
+
+          while (entries.hasNext()) {
+              def e = entries.next();
+              def k = e.getKey();
+              def v = e.getValue();
+
+              // Remove entries whose value is ?
+              if (v == "?" || v == "(null)" || v == "") {
+                  entries.remove();
+                  continue;
+              }
+
+              // Convert hex values to ASCII.
+              if (possibleHexKeys.contains(k) && isHexAscii(v)) {
+                  v = convertHexToString(v);
+                  audit.put(k, v);
+              }
+
+              // Trim quotes.
+              if (v instanceof String) {
+                  v = trimQuotes(params.single_quote, params.double_quote, v);
+                  audit.put(k, v);
+              }
+
+              // Convert arch.
+              if (k == "arch" && v == "c000003e") {
+                  audit.put(k, "x86_64");
+              }
+          }
+      params:
+        single_quote: "'"
+        double_quote: "\""
+  - convert:
+      field: auditd.log.sequence
+      type: long
+      ignore_missing: true
+  - convert:
+      field: auditd.log.lport
+      type: long
+      ignore_missing: true
+  - convert:
+      field: auditd.log.rport
+      type: long
+      ignore_missing: true
+  - convert:
+      field: auditd.log.entries
+      type: long
+      ignore_missing: true
+  - convert:
+      field: auditd.log.dst_prefixlen
+      type: long
+      ignore_missing: true
+  - convert:
+      field: auditd.log.ksize
+      type: long
+      ignore_missing: true
+  - convert:
+      field: auditd.log.size
+      type: long
+      ignore_missing: true
+  - convert:
+      field: auditd.log.src_prefixlen
+      type: long
+      ignore_missing: true
+  - set:
+      field: event.kind
+      value: event
+  - script:
+      lang: painless
+      ignore_failure: true
+      # Auditd record type to ECS mappings
+      # AUTOGENERATED FROM go-libaudit v2.2.0, DO NOT EDIT
+      params:
+        syscalls:
+          '*':
+            - event:
+                category:
+                  - process
+                type:
+                  - info
+          accept:
+            - event:
+                action:
+                  - accepted-connection-from
+                category:
+                  - network
+                type:
+                  - connection
+                  - start
+          accept4:
+            - event:
+                action:
+                  - accepted-connection-from
+                category:
+                  - network
+                type:
+                  - connection
+                  - start
+          access:
+            - event:
+                action:
+                  - checked-metadata-of
+                category:
+                  - file
+                type:
+                  - info
+          adjtimex:
+            - event:
+                action:
+                  - changed-system-time
+                category:
+                  - host
+                type:
+                  - change
+          bind:
+            - event:
+                action:
+                  - bound-socket
+                category:
+                  - network
+                type:
+                  - start
+          brk:
+            - event:
+                action:
+                  - allocated-memory
+                category:
+                  - process
+                type:
+                  - info
+          chmod:
+            - event:
+                action:
+                  - changed-file-permissions-of
+                category:
+                  - file
+                type:
+                  - change
+          chown:
+            - event:
+                action:
+                  - changed-file-ownership-of
+                category:
+                  - file
+                type:
+                  - change
+          clock_settime:
+            - event:
+                action:
+                  - changed-system-time
+                category:
+                  - host
+                type:
+                  - change
+          connect:
+            - event:
+                action:
+                  - connected-to
+                category:
+                  - network
+                type:
+                  - connection
+                  - start
+          creat:
+            - event:
+                action:
+                  - opened-file
+                category:
+                  - file
+                type:
+                  - creation
+          delete_module:
+            - event:
+                action:
+                  - unloaded-kernel-module
+                category:
+                  - driver
+                type:
+                  - end
+          execve:
+            - event:
+                action:
+                  - executed
+                category:
+                  - process
+                type:
+                  - start
+          execveat:
+            - event:
+                action:
+                  - executed
+                category:
+                  - process
+                type:
+                  - start
+          faccessat:
+            - event:
+                action:
+                  - checked-metadata-of
+                category:
+                  - file
+                type:
+                  - info
+          fallocate:
+            - event:
+                action:
+                  - opened-file
+                category:
+                  - file
+                type:
+                  - change
+          fchmod:
+            - event:
+                action:
+                  - changed-file-permissions-of
+                category:
+                  - file
+                type:
+                  - change
+          fchmodat:
+            - event:
+                action:
+                  - changed-file-permissions-of
+                category:
+                  - file
+                type:
+                  - change
+          fchown:
+            - event:
+                action:
+                  - changed-file-ownership-of
+                category:
+                  - file
+                type:
+                  - change
+          fchownat:
+            - event:
+                action:
+                  - changed-file-ownership-of
+                category:
+                  - file
+                type:
+                  - change
+          fgetxattr:
+            - event:
+                action:
+                  - checked-metadata-of
+                category:
+                  - file
+                type:
+                  - info
+          finit_module:
+            - event:
+                action:
+                  - loaded-kernel-module
+                category:
+                  - driver
+                type:
+                  - start
+          fremovexattr:
+            - event:
+                action:
+                  - changed-file-attributes-of
+                category:
+                  - file
+                type:
+                  - change
+          fsetxattr:
+            - event:
+                action:
+                  - changed-file-attributes-of
+                category:
+                  - file
+                type:
+                  - change
+          fstat:
+            - event:
+                action:
+                  - checked-metadata-of
+                category:
+                  - file
+                type:
+                  - info
+          fstatat:
+            - event:
+                action:
+                  - checked-metadata-of
+                category:
+                  - file
+                type:
+                  - info
+          fstatfs:
+            - event:
+                action:
+                  - checked-filesystem-metadata-of
+                category:
+                  - file
+                type:
+                  - info
+          ftruncate:
+            - event:
+                action:
+                  - opened-file
+                category:
+                  - file
+                type:
+                  - change
+          futimens:
+            - event:
+                action:
+                  - changed-timestamp-of
+                category:
+                  - file
+                type:
+                  - info
+          futimesat:
+            - event:
+                action:
+                  - changed-timestamp-of
+                category:
+                  - file
+                type:
+                  - info
+          getxattr:
+            - event:
+                action:
+                  - checked-metadata-of
+                category:
+                  - file
+                type:
+                  - info
+          init_module:
+            - event:
+                action:
+                  - loaded-kernel-module
+                category:
+                  - driver
+                type:
+                  - start
+          kill:
+            - event:
+                action:
+                  - killed-pid
+                category:
+                  - process
+                type:
+                  - end
+          lchown:
+            - event:
+                action:
+                  - changed-file-ownership-of
+                category:
+                  - file
+                type:
+                  - change
+          lgetxattr:
+            - event:
+                action:
+                  - checked-metadata-of
+                category:
+                  - file
+                type:
+                  - info
+          listen:
+            - event:
+                action:
+                  - listen-for-connections
+                category:
+                  - network
+                type:
+                  - start
+          lremovexattr:
+            - event:
+                action:
+                  - changed-file-attributes-of
+                category:
+                  - file
+                type:
+                  - change
+          lsetxattr:
+            - event:
+                action:
+                  - changed-file-attributes-of
+                category:
+                  - file
+                type:
+                  - change
+          lstat:
+            - event:
+                action:
+                  - checked-metadata-of
+                category:
+                  - file
+                type:
+                  - info
+          mkdir:
+            - event:
+                action:
+                  - created-directory
+                category:
+                  - file
+                type:
+                  - creation
+          mkdirat:
+            - event:
+                action:
+                  - created-directory
+                category:
+                  - file
+                type:
+                  - creation
+          mknod:
+            - event:
+                action:
+                  - make-device
+                category:
+                  - file
+                type:
+                  - creation
+          mknodat:
+            - event:
+                action:
+                  - make-device
+                category:
+                  - file
+                type:
+                  - creation
+          mmap:
+            - event:
+                action:
+                  - allocated-memory
+                category:
+                  - process
+                type:
+                  - info
+          mmap2:
+            - event:
+                action:
+                  - allocated-memory
+                category:
+                  - process
+                type:
+                  - info
+          mount:
+            - event:
+                action:
+                  - mounted
+                category:
+                  - file
+                type:
+                  - creation
+          newfstatat:
+            - event:
+                action:
+                  - checked-metadata-of
+                category:
+                  - file
+                type:
+                  - info
+          open:
+            - event:
+                action:
+                  - opened-file
+                category:
+                  - file
+                type:
+                  - info
+          openat:
+            - event:
+                action:
+                  - opened-file
+                category:
+                  - file
+                type:
+                  - info
+          read:
+            - event:
+                action:
+                  - read-file
+                category:
+                  - file
+                type:
+                  - info
+          readlink:
+            - event:
+                action:
+                  - opened-file
+                category:
+                  - file
+                type:
+                  - info
+          readlinkat:
+            - event:
+                action:
+                  - opened-file
+                category:
+                  - file
+                type:
+                  - info
+          recv:
+            - event:
+                action:
+                  - received-from
+                category:
+                  - network
+                type:
+                  - connection
+                  - info
+          recvfrom:
+            - event:
+                action:
+                  - received-from
+                category:
+                  - network
+                type:
+                  - connection
+                  - info
+          recvmmsg:
+            - event:
+                action:
+                  - received-from
+                category:
+                  - network
+                type:
+                  - connection
+                  - info
+          recvmsg:
+            - event:
+                action:
+                  - received-from
+                category:
+                  - network
+                type:
+                  - connection
+                  - info
+          removexattr:
+            - event:
+                action:
+                  - changed-file-attributes-of
+                category:
+                  - file
+                type:
+                  - change
+          rename:
+            - event:
+                action:
+                  - renamed
+                category:
+                  - file
+                type:
+                  - change
+          renameat:
+            - event:
+                action:
+                  - renamed
+                category:
+                  - file
+                type:
+                  - change
+          renameat2:
+            - event:
+                action:
+                  - renamed
+                category:
+                  - file
+                type:
+                  - change
+          rmdir:
+            - event:
+                action:
+                  - deleted
+                category:
+                  - file
+                type:
+                  - deletion
+          sched_setattr:
+            - event:
+                action:
+                  - adjusted-scheduling-policy-of
+                category:
+                  - process
+                type:
+                  - change
+          sched_setparam:
+            - event:
+                action:
+                  - adjusted-scheduling-policy-of
+                category:
+                  - process
+                type:
+                  - change
+          sched_setscheduler:
+            - event:
+                action:
+                  - adjusted-scheduling-policy-of
+                category:
+                  - process
+                type:
+                  - change
+          send:
+            - event:
+                action:
+                  - sent-to
+                category:
+                  - network
+                type:
+                  - connection
+                  - info
+          sendmmsg:
+            - event:
+                action:
+                  - sent-to
+                category:
+                  - network
+                type:
+                  - connection
+                  - info
+          sendmsg:
+            - event:
+                action:
+                  - sent-to
+                category:
+                  - network
+                type:
+                  - connection
+                  - info
+          sendto:
+            - event:
+                action:
+                  - sent-to
+                category:
+                  - network
+                type:
+                  - connection
+                  - info
+          setdomainname:
+            - event:
+                action:
+                  - changed-system-name
+                category:
+                  - host
+                type:
+                  - change
+          setegid:
+            - event:
+                action:
+                  - changed-identity-of
+                category:
+                  - process
+                type:
+                  - change
+          seteuid:
+            - event:
+                action:
+                  - changed-identity-of
+                category:
+                  - process
+                type:
+                  - change
+          setfsgid:
+            - event:
+                action:
+                  - changed-identity-of
+                category:
+                  - process
+                type:
+                  - change
+          setfsuid:
+            - event:
+                action:
+                  - changed-identity-of
+                category:
+                  - process
+                type:
+                  - change
+          setgid:
+            - event:
+                action:
+                  - changed-identity-of
+                category:
+                  - process
+                type:
+                  - change
+          sethostname:
+            - event:
+                action:
+                  - changed-system-name
+                category:
+                  - host
+                type:
+                  - change
+          setregid:
+            - event:
+                action:
+                  - changed-identity-of
+                category:
+                  - process
+                type:
+                  - change
+          setresgid:
+            - event:
+                action:
+                  - changed-identity-of
+                category:
+                  - process
+                type:
+                  - change
+          setresuid:
+            - event:
+                action:
+                  - changed-identity-of
+                category:
+                  - process
+                type:
+                  - change
+          setreuid:
+            - event:
+                action:
+                  - changed-identity-of
+                category:
+                  - process
+                type:
+                  - change
+          settimeofday:
+            - event:
+                action:
+                  - changed-system-time
+                category:
+                  - host
+                type:
+                  - change
+          setuid:
+            - event:
+                action:
+                  - changed-identity-of
+                category:
+                  - process
+                type:
+                  - change
+          setxattr:
+            - event:
+                action:
+                  - changed-file-attributes-of
+                category:
+                  - file
+                type:
+                  - change
+          stat:
+            - event:
+                action:
+                  - checked-metadata-of
+                category:
+                  - file
+                type:
+                  - info
+          stat64:
+            - event:
+                action:
+                  - checked-metadata-of
+                category:
+                  - file
+                type:
+                  - info
+          statfs:
+            - event:
+                action:
+                  - checked-filesystem-metadata-of
+                category:
+                  - file
+                type:
+                  - info
+          stime:
+            - event:
+                action:
+                  - changed-system-time
+                category:
+                  - host
+                type:
+                  - change
+          symlink:
+            - event:
+                action:
+                  - symlinked
+                category:
+                  - file
+                type:
+                  - creation
+          symlinkat:
+            - event:
+                action:
+                  - symlinked
+                category:
+                  - file
+                type:
+                  - creation
+          tgkill:
+            - event:
+                action:
+                  - killed-pid
+                category:
+                  - process
+                type:
+                  - end
+          tkill:
+            - event:
+                action:
+                  - killed-pid
+                category:
+                  - process
+                type:
+                  - end
+          truncate:
+            - event:
+                action:
+                  - opened-file
+                category:
+                  - file
+                type:
+                  - change
+          umount:
+            - event:
+                action:
+                  - unmounted
+                category:
+                  - file
+                type:
+                  - deletion
+          umount2:
+            - event:
+                action:
+                  - unmounted
+                category:
+                  - file
+                type:
+                  - deletion
+          unlink:
+            - event:
+                action:
+                  - deleted
+                category:
+                  - file
+                type:
+                  - deletion
+          unlinkat:
+            - event:
+                action:
+                  - deleted
+                category:
+                  - file
+                type:
+                  - deletion
+          utime:
+            - event:
+                action:
+                  - changed-timestamp-of
+                category:
+                  - file
+                type:
+                  - info
+          utimensat:
+            - event:
+                action:
+                  - changed-timestamp-of
+                category:
+                  - file
+                type:
+                  - info
+          utimes:
+            - event:
+                action:
+                  - changed-timestamp-of
+                category:
+                  - file
+                type:
+                  - info
+          write:
+            - event:
+                action:
+                  - wrote-to-file
+                category:
+                  - file
+                type:
+                  - change
+        types:
+          ACCT_LOCK:
+            - event:
+                action:
+                  - locked-account
+                category:
+                  - iam
+                type:
+                  - user
+                  - info
+          ACCT_UNLOCK:
+            - event:
+                action:
+                  - unlocked-account
+                category:
+                  - iam
+                type:
+                  - user
+                  - info
+          ADD_GROUP:
+            - copy:
+                - from:
+                    - auid
+                  to: user
+                - from:
+                    - uid
+                  to: user.effective
+                - from:
+                    - id
+                    - acct
+                  to: group
+              event:
+                action:
+                  - added-group-account-to
+                category:
+                  - iam
+                type:
+                  - group
+                  - creation
+          ADD_USER:
+            - copy:
+                - from:
+                    - auid
+                  to: user
+                - from:
+                    - uid
+                  to: user.effective
+                - from:
+                    - id
+                    - acct
+                  to: user.target
+              event:
+                action:
+                  - added-user-account
+                category:
+                  - iam
+                type:
+                  - user
+                  - creation
+          ANOM_ABEND:
+            - event:
+                action:
+                  - crashed-program
+                category:
+                  - process
+                type:
+                  - end
+          ANOM_EXEC:
+            - event:
+                action:
+                  - attempted-execution-of-forbidden-program
+                category:
+                  - process
+                type:
+                  - start
+          ANOM_LINK:
+            - event:
+                action:
+                  - used-suspicious-link
+          ANOM_LOGIN_FAILURES:
+            - event:
+                action:
+                  - failed-log-in-too-many-times-to
+          ANOM_LOGIN_LOCATION:
+            - event:
+                action:
+                  - attempted-log-in-from-unusual-place-to
+          ANOM_LOGIN_SESSIONS:
+            - event:
+                action:
+                  - opened-too-many-sessions-to
+          ANOM_LOGIN_TIME:
+            - event:
+                action:
+                  - attempted-log-in-during-unusual-hour-to
+          ANOM_PROMISCUOUS:
+            - event:
+                action:
+                  - changed-promiscuous-mode-on-device
+          ANOM_RBAC_INTEGRITY_FAIL:
+            - event:
+                action:
+                  - tested-file-system-integrity-of
+          AVC:
+            - event:
+                action:
+                  - violated-selinux-policy
+              has_fields:
+                - seresult
+            - event:
+                action:
+                  - violated-apparmor-policy
+              has_fields:
+                - apparmor
+          CHGRP_ID:
+            - event:
+                action:
+                  - changed-group
+                category:
+                  - process
+                type:
+                  - change
+          CHUSER_ID:
+            - event:
+                action:
+                  - changed-user-id
+                category:
+                  - process
+                type:
+                  - change
+          CONFIG_CHANGE:
+            - event:
+                action:
+                  - changed-audit-configuration
+                category:
+                  - process
+                  - configuration
+                type:
+                  - change
+          CRED_ACQ:
+            - copy:
+                - from:
+                    - auid
+                  to: user
+                - from:
+                    - acct
+                    - id
+                    - uid
+                  to: user.effective
+              event:
+                action:
+                  - acquired-credentials
+                category:
+                  - authentication
+                type:
+                  - info
+          CRED_DISP:
+            - copy:
+                - from:
+                    - auid
+                  to: user
+                - from:
+                    - acct
+                    - id
+                    - uid
+                  to: user.effective
+              event:
+                action:
+                  - disposed-credentials
+                category:
+                  - authentication
+                type:
+                  - info
+          CRED_REFR:
+            - copy:
+                - from:
+                    - auid
+                  to: user
+                - from:
+                    - acct
+                    - id
+                    - uid
+                  to: user.effective
+              event:
+                action:
+                  - refreshed-credentials
+                category:
+                  - authentication
+                type:
+                  - info
+          CRYPTO_KEY_USER:
+            - event:
+                action:
+                  - negotiated-crypto-key
+                category:
+                  - process
+                type:
+                  - info
+          CRYPTO_LOGIN:
+            - event:
+                action:
+                  - crypto-officer-logged-in
+          CRYPTO_LOGOUT:
+            - event:
+                action:
+                  - crypto-officer-logged-out
+                category:
+                  - process
+                type:
+                  - info
+          CRYPTO_SESSION:
+            - event:
+                action:
+                  - started-crypto-session
+                category:
+                  - process
+                type:
+                  - info
+          DAC_CHECK:
+            - event:
+                action:
+                  - access-result
+          DAEMON_ABORT:
+            - event:
+                action:
+                  - aborted-auditd-startup
+                category:
+                  - process
+                type:
+                  - stop
+          DAEMON_ACCEPT:
+            - event:
+                action:
+                  - remote-audit-connected
+                category:
+                  - network
+                type:
+                  - connection
+                  - start
+          DAEMON_CLOSE:
+            - event:
+                action:
+                  - remote-audit-disconnected
+                category:
+                  - network
+                type:
+                  - connection
+                  - start
+          DAEMON_CONFIG:
+            - event:
+                action:
+                  - changed-auditd-configuration
+                category:
+                  - process
+                  - configuration
+                type:
+                  - change
+          DAEMON_END:
+            - event:
+                action:
+                  - shutdown-audit
+                category:
+                  - process
+                type:
+                  - stop
+          DAEMON_ERR:
+            - event:
+                action:
+                  - audit-error
+                category:
+                  - process
+                type:
+                  - info
+          DAEMON_RECONFIG:
+            - event:
+                action:
+                  - reconfigured-auditd
+                category:
+                  - process
+                  - configuration
+                type:
+                  - info
+          DAEMON_RESUME:
+            - event:
+                action:
+                  - resumed-audit-logging
+                category:
+                  - process
+                type:
+                  - change
+          DAEMON_ROTATE:
+            - event:
+                action:
+                  - rotated-audit-logs
+                category:
+                  - process
+                type:
+                  - change
+          DAEMON_START:
+            - event:
+                action:
+                  - started-audit
+                category:
+                  - process
+                type:
+                  - start
+          DEL_GROUP:
+            - copy:
+                - from:
+                    - auid
+                  to: user
+                - from:
+                    - uid
+                  to: user.effective
+                - from:
+                    - id
+                    - acct
+                  to: group
+              event:
+                action:
+                  - deleted-group-account-from
+                category:
+                  - iam
+                type:
+                  - group
+                  - deletion
+          DEL_USER:
+            - copy:
+                - from:
+                    - auid
+                  to: user
+                - from:
+                    - uid
+                  to: user.effective
+                - from:
+                    - id
+                    - acct
+                  to: user.target
+              event:
+                action:
+                  - deleted-user-account
+                category:
+                  - iam
+                type:
+                  - user
+                  - deletion
+          FEATURE_CHANGE:
+            - event:
+                action:
+                  - changed-audit-feature
+                category:
+                  - configuration
+                type:
+                  - change
+          FS_RELABEL:
+            - event:
+                action:
+                  - relabeled-filesystem
+          GRP_AUTH:
+            - copy:
+                - from:
+                    - auid
+                  to: user
+                - from:
+                    - uid
+                  to: user.effective
+              event:
+                action:
+                  - authenticated-to-group
+                category:
+                  - authentication
+                type:
+                  - info
+          GRP_CHAUTHTOK:
+            - copy:
+                - from:
+                    - auid
+                  to: user
+                - from:
+                    - uid
+                  to: user.effective
+                - from:
+                    - acct
+                    - id
+                    - uid
+                  to: group
+              event:
+                action:
+                  - changed-group-password
+                category:
+                  - iam
+                type:
+                  - group
+                  - change
+          GRP_MGMT:
+            - copy:
+                - from:
+                    - auid
+                  to: user
+                - from:
+                    - uid
+                  to: group
+                - from:
+                    - uid
+                  to: user.effective
+              event:
+                action:
+                  - modified-group-account
+                category:
+                  - iam
+                type:
+                  - group
+                  - change
+          KERNEL:
+            - event:
+                action:
+                  - initialized-audit-subsystem
+                category:
+                  - process
+                type:
+                  - info
+          KERN_MODULE:
+            - event:
+                action:
+                  - loaded-kernel-module
+                category:
+                  - driver
+                type:
+                  - start
+          LABEL_LEVEL_CHANGE:
+            - event:
+                action:
+                  - modified-level-of
+          LABEL_OVERRIDE:
+            - event:
+                action:
+                  - overrode-label-of
+          LOGIN:
+            - copy:
+                - from:
+                    - old_auid
+                    - old-auid
+                  to: user
+                - from:
+                    - new-auid
+                    - new_auid
+                    - auid
+                  to: user.effective
+              event:
+                action:
+                  - changed-login-id-to
+                category:
+                  - authentication
+                type:
+                  - start
+          MAC_CHECK:
+            - event:
+                action:
+                  - mac-permission
+          MAC_CONFIG_CHANGE:
+            - event:
+                action:
+                  - changed-selinux-boolean
+                category:
+                  - configuration
+                type:
+                  - change
+          MAC_POLICY_LOAD:
+            - event:
+                action:
+                  - loaded-selinux-policy
+                category:
+                  - configuration
+                type:
+                  - access
+          MAC_STATUS:
+            - event:
+                action:
+                  - changed-selinux-enforcement
+                category:
+                  - configuration
+                type:
+                  - change
+          NETFILTER_CFG:
+            - event:
+                action:
+                  - loaded-firewall-rule-to
+                category:
+                  - configuration
+                type:
+                  - change
+          ROLE_ASSIGN:
+            - event:
+                action:
+                  - assigned-user-role-to
+                category:
+                  - iam
+                type:
+                  - user
+                  - change
+          ROLE_MODIFY:
+            - event:
+                action:
+                  - modified-role
+                category:
+                  - iam
+                type:
+                  - change
+          ROLE_REMOVE:
+            - event:
+                action:
+                  - removed-user-role-from
+                category:
+                  - iam
+                type:
+                  - user
+                  - change
+          SECCOMP:
+            - event:
+                action:
+                  - violated-seccomp-policy
+          SELINUX_ERR:
+            - event:
+                action:
+                  - caused-mac-policy-error
+          SERVICE_START:
+            - event:
+                action:
+                  - started-service
+                category:
+                  - process
+                type:
+                  - start
+          SERVICE_STOP:
+            - event:
+                action:
+                  - stopped-service
+                category:
+                  - process
+                type:
+                  - stop
+          SOFTWARE_UPDATE:
+            - event:
+                action:
+                  - package-updated
+                category:
+                  - package
+                type:
+                  - info
+          SYSTEM_BOOT:
+            - event:
+                action:
+                  - booted-system
+                category:
+                  - host
+                type:
+                  - start
+          SYSTEM_RUNLEVEL:
+            - event:
+                action:
+                  - changed-to-runlevel
+                category:
+                  - host
+                type:
+                  - change
+          SYSTEM_SHUTDOWN:
+            - event:
+                action:
+                  - shutdown-system
+                category:
+                  - host
+                type:
+                  - end
+          TEST:
+            - event:
+                action:
+                  - sent-test
+                category:
+                  - process
+                type:
+                  - info
+          TRUSTED_APP:
+            - event:
+                action:
+                  - unknown
+                category:
+                  - process
+                type:
+                  - info
+          TTY:
+            - event:
+                action:
+                  - typed
+          USER:
+            - event:
+                action:
+                  - sent-message
+          USER_ACCT:
+            - copy:
+                - from:
+                    - auid
+                  to: user
+                - from:
+                    - acct
+                    - id
+                    - uid
+                  to: user.effective
+              event:
+                action:
+                  - was-authorized
+                category:
+                  - authentication
+                type:
+                  - info
+          USER_AUTH:
+            - copy:
+                - from:
+                    - auid
+                  to: user
+                - from:
+                    - acct
+                    - id
+                    - uid
+                  to: user.effective
+              event:
+                action:
+                  - authenticated
+                category:
+                  - authentication
+                type:
+                  - info
+          USER_AVC:
+            - event:
+                action:
+                  - access-permission
+          USER_CHAUTHTOK:
+            - copy:
+                - from:
+                    - auid
+                  to: user
+                - from:
+                    - uid
+                  to: user.effective
+                - from:
+                    - acct
+                    - id
+                    - uid
+                  to: user.target
+              event:
+                action:
+                  - changed-password
+                category:
+                  - iam
+                type:
+                  - user
+                  - change
+          USER_CMD:
+            - event:
+                action:
+                  - ran-command
+                category:
+                  - process
+                type:
+                  - start
+          USER_END:
+            - copy:
+                - from:
+                    - auid
+                  to: user
+                - from:
+                    - acct
+                    - id
+                    - uid
+                  to: user.effective
+              event:
+                action:
+                  - ended-session
+                category:
+                  - session
+                type:
+                  - end
+          USER_ERR:
+            - copy:
+                - from:
+                    - auid
+                  to: user
+                - from:
+                    - acct
+                    - id
+                    - uid
+                  to: user.effective
+              event:
+                action:
+                  - error
+                category:
+                  - authentication
+                type:
+                  - info
+          USER_LOGIN:
+            - copy:
+                - from:
+                    - auid
+                  to: user
+                - from:
+                    - acct
+                    - id
+                    - uid
+                  to: user.effective
+              event:
+                action:
+                  - logged-in
+                category:
+                  - authentication
+                type:
+                  - start
+          USER_LOGOUT:
+            - copy:
+                - from:
+                    - auid
+                  to: user
+                - from:
+                    - acct
+                    - id
+                    - uid
+                  to: user.effective
+              event:
+                action:
+                  - logged-out
+                category:
+                  - authentication
+                type:
+                  - end
+          USER_MAC_CONFIG_CHANGE:
+            - event:
+                action:
+                  - changed-mac-configuration
+                category:
+                  - configuration
+                type:
+                  - change
+          USER_MAC_POLICY_LOAD:
+            - event:
+                action:
+                  - loaded-mac-policy
+                category:
+                  - configuration
+                type:
+                  - access
+          USER_MGMT:
+            - copy:
+                - from:
+                    - auid
+                  to: user
+                - from:
+                    - acct
+                    - id
+                    - uid
+                  to: user.target
+                - from:
+                    - uid
+                  to: user.effective
+              event:
+                action:
+                  - modified-user-account
+                category:
+                  - iam
+                type:
+                  - user
+                  - change
+          USER_ROLE_CHANGE:
+            - event:
+                action:
+                  - changed-role-to
+          USER_SELINUX_ERR:
+            - event:
+                action:
+                  - access-error
+          USER_START:
+            - copy:
+                - from:
+                    - auid
+                  to: user
+                - from:
+                    - acct
+                    - id
+                    - uid
+                  to: user.effective
+              event:
+                action:
+                  - started-session
+                category:
+                  - session
+                type:
+                  - start
+          USER_TTY:
+            - event:
+                action:
+                  - typed
+          USYS_CONFIG:
+            - event:
+                action:
+                  - changed-configuration
+                category:
+                  - configuration
+                type:
+                  - change
+          VIRT_CONTROL:
+            - event:
+                action:
+                  - issued-vm-control
+                category:
+                  - host
+                type:
+                  - info
+          VIRT_CREATE:
+            - event:
+                action:
+                  - created-vm-image
+                category:
+                  - host
+                type:
+                  - info
+          VIRT_DESTROY:
+            - event:
+                action:
+                  - deleted-vm-image
+                category:
+                  - host
+                type:
+                  - info
+          VIRT_INTEGRITY_CHECK:
+            - event:
+                action:
+                  - checked-integrity-of
+                category:
+                  - host
+                type:
+                  - info
+          VIRT_MACHINE_ID:
+            - event:
+                action:
+                  - assigned-vm-id
+                category:
+                  - host
+                type:
+                  - info
+          VIRT_MIGRATE_IN:
+            - event:
+                action:
+                  - migrated-vm-from
+                category:
+                  - host
+                type:
+                  - info
+          VIRT_MIGRATE_OUT:
+            - event:
+                action:
+                  - migrated-vm-to
+                category:
+                  - host
+                type:
+                  - info
+          VIRT_RESOURCE:
+            - event:
+                action:
+                  - assigned-vm-resource
+                category:
+                  - host
+                type:
+                  - info
+      # END OF AUTOGENERATED
+      source: >-
+        boolean hasFields(HashMap base, def list) {
+          if (list == null) return true;
+          for (int i=0; i<list.length; i++)
+            if (base[list[i]] == null) return false;
+          return true;
+        }
+        if (ctx?.auditd?.log?.record_type == null) {
+          return;
+        }
+        HashMap base = ctx.auditd.log;
+        def acts = params.types.get(base.record_type);
+        if (acts == null && base.syscall != null) {
+          acts = params.syscalls.get(base?.syscall);
+          if (acts == null) acts = params.syscalls.get('*');
+        }
+        if (acts == null) return;
+        def act = null;
+        for (int i=0; act == null && i<acts.length; i++) {
+          if (hasFields(base, acts[i]["has_fields"])) act = acts[i];
+        }
+
+        if (act?.event != null) {
+          def hm = new HashMap(act.event);
+          hm.forEach((k, v) -> ctx.event[k] = v);
+        }
+        if (act?.copy != null) {
+          List lst = new ArrayList();
+          for(int i=0; i<act.copy.length; i++) {
+            def value;
+            def srcList = act.copy[i]["from"];
+            for (int j=0; value == null && j<srcList.length; j++) {
+              value = base[srcList[j]];
+            }
+            if (value != null && value instanceof String) {
+              String suffix = value ==~ /[0-9]+/? ".id" : ".name";
+              lst.add([
+                "target": act.copy[i]["to"] + suffix,
+                "value": value
+              ]);
+            }
+          }
+          if (lst.size() > 0) {
+            ctx.auditd.log["copy"] = lst;
           }
         }
-        if (lst.size() > 0) {
-          ctx.auditd.log["copy"] = lst;
+  - foreach:
+      field: auditd.log.copy
+      ignore_missing: true
+      processor:
+        set:
+          field: "{{_ingest._value.target}}"
+          value: "{{_ingest._value.value}}"
+  - set:
+      if: "ctx.auditd.log?.record_type == 'SYSTEM_BOOT' || ctx.auditd.log?.record_type == 'SYSTEM_SHUTDOWN'"
+      field: event.category
+      value: host
+  - set:
+      if: "ctx.auditd.log?.record_type == 'SYSTEM_BOOT' || ctx.auditd.log?.record_type == 'SYSTEM_SHUTDOWN'"
+      field: event.type
+      value: info
+  - set:
+      if: "ctx.auditd.log?.record_type == 'SYSCALL' && ctx.auditd.log?.syscall == 'execve'"
+      field: event.category
+      value: process
+  - set:
+      if: "ctx.auditd.log?.record_type == 'SYSCALL' && ctx.auditd.log?.syscall == 'execve'"
+      field: event.type
+      value: info
+  - set:
+      if: "ctx.auditd.log?.record_type == 'VIRT_CONTROL' || ctx.auditd.log?.record_type == 'VIRT_MACHINE_ID'"
+      field: event.category
+      value: host
+  - set:
+      if: "ctx.auditd.log?.record_type == 'VIRT_CONTROL' && ctx.auditd.log?.op == 'start'"
+      field: event.type
+      value: start
+  - set:
+      if: "ctx.auditd.log?.record_type == 'VIRT_CONTROL' && ctx.auditd.log?.op == 'stop'"
+      field: event.type
+      value: end
+  - set:
+      if: "ctx.auditd.log?.record_type == 'VIRT_CONTROL' && ctx.auditd.log?.op == 'create'"
+      field: event.type
+      value: creation
+  - set:
+      if: "ctx.auditd.log?.record_type == 'VIRT_CONTROL' && ctx.auditd.log?.op == 'delete'"
+      field: event.type
+      value: deletion
+  - set:
+      if: "ctx.auditd.log?.record_type == 'VIRT_MACHINE_ID'"
+      field: event.type
+      value: creation
+  - set:
+      if: "ctx.auditd.log?.record_type == 'VIRT_MACHINE_ID'"
+      field: container.name
+      value: "{{ auditd.log.vm }}"
+      ignore_empty_value: true
+  - set:
+      if: "ctx.auditd.log?.record_type == 'VIRT_MACHINE_ID'"
+      field: container.runtime
+      value: "{{ auditd.log.virt }}"
+      ignore_empty_value: true
+  - set:
+      if: >
+        ctx.auditd.log?.record_type == 'SYSCALL' && (
+        ctx.auditd.log?.syscall == 'accept' || ctx.auditd.log?.syscall == '43' ||
+        ctx.auditd.log?.syscall == 'recvfrom' || ctx.auditd.log?.syscall == '45' ||
+        ctx.auditd.log?.syscall == 'recvmsg' || ctx.auditd.log?.syscall == '47' ||
+        ctx.auditd.log?.syscall == 'accept4' || ctx.auditd.log?.syscall == '288' )
+      field: network.direction
+      value: ingress
+  - set:
+      if: >
+        ctx.auditd.log?.record_type == 'SYSCALL' && (
+        ctx.auditd.log?.syscall == 'connect' || ctx.auditd.log?.syscall == '42' ||
+        ctx.auditd.log?.syscall == 'sendto' || ctx.auditd.log?.syscall == '44' ||
+        ctx.auditd.log?.syscall == 'sendmsg' || ctx.auditd.log?.syscall == '46')
+      field: network.direction
+      value: egress
+  - rename:
+      ignore_failure: true
+      field: auditd.log.arch
+      target_field: host.architecture
+  - rename:
+      ignore_failure: true
+      field: auditd.log.acct
+      target_field: user.name
+  - rename:
+      ignore_failure: true
+      field: auditd.log.user
+      target_field: user.name
+  - rename:
+      ignore_failure: true
+      field: auditd.log.uid
+      target_field: user.id
+  - rename:
+      ignore_failure: true
+      field: auditd.log.gid
+      target_field: user.group.id
+  - rename:
+      ignore_failure: true
+      field: auditd.log.agid
+      target_field: user.audit.group.id
+  - rename:
+      ignore_failure: true
+      field: auditd.log.auid
+      target_field: user.audit.id
+  - rename:
+      ignore_failure: true
+      field: auditd.log.fsgid
+      target_field: user.filesystem.group.id
+  - rename:
+      ignore_failure: true
+      field: auditd.log.fsuid
+      target_field: user.filesystem.id
+  - rename:
+      ignore_failure: true
+      field: auditd.log.egid
+      target_field: user.effective.group.id
+  - rename:
+      ignore_failure: true
+      field: auditd.log.euid
+      target_field: user.effective.id
+  - rename:
+      ignore_failure: true
+      field: auditd.log.sgid
+      target_field: user.saved.group.id
+  - rename:
+      ignore_failure: true
+      field: auditd.log.suid
+      target_field: user.saved.id
+  - rename:
+      ignore_failure: true
+      field: auditd.log.ogid
+      target_field: user.owner.group.id
+  - rename:
+      ignore_failure: true
+      field: auditd.log.ouid
+      target_field: user.owner.id
+  - rename:
+      ignore_failure: true
+      field: auditd.log.comm
+      target_field: process.name
+  - rename:
+      ignore_failure: true
+      field: auditd.log.exe
+      target_field: process.executable
+  - rename:
+      ignore_failure: true
+      field: auditd.log.pid
+      target_field: process.pid
+  - rename:
+      ignore_failure: true
+      field: auditd.log.ppid
+      target_field: process.ppid
+  - convert:
+      ignore_missing: true
+      field: process.pid
+      type: long
+  - convert:
+      ignore_missing: true
+      field: process.ppid
+      type: long
+  - rename:
+      ignore_failure: true
+      field: auditd.log.cmd
+      target_field: process.args
+  - split:
+      ignore_failure: true
+      field: process.args
+      separator: "\\s+"
+  - rename:
+      ignore_failure: true
+      field: auditd.log.argc
+      target_field: process.args_count
+  - script:
+      if: "ctx?.process?.args != null"
+      lang: painless
+      source: >-
+        if (ctx.process.args instanceof List) {
+          ctx.process.args_count = ctx.process.args.length;
         }
-      }
-- foreach:
-    field: auditd.log.copy
-    ignore_missing: true
-    processor:
-      set:
-        field: "{{_ingest._value.target}}"
-        value: "{{_ingest._value.value}}"
-- set:
-    if: "ctx.auditd.log?.record_type == 'SYSTEM_BOOT' || ctx.auditd.log?.record_type == 'SYSTEM_SHUTDOWN'"
-    field: event.category
-    value: host
-- set:
-    if: "ctx.auditd.log?.record_type == 'SYSTEM_BOOT' || ctx.auditd.log?.record_type == 'SYSTEM_SHUTDOWN'"
-    field: event.type
-    value: info
-- set:
-    if: "ctx.auditd.log?.record_type == 'SYSCALL' && ctx.auditd.log?.syscall == 'execve'"
-    field: event.category
-    value: process
-- set:
-    if: "ctx.auditd.log?.record_type == 'SYSCALL' && ctx.auditd.log?.syscall == 'execve'"
-    field: event.type
-    value: info
-- set:
-    if: "ctx.auditd.log?.record_type == 'VIRT_CONTROL' || ctx.auditd.log?.record_type == 'VIRT_MACHINE_ID'"
-    field: event.category
-    value: host
-- set:
-    if: "ctx.auditd.log?.record_type == 'VIRT_CONTROL' && ctx.auditd.log?.op == 'start'"
-    field: event.type
-    value: start
-- set:
-    if: "ctx.auditd.log?.record_type == 'VIRT_CONTROL' && ctx.auditd.log?.op == 'stop'"
-    field: event.type
-    value: end
-- set:
-    if: "ctx.auditd.log?.record_type == 'VIRT_CONTROL' && ctx.auditd.log?.op == 'create'"
-    field: event.type
-    value: creation
-- set:
-    if: "ctx.auditd.log?.record_type == 'VIRT_CONTROL' && ctx.auditd.log?.op == 'delete'"
-    field: event.type
-    value: deletion
-- set:
-    if: "ctx.auditd.log?.record_type == 'VIRT_MACHINE_ID'"
-    field: event.type
-    value: creation
-- set:
-    if: "ctx.auditd.log?.record_type == 'VIRT_MACHINE_ID'"
-    field: container.name
-    value: "{{ auditd.log.vm }}"
-    ignore_empty_value: true
-- set:
-    if: "ctx.auditd.log?.record_type == 'VIRT_MACHINE_ID'"
-    field: container.runtime
-    value: "{{ auditd.log.virt }}"
-    ignore_empty_value: true
-- set:
-    if: >
-      ctx.auditd.log?.record_type == 'SYSCALL' && (
-      ctx.auditd.log?.syscall == 'accept' || ctx.auditd.log?.syscall == '43' ||
-      ctx.auditd.log?.syscall == 'recvfrom' || ctx.auditd.log?.syscall == '45' ||
-      ctx.auditd.log?.syscall == 'recvmsg' || ctx.auditd.log?.syscall == '47' ||
-      ctx.auditd.log?.syscall == 'accept4' || ctx.auditd.log?.syscall == '288' )
-    field: network.direction
-    value: ingress
-- set:
-    if: >
-      ctx.auditd.log?.record_type == 'SYSCALL' && (
-      ctx.auditd.log?.syscall == 'connect' || ctx.auditd.log?.syscall == '42' ||
-      ctx.auditd.log?.syscall == 'sendto' || ctx.auditd.log?.syscall == '44' ||
-      ctx.auditd.log?.syscall == 'sendmsg' || ctx.auditd.log?.syscall == '46')
-    field: network.direction
-    value: egress
-- rename:
-    ignore_failure: true
-    field: auditd.log.arch
-    target_field: host.architecture
-- rename:
-    ignore_failure: true
-    field: auditd.log.acct
-    target_field: user.name
-- rename:
-    ignore_failure: true
-    field: auditd.log.user
-    target_field: user.name
-- rename:
-    ignore_failure: true
-    field: auditd.log.uid
-    target_field: user.id
-- rename:
-    ignore_failure: true
-    field: auditd.log.gid
-    target_field: user.group.id
-- rename:
-    ignore_failure: true
-    field: auditd.log.agid
-    target_field: user.audit.group.id
-- rename:
-    ignore_failure: true
-    field: auditd.log.auid
-    target_field: user.audit.id
-- rename:
-    ignore_failure: true
-    field: auditd.log.fsgid
-    target_field: user.filesystem.group.id
-- rename:
-    ignore_failure: true
-    field: auditd.log.fsuid
-    target_field: user.filesystem.id
-- rename:
-    ignore_failure: true
-    field: auditd.log.egid
-    target_field: user.effective.group.id
-- rename:
-    ignore_failure: true
-    field: auditd.log.euid
-    target_field: user.effective.id
-- rename:
-    ignore_failure: true
-    field: auditd.log.sgid
-    target_field: user.saved.group.id
-- rename:
-    ignore_failure: true
-    field: auditd.log.suid
-    target_field: user.saved.id
-- rename:
-    ignore_failure: true
-    field: auditd.log.ogid
-    target_field: user.owner.group.id
-- rename:
-    ignore_failure: true
-    field: auditd.log.ouid
-    target_field: user.owner.id
-- rename:
-    ignore_failure: true
-    field: auditd.log.comm
-    target_field: process.name
-- rename:
-    ignore_failure: true
-    field: auditd.log.exe
-    target_field: process.executable
-- rename:
-    ignore_failure: true
-    field: auditd.log.pid
-    target_field: process.pid
-- rename:
-    ignore_failure: true
-    field: auditd.log.ppid
-    target_field: process.ppid
-- convert:
-    ignore_missing: true
-    field: process.pid
-    type: long
-- convert:
-    ignore_missing: true
-    field: process.ppid
-    type: long
-- rename:
-    ignore_failure: true
-    field: auditd.log.cmd
-    target_field: process.args
-- split:
-    ignore_failure: true
-    field: process.args
-    separator: "\\s+"
-- rename:
-    ignore_failure: true
-    field: auditd.log.argc
-    target_field: process.args_count
-- script:
-    if: "ctx?.process?.args != null"
-    lang: painless
-    source: >-
-      if (ctx.process.args instanceof List) {
-        ctx.process.args_count = ctx.process.args.length;
-      }
-- convert:
-    ignore_missing: true
-    field: process.args_count
-    type: long
-- rename:
-    ignore_failure: true
-    field: auditd.log.exit
-    target_field: process.exit_code
-- convert:
-    ignore_missing: true
-    field: process.exit_code
-    type: long
-- rename:
-    ignore_missing: true
-    field: auditd.log.cwd
-    target_field: process.working_directory
-- rename:
-    ignore_failure: true
-    field: auditd.log.terminal
-    target_field: user.terminal
-- rename:
-    ignore_failure: true
-    field: auditd.log.msg
-    target_field: message
-- rename:
-    ignore_failure: true
-    field: auditd.log.res
-    target_field: event.outcome
-- rename:
-    ignore_failure: true
-    field: auditd.log.record_type
-    target_field: event.action
-- lowercase:
-    ignore_failure: true
-    field: event.action
-- rename:
-    ignore_failure: true
-    field: auditd.log.src
-    target_field: source.address
-- rename:
-    ignore_failure: true
-    field: auditd.log.addr
-    target_field: source.address
-    if: ctx?.source?.address == null
-- rename:
-    ignore_failure: true
-    field: auditd.log.dst
-    target_field: destination.address
-- grok:
-    field: source.address
-    patterns:
-    - "^%{IP:source.ip}$"
-    ignore_failure: true
-- geoip:
-    field: source.ip
-    target_field: source.geo
-    ignore_failure: true
-- geoip:
-    database_file: GeoLite2-ASN.mmdb
-    field: source.ip
-    target_field: source.as
-    properties:
-    - asn
-    - organization_name
-    ignore_missing: true
-- rename:
-    field: source.as.asn
-    target_field: source.as.number
-    ignore_missing: true
-- rename:
-    field: source.as.organization_name
-    target_field: source.as.organization.name
-    ignore_missing: true
-- remove:
-    field:
-      - auditd.log.kv
-      - auditd.log.sub_kv
-      - auditd.log.epoch
-      - auditd.log.copy
-    ignore_failure: true
-    ignore_missing: true
-- remove:
-    field: event.original
-    if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"
-    ignore_failure: true
-    ignore_missing: true
+  - convert:
+      ignore_missing: true
+      field: process.args_count
+      type: long
+  - rename:
+      ignore_failure: true
+      field: auditd.log.exit
+      target_field: process.exit_code
+  - convert:
+      ignore_missing: true
+      field: process.exit_code
+      type: long
+  - rename:
+      ignore_missing: true
+      field: auditd.log.cwd
+      target_field: process.working_directory
+  - rename:
+      ignore_failure: true
+      field: auditd.log.terminal
+      target_field: user.terminal
+  - rename:
+      ignore_failure: true
+      field: auditd.log.msg
+      target_field: message
+  - rename:
+      ignore_failure: true
+      field: auditd.log.res
+      target_field: event.outcome
+  - rename:
+      ignore_failure: true
+      field: auditd.log.record_type
+      target_field: event.action
+  - lowercase:
+      ignore_failure: true
+      field: event.action
+  - rename:
+      ignore_failure: true
+      field: auditd.log.src
+      target_field: source.address
+  - rename:
+      ignore_failure: true
+      field: auditd.log.addr
+      target_field: source.address
+      if: ctx?.source?.address == null
+  - rename:
+      ignore_failure: true
+      field: auditd.log.dst
+      target_field: destination.address
+  - grok:
+      field: source.address
+      patterns:
+      - "^%{IP:source.ip}$"
+      ignore_failure: true
+  - geoip:
+      field: source.ip
+      target_field: source.geo
+      ignore_failure: true
+  - geoip:
+      database_file: GeoLite2-ASN.mmdb
+      field: source.ip
+      target_field: source.as
+      properties:
+      - asn
+      - organization_name
+      ignore_missing: true
+  - rename:
+      field: source.as.asn
+      target_field: source.as.number
+      ignore_missing: true
+  - rename:
+      field: source.as.organization_name
+      target_field: source.as.organization.name
+      ignore_missing: true
+  - remove:
+      field:
+        - auditd.log.kv
+        - auditd.log.sub_kv
+        - auditd.log.epoch
+        - auditd.log.copy
+      ignore_failure: true
+      ignore_missing: true
+  - remove:
+      field: event.original
+      if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"
+      ignore_failure: true
+      ignore_missing: true
 on_failure:
-- set:
-    field: error.message
-    value: "{{ _ingest.on_failure_message }}"
+  - set:
+      field: error.message
+      value: "{{ _ingest.on_failure_message }}"

--- a/packages/auditd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/auditd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: ecs.version
-    value: 1.9.0
+    value: 1.10.0
 - rename:
     field: message
     target_field: event.original

--- a/packages/auditd/data_stream/log/fields/ecs.yml
+++ b/packages/auditd/data_stream/log/fields/ecs.yml
@@ -292,3 +292,6 @@
           norms: false
       description: Short name or login of the user.
       default_field: false
+- name: error.message
+  type: text
+  description: Error message.

--- a/packages/auditd/data_stream/log/manifest.yml
+++ b/packages/auditd/data_stream/log/manifest.yml
@@ -20,6 +20,14 @@ streams:
         show_user: false
         default:
           - auditd-log
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
       - name: processors
         type: yaml
         title: Processors
@@ -29,14 +37,6 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-      - name: preserve_original_event
-        required: true
-        show_user: true
-        title: Preserve original event
-        description: Preserves a raw copy of the original event, added to the field `event.original`
-        type: bool
-        multi: false
-        default: false
     template_path: log.yml.hbs
     title: Auditd logs
     description: Collect Auditd logs using log input

--- a/packages/auditd/data_stream/log/manifest.yml
+++ b/packages/auditd/data_stream/log/manifest.yml
@@ -12,6 +12,23 @@ streams:
         show_user: true
         default:
           - /var/log/audit/audit.log*
+      - name: tags
+        type: text
+        title: Tags
+        multi: true
+        required: true
+        show_user: false
+        default:
+          - auditd-log
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
       - name: preserve_original_event
         required: true
         show_user: true

--- a/packages/auditd/docs/README.md
+++ b/packages/auditd/docs/README.md
@@ -153,6 +153,7 @@ An example event for `log` looks as following:
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.address | Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
 | ecs.version | ECS version | keyword |
+| error.message | Error message. | text |
 | event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
 | event.ingested | Timestamp when an event arrived in the central data store. This is different from `@timestamp`, which is when the event originally occurred.  It's also different from `event.created`, which is meant to capture the first time an agent saw the event. In normal conditions, assuming no tampering, the timestamps should chronologically look like this: `@timestamp` < `event.created` < `event.ingested`. | date |
 | event.outcome | This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy. `event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event. Note that when a single transaction is described in multiple events, each event may populate different values of `event.outcome`, according to their perspective. Also note that in the case of a compound event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer. Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for which an outcome does not make logical sense. | keyword |
@@ -205,7 +206,7 @@ An example event for `log` looks as following:
 | user.audit.name | Short name or login of the user. | keyword |
 | user.effective.group.id | Unique identifier for the group on the system/platform. | keyword |
 | user.effective.group.name | Name of the group. | keyword |
-| user.effective.id | Unique identifier of the user. | keyword |
+| user.effective.id | One or multiple unique identifiers of the user. | keyword |
 | user.effective.name | Short name or login of the user. | keyword |
 | user.filesystem.group.id | Unique identifier for the group on the system/platform. | keyword |
 | user.filesystem.group.name | Name of the group. | keyword |

--- a/packages/auditd/docs/README.md
+++ b/packages/auditd/docs/README.md
@@ -16,7 +16,7 @@ This is the Auditd `log` dataset.
 
 An example event for `log` looks as following:
 
-```$json
+```json
 {
     "@timestamp": "2017-01-31T20:17:14.891Z",
     "destination": {

--- a/packages/auditd/manifest.yml
+++ b/packages/auditd/manifest.yml
@@ -1,6 +1,6 @@
 name: auditd
 title: Auditd
-version: 0.1.2
+version: 0.1.3
 release: experimental
 description: Auditd Integration
 type: integration

--- a/packages/auditd/manifest.yml
+++ b/packages/auditd/manifest.yml
@@ -1,6 +1,6 @@
 name: auditd
 title: Auditd
-version: 0.1.3
+version: 1.0.0
 release: experimental
 description: Auditd Integration
 type: integration

--- a/packages/auditd/manifest.yml
+++ b/packages/auditd/manifest.yml
@@ -1,6 +1,6 @@
 name: auditd
 title: Auditd
-version: 1.0.0
+version: 0.2.0
 release: experimental
 description: Auditd Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?

Updates package ECS version to 1.10.
Sync module changes to packages if any.
Adds Preserve Raw event functionality if not already exists.
Adds pipeline tests if missing.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Related issues

- Relates #994 
