### PR TITLE
[cisco] Make event.original optional 

### DIFF
--- a/packages/cisco/_dev/build/docs/README.md
+++ b/packages/cisco/_dev/build/docs/README.md
@@ -17,11 +17,15 @@ datasets for receiving logs over syslog or read from a file:
 
 The `asa` dataset collects the Cisco firewall logs.
 
+{{event "asa"}}
+
 {{fields "asa"}}
 
 ### FTD
 
 The `ftd` dataset collects the Firepower Threat Defense logs.
+
+{{event "ftd"}}
 
 {{fields "ftd"}}
 
@@ -29,16 +33,22 @@ The `ftd` dataset collects the Firepower Threat Defense logs.
 
 The `ios` dataset collects the Cisco IOS router and switch logs.
 
+{{event "ios"}}
+
 {{fields "ios"}}
 
 ### Nexus
 
 The `nexus` dataset collects Cisco Nexus logs.
 
+{{event "nexus"}}
+
 {{fields "nexus"}}
 
 ### Meraki
 
 The `meraki` dataset collects Cisco Meraki logs.
+
+{{event "meraki"}}
 
 {{fields "meraki"}}

--- a/packages/cisco/changelog.yml
+++ b/packages/cisco/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.9.2"
+  changes:
+    - description: make event.original optional
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1073
 - version: "0.9.1"
   changes:
     - description: fix broken package

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-additional-messages.log-config.yml
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-additional-messages.log-config.yml
@@ -1,9 +1,0 @@
-dynamic_fields:
-  event.ingested: "^.*$"
-  "@timestamp": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}Z$"
-  event.start: "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}Z$"
-  event.end: "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}Z$"
-numeric_keyword_fields:
-  - "network.iana_number"
-  - "event.code"
-  - "syslog.facility"

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -20,6 +20,9 @@
                 "port": 53500,
                 "ip": "10.10.10.10"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -59,9 +62,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.466913916Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:03.330703663Z",
                 "original": "%FTD-6-302013: Built inbound TCP connection 111111111 for net:10.10.10.10/53500 (8.8.8.8/53500) to fw111:192.168.2.2/53500 (8.8.5.4/53500)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -104,6 +107,9 @@
                 "port": 53500,
                 "ip": "10.10.10.10"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -143,9 +149,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.466928433Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:03.330721382Z",
                 "original": "%FTD-6-302015: Built inbound UDP connection 111111111 for net:10.10.10.10/53500 (8.8.8.8/53500) to fw111:192.168.2.2/53500 (8.8.5.4/53500)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -183,6 +189,9 @@
                 "address": "192.168.2.2",
                 "ip": "192.168.2.2"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "icmp",
                 "direction": "inbound"
@@ -211,9 +220,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.466933108Z",
-                "code": "302020",
+                "ingested": "2021-06-03T06:53:03.330725364Z",
                 "original": "%FTD-6-302020: Built inbound ICMP connection for faddr 10.10.10.10/0 gaddr 8.8.8.8/0 laddr 192.168.2.2/0 type 3 code 3",
+                "code": "302020",
                 "kind": "event",
                 "action": "flow-expiration",
                 "category": [
@@ -232,6 +241,16 @@
             }
         },
         {
+            "log": {
+                "level": "debug"
+            },
+            "source": {
+                "address": "192.168.2.2",
+                "ip": "192.168.2.2"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "dev01",
                 "product": "asa",
@@ -255,22 +274,15 @@
                     "192.168.2.2"
                 ]
             },
-            "log": {
-                "level": "debug"
-            },
             "host": {
                 "hostname": "dev01"
-            },
-            "source": {
-                "address": "192.168.2.2",
-                "ip": "192.168.2.2"
             },
             "event": {
                 "severity": 7,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:24.466937640Z",
-                "code": "609002",
+                "ingested": "2021-06-03T06:53:03.330726882Z",
                 "original": "%FTD-7-609002: Teardown local-host net:192.168.2.2 duration 0:00:00",
+                "code": "609002",
                 "kind": "event",
                 "start": "2021-05-05T17:51:17.000Z",
                 "action": "flow-expiration",
@@ -291,6 +303,16 @@
             }
         },
         {
+            "log": {
+                "level": "debug"
+            },
+            "source": {
+                "address": "192.168.2.2",
+                "ip": "192.168.2.2"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "dev01",
                 "product": "asa",
@@ -314,21 +336,14 @@
                     "192.168.2.2"
                 ]
             },
-            "log": {
-                "level": "debug"
-            },
             "host": {
                 "hostname": "dev01"
             },
-            "source": {
-                "address": "192.168.2.2",
-                "ip": "192.168.2.2"
-            },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:40:24.466942120Z",
-                "code": "609001",
+                "ingested": "2021-06-03T06:53:03.330728342Z",
                 "original": "%FTD-7-609001: Built local-host net:192.168.2.2",
+                "code": "609001",
                 "kind": "event",
                 "action": "flow-expiration",
                 "category": [
@@ -361,6 +376,9 @@
                 "address": "192.168.2.2",
                 "ip": "192.168.2.2"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "icmp",
                 "direction": "inbound"
@@ -389,9 +407,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.466946500Z",
-                "code": "302020",
+                "ingested": "2021-06-03T06:53:03.330729732Z",
                 "original": "%FTD-6-302020: Built inbound ICMP connection for faddr 10.10.10.10/0 gaddr 8.8.8.8/0 laddr 192.168.2.2/0 type 3 code 1",
+                "code": "302020",
                 "kind": "event",
                 "action": "flow-expiration",
                 "category": [
@@ -429,6 +447,9 @@
                 "port": 111,
                 "ip": "10.10.10.10"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "transport": "tcp flow"
             },
@@ -466,9 +487,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.466950910Z",
-                "code": "805001",
+                "ingested": "2021-06-03T06:53:03.330731146Z",
                 "original": "%FTD-6-805001: Offloaded TCP Flow for connection 111111111 from fw111:10.10.10.10/111 (8.8.8.8/111) to fw111:192.168.2.2/111 (8.8.5.4/111)",
+                "code": "805001",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -505,6 +526,9 @@
                 "address": "10.192.18.4",
                 "ip": "10.192.18.4"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -543,9 +567,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.466955338Z",
-                "code": "805002",
+                "ingested": "2021-06-03T06:53:03.330732530Z",
                 "original": "%FTD-6-805002: TCP Flow is no longer offloaded for connection 941243214 from net:10.192.18.4/51261 (10.192.18.4/51261) to fw109:10.192.70.66/443 (10.192.70.66/443)",
+                "code": "805002",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -582,6 +606,9 @@
                 "address": "192.168.2.2",
                 "ip": "192.168.2.2"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -615,9 +642,9 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:40:24.466959609Z",
-                "code": "710005",
+                "ingested": "2021-06-03T06:53:03.330733970Z",
                 "original": "%FTD-7-710005: UDP request discarded from 192.168.2.2/68 to fw111:10.10.10.10/67",
+                "code": "710005",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -648,6 +675,9 @@
                 "address": "192.168.2.2",
                 "ip": "192.168.2.2"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "ftp"
             },
@@ -693,9 +723,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.466963847Z",
-                "code": "303002",
+                "ingested": "2021-06-03T06:53:03.330735370Z",
                 "original": "%FTD-6-303002: FTP connection from net:192.168.2.2/63656 to fw111:10.192.18.4/21, user testuser Stored file /export/home/sysm/ftproot/sdsdsds/tmp.log",
+                "code": "303002",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -737,9 +767,9 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:40:24.466968087Z",
-                "code": "710006",
+                "ingested": "2021-06-03T06:53:03.330736820Z",
                 "original": "%FTD-7-710006: VRRP request discarded from 192.168.2.2 to fw111:192.18.4",
+                "code": "710006",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -753,9 +783,22 @@
                 "asa": {
                     "message_id": "710006"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
+            "log": {
+                "level": "warning"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "iana_number": "1",
+                "transport": "icmp"
+            },
             "observer": {
                 "hostname": "dev01",
                 "product": "asa",
@@ -776,17 +819,14 @@
                     "dev01"
                 ]
             },
-            "log": {
-                "level": "warning"
-            },
             "host": {
                 "hostname": "dev01"
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:24.466972575Z",
-                "code": "313005",
+                "ingested": "2021-06-03T06:53:03.330738380Z",
                 "original": "%FTD-4-313005: No matching connection for ICMP error message: icmp src fw111:10.192.33.100 dst fw111:192.18.4 (type 3, code 3) on fw111 interface. Original IP payload: udp src 192.18.4/53 dst 8.8.8.8/10872.",
+                "code": "313005",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -801,10 +841,6 @@
                     "source_interface": "fw111",
                     "message_id": "313005"
                 }
-            },
-            "network": {
-                "iana_number": "1",
-                "transport": "icmp"
             }
         },
         {
@@ -822,6 +858,9 @@
                 "address": "10.10.10.10",
                 "ip": "10.10.10.10"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "1",
                 "transport": "icmp"
@@ -850,9 +889,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.466976964Z",
-                "code": "302021",
+                "ingested": "2021-06-03T06:53:03.330739817Z",
                 "original": "%ASA-6-302021: Teardown ICMP connection for faddr 192.168.2.2/0 gaddr 8.8.8.8/2 laddr 10.10.10.10/2 type 8 code 0",
+                "code": "302021",
                 "kind": "event",
                 "action": "flow-expiration",
                 "category": [
@@ -872,6 +911,16 @@
             }
         },
         {
+            "log": {
+                "level": "debug"
+            },
+            "source": {
+                "address": "10.10.10.10",
+                "ip": "10.10.10.10"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "dev01",
                 "product": "asa",
@@ -895,21 +944,14 @@
                     "10.10.10.10"
                 ]
             },
-            "log": {
-                "level": "debug"
-            },
             "host": {
                 "hostname": "dev01"
             },
-            "source": {
-                "address": "10.10.10.10",
-                "ip": "10.10.10.10"
-            },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:40:24.466981299Z",
-                "code": "609001",
+                "ingested": "2021-06-03T06:53:03.330741211Z",
                 "original": "%ASA-7-609001: Built local-host net:10.10.10.10",
+                "code": "609001",
                 "kind": "event",
                 "action": "flow-expiration",
                 "category": [
@@ -928,6 +970,16 @@
             }
         },
         {
+            "log": {
+                "level": "debug"
+            },
+            "source": {
+                "address": "10.10.10.10",
+                "ip": "10.10.10.10"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "dev01",
                 "product": "asa",
@@ -951,22 +1003,15 @@
                     "10.10.10.10"
                 ]
             },
-            "log": {
-                "level": "debug"
-            },
             "host": {
                 "hostname": "dev01"
-            },
-            "source": {
-                "address": "10.10.10.10",
-                "ip": "10.10.10.10"
             },
             "event": {
                 "severity": 7,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:24.466985648Z",
-                "code": "609002",
+                "ingested": "2021-06-03T06:53:03.330743276Z",
                 "original": "%ASA-7-609002: Teardown local-host identity:10.10.10.10 duration 0:00:00",
+                "code": "609002",
                 "kind": "event",
                 "start": "2021-05-05T18:24:31.000Z",
                 "action": "flow-expiration",
@@ -1001,6 +1046,9 @@
                 "address": "10.192.46.90",
                 "ip": "10.192.46.90"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "icmp",
                 "direction": "inbound"
@@ -1029,9 +1077,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.466989908Z",
-                "code": "302020",
+                "ingested": "2021-06-03T06:53:03.330744797Z",
                 "original": "%ASA-6-302020: Built inbound ICMP connection for faddr 10.10.10.10/0 gaddr 8.8.8.8/0 laddr 10.192.46.90/0",
+                "code": "302020",
                 "kind": "event",
                 "action": "flow-expiration",
                 "category": [
@@ -1064,6 +1112,9 @@
                 "address": "192.168.2.2",
                 "ip": "192.168.2.2"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "icmp",
                 "direction": "outbound"
@@ -1092,9 +1143,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.466994206Z",
-                "code": "302020",
+                "ingested": "2021-06-03T06:53:03.330746377Z",
                 "original": "%ASA-6-302020: Built outbound ICMP connection for faddr 10.10.10.10/0 gaddr 8.8.8.8/0 laddr 192.168.2.2/0 type 3 code 3",
+                "code": "302020",
                 "kind": "event",
                 "action": "flow-expiration",
                 "category": [
@@ -1126,6 +1177,9 @@
                 "address": "10.10.10.10",
                 "ip": "10.10.10.10"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 0,
                 "iana_number": "6",
@@ -1166,9 +1220,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:24.466998541Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:03.330747770Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 2960892904 for out111:10.10.10.10/443 to fw111:192.168.2.2/55225 duration 0:00:00 bytes 0 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2021-05-05T18:29:32.000Z",
                 "action": "flow-expiration",
@@ -1210,6 +1264,9 @@
                 "port": 80,
                 "ip": "192.168.2.2"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -1249,9 +1306,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.467002797Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:03.330749192Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 1588662 for intfacename:192.168.2.2/80 (8.8.8.8/80) to net:10.10.10.10/54839 (8.8.8.8/54839)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1288,6 +1345,9 @@
                 "address": "10.10.10.10",
                 "ip": "10.10.10.10"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -1327,9 +1387,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:24.467007115Z",
-                "code": "302012",
+                "ingested": "2021-06-03T06:53:03.330750558Z",
                 "original": "%ASA-6-302012: Teardown dynamic UDP translation from fw111:10.10.10.10/54230 to out111:192.168.2.2/54230 duration 0:00:00",
+                "code": "302012",
                 "kind": "event",
                 "start": "2021-05-05T18:29:32.000Z",
                 "action": "flow-expiration",
@@ -1362,6 +1422,9 @@
                 "address": "10.10.10.10",
                 "ip": "10.10.10.10"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "1",
                 "transport": "icmp"
@@ -1395,9 +1458,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:24.467011453Z",
-                "code": "313004",
+                "ingested": "2021-06-03T06:53:03.330751982Z",
                 "original": "%ASA-4-313004: Denied ICMP type=0, from laddr 10.10.10.10 on interface fw502 to 192.168.2.2: no matching session",
+                "code": "313004",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1431,6 +1494,9 @@
                 "address": "10.10.10.10",
                 "ip": "10.10.10.10"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1469,9 +1535,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.467025640Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:03.330753395Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from fw111:10.10.10.10/57006 to out111:192.168.2.2/57006",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1503,6 +1569,9 @@
                 "address": "192.168.2.2",
                 "ip": "192.168.2.2"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -1537,9 +1606,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:40:24.467031711Z",
-                "code": "106001",
+                "ingested": "2021-06-03T06:53:03.330754811Z",
                 "original": "%ASA-2-106001: Inbound TCP connection denied from 192.168.2.2/43803 to 10.10.10.10/14322 flags SYN  on interface out111",
+                "code": "106001",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1590,6 +1659,9 @@
                 "address": "10.10.10.10",
                 "ip": "10.10.10.10"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 64585,
                 "iana_number": "17",
@@ -1630,9 +1702,9 @@
             "event": {
                 "severity": 2,
                 "duration": 124000000000,
-                "ingested": "2021-05-13T11:40:24.467036330Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:03.330756314Z",
                 "original": "%ASA-2-302016: Teardown UDP connection 1671727 for intfacename:10.10.10.10/161 to net:192.186.2.2/53356 duration 0:02:04 bytes 64585",
+                "code": "302016",
                 "kind": "event",
                 "start": "2021-05-05T18:38:46.000Z",
                 "action": "flow-expiration",
@@ -1674,6 +1746,9 @@
                 "port": 161,
                 "ip": "10.10.10.10"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -1713,9 +1788,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:40:24.467040623Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:03.330757735Z",
                 "original": "%ASA-2-302015: Built outbound UDP connection 1743372 for intfacename:10.10.10.10/161 (8.8.8.4/161) to net:192.168.2.2/22638 (8.8.8.8/22638)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1758,6 +1833,9 @@
                 "port": 161,
                 "ip": "10.10.10.10"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -1797,9 +1875,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:40:24.467044995Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:03.330759105Z",
                 "original": "%ASA-2-302015: Built outbound UDP connection 1743372 for intfacename:10.10.10.10/161 (8.8.8.4/161) to net:192.168.2.2/22638 (8.8.8.8/22638)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1836,6 +1914,9 @@
                 "address": "10.10.10.10",
                 "ip": "10.10.10.10"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1874,9 +1955,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:24.467049393Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:03.330760524Z",
                 "original": "%ASA-4-106023: Deny tcp src fw111:10.10.10.10/64388 dst out111:192.168.2.2/443 by access-group \"out1111_access_out\" [0x47e21ef4, 0x47e21ef4]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1909,6 +1990,9 @@
                 "address": "192.168.2.2",
                 "ip": "192.168.2.2"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1942,9 +2026,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:24.467053625Z",
-                "code": "106021",
+                "ingested": "2021-06-03T06:53:03.330761916Z",
                 "original": "%ASA-4-106021: Deny TCP reverse path check from 192.168.2.2 to 10.10.10.10 on interface fw111",
+                "code": "106021",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1977,6 +2061,9 @@
                 "address": "192.168.2.2",
                 "ip": "192.168.2.2"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -2011,9 +2098,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:40:24.467469359Z",
-                "code": "106006",
+                "ingested": "2021-06-03T06:53:03.330763328Z",
                 "original": "%ASA-2-106006: Deny inbound UDP from 192.168.2.2/65020 to 10.10.10.10/65020 on interface fw111",
+                "code": "106006",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2046,6 +2133,9 @@
                 "address": "192.168.2.2",
                 "ip": "192.168.2.2"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "transport": "(no"
             },
@@ -2078,9 +2168,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.467479320Z",
-                "code": "106015",
+                "ingested": "2021-06-03T06:53:03.330764721Z",
                 "original": "%ASA-6-106015: Deny TCP (no connection) from 192.168.2.2/53089 to 10.10.10.10/443 flags FIN PSH ACK  on interface out111",
+                "code": "106015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2112,6 +2202,9 @@
                 "address": "192.168.2.2",
                 "ip": "192.168.2.2"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "transport": "(no"
             },
@@ -2144,9 +2237,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.467483982Z",
-                "code": "106015",
+                "ingested": "2021-06-03T06:53:03.330766135Z",
                 "original": "%ASA-6-106015: Deny TCP (no connection) from 192.168.2.2/17127 to 10.10.10.10/443 flags PSH ACK  on interface out111",
+                "code": "106015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2178,6 +2271,9 @@
                 "address": "192.168.2.2",
                 "ip": "192.168.2.2"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "transport": "(no"
             },
@@ -2210,9 +2306,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.467488261Z",
-                "code": "106015",
+                "ingested": "2021-06-03T06:53:03.330767506Z",
                 "original": "%ASA-6-106015: Deny TCP (no connection) from 192.168.2.2/24223 to 10.10.10.10/443 flags RST  on interface fw111",
+                "code": "106015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2250,6 +2346,9 @@
                 "port": 38540,
                 "ip": "10.10.10.10"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2288,9 +2387,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.467492469Z",
-                "code": "302022",
+                "ingested": "2021-06-03T06:53:03.330768948Z",
                 "original": "%ASA-6-302022: Built director stub TCP connection for fw1111:10.10.10.10/38540 (8.8.8.5/38540) to net:192.168.2.2/10051 (8.8.8.8/10051)",
+                "code": "302022",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2332,6 +2431,9 @@
                 "port": 38540,
                 "ip": "10.10.10.10"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2370,9 +2472,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.467496615Z",
-                "code": "302022",
+                "ingested": "2021-06-03T06:53:03.330770323Z",
                 "original": "%ASA-6-302022: Built forwarder  stub TCP connection for fw111:10.10.10.10/38540 (8.8.8.5/38540) to net:192.168.2.2/10051 (8.8.8.8/10051)",
+                "code": "302022",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2414,6 +2516,9 @@
                 "port": 38540,
                 "ip": "10.10.10.10"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2452,9 +2557,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.467501129Z",
-                "code": "302022",
+                "ingested": "2021-06-03T06:53:03.330771850Z",
                 "original": "%ASA-6-302022: Built backup  stub TCP connection for fw111:10.10.10.10/38540 (8.8.8.5/38540) to net:192.1682.2.2/10051 (8.8.8.8/10051)",
+                "code": "302022",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2500,9 +2605,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.467505452Z",
-                "code": "302023",
+                "ingested": "2021-06-03T06:53:03.330773243Z",
                 "original": "%ASA-6-302023: Teardown stub TCP connection for fw111:10.10.10.10/39210 to net:192.168.2.2/10051 duration 0:00:00 forwarded bytes 0 Cluster flow with CLU closed on owner",
+                "code": "302023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2516,7 +2621,10 @@
                 "asa": {
                     "message_id": "302023"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -2542,9 +2650,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.467509646Z",
-                "code": "302023",
+                "ingested": "2021-06-03T06:53:03.330774697Z",
                 "original": "%ASA-6-302023: Teardown stub TCP connection for net:10.10.10.10/10051 to unknown:192.168.2.2/39222 duration 0:00:00 forwarded bytes 0 Forwarding or redirect flow removed to create director or backup flow",
+                "code": "302023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2558,7 +2666,10 @@
                 "asa": {
                     "message_id": "302023"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -2590,9 +2701,9 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:40:24.467513835Z",
-                "code": "111009",
+                "ingested": "2021-06-03T06:53:03.330776087Z",
                 "original": "%ASA-7-111009: User 'aaaa' executed cmd: show access-list fw211111_access_out brief",
+                "code": "111009",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2607,7 +2718,10 @@
                     "message_id": "111009",
                     "command_line_arguments": "show access-list fw211111_access_out brief"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -2639,9 +2753,9 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:40:24.467517973Z",
-                "code": "111009",
+                "ingested": "2021-06-03T06:53:03.330777946Z",
                 "original": "%ASA-7-111009: User 'aaaa' executed cmd: show access-list aaa_out brief",
+                "code": "111009",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2656,7 +2770,10 @@
                     "message_id": "111009",
                     "command_line_arguments": "show access-list aaa_out brief"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "log": {
@@ -2672,6 +2789,9 @@
                 "address": "192.168.2.2",
                 "ip": "192.168.2.2"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2710,9 +2830,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.467522115Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:03.330779544Z",
                 "original": "%ASA-6-106100: access-list fw111_out permitted tcp ptaaac/192.168.2.2(62157) -\u003e fw111/10.10.10.10(3452) hit-cnt 1 first hit [0x38ff326b, 0x00000000]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2747,6 +2867,9 @@
                 "address": "192.168.2.2",
                 "ip": "192.168.2.2"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2785,9 +2908,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.467526270Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:03.330780958Z",
                 "original": "%ASA-6-106100: access-list fw111_out permitted tcp net/192.168.2.2(49033) -\u003e fw111/10.10.10.10(6007) hit-cnt 2 300-second interval [0x38ff326b, 0x00000000]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2832,9 +2955,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.467530412Z",
-                "code": "302027",
+                "ingested": "2021-06-03T06:53:03.330782337Z",
                 "original": "%ASA-6-302027: Teardown stub ICMP connection for fw1111:10.10.10.10/6426 to net:192.168.2.2/0 duration 1:00:04 forwarded bytes 56 Cluster flow with CLU closed on owner",
+                "code": "302027",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2848,7 +2971,10 @@
                 "asa": {
                     "message_id": "302027"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -2874,9 +3000,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.467534547Z",
-                "code": "302026",
+                "ingested": "2021-06-03T06:53:03.330783770Z",
                 "original": "%ASA-6-302026: Built director stub ICMP connection for fw111:10.10.10.10/32004 (8.8.8.5) to net:192.168.2.2/0 (8.8.8.8)",
+                "code": "302026",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2890,7 +3016,10 @@
                 "asa": {
                     "message_id": "302026"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "log": {
@@ -2906,6 +3035,9 @@
                 "address": "10.10.10.10",
                 "ip": "10.10.10.10"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -2939,9 +3071,9 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:40:24.467538767Z",
-                "code": "710005",
+                "ingested": "2021-06-03T06:53:03.330785142Z",
                 "original": "%ASA-7-710005: UDP request discarded from 10.10.10.10/1985 to net:192.168.2.2/1985",
+                "code": "710005",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2982,9 +3114,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.467542993Z",
-                "code": "302025",
+                "ingested": "2021-06-03T06:53:03.330786568Z",
                 "original": "%ASA-6-302025: Teardown stub UDP connection for net:192.168.2.2/123 to unknown:10.10.10.10/123 duration 0:01:00 forwarded bytes 48 Cluster flow with CLU removed from due to idle timeout",
+                "code": "302025",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2998,7 +3130,10 @@
                 "asa": {
                     "message_id": "302025"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -3024,9 +3159,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.467551192Z",
-                "code": "302024",
+                "ingested": "2021-06-03T06:53:03.330788038Z",
                 "original": "%ASA-6-302024: Built backup stub UDP connection for net:192.168.2.2/9051 (8.8.8.5(19051) to fw111:10.10.10.10/123 (8.8.8.8/123)",
+                "code": "302024",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3040,7 +3175,10 @@
                 "asa": {
                     "message_id": "302024"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "log": {
@@ -3054,6 +3192,9 @@
                 "address": "10.10.10.10",
                 "ip": "10.10.10.10"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "1",
                 "transport": "icmp",
@@ -3092,9 +3233,9 @@
             },
             "event": {
                 "severity": 3,
-                "ingested": "2021-05-13T11:40:24.467555567Z",
-                "code": "106014",
+                "ingested": "2021-06-03T06:53:03.330789443Z",
                 "original": "%ASA-3-106014: Deny inbound icmp src fw111:10.10.10.10 dst fw111:10.10.10.10(type 8, code 0)",
+                "code": "106014",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3138,9 +3279,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:24.467559744Z",
-                "code": "733100",
+                "ingested": "2021-06-03T06:53:03.330790832Z",
                 "original": "%ASA-4-733100: [192.168.2.2] drop rate-1 exceeded. Current burst rate is 0 per second, max configured rate is -4; Current average rate is 7 per second, max configured rate is -4; Cumulative total count is 9063",
+                "code": "733100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3163,7 +3304,10 @@
                         "object": "192.168.2.2"
                     }
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "log": {
@@ -3179,6 +3323,9 @@
                 "address": "10.10.10.10",
                 "ip": "10.10.10.10"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "transport": "sctp",
                 "direction": "inbound"
@@ -3216,9 +3363,9 @@
             },
             "event": {
                 "severity": 3,
-                "ingested": "2021-05-13T11:40:24.467564007Z",
-                "code": "106010",
+                "ingested": "2021-06-03T06:53:03.330792285Z",
                 "original": "%ASA-3-106010: Deny inbound sctp src fw111:10.10.10.10/5114 dst fw111:10.10.10.10/2",
+                "code": "106010",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3252,6 +3399,9 @@
                 "address": "10.10.10.10",
                 "ip": "10.10.10.10"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -3290,9 +3440,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:24.467568313Z",
-                "code": "507003",
+                "ingested": "2021-06-03T06:53:03.330793662Z",
                 "original": "%ASA-4-507003: tcp flow from fw111:10.10.10.10/49574 to out111:192.168.2.2/80 terminated by inspection engine, reason - disconnected, dropped packet.",
+                "code": "507003",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3325,6 +3475,9 @@
             "url": {
                 "original": "http://10.20.30.40/"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "dev01",
                 "product": "asa",
@@ -3348,9 +3501,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:24.467572525Z",
-                "code": "304001",
+                "ingested": "2021-06-03T06:53:03.330795174Z",
                 "original": "%ASA-5-304001: 10.20.30.40 Accessed URL 10.20.30.40:http://10.20.30.40/",
+                "code": "304001",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3383,6 +3536,9 @@
             "url": {
                 "original": "http://10.20.30.40/IOFUHSIU98[0]"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "dev01",
                 "product": "asa",
@@ -3406,9 +3562,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:24.467576686Z",
-                "code": "304001",
+                "ingested": "2021-06-03T06:53:03.330796579Z",
                 "original": "%ASA-5-304001: 10.20.30.40 Accessed URL someuser@10.20.30.40:http://10.20.30.40/IOFUHSIU98[0]",
+                "code": "304001",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3441,6 +3597,9 @@
             "url": {
                 "original": "http://10.20.30.40/some/longer/url-asd-er9789870[0]_=23"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "dev01",
                 "product": "asa",
@@ -3464,9 +3623,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:24.467580847Z",
-                "code": "304001",
+                "ingested": "2021-06-03T06:53:03.330797988Z",
                 "original": "%ASA-5-304001: 10.20.30.40 Accessed JAVA URL 10.20.30.40:http://10.20.30.40/some/longer/url-asd-er9789870[0]_=23",
+                "code": "304001",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3499,6 +3658,9 @@
             "url": {
                 "original": "http://10.20.30.40/"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "dev01",
                 "product": "asa",
@@ -3522,9 +3684,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:24.467585121Z",
-                "code": "304001",
+                "ingested": "2021-06-03T06:53:03.330799377Z",
                 "original": "%ASA-5-304001: 10.20.30.40 Accessed JAVA URL someuser@10.20.30.40:http://10.20.30.40/",
+                "code": "304001",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3586,6 +3748,9 @@
                 "port": 54242,
                 "ip": "1.2.3.4"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 245,
                 "iana_number": "6",
@@ -3626,9 +3791,9 @@
             "event": {
                 "severity": 6,
                 "duration": 3602000000000,
-                "ingested": "2021-05-13T11:40:24.467597839Z",
-                "code": "302304",
+                "ingested": "2021-06-03T06:53:03.330800848Z",
                 "original": "%ASA-6-302304: Teardown TCP state-bypass connection 2751765169 from server.deflan:1.2.3.4/54242 to server.deflan:2.3.4.5/9101 duration 1:00:02 bytes 245 Connection timeout",
+                "code": "302304",
                 "kind": "event",
                 "start": "2021-04-27T03:12:21.000Z",
                 "action": "flow-expiration",
@@ -3664,6 +3829,9 @@
                 "address": "10.10.10.2",
                 "ip": "10.10.10.2"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -3702,9 +3870,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:24.467602100Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:03.330802248Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:10.10.10.2/56444 dst srv:192.168.2.2/51635(testhostname.domain) by access-group \"global_access_1\"",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3757,6 +3925,9 @@
                 "address": "somedomainname.local",
                 "domain": "somedomainname.local"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -3795,9 +3966,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:24.467608963Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:03.330803725Z",
                 "original": "%ASA-5-106100: access-list testrulename denied tcp insideintf/somedomainname.local(27218) -\u003e OUTSIDE/195.122.12.242(53) hit-cnt 1 first hit [0x16847359, 0x00000000]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3819,6 +3990,16 @@
             }
         },
         {
+            "log": {
+                "level": "notification"
+            },
+            "source": {
+                "address": "console",
+                "domain": "console"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "dev01",
                 "product": "asa",
@@ -3835,21 +4016,14 @@
                     "console"
                 ]
             },
-            "log": {
-                "level": "notification"
-            },
             "host": {
                 "hostname": "dev01"
             },
-            "source": {
-                "address": "console",
-                "domain": "console"
-            },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:24.467613505Z",
-                "code": "111004",
+                "ingested": "2021-06-03T06:53:03.330805137Z",
                 "original": "%ASA-5-111004: console end configuration: OK",
+                "code": "111004",
                 "kind": "event",
                 "action": "firewall-rule",
                 "type": [
@@ -3867,6 +4041,16 @@
             }
         },
         {
+            "log": {
+                "level": "notification"
+            },
+            "source": {
+                "address": "10.10.0.87",
+                "ip": "10.10.0.87"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "dev01",
                 "product": "asa",
@@ -3888,24 +4072,17 @@
                     "10.10.0.87"
                 ]
             },
-            "log": {
-                "level": "notification"
-            },
             "host": {
                 "user": {
                     "name": "enable_15"
                 },
                 "hostname": "dev01"
             },
-            "source": {
-                "address": "10.10.0.87",
-                "ip": "10.10.0.87"
-            },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:24.467617730Z",
-                "code": "111010",
+                "ingested": "2021-06-03T06:53:03.330806591Z",
                 "original": "%ASA-5-111010: User 'enable_15', running 'CLI' from IP 10.10.0.87, executed 'clear'",
+                "code": "111010",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3952,9 +4129,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:24.467621907Z",
-                "code": "502103",
+                "ingested": "2021-06-03T06:53:03.330808046Z",
                 "original": "%ASA-5-502103: User priv level changed: Uname: enable_15 From: 1 To: 15",
+                "code": "502103",
                 "kind": "event",
                 "action": "firewall-rule",
                 "type": [
@@ -3972,7 +4149,10 @@
                         "old": "1"
                     }
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "log": {
@@ -3990,6 +4170,9 @@
                 },
                 "ip": "10.10.1.212"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "https"
             },
@@ -4025,9 +4208,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.467626093Z",
-                "code": "605004",
+                "ingested": "2021-06-03T06:53:03.330809508Z",
                 "original": "%ASA-6-605004: Login denied from 10.10.1.212/51923 to FCD-FS-LAN:10.10.1.254/https for user \"*****\"",
+                "code": "605004",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4047,6 +4230,16 @@
             }
         },
         {
+            "log": {
+                "level": "informational"
+            },
+            "source": {
+                "address": "10.10.0.87",
+                "ip": "10.10.0.87"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "dev01",
                 "product": "asa",
@@ -4068,24 +4261,17 @@
                     "10.10.0.87"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "user": {
                     "name": "admin"
                 },
                 "hostname": "dev01"
             },
-            "source": {
-                "address": "10.10.0.87",
-                "ip": "10.10.0.87"
-            },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.467630208Z",
-                "code": "611102",
+                "ingested": "2021-06-03T06:53:03.330810928Z",
                 "original": "%ASA-6-611102: User authentication failed: IP address: 10.10.0.87, Uname: admin",
+                "code": "611102",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4118,6 +4304,9 @@
                 },
                 "ip": "10.10.0.87"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "ssh"
             },
@@ -4153,9 +4342,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.467634338Z",
-                "code": "605005",
+                "ingested": "2021-06-03T06:53:03.330812445Z",
                 "original": "%ASA-6-605005: Login permitted from 10.10.0.87/6651 to FCD-FS-LAN:10.10.1.254/ssh for user \"admin\"",
+                "code": "605005",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4175,6 +4364,16 @@
             }
         },
         {
+            "log": {
+                "level": "informational"
+            },
+            "source": {
+                "address": "10.10.0.87",
+                "ip": "10.10.0.87"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "dev01",
                 "product": "asa",
@@ -4196,24 +4395,17 @@
                     "10.10.0.87"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "user": {
                     "name": "admin"
                 },
                 "hostname": "dev01"
             },
-            "source": {
-                "address": "10.10.0.87",
-                "ip": "10.10.0.87"
-            },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.467638436Z",
-                "code": "611101",
+                "ingested": "2021-06-03T06:53:03.330814578Z",
                 "original": "%ASA-6-611101: User authentication succeeded: IP address: 10.10.0.87, Uname: admin",
+                "code": "611101",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4231,29 +4423,8 @@
             }
         },
         {
-            "observer": {
-                "hostname": "dev01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco"
-            },
-            "@timestamp": "2021-04-27T02:03:03.000Z",
-            "ecs": {
-                "version": "1.9.0"
-            },
-            "related": {
-                "hosts": [
-                    "dev01"
-                ],
-                "ip": [
-                    "91.240.17.178"
-                ]
-            },
             "log": {
                 "level": "notification"
-            },
-            "host": {
-                "hostname": "dev01"
             },
             "source": {
                 "geo": {
@@ -4277,11 +4448,35 @@
                 "address": "91.240.17.178",
                 "ip": "91.240.17.178"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "observer": {
+                "hostname": "dev01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "@timestamp": "2021-04-27T02:03:03.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "related": {
+                "hosts": [
+                    "dev01"
+                ],
+                "ip": [
+                    "91.240.17.178"
+                ]
+            },
+            "host": {
+                "hostname": "dev01"
+            },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:24.467642606Z",
-                "code": "713049",
+                "ingested": "2021-06-03T06:53:03.330816078Z",
                 "original": "%ASA-5-713049: Group = 91.240.17.178, IP = 91.240.17.178, Security negotiation complete for LAN-to-LAN Group (91.240.17.178) Responder, Inbound SPI = 0x276b1da2, Outbound SPI = 0x0e1a581d",
+                "code": "713049",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4330,6 +4525,9 @@
                 },
                 "bytes": 297103
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "dev01",
                 "product": "asa",
@@ -4357,9 +4555,9 @@
             "event": {
                 "severity": 4,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:24.467646782Z",
-                "code": "113019",
+                "ingested": "2021-06-03T06:53:03.330817520Z",
                 "original": "%ASA-4-113019: Group = 91.240.17.178, Username = 91.240.17.178, IP = 91.240.17.178, Session disconnected. Session Type: LAN-to-LAN, Duration: 0h:32m:16s, Bytes xmt: 297103, Bytes rcv: 1216163, Reason: User Requested",
+                "code": "113019",
                 "kind": "event",
                 "start": "2021-04-27T02:03:03.000Z",
                 "action": "firewall-rule",
@@ -4378,32 +4576,8 @@
             }
         },
         {
-            "observer": {
-                "hostname": "dev01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco"
-            },
-            "@timestamp": "2021-04-27T02:03:03.000Z",
-            "ecs": {
-                "version": "1.9.0"
-            },
-            "related": {
-                "user": [
-                    "testuser"
-                ],
-                "hosts": [
-                    "dev01"
-                ],
-                "ip": [
-                    "8.8.8.8"
-                ]
-            },
             "log": {
                 "level": "warning"
-            },
-            "host": {
-                "hostname": "dev01"
             },
             "source": {
                 "geo": {
@@ -4427,11 +4601,38 @@
                 },
                 "ip": "8.8.8.8"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "observer": {
+                "hostname": "dev01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "@timestamp": "2021-04-27T02:03:03.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "related": {
+                "user": [
+                    "testuser"
+                ],
+                "hosts": [
+                    "dev01"
+                ],
+                "ip": [
+                    "8.8.8.8"
+                ]
+            },
+            "host": {
+                "hostname": "dev01"
+            },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:24.467650985Z",
-                "code": "722051",
+                "ingested": "2021-06-03T06:53:03.330818994Z",
                 "original": "%ASA-4-722051: Group some-policy User testuser IP 8.8.8.8 IPv4 Address 8.8.4.4 IPv6 address 2001:4860:4860::8888 assigned to session",
+                "code": "722051",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4449,32 +4650,8 @@
             }
         },
         {
-            "observer": {
-                "hostname": "dev01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco"
-            },
-            "@timestamp": "2021-04-27T02:03:03.000Z",
-            "ecs": {
-                "version": "1.9.0"
-            },
-            "related": {
-                "user": [
-                    "testuser"
-                ],
-                "hosts": [
-                    "dev01"
-                ],
-                "ip": [
-                    "8.8.8.8"
-                ]
-            },
             "log": {
                 "level": "informational"
-            },
-            "host": {
-                "hostname": "dev01"
             },
             "source": {
                 "geo": {
@@ -4498,11 +4675,38 @@
                 },
                 "ip": "8.8.8.8"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "observer": {
+                "hostname": "dev01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "@timestamp": "2021-04-27T02:03:03.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "related": {
+                "user": [
+                    "testuser"
+                ],
+                "hosts": [
+                    "dev01"
+                ],
+                "ip": [
+                    "8.8.8.8"
+                ]
+            },
+            "host": {
+                "hostname": "dev01"
+            },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:24.467655152Z",
-                "code": "716002",
+                "ingested": "2021-06-03T06:53:03.330820368Z",
                 "original": "%ASA-6-716002: Group another-policy User testuser IP 8.8.8.8 WebVPN session terminated: User Requested.",
+                "code": "716002",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4568,6 +4772,9 @@
                 "port": 6370,
                 "ip": "104.46.88.19"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -4601,9 +4808,9 @@
             },
             "event": {
                 "severity": 3,
-                "ingested": "2021-05-13T11:40:24.467660291Z",
-                "code": "710003",
+                "ingested": "2021-06-03T06:53:03.330821840Z",
                 "original": "%ASA-3-710003: TCP access denied by ACL from 104.46.88.19/6370 to outside:195.74.114.34/23",
+                "code": "710003",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-asa-fix.log-config.yml
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-asa-fix.log-config.yml
@@ -1,6 +1,0 @@
-dynamic_fields:
-  event.ingested: ".*"
-numeric_keyword_fields:
-  - "network.iana_number"
-  - "event.code"
-  - "syslog.facility"

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-asa-fix.log-expected.json
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-asa-fix.log-expected.json
@@ -14,6 +14,9 @@
                 "address": "10.123.123.123",
                 "ip": "10.123.123.123"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 148,
                 "iana_number": "17",
@@ -54,9 +57,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:30.979558755Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:05.971960714Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 110577675 for Outside:10.123.123.123/53723(LOCAL\\Elastic) to Inside:10.233.123.123/53 duration 0:00:00 bytes 148 (zzzzzz)",
+                "code": "302016",
                 "kind": "event",
                 "start": "2020-04-17T14:08:08.000Z",
                 "action": "flow-expiration",
@@ -91,6 +94,9 @@
                 "address": "10.123.123.123",
                 "ip": "10.123.123.123"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "1",
                 "transport": "icmp"
@@ -128,9 +134,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:30.979581315Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:05.971967472Z",
                 "original": "%ASA-4-106023: Deny icmp src Inside:10.123.123.123 dst Outside:10.123.123.123 (type 11, code 0) by access-group \"Inside_access_in\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -165,6 +171,9 @@
                 "address": "10.123.123.123",
                 "ip": "10.123.123.123"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -195,9 +204,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:30.979586876Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:05.971968980Z",
                 "original": "%ASA-4-106023: Deny tcp src dmz:10.123.123.123/6316 dst outside:10.123.123.123/53 type 3, code 0, by access-group \"acl_dmz\" [0xe3afb522, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -232,6 +241,9 @@
                 "address": "10.123.123.123",
                 "ip": "10.123.123.123"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -269,9 +281,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:30.979591555Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:05.971970368Z",
                 "original": "%ASA-4-106023: Deny udp src Inside:10.123.123.123/57621(LOCAL\\Elastic) dst Outside:10.123.123.123/57621 by access-group \"Inside_access_in\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -305,6 +317,9 @@
                 "address": "10.123.123.123",
                 "ip": "10.123.123.123"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "SNL-ASA-VPN-A01",
                 "product": "asa",
@@ -328,9 +343,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:40:30.979596060Z",
-                "code": "106017",
+                "ingested": "2021-06-03T06:53:05.971971748Z",
                 "original": "%ASA-2-106017: Deny IP due to Land Attack from 10.123.123.123 to 10.123.123.123",
+                "code": "106017",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -356,6 +371,9 @@
                 "address": "fe80::1ff:fe23:4567:890a",
                 "ip": "fe80::1ff:fe23:4567:890a"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "58",
                 "transport": "ipv6-icmp"
@@ -388,9 +406,9 @@
             },
             "event": {
                 "severity": 3,
-                "ingested": "2021-05-13T11:40:30.979600531Z",
-                "code": "313008",
+                "ingested": "2021-06-03T06:53:05.971973067Z",
                 "original": "%ASA-3-313008: Denied IPv6-ICMP type=134, code=0 from fe80::1ff:fe23:4567:890a on interface ISP1",
+                "code": "313008",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -425,6 +443,9 @@
                 "address": "10.255.0.206",
                 "ip": "10.255.0.206"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "1",
                 "transport": "icmp"
@@ -456,9 +477,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:30.979605002Z",
-                "code": "313009",
+                "ingested": "2021-06-03T06:53:05.971974392Z",
                 "original": "%ASA-4-313009: Denied invalid ICMP code 9, for Inside:10.255.0.206/8795 (10.255.0.206/8795) to identity:10.12.31.51/0 (10.12.31.51/0), ICMP id 295, ICMP type 8",
+                "code": "313009",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -497,6 +518,9 @@
                 "address": "127.2.3.4",
                 "ip": "127.2.3.4"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -528,9 +552,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:30.979609446Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:05.971975706Z",
                 "original": "%ASA-6-106100: access-list incoming permitted udp dmz2/127.2.3.4(56575) -\u003e inside/127.3.4.5(53) hit-cnt 1 first hit [0x93d0e533, 0x578ef52f]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -565,6 +589,9 @@
                 "address": "127.2.3.4",
                 "ip": "127.2.3.4"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -596,9 +623,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:30.979613895Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:05.971977012Z",
                 "original": "%ASA-6-106100: access-list incoming permitted udp dmz2/127.2.3.4(56575)(LOCAL\\\\username) -\u003e inside/127.3.4.5(53) hit-cnt 1 first hit [0x93d0e533, 0x578ef52f]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -633,6 +660,9 @@
                 "address": "10.123.123.20",
                 "ip": "10.123.123.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -667,9 +697,9 @@
             },
             "event": {
                 "severity": 3,
-                "ingested": "2021-05-13T11:40:30.979618375Z",
-                "code": "106102",
+                "ingested": "2021-06-03T06:53:05.971978321Z",
                 "original": "%ASA-session-3-106102: access-list dev_inward_client permitted udp for user redacted outside/10.123.123.20(49721) -\u003e inside/10.223.223.40(53) hit-cnt 1 first hit [0x3c8b88c1, 0xbee595c3]",
+                "code": "106102",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -719,6 +749,9 @@
                 "address": "10.1.2.3",
                 "ip": "10.1.2.3"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "1",
                 "transport": "icmp"
@@ -753,9 +786,9 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-05-13T11:40:30.979622815Z",
-                "code": "106103",
+                "ingested": "2021-06-03T06:53:05.971979648Z",
                 "original": "%ASA-1-106103: access-list filter denied icmp for user joe inside/10.1.2.3(64321) -\u003e outside/1.2.33.40(8080) hit-cnt 1 first hit [0x3c8b88c1, 0xbee595c3]",
+                "code": "106103",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-asa.log-config.yml
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-asa.log-config.yml
@@ -1,6 +1,0 @@
-dynamic_fields:
-  event.ingested: ".*"
-numeric_keyword_fields:
-  - "network.iana_number"
-  - "event.code"
-  - "syslog.facility"

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-asa.log-expected.json
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-asa.log-expected.json
@@ -18,6 +18,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -56,9 +59,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.086396014Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431222405Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1772 to outside:100.66.98.44/8256",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -94,6 +97,9 @@
                 "address": "100.66.205.104",
                 "ip": "100.66.205.104"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -133,9 +139,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.086412489Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431231152Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11757 for outside:100.66.205.104/80 (100.66.205.104/80) to inside:172.31.98.44/1772 (172.31.98.44/1772)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -176,6 +182,9 @@
                 "address": "100.66.211.242",
                 "ip": "100.66.211.242"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 38110,
                 "iana_number": "6",
@@ -216,9 +225,9 @@
             "event": {
                 "severity": 6,
                 "duration": 67000000000,
-                "ingested": "2021-05-13T11:40:32.086418562Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431233817Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11749 for outside:100.66.211.242/80 to inside:172.31.98.44/1758 duration 0:01:07 bytes 38110 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:49.000Z",
                 "action": "flow-expiration",
@@ -258,6 +267,9 @@
                 "address": "100.66.211.242",
                 "ip": "100.66.211.242"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 44010,
                 "iana_number": "6",
@@ -298,9 +310,9 @@
             "event": {
                 "severity": 6,
                 "duration": 67000000000,
-                "ingested": "2021-05-13T11:40:32.086424289Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431235335Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11748 for outside:100.66.211.242/80 to inside:172.31.98.44/1757 duration 0:01:07 bytes 44010 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:49.000Z",
                 "action": "flow-expiration",
@@ -340,6 +352,9 @@
                 "address": "100.66.185.90",
                 "ip": "100.66.185.90"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 7652,
                 "iana_number": "6",
@@ -380,9 +395,9 @@
             "event": {
                 "severity": 6,
                 "duration": 67000000000,
-                "ingested": "2021-05-13T11:40:32.086429914Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431236881Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11745 for outside:100.66.185.90/80 to inside:172.31.98.44/1755 duration 0:01:07 bytes 7652 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:49.000Z",
                 "action": "flow-expiration",
@@ -422,6 +437,9 @@
                 "address": "100.66.185.90",
                 "ip": "100.66.185.90"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 7062,
                 "iana_number": "6",
@@ -462,9 +480,9 @@
             "event": {
                 "severity": 6,
                 "duration": 67000000000,
-                "ingested": "2021-05-13T11:40:32.086435505Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431238532Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11744 for outside:100.66.185.90/80 to inside:172.31.98.44/1754 duration 0:01:07 bytes 7062 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:49.000Z",
                 "action": "flow-expiration",
@@ -504,6 +522,9 @@
                 "address": "100.66.160.197",
                 "ip": "100.66.160.197"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 5738,
                 "iana_number": "6",
@@ -544,9 +565,9 @@
             "event": {
                 "severity": 6,
                 "duration": 68000000000,
-                "ingested": "2021-05-13T11:40:32.086441110Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431239986Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11742 for outside:100.66.160.197/80 to inside:172.31.98.44/1752 duration 0:01:08 bytes 5738 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:48.000Z",
                 "action": "flow-expiration",
@@ -586,6 +607,9 @@
                 "address": "100.66.205.14",
                 "ip": "100.66.205.14"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 4176,
                 "iana_number": "6",
@@ -626,9 +650,9 @@
             "event": {
                 "severity": 6,
                 "duration": 68000000000,
-                "ingested": "2021-05-13T11:40:32.086446645Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431241374Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11738 for outside:100.66.205.14/80 to inside:172.31.98.44/1749 duration 0:01:08 bytes 4176 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:48.000Z",
                 "action": "flow-expiration",
@@ -668,6 +692,9 @@
                 "address": "100.66.124.33",
                 "ip": "100.66.124.33"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 1715,
                 "iana_number": "6",
@@ -708,9 +735,9 @@
             "event": {
                 "severity": 6,
                 "duration": 68000000000,
-                "ingested": "2021-05-13T11:40:32.087142754Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431242747Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11739 for outside:100.66.124.33/80 to inside:172.31.98.44/1750 duration 0:01:08 bytes 1715 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:48.000Z",
                 "action": "flow-expiration",
@@ -750,6 +777,9 @@
                 "address": "100.66.35.9",
                 "ip": "100.66.35.9"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 45595,
                 "iana_number": "6",
@@ -790,9 +820,9 @@
             "event": {
                 "severity": 6,
                 "duration": 69000000000,
-                "ingested": "2021-05-13T11:40:32.087153756Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431244112Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11731 for outside:100.66.35.9/80 to inside:172.31.98.44/1747 duration 0:01:09 bytes 45595 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:47.000Z",
                 "action": "flow-expiration",
@@ -832,6 +862,9 @@
                 "address": "100.66.211.242",
                 "ip": "100.66.211.242"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 27359,
                 "iana_number": "6",
@@ -872,9 +905,9 @@
             "event": {
                 "severity": 6,
                 "duration": 69000000000,
-                "ingested": "2021-05-13T11:40:32.087158979Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431246428Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11723 for outside:100.66.211.242/80 to inside:172.31.98.44/1742 duration 0:01:09 bytes 27359 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:47.000Z",
                 "action": "flow-expiration",
@@ -914,6 +947,9 @@
                 "address": "100.66.218.21",
                 "ip": "100.66.218.21"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 4457,
                 "iana_number": "6",
@@ -954,9 +990,9 @@
             "event": {
                 "severity": 6,
                 "duration": 69000000000,
-                "ingested": "2021-05-13T11:40:32.087164105Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431248479Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11715 for outside:100.66.218.21/80 to inside:172.31.98.44/1741 duration 0:01:09 bytes 4457 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:47.000Z",
                 "action": "flow-expiration",
@@ -996,6 +1032,9 @@
                 "address": "100.66.198.27",
                 "ip": "100.66.198.27"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 26709,
                 "iana_number": "6",
@@ -1036,9 +1075,9 @@
             "event": {
                 "severity": 6,
                 "duration": 69000000000,
-                "ingested": "2021-05-13T11:40:32.087168904Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431250257Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11711 for outside:100.66.198.27/80 to inside:172.31.98.44/1739 duration 0:01:09 bytes 26709 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:47.000Z",
                 "action": "flow-expiration",
@@ -1078,6 +1117,9 @@
                 "address": "100.66.198.27",
                 "ip": "100.66.198.27"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 22097,
                 "iana_number": "6",
@@ -1118,9 +1160,9 @@
             "event": {
                 "severity": 6,
                 "duration": 69000000000,
-                "ingested": "2021-05-13T11:40:32.087173633Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431251925Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11712 for outside:100.66.198.27/80 to inside:172.31.98.44/1740 duration 0:01:09 bytes 22097 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:47.000Z",
                 "action": "flow-expiration",
@@ -1160,6 +1202,9 @@
                 "address": "100.66.202.211",
                 "ip": "100.66.202.211"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 2209,
                 "iana_number": "6",
@@ -1200,9 +1245,9 @@
             "event": {
                 "severity": 6,
                 "duration": 70000000000,
-                "ingested": "2021-05-13T11:40:32.087178281Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431253269Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11708 for outside:100.66.202.211/80 to inside:172.31.98.44/1738 duration 0:01:10 bytes 2209 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:46.000Z",
                 "action": "flow-expiration",
@@ -1242,6 +1287,9 @@
                 "address": "100.66.124.15",
                 "ip": "100.66.124.15"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 10404,
                 "iana_number": "6",
@@ -1282,9 +1330,9 @@
             "event": {
                 "severity": 6,
                 "duration": 67000000000,
-                "ingested": "2021-05-13T11:40:32.087183090Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431254850Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11746 for outside:100.66.124.15/80 to inside:172.31.98.44/1756 duration 0:01:07 bytes 10404 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:49.000Z",
                 "action": "flow-expiration",
@@ -1324,6 +1372,9 @@
                 "address": "100.66.124.15",
                 "ip": "100.66.124.15"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 123694,
                 "iana_number": "6",
@@ -1364,9 +1415,9 @@
             "event": {
                 "severity": 6,
                 "duration": 70000000000,
-                "ingested": "2021-05-13T11:40:32.087187945Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431256385Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11706 for outside:100.66.124.15/80 to inside:172.31.98.44/1737 duration 0:01:10 bytes 123694 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:46.000Z",
                 "action": "flow-expiration",
@@ -1406,6 +1457,9 @@
                 "address": "100.66.209.247",
                 "ip": "100.66.209.247"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 35835,
                 "iana_number": "6",
@@ -1446,9 +1500,9 @@
             "event": {
                 "severity": 6,
                 "duration": 71000000000,
-                "ingested": "2021-05-13T11:40:32.087192748Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431257752Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11702 for outside:100.66.209.247/80 to inside:172.31.98.44/1736 duration 0:01:11 bytes 35835 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:45.000Z",
                 "action": "flow-expiration",
@@ -1488,6 +1542,9 @@
                 "address": "100.66.35.162",
                 "ip": "100.66.35.162"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 0,
                 "iana_number": "6",
@@ -1528,9 +1585,9 @@
             "event": {
                 "severity": 6,
                 "duration": 30000000000,
-                "ingested": "2021-05-13T11:40:32.087197466Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431259143Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11753 for outside:100.66.35.162/80 to inside:172.31.98.44/1765 duration 0:00:30 bytes 0 SYN Timeout",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:26.000Z",
                 "action": "flow-expiration",
@@ -1570,6 +1627,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -1608,9 +1668,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087202197Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431260548Z",
                 "original": "%ASA-6-305011: Built dynamic UDP translation from inside:172.31.98.44/56132 to outside:100.66.98.44/1188",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1646,6 +1706,9 @@
                 "address": "100.66.80.32",
                 "ip": "100.66.80.32"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -1685,9 +1748,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087206916Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:06.431261891Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11758 for outside:100.66.80.32/53 (100.66.80.32/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1728,6 +1791,9 @@
                 "address": "100.66.80.32",
                 "ip": "100.66.80.32"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 148,
                 "iana_number": "17",
@@ -1768,9 +1834,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.087211558Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431263430Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11758 for outside:100.66.80.32/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 148",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -1810,6 +1876,9 @@
                 "address": "100.66.252.6",
                 "ip": "100.66.252.6"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -1849,9 +1918,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087216163Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:06.431264782Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11759 for outside:100.66.252.6/53 (100.66.252.6/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1892,6 +1961,9 @@
                 "address": "100.66.252.6",
                 "ip": "100.66.252.6"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 164,
                 "iana_number": "17",
@@ -1932,9 +2004,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.087220882Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431266324Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11759 for outside:100.66.252.6/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 164",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -1974,6 +2046,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2012,9 +2087,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087225521Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431267673Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1773 to outside:100.66.98.44/8257",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2050,6 +2125,9 @@
                 "address": "100.66.252.226",
                 "ip": "100.66.252.226"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -2089,9 +2167,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087230210Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431269061Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11760 for outside:100.66.252.226/80 (100.66.252.226/80) to inside:172.31.98.44/1773 (172.31.98.44/1773)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2132,6 +2210,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2170,9 +2251,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087234909Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431270744Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1774 to outside:100.66.98.44/8258",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2208,6 +2289,9 @@
                 "address": "100.66.252.226",
                 "ip": "100.66.252.226"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -2247,9 +2331,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087239574Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431272218Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11761 for outside:100.66.252.226/80 (100.66.252.226/80) to inside:172.31.98.44/1774 (172.31.98.44/1774)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2290,6 +2374,9 @@
                 "address": "100.66.238.126",
                 "ip": "100.66.238.126"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -2329,9 +2416,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087244261Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:06.431273777Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11762 for outside:100.66.238.126/53 (100.66.238.126/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2372,6 +2459,9 @@
                 "address": "100.66.93.51",
                 "ip": "100.66.93.51"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -2411,9 +2501,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087248911Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:06.431275155Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11763 for outside:100.66.93.51/53 (100.66.93.51/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2454,6 +2544,9 @@
                 "address": "100.66.238.126",
                 "ip": "100.66.238.126"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 111,
                 "iana_number": "17",
@@ -2494,9 +2587,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.087253581Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431276496Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11762 for outside:100.66.238.126/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 111",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -2536,6 +2629,9 @@
                 "address": "100.66.93.51",
                 "ip": "100.66.93.51"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 237,
                 "iana_number": "17",
@@ -2576,9 +2672,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.087258237Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431277958Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11763 for outside:100.66.93.51/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 237",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -2618,6 +2714,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2656,9 +2755,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087262983Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431279493Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1775 to outside:100.66.98.44/8259",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2694,6 +2793,9 @@
                 "address": "100.66.225.103",
                 "ip": "100.66.225.103"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -2733,9 +2835,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087271123Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431280870Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11764 for outside:100.66.225.103/443 (100.66.225.103/443) to inside:172.31.98.44/1775 (172.31.98.44/1775)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2776,6 +2878,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -2814,9 +2919,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087276632Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431282335Z",
                 "original": "%ASA-6-305011: Built dynamic UDP translation from inside:172.31.98.44/56132 to outside:100.66.98.44/1189",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2852,6 +2957,9 @@
                 "address": "100.66.240.126",
                 "ip": "100.66.240.126"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -2891,9 +2999,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087281439Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:06.431283699Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11772 for outside:100.66.240.126/53 (100.66.240.126/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2934,6 +3042,9 @@
                 "address": "100.66.44.45",
                 "ip": "100.66.44.45"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -2973,9 +3084,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087286157Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:06.431285032Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11773 for outside:100.66.44.45/53 (100.66.44.45/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3016,6 +3127,9 @@
                 "address": "100.66.240.126",
                 "ip": "100.66.240.126"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 87,
                 "iana_number": "17",
@@ -3056,9 +3170,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.087290955Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431286506Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11772 for outside:100.66.240.126/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 87",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -3098,6 +3212,9 @@
                 "address": "100.66.44.45",
                 "ip": "100.66.44.45"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 221,
                 "iana_number": "17",
@@ -3138,9 +3255,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.087295690Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431288865Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11773 for outside:100.66.44.45/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 221",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -3180,6 +3297,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -3218,9 +3338,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087300397Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431290431Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1452 to outside:100.66.98.44/8265",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3256,6 +3376,9 @@
                 "address": "100.66.179.219",
                 "ip": "100.66.179.219"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -3295,9 +3418,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087305074Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431291783Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11774 for outside:100.66.179.219/80 (100.66.179.219/80) to inside:172.31.98.44/1452 (172.31.98.44/1452)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3338,6 +3461,9 @@
                 "address": "100.66.157.232",
                 "ip": "100.66.157.232"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -3377,9 +3503,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087309732Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:06.431293216Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11775 for outside:100.66.157.232/53 (100.66.157.232/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3420,6 +3546,9 @@
                 "address": "100.66.178.133",
                 "ip": "100.66.178.133"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -3459,9 +3588,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087314375Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:06.431294586Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11776 for outside:100.66.178.133/53 (100.66.178.133/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3502,6 +3631,9 @@
                 "address": "100.66.157.232",
                 "ip": "100.66.157.232"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 101,
                 "iana_number": "17",
@@ -3542,9 +3674,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.087319153Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431296269Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11775 for outside:100.66.157.232/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 101",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -3584,6 +3716,9 @@
                 "address": "100.66.178.133",
                 "ip": "100.66.178.133"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 126,
                 "iana_number": "17",
@@ -3624,9 +3759,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.087323875Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431298020Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11776 for outside:100.66.178.133/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 126",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -3666,6 +3801,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -3704,9 +3842,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087328561Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431299700Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1453 to outside:100.66.98.44/8266",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3742,6 +3880,9 @@
                 "address": "100.66.133.112",
                 "ip": "100.66.133.112"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -3781,9 +3922,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087333224Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431301270Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11777 for outside:100.66.133.112/80 (100.66.133.112/80) to inside:172.31.98.44/1453 (172.31.98.44/1453)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3824,6 +3965,9 @@
                 "address": "100.66.133.112",
                 "ip": "100.66.133.112"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 862,
                 "iana_number": "6",
@@ -3864,9 +4008,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.087338058Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431302985Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11777 for outside:100.66.133.112/80 to inside:172.31.98.44/1453 duration 0:00:00 bytes 862 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -3906,6 +4050,9 @@
                 "address": "100.66.204.197",
                 "ip": "100.66.204.197"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -3945,9 +4092,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087342795Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:06.431304381Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11779 for outside:100.66.204.197/53 (100.66.204.197/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3988,6 +4135,9 @@
                 "address": "100.66.157.232",
                 "ip": "100.66.157.232"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 104,
                 "iana_number": "17",
@@ -4028,9 +4178,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.087347500Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431305918Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11778 for outside:100.66.157.232/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 104",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -4070,6 +4220,9 @@
                 "address": "100.66.204.197",
                 "ip": "100.66.204.197"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 176,
                 "iana_number": "17",
@@ -4110,9 +4263,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.087352349Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431307571Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11779 for outside:100.66.204.197/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 176",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -4152,6 +4305,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -4190,9 +4346,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087357073Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431309269Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1454 to outside:100.66.98.44/8267",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4228,6 +4384,9 @@
                 "address": "100.66.128.3",
                 "ip": "100.66.128.3"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -4267,9 +4426,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087361770Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431310857Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11780 for outside:100.66.128.3/80 (100.66.128.3/80) to inside:172.31.98.44/1454 (172.31.98.44/1454)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4310,6 +4469,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -4348,9 +4510,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087366561Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431312435Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1455 to outside:100.66.98.44/8268",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4386,6 +4548,9 @@
                 "address": "100.66.128.3",
                 "ip": "100.66.128.3"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -4425,9 +4590,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087371409Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431313749Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11781 for outside:100.66.128.3/80 (100.66.128.3/80) to inside:172.31.98.44/1455 (172.31.98.44/1455)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4468,6 +4633,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -4506,9 +4674,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087376153Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431315064Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1456 to outside:100.66.98.44/8269",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4544,6 +4712,9 @@
                 "address": "100.66.128.3",
                 "ip": "100.66.128.3"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -4583,9 +4754,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087380815Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431316512Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11782 for outside:100.66.128.3/80 (100.66.128.3/80) to inside:172.31.98.44/1456 (172.31.98.44/1456)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4626,6 +4797,9 @@
                 "address": "100.66.100.4",
                 "ip": "100.66.100.4"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -4665,9 +4839,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087385517Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:06.431317857Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11783 for outside:100.66.100.4/53 (100.66.100.4/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4708,6 +4882,9 @@
                 "address": "100.66.100.4",
                 "ip": "100.66.100.4"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 104,
                 "iana_number": "17",
@@ -4748,9 +4925,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.087390180Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431319279Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11783 for outside:100.66.100.4/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 104",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -4790,6 +4967,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -4828,9 +5008,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087394823Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431320730Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1457 to outside:100.66.98.44/8270",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4866,6 +5046,9 @@
                 "address": "100.66.198.40",
                 "ip": "100.66.198.40"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -4905,9 +5088,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087399433Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431322642Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11784 for outside:100.66.198.40/80 (100.66.198.40/80) to inside:172.31.98.44/1457 (172.31.98.44/1457)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4948,6 +5131,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -4986,9 +5172,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087404094Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431324374Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1458 to outside:100.66.98.44/8271",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5024,6 +5210,9 @@
                 "address": "100.66.198.40",
                 "ip": "100.66.198.40"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -5063,9 +5252,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087408859Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431326303Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11785 for outside:100.66.198.40/80 (100.66.198.40/80) to inside:172.31.98.44/1458 (172.31.98.44/1458)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5106,6 +5295,9 @@
                 "address": "100.66.1.107",
                 "ip": "100.66.1.107"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -5145,9 +5337,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087413585Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:06.431327870Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11786 for outside:100.66.1.107/53 (100.66.1.107/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5188,6 +5380,9 @@
                 "address": "100.66.198.40",
                 "ip": "100.66.198.40"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 593,
                 "iana_number": "6",
@@ -5228,9 +5423,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.087418277Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431335764Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11784 for outside:100.66.198.40/80 to inside:172.31.98.44/1457 duration 0:00:00 bytes 593 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -5270,6 +5465,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -5308,9 +5506,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087422948Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431337641Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1459 to outside:100.66.98.44/8272",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5346,6 +5544,9 @@
                 "address": "100.66.198.40",
                 "ip": "100.66.198.40"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -5385,9 +5586,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087427626Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431339286Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11787 for outside:100.66.198.40/80 (100.66.198.40/80) to inside:172.31.98.44/1459 (172.31.98.44/1459)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5428,6 +5629,9 @@
                 "address": "100.66.1.107",
                 "ip": "100.66.1.107"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 375,
                 "iana_number": "17",
@@ -5468,9 +5672,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.087432375Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431340788Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11786 for outside:100.66.1.107/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 375",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -5510,6 +5714,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -5548,9 +5755,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087437014Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431342167Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1460 to outside:100.66.98.44/8273",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5586,6 +5793,9 @@
                 "address": "100.66.192.44",
                 "ip": "100.66.192.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -5625,9 +5835,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087441706Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431343575Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11788 for outside:100.66.192.44/80 (100.66.192.44/80) to inside:172.31.98.44/1460 (172.31.98.44/1460)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5651,15 +5861,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -5670,17 +5886,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087446384Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431344947Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1454 to outside:100.66.98.44/8267 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5714,6 +5927,9 @@
                 "address": "172.31.156.80",
                 "ip": "172.31.156.80"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -5752,9 +5968,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087451169Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431346593Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.156.80/1385 to outside:100.66.98.44/8277",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5790,6 +6006,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -5829,9 +6048,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087455896Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431347957Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11797 for outside:100.66.19.254/80 (100.66.19.254/80) to inside:172.31.156.80/1385 (172.31.156.80/1385)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5855,15 +6074,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -5874,17 +6099,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087460549Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431349346Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1455 to outside:100.66.98.44/8268 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5901,15 +6123,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -5920,17 +6148,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087465347Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431351437Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1456 to outside:100.66.98.44/8269 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5947,15 +6172,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -5966,17 +6197,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087470081Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431352879Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1457 to outside:100.66.98.44/8270 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5993,15 +6221,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -6012,17 +6246,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087474749Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431356887Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1458 to outside:100.66.98.44/8271 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -6039,15 +6270,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -6058,17 +6295,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087479372Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431358749Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1459 to outside:100.66.98.44/8272 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -6085,15 +6319,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -6104,17 +6344,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087484053Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431360216Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1460 to outside:100.66.98.44/8273 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -6148,6 +6385,9 @@
                 "address": "100.66.115.46",
                 "ip": "100.66.115.46"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 575,
                 "iana_number": "6",
@@ -6188,9 +6428,9 @@
             "event": {
                 "severity": 6,
                 "duration": 325000000000,
-                "ingested": "2021-05-13T11:40:32.087488681Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431361727Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11564 for outside:100.66.115.46/80 to inside:172.31.156.80/1382 duration 0:05:25 bytes 575 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:29:31.000Z",
                 "action": "flow-expiration",
@@ -6230,6 +6470,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 5391,
                 "iana_number": "6",
@@ -6270,9 +6513,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.087493414Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431363080Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11797 for outside:100.66.19.254/80 to inside:172.31.156.80/1385 duration 0:00:00 bytes 5391 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -6312,6 +6555,9 @@
                 "address": "172.31.156.80",
                 "ip": "172.31.156.80"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -6350,9 +6596,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087498119Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431364513Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.156.80/1386 to outside:100.66.98.44/8278",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -6388,6 +6634,9 @@
                 "address": "100.66.115.46",
                 "ip": "100.66.115.46"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -6427,9 +6676,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087502781Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431365964Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11798 for outside:100.66.115.46/80 (100.66.115.46/80) to inside:172.31.156.80/1386 (172.31.156.80/1386)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -6470,6 +6719,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -6508,9 +6760,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.087507409Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431367421Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -6549,6 +6801,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -6587,9 +6842,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.087512064Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431368778Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -6628,6 +6883,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -6666,9 +6924,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.087516742Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431370158Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -6707,6 +6965,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -6745,9 +7006,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.087521467Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431371518Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -6786,6 +7047,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -6824,9 +7088,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.087526092Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431373137Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -6865,6 +7129,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -6903,9 +7170,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.087530694Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431374521Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -6944,6 +7211,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -6982,9 +7252,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.087535362Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431375991Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -7023,6 +7293,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -7061,9 +7334,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.087539973Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431377458Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -7102,6 +7375,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -7140,9 +7416,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.087544577Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431378836Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -7181,6 +7457,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -7219,9 +7498,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.087549182Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431380179Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -7260,6 +7539,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -7298,9 +7580,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.087553802Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431381808Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -7339,6 +7621,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -7377,9 +7662,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.087558455Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431383354Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -7418,6 +7703,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -7456,9 +7744,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.087576043Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431384724Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -7497,6 +7785,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -7535,9 +7826,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087582585Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431386254Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1275 to outside:100.66.98.44/8279",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -7573,6 +7864,9 @@
                 "address": "100.66.205.99",
                 "ip": "100.66.205.99"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -7612,9 +7906,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087587432Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431387618Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11799 for outside:100.66.205.99/80 (100.66.205.99/80) to inside:172.31.98.44/1275 (172.31.98.44/1275)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -7655,6 +7949,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -7693,9 +7990,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087592231Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431389066Z",
                 "original": "%ASA-6-305011: Built dynamic UDP translation from inside:172.31.98.44/56132 to outside:100.66.98.44/1190",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -7731,6 +8028,9 @@
                 "address": "100.66.14.30",
                 "ip": "100.66.14.30"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -7770,9 +8070,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087597027Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:06.431390525Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11800 for outside:100.66.14.30/53 (100.66.14.30/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -7813,6 +8113,9 @@
                 "address": "100.66.14.30",
                 "ip": "100.66.14.30"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 373,
                 "iana_number": "17",
@@ -7853,9 +8156,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.087601811Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431391957Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11800 for outside:100.66.14.30/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 373",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -7895,6 +8198,9 @@
                 "address": "100.66.252.210",
                 "ip": "100.66.252.210"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -7934,9 +8240,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087606512Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:06.431393347Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11801 for outside:100.66.252.210/53 (100.66.252.210/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -7977,6 +8283,9 @@
                 "address": "100.66.252.210",
                 "ip": "100.66.252.210"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 207,
                 "iana_number": "17",
@@ -8017,9 +8326,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.087611183Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431394683Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11801 for outside:100.66.252.210/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 207",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -8059,6 +8368,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -8097,9 +8409,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.087615891Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431396082Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1276 to outside:100.66.98.44/8280",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -8135,6 +8447,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -8174,9 +8489,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088499665Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431397665Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11802 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1276 (172.31.98.44/1276)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -8217,6 +8532,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -8255,9 +8573,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088510886Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431399066Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1277 to outside:100.66.98.44/8281",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -8293,6 +8611,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -8332,9 +8653,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088516104Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431401034Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11803 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1277 (172.31.98.44/1277)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -8375,6 +8696,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 12853,
                 "iana_number": "6",
@@ -8415,9 +8739,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088520916Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431402520Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11802 for outside:100.66.98.165/80 to inside:172.31.98.44/1276 duration 0:00:00 bytes 12853 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -8457,6 +8781,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -8495,9 +8822,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088525681Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431403885Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1278 to outside:100.66.98.44/8282",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -8533,6 +8860,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -8572,9 +8902,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088530455Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431405263Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11804 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1278 (172.31.98.44/1278)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -8615,6 +8945,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 5291,
                 "iana_number": "6",
@@ -8655,9 +8988,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088535617Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431407937Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11803 for outside:100.66.98.165/80 to inside:172.31.98.44/1277 duration 0:00:00 bytes 5291 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -8697,6 +9030,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -8735,9 +9071,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088540292Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431409568Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1279 to outside:100.66.98.44/8283",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -8773,6 +9109,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -8812,9 +9151,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088545132Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431411170Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11805 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1279 (172.31.98.44/1279)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -8855,6 +9194,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 965,
                 "iana_number": "6",
@@ -8895,9 +9237,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088549789Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431413113Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11804 for outside:100.66.98.165/80 to inside:172.31.98.44/1278 duration 0:00:00 bytes 965 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -8937,6 +9279,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 8605,
                 "iana_number": "6",
@@ -8977,9 +9322,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088554465Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431414658Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11805 for outside:100.66.98.165/80 to inside:172.31.98.44/1279 duration 0:00:00 bytes 8605 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -9019,6 +9364,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -9057,9 +9405,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088559143Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431416209Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1280 to outside:100.66.98.44/8284",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -9095,6 +9443,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -9134,9 +9485,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088583384Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431417787Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11806 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1280 (172.31.98.44/1280)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -9177,6 +9528,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 3428,
                 "iana_number": "6",
@@ -9217,9 +9571,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088595499Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431419137Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11806 for outside:100.66.98.165/80 to inside:172.31.98.44/1280 duration 0:00:00 bytes 3428 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -9259,6 +9613,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -9297,9 +9654,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088603908Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431420501Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1281 to outside:100.66.98.44/8285",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -9335,6 +9692,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -9374,9 +9734,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088609405Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431421858Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11807 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1281 (172.31.98.44/1281)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -9417,6 +9777,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -9455,9 +9818,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088614250Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431423507Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1282 to outside:100.66.98.44/8286",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -9493,6 +9856,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -9532,9 +9898,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088619018Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431425053Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11808 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1282 (172.31.98.44/1282)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -9575,6 +9941,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -9613,9 +9982,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088623753Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431426420Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1283 to outside:100.66.98.44/8287",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -9651,6 +10020,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -9690,9 +10062,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088628530Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431427777Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11809 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1283 (172.31.98.44/1283)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -9733,6 +10105,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -9771,9 +10146,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088633278Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431429230Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1284 to outside:100.66.98.44/8288",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -9809,6 +10184,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -9848,9 +10226,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088637920Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431430580Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11810 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1284 (172.31.98.44/1284)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -9891,6 +10269,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 2028,
                 "iana_number": "6",
@@ -9931,9 +10312,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088642699Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431432472Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11807 for outside:100.66.98.165/80 to inside:172.31.98.44/1281 duration 0:00:00 bytes 2028 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -9973,6 +10354,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 1085,
                 "iana_number": "6",
@@ -10013,9 +10397,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088647431Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431433949Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11808 for outside:100.66.98.165/80 to inside:172.31.98.44/1282 duration 0:00:00 bytes 1085 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -10055,6 +10439,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 868,
                 "iana_number": "6",
@@ -10095,9 +10482,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088652142Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431435406Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11809 for outside:100.66.98.165/80 to inside:172.31.98.44/1283 duration 0:00:00 bytes 868 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -10137,6 +10524,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -10175,9 +10565,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088656823Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431436769Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1285 to outside:100.66.98.44/8289",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -10213,6 +10603,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -10252,9 +10645,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088661530Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431438167Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11811 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1285 (172.31.98.44/1285)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -10295,6 +10688,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -10333,9 +10729,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088666256Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431439517Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1286 to outside:100.66.98.44/8290",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -10371,6 +10767,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -10410,9 +10809,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088671002Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431441001Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11812 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1286 (172.31.98.44/1286)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -10453,6 +10852,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 4439,
                 "iana_number": "6",
@@ -10493,9 +10895,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088675701Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431442414Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11810 for outside:100.66.98.165/80 to inside:172.31.98.44/1284 duration 0:00:00 bytes 4439 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -10535,6 +10937,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -10573,9 +10978,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088680407Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431443836Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1287 to outside:100.66.98.44/8291",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -10611,6 +11016,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -10650,9 +11058,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088685070Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431445246Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11813 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1287 (172.31.98.44/1287)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -10693,6 +11101,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 914,
                 "iana_number": "6",
@@ -10733,9 +11144,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088689861Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431446673Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11811 for outside:100.66.98.165/80 to inside:172.31.98.44/1285 duration 0:00:00 bytes 914 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -10775,6 +11186,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 871,
                 "iana_number": "6",
@@ -10815,9 +11229,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088694561Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431448159Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11812 for outside:100.66.98.165/80 to inside:172.31.98.44/1286 duration 0:00:00 bytes 871 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -10857,6 +11271,9 @@
                 "address": "100.66.100.107",
                 "ip": "100.66.100.107"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -10896,9 +11313,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088699289Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:06.431449989Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11814 for outside:100.66.100.107/53 (100.66.100.107/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -10939,6 +11356,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -10977,9 +11397,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088703967Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431451822Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1288 to outside:100.66.98.44/8292",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -11015,6 +11435,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -11054,9 +11477,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088708709Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431453871Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11815 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1288 (172.31.98.44/1288)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -11097,6 +11520,9 @@
                 "address": "100.66.100.107",
                 "ip": "100.66.100.107"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 384,
                 "iana_number": "17",
@@ -11137,9 +11563,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088713453Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431455406Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11814 for outside:100.66.100.107/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 384",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -11179,6 +11605,9 @@
                 "address": "100.66.104.8",
                 "ip": "100.66.104.8"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -11218,9 +11647,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088718074Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:06.431456846Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11816 for outside:100.66.104.8/53 (100.66.104.8/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -11261,6 +11690,9 @@
                 "address": "100.66.104.8",
                 "ip": "100.66.104.8"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 94,
                 "iana_number": "17",
@@ -11301,9 +11733,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088722761Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431458578Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11816 for outside:100.66.104.8/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 94",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -11343,6 +11775,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -11381,9 +11816,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088727483Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431460168Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1289 to outside:100.66.98.44/8293",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -11419,6 +11854,9 @@
                 "address": "100.66.123.191",
                 "ip": "100.66.123.191"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -11458,9 +11896,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088732299Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431461711Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11817 for outside:100.66.123.191/80 (100.66.123.191/80) to inside:172.31.98.44/1289 (172.31.98.44/1289)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -11501,6 +11939,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 945,
                 "iana_number": "6",
@@ -11541,9 +11982,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088739805Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431463095Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11815 for outside:100.66.98.165/80 to inside:172.31.98.44/1288 duration 0:00:00 bytes 945 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -11583,6 +12024,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 13284,
                 "iana_number": "6",
@@ -11623,9 +12067,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088745133Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431465784Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11813 for outside:100.66.98.165/80 to inside:172.31.98.44/1287 duration 0:00:00 bytes 13284 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -11665,6 +12109,9 @@
                 "address": "100.66.100.4",
                 "ip": "100.66.100.4"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -11704,9 +12151,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088749922Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:06.431467509Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11818 for outside:100.66.100.4/53 (100.66.100.4/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -11747,6 +12194,9 @@
                 "address": "100.66.100.4",
                 "ip": "100.66.100.4"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 104,
                 "iana_number": "17",
@@ -11787,9 +12237,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088754636Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431469185Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11818 for outside:100.66.100.4/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 104",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -11829,6 +12279,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -11867,9 +12320,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088759425Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431470641Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1290 to outside:100.66.98.44/8294",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -11905,6 +12358,9 @@
                 "address": "100.66.198.25",
                 "ip": "100.66.198.25"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -11944,9 +12400,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088764111Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431472117Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11819 for outside:100.66.198.25/80 (100.66.198.25/80) to inside:172.31.98.44/1290 (172.31.98.44/1290)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -11987,6 +12443,9 @@
                 "address": "100.66.48.1",
                 "ip": "100.66.48.1"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 58512,
                 "iana_number": "17",
@@ -12027,9 +12486,9 @@
             "event": {
                 "severity": 6,
                 "duration": 3526000000000,
-                "ingested": "2021-05-13T11:40:32.088768789Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431473464Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 9828 for outside:100.66.48.1/67 to NP Identity Ifc:255.255.255.255/68 duration 0:58:46 bytes 58512",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T11:36:10.000Z",
                 "action": "flow-expiration",
@@ -12052,15 +12511,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -12071,17 +12536,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088773418Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431474859Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1272 to outside:100.66.98.44/8276 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -12115,6 +12577,9 @@
                 "address": "100.66.3.39",
                 "ip": "100.66.3.39"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -12154,9 +12619,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088778083Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:06.431476363Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11820 for outside:100.66.3.39/53 (100.66.3.39/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -12197,6 +12662,9 @@
                 "address": "100.66.162.30",
                 "ip": "100.66.162.30"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -12236,9 +12704,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088782791Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:06.431477739Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11821 for outside:100.66.162.30/53 (100.66.162.30/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -12279,6 +12747,9 @@
                 "address": "100.66.3.39",
                 "ip": "100.66.3.39"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 168,
                 "iana_number": "17",
@@ -12319,9 +12790,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088787448Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431479081Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11820 for outside:100.66.3.39/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 168",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -12361,6 +12832,9 @@
                 "address": "100.66.3.39",
                 "ip": "100.66.3.39"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -12400,9 +12874,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088792124Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:06.431480479Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11822 for outside:100.66.3.39/53 (100.66.3.39/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -12443,6 +12917,9 @@
                 "address": "100.66.162.30",
                 "ip": "100.66.162.30"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 198,
                 "iana_number": "17",
@@ -12483,9 +12960,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088796802Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431481824Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11821 for outside:100.66.162.30/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 198",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -12525,6 +13002,9 @@
                 "address": "100.66.3.39",
                 "ip": "100.66.3.39"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 150,
                 "iana_number": "17",
@@ -12565,9 +13045,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088812525Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431483298Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11822 for outside:100.66.3.39/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 150",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -12607,6 +13087,9 @@
                 "address": "100.66.48.186",
                 "ip": "100.66.48.186"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -12646,9 +13129,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088820298Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:06.431484661Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11823 for outside:100.66.48.186/53 (100.66.48.186/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -12689,6 +13172,9 @@
                 "address": "100.66.48.186",
                 "ip": "100.66.48.186"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 84,
                 "iana_number": "17",
@@ -12729,9 +13215,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088824948Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431486033Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11823 for outside:100.66.48.186/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 84",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -12771,6 +13257,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -12809,9 +13298,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088829627Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431487385Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1291 to outside:100.66.98.44/8295",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -12847,6 +13336,9 @@
                 "address": "100.66.54.190",
                 "ip": "100.66.54.190"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -12886,9 +13378,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088834199Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431488748Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11824 for outside:100.66.54.190/80 (100.66.54.190/80) to inside:172.31.98.44/1291 (172.31.98.44/1291)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -12929,6 +13421,9 @@
                 "address": "100.66.254.94",
                 "ip": "100.66.254.94"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -12968,9 +13463,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088845833Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:06.431490584Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11825 for outside:100.66.254.94/53 (100.66.254.94/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -13011,6 +13506,9 @@
                 "address": "100.66.254.94",
                 "ip": "100.66.254.94"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 188,
                 "iana_number": "17",
@@ -13051,9 +13549,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088851565Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431492184Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11825 for outside:100.66.254.94/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 188",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -13093,6 +13591,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -13131,9 +13632,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088856300Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431493866Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1292 to outside:100.66.98.44/8296",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -13169,6 +13670,9 @@
                 "address": "100.66.54.190",
                 "ip": "100.66.54.190"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -13208,9 +13712,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088860974Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431495239Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11826 for outside:100.66.54.190/80 (100.66.54.190/80) to inside:172.31.98.44/1292 (172.31.98.44/1292)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -13251,6 +13755,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -13289,9 +13796,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088871564Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431496582Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1293 to outside:100.66.98.44/8297",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -13327,6 +13834,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -13366,9 +13876,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088876938Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431498122Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11827 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1293 (172.31.98.44/1293)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -13409,6 +13919,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -13447,9 +13960,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088881601Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431499561Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1294 to outside:100.66.98.44/8298",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -13485,6 +13998,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -13524,9 +14040,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088886264Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431500950Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11828 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1294 (172.31.98.44/1294)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -13567,6 +14083,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 5964,
                 "iana_number": "6",
@@ -13607,9 +14126,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088890877Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431502398Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11827 for outside:100.66.98.165/80 to inside:172.31.98.44/1293 duration 0:00:00 bytes 5964 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -13649,6 +14168,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -13687,9 +14209,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088902184Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431503763Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1295 to outside:100.66.98.44/8299",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -13725,6 +14247,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -13764,9 +14289,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088906899Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431505108Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11829 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1295 (172.31.98.44/1295)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -13807,6 +14332,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -13845,9 +14373,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088911545Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431506640Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1296 to outside:100.66.98.44/8300",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -13883,6 +14411,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -13922,9 +14453,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088916138Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431508106Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11830 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1296 (172.31.98.44/1296)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -13965,6 +14496,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 6694,
                 "iana_number": "6",
@@ -14005,9 +14539,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088926320Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431509643Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11828 for outside:100.66.98.165/80 to inside:172.31.98.44/1294 duration 0:00:00 bytes 6694 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -14047,6 +14581,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 1493,
                 "iana_number": "6",
@@ -14087,9 +14624,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088932718Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431513505Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11829 for outside:100.66.98.165/80 to inside:172.31.98.44/1295 duration 0:00:00 bytes 1493 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -14129,6 +14666,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 893,
                 "iana_number": "6",
@@ -14169,9 +14709,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088937443Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431514986Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11830 for outside:100.66.98.165/80 to inside:172.31.98.44/1296 duration 0:00:00 bytes 893 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -14211,6 +14751,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -14249,9 +14792,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088942144Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431516284Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1297 to outside:100.66.98.44/8301",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -14287,6 +14830,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -14326,9 +14872,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088946741Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431517661Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11831 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1297 (172.31.98.44/1297)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -14369,6 +14915,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -14407,9 +14956,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088956894Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431519201Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1298 to outside:100.66.98.44/8302",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -14445,6 +14994,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -14484,9 +15036,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088963023Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431521404Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11832 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1298 (172.31.98.44/1298)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -14527,6 +15079,9 @@
                 "address": "100.66.179.9",
                 "ip": "100.66.179.9"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -14566,9 +15121,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088967686Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:06.431524206Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11833 for outside:100.66.179.9/53 (100.66.179.9/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -14609,6 +15164,9 @@
                 "address": "100.66.179.9",
                 "ip": "100.66.179.9"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 150,
                 "iana_number": "17",
@@ -14649,9 +15207,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088972306Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431525854Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11833 for outside:100.66.179.9/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 150",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -14691,6 +15249,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 2750,
                 "iana_number": "6",
@@ -14731,9 +15292,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.088976925Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431527497Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11831 for outside:100.66.98.165/80 to inside:172.31.98.44/1297 duration 0:00:00 bytes 2750 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -14773,6 +15334,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -14811,9 +15375,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088987833Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431528818Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1299 to outside:100.66.98.44/8303",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -14849,6 +15413,9 @@
                 "address": "100.66.247.99",
                 "ip": "100.66.247.99"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -14888,9 +15455,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088993318Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431530135Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11834 for outside:100.66.247.99/80 (100.66.247.99/80) to inside:172.31.98.44/1299 (172.31.98.44/1299)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -14931,6 +15498,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -14969,9 +15539,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.088998007Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431531538Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1300 to outside:100.66.98.44/8304",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15007,6 +15577,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -15046,9 +15619,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089002713Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431532845Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11835 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1300 (172.31.98.44/1300)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15089,6 +15662,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 881,
                 "iana_number": "6",
@@ -15129,9 +15705,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.089012073Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431534335Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11832 for outside:100.66.98.165/80 to inside:172.31.98.44/1298 duration 0:00:00 bytes 881 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -15171,6 +15747,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 2202,
                 "iana_number": "6",
@@ -15211,9 +15790,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.089019111Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431535820Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11835 for outside:100.66.98.165/80 to inside:172.31.98.44/1300 duration 0:00:00 bytes 2202 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -15253,6 +15832,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -15291,9 +15873,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089023747Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431537219Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1301 to outside:100.66.98.44/8305",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15329,6 +15911,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -15368,9 +15953,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089028361Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431538667Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11836 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1301 (172.31.98.44/1301)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15411,6 +15996,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -15449,9 +16037,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089033027Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431540356Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1302 to outside:100.66.98.44/8306",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15487,6 +16075,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -15526,9 +16117,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089037636Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431541669Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11837 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1302 (172.31.98.44/1302)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15552,15 +16143,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -15571,17 +16168,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089042350Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431543265Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1276 to outside:100.66.98.44/8280 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15598,15 +16192,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -15617,17 +16217,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089047057Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431544721Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1277 to outside:100.66.98.44/8281 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15644,15 +16241,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -15663,17 +16266,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089051641Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431546391Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1278 to outside:100.66.98.44/8282 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15690,15 +16290,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -15709,17 +16315,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089056289Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431547856Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1279 to outside:100.66.98.44/8283 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15736,15 +16339,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -15755,17 +16364,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089060982Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431549558Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1280 to outside:100.66.98.44/8284 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15782,15 +16388,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -15801,17 +16413,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089065578Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431550874Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1281 to outside:100.66.98.44/8285 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15828,15 +16437,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -15847,17 +16462,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089070219Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431552553Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1282 to outside:100.66.98.44/8286 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15874,15 +16486,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -15893,17 +16511,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089074815Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431553978Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1283 to outside:100.66.98.44/8287 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15920,15 +16535,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -15939,17 +16560,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089079464Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431555605Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1284 to outside:100.66.98.44/8288 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15966,15 +16584,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -15985,17 +16609,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089084063Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431557106Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1285 to outside:100.66.98.44/8289 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16012,15 +16633,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -16031,17 +16658,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089088677Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431558446Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1286 to outside:100.66.98.44/8290 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16058,15 +16682,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -16077,17 +16707,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089093247Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431559748Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1287 to outside:100.66.98.44/8291 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16104,15 +16731,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -16123,17 +16756,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089097892Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431561285Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1288 to outside:100.66.98.44/8292 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16150,15 +16780,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -16169,17 +16805,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089102537Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431562695Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1293 to outside:100.66.98.44/8297 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16196,15 +16829,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -16215,17 +16854,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089107220Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431564029Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1294 to outside:100.66.98.44/8298 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16259,6 +16895,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -16297,9 +16936,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089111856Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431632296Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1304 to outside:100.66.98.44/8308",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16335,6 +16974,9 @@
                 "address": "100.66.205.99",
                 "ip": "100.66.205.99"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -16374,9 +17016,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089116479Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431635152Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11840 for outside:100.66.205.99/80 (100.66.205.99/80) to inside:172.31.98.44/1304 (172.31.98.44/1304)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16400,15 +17042,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -16419,17 +17067,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089121178Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431636870Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1295 to outside:100.66.98.44/8299 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16446,15 +17091,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -16465,17 +17116,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089132185Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431638854Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1296 to outside:100.66.98.44/8300 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16509,6 +17157,9 @@
                 "address": "100.66.0.124",
                 "ip": "100.66.0.124"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -16548,9 +17199,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089138791Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:06.431640314Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11841 for outside:100.66.0.124/53 (100.66.0.124/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16591,6 +17242,9 @@
                 "address": "100.66.160.2",
                 "ip": "100.66.160.2"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -16630,9 +17284,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089143445Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:06.431641650Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11842 for outside:100.66.160.2/53 (100.66.160.2/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16673,6 +17327,9 @@
                 "address": "100.66.0.124",
                 "ip": "100.66.0.124"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 318,
                 "iana_number": "17",
@@ -16713,9 +17370,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.089148066Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431643083Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11841 for outside:100.66.0.124/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 318",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -16755,6 +17412,9 @@
                 "address": "100.66.160.2",
                 "ip": "100.66.160.2"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 104,
                 "iana_number": "17",
@@ -16795,9 +17455,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:32.089152735Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:06.431646431Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11842 for outside:100.66.160.2/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 104",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -16837,6 +17497,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -16875,9 +17538,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089163179Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431648485Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1305 to outside:100.66.98.44/8309",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16913,6 +17576,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -16952,9 +17618,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089168825Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431650031Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11843 for outside:100.66.124.24/80 (100.66.124.24/80) to inside:172.31.98.44/1305 (172.31.98.44/1305)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16978,15 +17644,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -16997,17 +17669,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089173521Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431651730Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1297 to outside:100.66.98.44/8301 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17024,15 +17693,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -17043,17 +17718,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089178162Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431653233Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1298 to outside:100.66.98.44/8302 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17070,15 +17742,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -17089,17 +17767,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089182947Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431654843Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1299 to outside:100.66.98.44/8303 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17116,15 +17791,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -17135,17 +17816,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089194181Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431656234Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1300 to outside:100.66.98.44/8304 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17162,15 +17840,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -17181,17 +17865,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089199071Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431657841Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1301 to outside:100.66.98.44/8305 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17208,15 +17889,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -17227,17 +17914,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089203752Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431659361Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1302 to outside:100.66.98.44/8306 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17254,15 +17938,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -17273,17 +17963,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089208450Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:06.431660725Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1303 to outside:100.66.98.44/8307 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17317,6 +18004,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 410333,
                 "iana_number": "6",
@@ -17357,9 +18047,9 @@
             "event": {
                 "severity": 6,
                 "duration": 4000000000,
-                "ingested": "2021-05-13T11:40:32.089217980Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:06.431662140Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11843 for outside:100.66.124.24/80 to inside:172.31.98.44/1305 duration 0:00:04 bytes 410333 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:52.000Z",
                 "action": "flow-expiration",
@@ -17399,6 +18089,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -17437,9 +18130,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089224836Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431663540Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17478,6 +18171,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -17516,9 +18212,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089229500Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431665217Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17557,6 +18253,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -17595,9 +18294,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089234091Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431666647Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17636,6 +18335,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -17674,9 +18376,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089238796Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:06.431668062Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1306 to outside:100.66.98.44/8310",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17712,6 +18414,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -17751,9 +18456,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:32.089243437Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:06.431669449Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11844 for outside:100.66.124.24/80 (100.66.124.24/80) to inside:172.31.98.44/1306 (172.31.98.44/1306)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17794,6 +18499,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -17832,9 +18540,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089248075Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431671086Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17873,6 +18581,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -17911,9 +18622,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089252756Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431672531Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17952,6 +18663,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -17990,9 +18704,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089257449Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431704979Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18031,6 +18745,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18069,9 +18786,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089265024Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431707174Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18110,6 +18827,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18148,9 +18868,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089270110Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431709048Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18189,6 +18909,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18227,9 +18950,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089274784Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431710759Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18268,6 +18991,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18306,9 +19032,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089279480Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431712176Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18347,6 +19073,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18385,9 +19114,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089284091Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431713696Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18426,6 +19155,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18464,9 +19196,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089288790Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431715222Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18505,6 +19237,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18543,9 +19278,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089296736Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431716593Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18584,6 +19319,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18622,9 +19360,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089303196Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431718891Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18663,6 +19401,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18701,9 +19442,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089317218Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431720469Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18742,6 +19483,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18780,9 +19524,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089323273Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431722322Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18821,6 +19565,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18859,9 +19606,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089328214Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431723701Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18900,6 +19647,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18938,9 +19688,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089332964Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431725106Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18979,6 +19729,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19017,9 +19770,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089337743Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431726519Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -19058,6 +19811,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19096,9 +19852,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089342524Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431727908Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -19137,6 +19893,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19175,9 +19934,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089347312Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431729417Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -19216,6 +19975,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19254,9 +20016,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089352103Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431730924Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -19295,6 +20057,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19333,9 +20098,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089356912Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431733725Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -19374,6 +20139,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19412,9 +20180,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089361687Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431735326Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -19453,6 +20221,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19491,9 +20262,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089366495Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431736689Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -19532,6 +20303,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19570,9 +20344,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089371267Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431738015Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -19611,6 +20385,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19649,9 +20426,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089376041Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431739701Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -19690,6 +20467,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19728,9 +20508,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089380784Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431741056Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -19769,6 +20549,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19807,9 +20590,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089385575Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431742399Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -19848,6 +20631,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19886,9 +20672,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089390178Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431743725Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -19927,6 +20713,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19965,9 +20754,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089394843Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431745057Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -20006,6 +20795,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -20044,9 +20836,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089399485Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431746471Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -20085,6 +20877,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -20123,9 +20918,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089404177Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431747854Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -20164,6 +20959,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -20202,9 +21000,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089408851Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431749289Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -20243,6 +21041,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -20281,9 +21082,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089413778Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431750641Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -20322,6 +21123,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -20360,9 +21164,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:32.089418434Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:06.431751978Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-common-config.yml
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-common-config.yml
@@ -1,0 +1,5 @@
+dynamic_fields:
+  event.ingested: "^.*$"
+fields:
+  tags:
+    - preserve_original_event

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-dap-records.log-config.yml
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-dap-records.log-config.yml
@@ -1,6 +1,0 @@
-dynamic_fields:
-  event.ingested: ".*"
-numeric_keyword_fields:
-  - "network.iana_number"
-  - "event.code"
-  - "syslog.facility"

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-dap-records.log-expected.json
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-dap-records.log-expected.json
@@ -1,20 +1,6 @@
 {
     "expected": [
         {
-            "observer": {
-                "type": "firewall",
-                "product": "asa",
-                "vendor": "Cisco"
-            },
-            "@timestamp": "2020-02-20T16:11:11.000Z",
-            "ecs": {
-                "version": "1.9.0"
-            },
-            "related": {
-                "ip": [
-                    "1.2.3.4"
-                ]
-            },
             "log": {
                 "level": "informational"
             },
@@ -34,11 +20,28 @@
                 "address": "1.2.3.4",
                 "ip": "1.2.3.4"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "observer": {
+                "type": "firewall",
+                "product": "asa",
+                "vendor": "Cisco"
+            },
+            "@timestamp": "2020-02-20T16:11:11.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "related": {
+                "ip": [
+                    "1.2.3.4"
+                ]
+            },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:58.488612539Z",
-                "code": "734001",
+                "ingested": "2021-06-03T06:53:17.841860845Z",
                 "original": "%ASA-6-734001: DAP: User firsname.lastname@domain.net, Addr 1.2.3.4, Connection AnyConnect: The following DAP records were selected for this connection: dap_1, dap_2",
+                "code": "734001",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-filtered.log-config.yml
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-filtered.log-config.yml
@@ -1,7 +1,0 @@
-dynamic_fields:
-  event.ingested: "^.*$"
-  "@timestamp": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}Z$"
-numeric_keyword_fields:
-  - "network.iana_number"
-  - "event.code"
-  - "syslog.facility"

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-filtered.log-expected.json
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-filtered.log-expected.json
@@ -1,15 +1,21 @@
 {
     "expected": [
         {
+            "process": {
+                "name": "asa",
+                "pid": 1234
+            },
+            "log": {
+                "level": "debug"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "beats",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "asa",
-                "pid": 1234
             },
             "@timestamp": "2021-01-01T01:00:27.000Z",
             "ecs": {
@@ -20,17 +26,14 @@
                     "beats"
                 ]
             },
-            "log": {
-                "level": "debug"
-            },
             "host": {
                 "hostname": "beats"
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:40:58.585656707Z",
-                "code": "999999",
+                "ingested": "2021-06-03T06:53:17.883071783Z",
                 "original": "%ASA-7-999999: This message is not filtered.",
+                "code": "999999",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -66,15 +69,14 @@
                     "beats"
                 ]
             },
-            "log": {},
             "host": {
                 "hostname": "beats"
             },
             "event": {
                 "severity": 8,
-                "ingested": "2021-05-13T11:40:58.585669320Z",
-                "code": "999999",
+                "ingested": "2021-06-03T06:53:17.883078107Z",
                 "original": "%ASA-8-999999: This phony message is dropped due to log level.",
+                "code": "999999",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -88,7 +90,10 @@
                 "asa": {
                     "message_id": "999999"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "process": {
@@ -108,6 +113,9 @@
                 "address": "10.13.12.11",
                 "ip": "10.13.12.11"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -142,9 +150,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:40:58.585672459Z",
-                "code": "106001",
+                "ingested": "2021-06-03T06:53:17.883079554Z",
                 "original": "%ASA-2-106001: Inbound TCP connection denied from 10.13.12.11/45321 to 192.168.33.12/443 flags URG+SYN+RST on interface eth0",
+                "code": "106001",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-hostnames.log-config.yml
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-hostnames.log-config.yml
@@ -1,6 +1,0 @@
-dynamic_fields:
-  event.ingested: ".*"
-numeric_keyword_fields:
-  - "network.iana_number"
-  - "event.code"
-  - "syslog.facility"

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-hostnames.log-expected.json
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-hostnames.log-expected.json
@@ -13,6 +13,9 @@
                 },
                 "domain": "Prod-host.name.addr"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "1",
                 "transport": "icmp"
@@ -39,9 +42,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:58.862823612Z",
-                "code": "302021",
+                "ingested": "2021-06-03T06:53:17.973899722Z",
                 "original": "%ASA-6-302021: Teardown ICMP connection for faddr target.destination.hostname.local/10005 gaddr 10.0.55.66/0 laddr Prod-host.name.addr/0",
+                "code": "302021",
                 "kind": "event",
                 "action": "flow-expiration",
                 "category": [
@@ -71,6 +74,9 @@
                 "address": "192.0.2.134",
                 "ip": "192.0.2.134"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "1",
                 "transport": "icmp"
@@ -99,9 +105,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:58.862835303Z",
-                "code": "302021",
+                "ingested": "2021-06-03T06:53:17.973906007Z",
                 "original": "%ASA-6-302021: Teardown ICMP connection for faddr 192.0.2.15/0 gaddr 192.0.2.134/57808 laddr 192.0.2.134/57808 type 8 code 0",
+                "code": "302021",
                 "kind": "event",
                 "action": "flow-expiration",
                 "category": [

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-not-ip.log-config.yml
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-not-ip.log-config.yml
@@ -1,6 +1,0 @@
-dynamic_fields:
-  event.ingested: ".*"
-numeric_keyword_fields:
-  - "network.iana_number"
-  - "event.code"
-  - "syslog.facility"

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-not-ip.log-expected.json
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-not-ip.log-expected.json
@@ -19,6 +19,9 @@
                 "address": "WHAT-IS-THIS-A-HOSTNAME-192.0.2.244",
                 "domain": "WHAT-IS-THIS-A-HOSTNAME-192.0.2.244"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -52,9 +55,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:59.026679814Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:18.043769675Z",
                 "original": "%ASA-5-106100: access-list AL-DMZ-LB-IN denied tcp LB-DMZ/WHAT-IS-THIS-A-HOSTNAME-192.0.2.244(27218) -\u003e OUTSIDE/203.0.113.42(53) hit-cnt 1 first hit [0x16847359, 0x00000000]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -87,6 +90,9 @@
                 "address": "192.168.132.46",
                 "ip": "192.168.132.46"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "1",
                 "transport": "icmp"
@@ -115,9 +121,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:59.026691754Z",
-                "code": "302021",
+                "ingested": "2021-06-03T06:53:18.043776014Z",
                 "original": "%ASA-6-302021: Teardown ICMP connection for faddr 172.24.177.29/0 gaddr mydomain.example.net/17233 laddr 192.168.132.46/17233",
+                "code": "302021",
                 "kind": "event",
                 "action": "flow-expiration",
                 "category": [
@@ -156,6 +162,9 @@
                 "port": 1234,
                 "ip": "10.10.10.1"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -195,9 +204,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:59.026694925Z",
-                "code": "338204",
+                "ingested": "2021-06-03T06:53:18.043777511Z",
                 "original": "%ASA-4-338204: Dynamic filter dropped greylisted TCP traffic from eth0:10.10.10.1/1234 (source.example.net/11234) to wan:172.24.177.3/80 (www.example.org/80), destination malicious address resolved from dynamic list: example.org, threat-level: high, category: malware",
+                "code": "338204",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-sample.log-config.yml
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-sample.log-config.yml
@@ -1,6 +1,0 @@
-dynamic_fields:
-  event.ingested: ".*"
-numeric_keyword_fields:
-  - "network.iana_number"
-  - "event.code"
-  - "syslog.facility"

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-sample.log-expected.json
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-sample.log-expected.json
@@ -14,6 +14,9 @@
                 "address": "10.1.2.30",
                 "ip": "10.1.2.30"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -45,9 +48,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:59.328204939Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:18.181444336Z",
                 "original": "%ASA-4-106023: Deny tcp src dmz:10.1.2.30/63016 dst outside:192.0.0.8/53 by access-group \"acl_dmz\" [0xe3aab522, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -82,6 +85,9 @@
                 "address": "10.1.2.30",
                 "ip": "10.1.2.30"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -113,9 +119,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:59.328216206Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:18.181451436Z",
                 "original": "%ASA-4-106023: Deny tcp src dmz:10.1.2.30/63016 dst outside:192.0.0.8/53 type 3, code 0, by access-group \"acl_dmz\" [0xe3aab522, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -150,6 +156,9 @@
                 "address": "10.1.2.16",
                 "ip": "10.1.2.16"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -181,9 +190,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:59.328219351Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:18.181452896Z",
                 "original": "%ASA-session-5-106100: access-list acl_in permitted tcp inside/10.1.2.16(2241) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -219,6 +228,9 @@
                 "address": "172.29.2.101",
                 "ip": "172.29.2.101"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -257,9 +269,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:59.328222194Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:18.181454234Z",
                 "original": "%ASA-6-106100: access-list inside denied udp inside/172.29.2.101(1039) -\u003e outside/192.0.2.10(53) hit-cnt 1 first hit [0xd820e56a, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -294,6 +306,9 @@
                 "address": "172.29.2.3",
                 "ip": "172.29.2.3"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -332,9 +347,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:59.328225050Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:18.181456398Z",
                 "original": "%ASA-6-106100: access-list inside permitted udp inside/172.29.2.3(1065) -\u003e outside/192.0.2.57(53) hit-cnt 144 300-second interval [0xe982c7a4, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -369,6 +384,9 @@
                 "address": "10.123.3.42",
                 "ip": "10.123.3.42"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -400,9 +418,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:59.328227852Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:18.181457810Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from outside:10.123.3.42/4952 to outside:192.0.2.130/12834",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -437,6 +455,9 @@
                 "address": "192.0.2.43",
                 "ip": "192.0.2.43"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -469,9 +490,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:59.328230644Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:18.181459158Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 89743274 for outside:192.0.2.43/443 (192.0.2.43/443) to outside:10.123.3.42/4952 (10.123.3.42.130/12834)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -508,6 +529,9 @@
                 "address": "10.123.1.35",
                 "ip": "10.123.1.35"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -539,9 +563,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:59.328233470Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:18.181460449Z",
                 "original": "%ASA-6-305011: Built dynamic UDP translation from outside:10.123.1.35/52925 to outside:192.0.2.130/25882",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -579,6 +603,9 @@
                 "port": 53,
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -611,9 +638,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:59.328236289Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:18.181461766Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 89743275 for outside:192.0.2.222/53 (192.0.2.43/53) to outside:10.123.1.35/52925 (10.123.1.35/25882)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -650,6 +677,9 @@
                 "address": "10.123.3.42",
                 "ip": "10.123.3.42"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -681,9 +711,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:59.328239087Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:18.181463032Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from outside:10.123.3.42/4953 to outside:192.0.2.130/45392",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -719,6 +749,9 @@
                 "address": "192.0.2.1",
                 "ip": "192.0.2.1"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -751,9 +784,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:59.328241891Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:18.181464385Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 89743276 for outside:192.0.2.1/80 (192.0.2.1/80) to outside:10.123.3.42/4953 (10.123.3.130/45392)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -790,6 +823,9 @@
                 "address": "192.0.2.222",
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 140,
                 "iana_number": "17",
@@ -823,9 +859,9 @@
             "event": {
                 "severity": 6,
                 "duration": 5025000000000,
-                "ingested": "2021-05-13T11:40:59.328244952Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:18.181465855Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 89743275 for outside:192.0.2.222/53 to inside:10.123.1.35/52925 duration 1:23:45 bytes 140",
+                "code": "302016",
                 "kind": "event",
                 "start": "2013-04-29T11:36:05.000Z",
                 "action": "flow-expiration",
@@ -861,6 +897,9 @@
                 "address": "192.0.2.222",
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 9999999,
                 "iana_number": "17",
@@ -894,9 +933,9 @@
             "event": {
                 "severity": 6,
                 "duration": 36000000000000,
-                "ingested": "2021-05-13T11:40:59.328247802Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:18.181467160Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 666 for outside:192.0.2.222/53 user1 to inside:10.123.1.35/52925 user2 duration 10:00:00 bytes 9999999",
+                "code": "302016",
                 "kind": "event",
                 "start": "2013-04-29T02:59:50.000Z",
                 "action": "flow-expiration",
@@ -932,6 +971,9 @@
                 "address": "192.168.132.46",
                 "ip": "192.168.132.46"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "1",
                 "transport": "icmp"
@@ -960,9 +1002,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:59.328250614Z",
-                "code": "302021",
+                "ingested": "2021-06-03T06:53:18.181468437Z",
                 "original": "%ASA-6-302021: Teardown ICMP connection for faddr 172.24.177.29/0 gaddr 192.168.132.46/17233 laddr 192.168.132.46/17233",
+                "code": "302021",
                 "kind": "event",
                 "action": "flow-expiration",
                 "category": [
@@ -994,6 +1036,9 @@
                 "address": "192.168.3.42",
                 "ip": "192.168.3.42"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1025,9 +1070,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:59.328253406Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:18.181469756Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:192.168.3.42/4954 to outside:192.0.0.130/10879",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1063,6 +1108,9 @@
                 "address": "192.0.0.17",
                 "ip": "192.0.0.17"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -1095,9 +1143,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:59.328256210Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:18.181471057Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 89743277 for outside:192.0.0.17/80 (192.0.0.17/80) to inside:192.168.3.42/4954 (10.0.0.130/10879)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1134,6 +1182,9 @@
                 "address": "192.0.0.66",
                 "ip": "192.0.0.66"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -1157,9 +1208,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:40:59.328259107Z",
-                "code": "106007",
+                "ingested": "2021-06-03T06:53:18.181472448Z",
                 "original": "%ASA-2-106007: Deny inbound UDP from 192.0.0.66/12981 to 10.1.2.60/53 due to DNS Query",
+                "code": "106007",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1191,6 +1242,9 @@
                 "address": "10.0.0.16",
                 "ip": "10.0.0.16"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1222,9 +1276,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:59.328261940Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:18.181473751Z",
                 "original": "%ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2006) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1259,6 +1313,9 @@
                 "address": "10.0.0.46",
                 "ip": "10.0.0.46"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1290,9 +1347,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:59.328264748Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:18.181475024Z",
                 "original": "%ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49734) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1327,6 +1384,9 @@
                 "address": "10.0.0.46",
                 "ip": "10.0.0.46"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1358,9 +1418,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:59.328267532Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:18.181476312Z",
                 "original": "%ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49735) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1395,6 +1455,9 @@
                 "address": "10.0.0.46",
                 "ip": "10.0.0.46"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1426,9 +1489,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:59.328270320Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:18.181477615Z",
                 "original": "%ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49736) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1463,6 +1526,9 @@
                 "address": "10.0.0.46",
                 "ip": "10.0.0.46"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1494,9 +1560,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:59.328273107Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:18.181478898Z",
                 "original": "%ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49737) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1531,6 +1597,9 @@
                 "address": "10.0.0.46",
                 "ip": "10.0.0.46"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1562,9 +1631,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:59.328275907Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:18.181480174Z",
                 "original": "%ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49738) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1599,6 +1668,9 @@
                 "address": "10.0.0.46",
                 "ip": "10.0.0.46"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1630,9 +1702,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:59.328278828Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:18.181481543Z",
                 "original": "%ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49746) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1667,6 +1739,9 @@
                 "address": "10.0.0.16",
                 "ip": "10.0.0.16"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1698,9 +1773,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:59.328281672Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:18.181482816Z",
                 "original": "%ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2007) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1735,6 +1810,9 @@
                 "address": "10.0.0.13",
                 "ip": "10.0.0.13"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1766,9 +1844,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:59.328284484Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:18.181484108Z",
                 "original": "%ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.13(43013) -\u003e dmz/192.168.33.31(25) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1803,6 +1881,9 @@
                 "address": "10.0.0.16",
                 "ip": "10.0.0.16"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1834,9 +1915,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:59.328287292Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:18.181485392Z",
                 "original": "%ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2008) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1871,6 +1952,9 @@
                 "address": "192.0.2.66",
                 "ip": "192.0.2.66"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -1898,9 +1982,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:40:59.328290092Z",
-                "code": "106006",
+                "ingested": "2021-06-03T06:53:18.181486661Z",
                 "original": "%ASA-2-106006: Deny inbound UDP from 192.0.2.66/137 to 10.1.2.42/137 on interface inside",
+                "code": "106006",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1933,6 +2017,9 @@
                 "address": "192.0.2.66",
                 "ip": "192.0.2.66"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -1956,9 +2043,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:40:59.328292885Z",
-                "code": "106007",
+                "ingested": "2021-06-03T06:53:18.181487920Z",
                 "original": "%ASA-2-106007: Deny inbound UDP from 192.0.2.66/12981 to 10.1.5.60/53 due to DNS Query",
+                "code": "106007",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1990,6 +2077,9 @@
                 "address": "10.0.0.16",
                 "ip": "10.0.0.16"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2021,9 +2111,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:59.328295676Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:18.181489197Z",
                 "original": "%ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2009) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2058,6 +2148,9 @@
                 "address": "10.0.0.46",
                 "ip": "10.0.0.46"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2089,9 +2182,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:59.328298474Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:18.181490477Z",
                 "original": "%ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49776) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2126,6 +2219,9 @@
                 "address": "10.0.0.16",
                 "ip": "10.0.0.16"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2157,9 +2253,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:59.328301338Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:18.181491784Z",
                 "original": "%ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2010) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2194,6 +2290,9 @@
                 "address": "10.0.0.16",
                 "ip": "10.0.0.16"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2225,9 +2324,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:59.328304337Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:18.181493057Z",
                 "original": "%ASA-5-106100: access-list acl_in denied tcp inside/10.0.0.16(2011) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2262,6 +2361,9 @@
                 "address": "10.0.0.16",
                 "ip": "10.0.0.16"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2293,9 +2395,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:59.328307131Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:18.181494350Z",
                 "original": "%ASA-5-106100: access-list acl_in denied tcp inside/10.0.0.16(2012) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2330,6 +2432,9 @@
                 "address": "192.0.2.126",
                 "ip": "192.0.2.126"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2361,9 +2466,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:59.328310034Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:18.181495731Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:192.0.2.126/53638 dst inside:10.0.0.132/8111 by access-group \"acl_out\" [0x71761f18, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2398,6 +2503,9 @@
                 "address": "192.0.2.126",
                 "ip": "192.0.2.126"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2429,9 +2537,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:59.328351592Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:18.181497003Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:192.0.2.126/53638 dst inside:10.0.0.132/8111 by access-group \"acl_out\" [0x71761f18, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2466,6 +2574,9 @@
                 "address": "10.0.0.46",
                 "ip": "10.0.0.46"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2497,9 +2608,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:59.328358623Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:18.181498290Z",
                 "original": "%ASA-5-106100: access-list acl_in est-allowed tcp inside/10.0.0.46(49840) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2534,6 +2645,9 @@
                 "address": "10.0.0.16",
                 "ip": "10.0.0.16"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2565,9 +2679,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:59.328361733Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:18.181499552Z",
                 "original": "%ASA-5-106100: access-list acl_in est-allowed tcp inside/10.0.0.16(2013) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2602,6 +2716,9 @@
                 "address": "10.0.0.16",
                 "ip": "10.0.0.16"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2633,9 +2750,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:59.328364631Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:18.181500849Z",
                 "original": "%ASA-session-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2241) -\u003e outside/192.0.0.99(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2674,6 +2791,9 @@
                 "address": "192.168.77.12",
                 "ip": "192.168.77.12"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -2706,9 +2826,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:59.328367437Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:18.181502204Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 447235 for outside:192.168.77.12/11180 (192.168.77.12/11180) to identity:10.0.13.13/80 (10.0.13.13/80)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2748,6 +2868,9 @@
                 "address": "192.168.1.33",
                 "ip": "192.168.1.33"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -2779,9 +2902,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:59.328370215Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:18.181503522Z",
                 "original": "%ASA-4-106023: Deny udp src dmz:192.168.1.33/5555 dst outside:192.0.0.12/53 by access-group \"dmz\" [0x123a465e, 0x4c7bf613]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2819,6 +2942,9 @@
                 "address": "192.168.1.33",
                 "ip": "192.168.1.33"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -2850,9 +2976,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:59.328373078Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:18.181505451Z",
                 "original": "%ASA-4-106023: Deny udp src dmz:192.168.1.33/5555 dst outside:192.0.0.12/53 by access-group \"dmz\" [0x123a465e, 0x4c7bf613]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2890,6 +3016,9 @@
                 "address": "192.0.2.222",
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -2924,9 +3053,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:59.328375851Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:18.181506788Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 447236 for outside:192.0.2.222/1234 (192.0.2.222/1234) to dmz:OCSP_Server/5678 (OCSP_Server/5678)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2966,6 +3095,9 @@
                 "address": "192.0.2.222",
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -3000,9 +3132,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:59.328378628Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:18.181508139Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 447236 for outside:192.0.2.222/1234 (192.0.2.222/1234) to dmz:OCSP_Server/5678 (OCSP_Server/5678)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3042,6 +3174,9 @@
                 "address": "192.0.2.222",
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 14804,
                 "iana_number": "6",
@@ -3075,9 +3210,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:40:59.328381403Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:18.181509442Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 447236 for outside:192.0.2.222/1234 to dmz:192.168.1.34/5678 duration 0:00:00 bytes 14804 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-12-11T08:01:31.000Z",
                 "action": "flow-expiration",
@@ -3116,6 +3251,9 @@
                 "address": "192.0.2.222",
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 134781,
                 "iana_number": "6",
@@ -3149,9 +3287,9 @@
             "event": {
                 "severity": 6,
                 "duration": 68000000000,
-                "ingested": "2021-05-13T11:40:59.328384239Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:18.181510720Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 447234 for outside:192.0.2.222/1234 to dmz:192.168.1.35/5678 duration 0:01:08 bytes 134781 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-12-11T08:00:30.000Z",
                 "action": "flow-expiration",
@@ -3190,6 +3328,9 @@
                 "address": "192.0.2.222",
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 134781,
                 "iana_number": "6",
@@ -3223,9 +3364,9 @@
             "event": {
                 "severity": 6,
                 "duration": 68000000000,
-                "ingested": "2021-05-13T11:40:59.328387021Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:18.181511975Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 447234 for outside:192.0.2.222/1234 to dmz:192.168.1.35/5678 duration 0:01:08 bytes 134781 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-12-11T08:00:30.000Z",
                 "action": "flow-expiration",
@@ -3264,6 +3405,9 @@
                 "address": "192.0.2.222",
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "transport": "(no"
             },
@@ -3289,9 +3433,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:59.328389804Z",
-                "code": "106015",
+                "ingested": "2021-06-03T06:53:18.181513238Z",
                 "original": "%ASA-6-106015: Deny TCP (no connection) from 192.0.2.222/1234 to 192.168.1.34/5679 flags RST  on interface outside",
+                "code": "106015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3326,6 +3470,9 @@
                 "address": "192.0.2.222",
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "transport": "(no"
             },
@@ -3351,9 +3498,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:59.328392577Z",
-                "code": "106015",
+                "ingested": "2021-06-03T06:53:18.181514494Z",
                 "original": "%ASA-6-106015: Deny TCP (no connection) from 192.0.2.222/1234 to 192.168.1.34/5679 flags RST  on interface outside",
+                "code": "106015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3388,6 +3535,9 @@
                 "address": "192.168.1.34",
                 "ip": "192.168.1.34"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -3419,9 +3569,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:59.328395368Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:18.181515778Z",
                 "original": "%ASA-4-106023: Deny udp src dmz:192.168.1.34/5679 dst outside:192.0.0.12/5000 by access-group \"dmz\" [0x123a465e, 0x8c20f21]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3459,6 +3609,9 @@
                 "address": "192.0.2.222",
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -3491,9 +3644,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:59.328406073Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:18.181517177Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 447237 for outside:192.0.2.222/1234 (192.0.2.222/1234) to dmz:192.168.1.34/65000 (192.168.1.34/65000)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3533,6 +3686,9 @@
                 "address": "192.0.2.222",
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -3565,9 +3721,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:40:59.328409513Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:18.181518442Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 447237 for outside:192.0.2.222/1234 (192.0.2.222/1234) to dmz:192.168.1.34/65000 (192.168.1.34/65000)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3607,6 +3763,9 @@
                 "address": "192.0.2.222",
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 11420,
                 "iana_number": "6",
@@ -3640,9 +3799,9 @@
             "event": {
                 "severity": 6,
                 "duration": 86399000000000,
-                "ingested": "2021-05-13T11:40:59.328412350Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:18.181519702Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 447237 for outside:192.0.2.222/1234 to dmz:10.10.10.10/1235 duration 23:59:59 bytes 11420 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-12-10T08:01:54.000Z",
                 "action": "flow-expiration",
@@ -3678,6 +3837,9 @@
                 "address": "10.44.4.4",
                 "ip": "10.44.4.4"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 1416,
                 "iana_number": "17",
@@ -3711,9 +3873,9 @@
             "event": {
                 "severity": 6,
                 "duration": 122000000000,
-                "ingested": "2021-05-13T11:40:59.328415148Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:18.181520987Z",
                 "original": "%ASA-6-302016 Teardown UDP connection 40 for outside:10.44.4.4/500 to inside:10.44.2.2/500 duration 0:02:02 bytes 1416",
+                "code": "302016",
                 "kind": "event",
                 "start": "2012-08-15T23:28:07.000Z",
                 "action": "flow-expiration",
@@ -3747,6 +3909,9 @@
                 "address": "0.0.0.0",
                 "ip": "0.0.0.0"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "GIFRCHN01",
                 "product": "asa",
@@ -3776,9 +3941,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:40:59.328422478Z",
-                "code": "106016",
+                "ingested": "2021-06-03T06:53:18.181522238Z",
                 "original": "%ASA-2-106016: Deny IP spoof from (0.0.0.0) to 192.88.99.47 on interface Mobile_Traffic",
+                "code": "106016",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3809,6 +3974,9 @@
                 "address": "0.0.0.0",
                 "ip": "0.0.0.0"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "GIFRCHN01",
                 "product": "asa",
@@ -3838,9 +4006,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:40:59.328427032Z",
-                "code": "106016",
+                "ingested": "2021-06-03T06:53:18.181523502Z",
                 "original": "%ASA-2-106016: Deny IP spoof from (0.0.0.0) to 192.88.99.57 on interface Mobile_Traffic",
+                "code": "106016",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3871,6 +4039,9 @@
                 "address": "0.0.0.0",
                 "ip": "0.0.0.0"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "GIFRCHN01",
                 "product": "asa",
@@ -3900,9 +4071,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:40:59.328429884Z",
-                "code": "106016",
+                "ingested": "2021-06-03T06:53:18.181524824Z",
                 "original": "%ASA-2-106016: Deny IP spoof from (0.0.0.0) to 192.88.99.47 on interface Mobile_Traffic",
+                "code": "106016",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3933,6 +4104,9 @@
                 "address": "0.0.0.0",
                 "ip": "0.0.0.0"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "GIFRCHN01",
                 "product": "asa",
@@ -3962,9 +4136,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:40:59.328432712Z",
-                "code": "106016",
+                "ingested": "2021-06-03T06:53:18.181526122Z",
                 "original": "%ASA-2-106016: Deny IP spoof from (0.0.0.0) to 192.88.99.47 on interface Mobile_Traffic",
+                "code": "106016",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3995,6 +4169,9 @@
                 "address": "0.0.0.0",
                 "ip": "0.0.0.0"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "GIFRCHN01",
                 "product": "asa",
@@ -4024,9 +4201,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:40:59.328435514Z",
-                "code": "106016",
+                "ingested": "2021-06-03T06:53:18.181533166Z",
                 "original": "%ASA-2-106016: Deny IP spoof from (0.0.0.0) to 192.88.99.57 on interface Mobile_Traffic",
+                "code": "106016",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4057,6 +4234,9 @@
                 "address": "0.0.0.0",
                 "ip": "0.0.0.0"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "GIFRCHN01",
                 "product": "asa",
@@ -4086,9 +4266,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:40:59.328438395Z",
-                "code": "106016",
+                "ingested": "2021-06-03T06:53:18.181534491Z",
                 "original": "%ASA-2-106016: Deny IP spoof from (0.0.0.0) to 192.88.99.57 on interface Mobile_Traffic",
+                "code": "106016",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4119,6 +4299,9 @@
                 "address": "0.0.0.0",
                 "ip": "0.0.0.0"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "GIFRCHN01",
                 "product": "asa",
@@ -4148,9 +4331,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:40:59.328441191Z",
-                "code": "106016",
+                "ingested": "2021-06-03T06:53:18.181535874Z",
                 "original": "%ASA-2-106016: Deny IP spoof from (0.0.0.0) to 192.168.1.255 on interface Mobile_Traffic",
+                "code": "106016",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4181,6 +4364,9 @@
                 "address": "0.0.0.0",
                 "ip": "0.0.0.0"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "GIFRCHN01",
                 "product": "asa",
@@ -4210,9 +4396,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:40:59.328444240Z",
-                "code": "106016",
+                "ingested": "2021-06-03T06:53:18.181537153Z",
                 "original": "%ASA-2-106016: Deny IP spoof from (0.0.0.0) to 192.168.1.255 on interface Mobile_Traffic",
+                "code": "106016",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4245,6 +4431,9 @@
                 "address": "192.0.2.95",
                 "ip": "192.0.2.95"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -4283,9 +4472,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:59.328447135Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:18.181538427Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:192.0.2.95/24069 dst inside:10.32.112.125/25 by access-group \"PERMIT_IN\" [0x0, 0x0]\"",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4314,6 +4503,9 @@
                 "address": "10.2.3.5",
                 "ip": "10.2.3.5"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "1",
                 "transport": "icmp"
@@ -4346,9 +4538,9 @@
             },
             "event": {
                 "severity": 3,
-                "ingested": "2021-05-13T11:40:59.328449952Z",
-                "code": "313001",
+                "ingested": "2021-06-03T06:53:18.181539731Z",
                 "original": "%ASA-3-313001: Denied ICMP type=3, code=3 from 10.2.3.5 on interface Outside",
+                "code": "313001",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4381,6 +4573,9 @@
                 "address": "172.16.30.2",
                 "ip": "172.16.30.2"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "1",
                 "transport": "icmp"
@@ -4407,9 +4602,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:59.328452814Z",
-                "code": "313004",
+                "ingested": "2021-06-03T06:53:18.181541003Z",
                 "original": "%ASA-4-313004: Denied ICMP type=0, from laddr 172.16.30.2 on interface inside to 172.16.1.10: no matching session",
+                "code": "313004",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4451,6 +4646,9 @@
                 "port": 6798,
                 "ip": "10.1.1.45"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -4485,9 +4683,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:59.328455604Z",
-                "code": "338002",
+                "ingested": "2021-06-03T06:53:18.181542284Z",
                 "original": "%ASA-4-338002: Dynamic Filter permitted black listed TCP traffic from inside:10.1.1.45/6798 (192.88.99.1/7890) to outside:192.88.99.129/80 (192.88.99.129/80), destination 192.88.99.129 resolved from dynamic list: bad.example.com",
+                "code": "338002",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4529,6 +4727,9 @@
                 "port": 33340,
                 "ip": "10.1.1.1"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -4560,9 +4761,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:59.328458374Z",
-                "code": "338004",
+                "ingested": "2021-06-03T06:53:18.181543556Z",
                 "original": "%ASA-4-338004: Dynamic Filter monitored blacklisted TCP traffic from inside:10.1.1.1/33340 (10.2.1.1/33340) to outsidet:192.0.2.223/80 (192.0.2.223/80), destination 192.0.2.223 resolved from dynamic list: 192.0.2.223/255.255.255.255, threat-level: very-high, category: Malware",
+                "code": "338004",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4605,6 +4806,9 @@
                 "port": 33340,
                 "ip": "10.1.1.1"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -4636,9 +4840,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:40:59.328465514Z",
-                "code": "338008",
+                "ingested": "2021-06-03T06:53:18.181544864Z",
                 "original": "%ASA-4-338008: Dynamic Filter dropped blacklisted TCP traffic from inside:10.1.1.1/33340 (10.2.1.1/33340) to outsidet:192.0.2.223/80 (192.0.2.223/80), destination 192.0.2.223 resolved from dynamic list: 192.0.2.223/255.255.255.255, threat-level: very-high, category: Malware",
+                "code": "338008",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4680,6 +4884,9 @@
             "url": {
                 "original": "/app"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "type": "firewall",
                 "product": "asa",
@@ -4697,9 +4904,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:59.328472776Z",
-                "code": "304001",
+                "ingested": "2021-06-03T06:53:18.181546153Z",
                 "original": "%ASA-5-304001: 10.30.30.30 Accessed URL 192.0.2.1:/app",
+                "code": "304001",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4732,6 +4939,9 @@
             "url": {
                 "original": "http://example.com"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "type": "firewall",
                 "product": "asa",
@@ -4749,9 +4959,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:59.328480100Z",
-                "code": "304001",
+                "ingested": "2021-06-03T06:53:18.181547419Z",
                 "original": "%ASA-5-304001: 10.5.111.32 Accessed URL 192.0.2.32:http://example.com",
+                "code": "304001",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4784,6 +4994,9 @@
             "url": {
                 "original": "http://www.example.net/images/favicon.ico"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "product": "asa",
                 "type": "firewall",
@@ -4806,9 +5019,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:40:59.328483069Z",
-                "code": "304002",
+                "ingested": "2021-06-03T06:53:18.181548709Z",
                 "original": "%ASA-5-304002: Access denied URL http://www.example.net/images/favicon.ico SRC 10.69.6.39 DEST 192.0.0.19 on interface inside",
+                "code": "304002",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [

--- a/packages/cisco/data_stream/asa/_dev/test/system/test-logfile-config.yml
+++ b/packages/cisco/data_stream/asa/_dev/test/system/test-logfile-config.yml
@@ -4,3 +4,4 @@ data_stream:
   vars:
     paths:
       - "{{SERVICE_LOGS_DIR}}/*asa*.log"
+    preserve_original_event: true

--- a/packages/cisco/data_stream/asa/_dev/test/system/test-udp-config.yml
+++ b/packages/cisco/data_stream/asa/_dev/test/system/test-udp-config.yml
@@ -5,3 +5,4 @@ data_stream:
   vars:
     udp_host: 0.0.0.0
     udp_port: 9514
+    preserve_original_event: true

--- a/packages/cisco/data_stream/asa/agent/stream/stream.yml.hbs
+++ b/packages/cisco/data_stream/asa/agent/stream/stream.yml.hbs
@@ -3,6 +3,12 @@ paths:
   - {{path}}
 {{/each}}
 exclude_files: [".gz$"]
-tags: {{tags}}
+tags:
+{{#each tags as |tag i|}}
+ - {{tag}}
+{{/each}}
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 processors:
   - add_locale: ~

--- a/packages/cisco/data_stream/asa/agent/stream/udp.yml.hbs
+++ b/packages/cisco/data_stream/asa/agent/stream/udp.yml.hbs
@@ -1,5 +1,11 @@
 udp:
 host: "{{udp_host}}:{{udp_port}}"
-tags: {{tags}}
+tags:
+{{#each tags as |tag i|}}
+ - {{tag}}
+{{/each}}
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 processors:
   - add_locale: ~

--- a/packages/cisco/data_stream/asa/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco/data_stream/asa/elasticsearch/ingest_pipeline/default.yml
@@ -16,7 +16,7 @@ processors:
   - grok:
       field: message
       patterns:
-        - "(?:%{SYSLOG_HEADER})?\\s*%{GREEDYDATA:log.original}"
+        - "(?:%{SYSLOG_HEADER})?\\s*%{GREEDYDATA:event.original}"
       pattern_definitions:
         SYSLOG_HEADER: "(?:%{SYSLOGFACILITY}\\s*)?(?:%{FTD_DATE:_temp_.raw_date}:?\\s+)?(?:%{PROCESS_HOST}|%{HOST_PROCESS})(?:{DATA})?%{SYSLOG_END}?"
         SYSLOGFACILITY: "<%{NONNEGINT:log.syslog.facility.code:int}(?:.%{NONNEGINT:log.syslog.priority:int})?>"
@@ -34,7 +34,7 @@ processors:
   #
   # This parses the header of an EMBLEM-style message for FTD and ASA prefixes.
   - grok:
-      field: log.original
+      field: event.original
       patterns:
         - "%{FTD_PREFIX}-(?:%{FTD_SUFFIX:_temp_.cisco.suffix}-)?%{NONNEGINT:event.severity:int}-%{POSINT:_temp_.cisco.message_id}?:?\\s*%{GREEDYDATA:message}"
         # Before version 6.3, messages for connection, security intelligence, and intrusion events didn't include an event type ID in the message header.
@@ -1448,10 +1448,6 @@ processors:
   # Rename some 7.x fields
   #
   - rename:
-      field: log.original
-      target_field: event.original
-      ignore_missing: true
-  - rename:
       field: cisco.asa.list_id
       target_field: cisco.asa.rule_name
       ignore_missing: true
@@ -1603,6 +1599,11 @@ processors:
       value: "{{source.domain}}"
       if: ctx.source?.domain != null && ctx.source?.domain != ''
       allow_duplicates: false
+  - remove:
+      field: event.original
+      if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"
+      ignore_failure: true
+      ignore_missing: true
 on_failure:
   # Copy any fields under _temp_.cisco to its final destination. Those can help
   # with diagnosing the failure.

--- a/packages/cisco/data_stream/asa/fields/ecs.yml
+++ b/packages/cisco/data_stream/asa/fields/ecs.yml
@@ -105,9 +105,6 @@
 - name: log.level
   type: keyword
   description: Log level of the log event.
-- name: log.original
-  type: keyword
-  description: Original log message with light interpretation only (encoding, newlines).
 - name: network.bytes
   type: long
   description: Total bytes transferred in both directions.

--- a/packages/cisco/data_stream/asa/manifest.yml
+++ b/packages/cisco/data_stream/asa/manifest.yml
@@ -29,6 +29,14 @@ streams:
         required: true
         show_user: true
         default: 9001
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
       - name: log_level
         type: integer
         title: Log Level
@@ -49,6 +57,14 @@ streams:
         show_user: true
         default:
           - /var/log/cisco-asa.log
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
       - name: tags
         type: text
         title: Tags

--- a/packages/cisco/data_stream/asa/sample_event.json
+++ b/packages/cisco/data_stream/asa/sample_event.json
@@ -1,0 +1,125 @@
+{
+    "@timestamp": "2018-10-10T12:34:56.000Z",
+    "agent": {
+        "ephemeral_id": "f5535a1f-52da-44d4-a626-f85bbdc25e74",
+        "hostname": "docker-fleet-agent",
+        "id": "37c96a8c-c323-4db5-b898-9ba84c49e2ea",
+        "name": "docker-fleet-agent",
+        "type": "filebeat",
+        "version": "7.14.0"
+    },
+    "cisco": {
+        "asa": {
+            "destination_interface": "outside",
+            "message_id": "305011",
+            "source_interface": "inside"
+        }
+    },
+    "data_stream": {
+        "dataset": "cisco.asa",
+        "namespace": "ep",
+        "type": "logs"
+    },
+    "destination": {
+        "address": "100.66.98.44",
+        "ip": "100.66.98.44",
+        "port": 8256
+    },
+    "ecs": {
+        "version": "1.9.0"
+    },
+    "elastic_agent": {
+        "id": "732b7efe-6d7b-40fc-bbfe-799296be9d11",
+        "snapshot": true,
+        "version": "7.14.0"
+    },
+    "event": {
+        "action": "firewall-rule",
+        "category": [
+            "network"
+        ],
+        "code": "305011",
+        "dataset": "cisco.asa",
+        "ingested": "2021-06-03T09:22:20.519428820Z",
+        "kind": "event",
+        "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1772 to outside:100.66.98.44/8256",
+        "severity": 6,
+        "timezone": "+00:00",
+        "type": [
+            "info"
+        ]
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": true,
+        "hostname": "localhost",
+        "id": "f46ddd9d65ff20633d9c337909855778",
+        "ip": [
+            "172.19.0.7"
+        ],
+        "mac": [
+            "02:42:ac:13:00:07"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+            "codename": "Core",
+            "family": "redhat",
+            "kernel": "5.10.25-linuxkit",
+            "name": "CentOS Linux",
+            "platform": "centos",
+            "type": "linux",
+            "version": "7 (Core)"
+        }
+    },
+    "input": {
+        "type": "udp"
+    },
+    "log": {
+        "level": "informational",
+        "source": {
+            "address": "172.19.0.4:47315"
+        }
+    },
+    "network": {
+        "iana_number": "6",
+        "transport": "tcp"
+    },
+    "observer": {
+        "egress": {
+            "interface": {
+                "name": "inside"
+            }
+        },
+        "hostname": "localhost",
+        "ingress": {
+            "interface": {
+                "name": "outside"
+            }
+        },
+        "product": "asa",
+        "type": "firewall",
+        "vendor": "Cisco"
+    },
+    "process": {
+        "name": "CiscoASA",
+        "pid": 999
+    },
+    "related": {
+        "hosts": [
+            "localhost"
+        ],
+        "ip": [
+            "172.31.98.44",
+            "100.66.98.44"
+        ]
+    },
+    "source": {
+        "address": "172.31.98.44",
+        "ip": "172.31.98.44",
+        "port": 1772
+    },
+    "tags": [
+        "cisco-asa",
+        "preserve_original_event"
+    ]
+}

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-asa-fix.log-config.yml
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-asa-fix.log-config.yml
@@ -1,2 +1,0 @@
-dynamic_fields:
-  event.ingested: ".*"

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-asa-fix.log-expected.json
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-asa-fix.log-expected.json
@@ -14,6 +14,9 @@
                 "address": "10.123.123.123",
                 "ip": "10.123.123.123"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 148,
                 "iana_number": "17",
@@ -54,9 +57,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:06.519251983Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.179404393Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 110577675 for Outside:10.123.123.123/53723(LOCAL\\Elastic) to Inside:10.233.123.123/53 duration 0:00:00 bytes 148 (zzzzzz)",
+                "code": "302016",
                 "kind": "event",
                 "start": "2020-04-17T14:08:08.000Z",
                 "action": "flow-expiration",
@@ -91,6 +94,9 @@
                 "address": "10.123.123.123",
                 "ip": "10.123.123.123"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "1",
                 "transport": "icmp"
@@ -128,9 +134,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:06.519275475Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.179410879Z",
                 "original": "%ASA-4-106023: Deny icmp src Inside:10.123.123.123 dst Outside:10.123.123.123 (type 11, code 0) by access-group \"Inside_access_in\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -165,6 +171,9 @@
                 "address": "10.123.123.123",
                 "ip": "10.123.123.123"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -195,9 +204,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:06.519279152Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.179412400Z",
                 "original": "%ASA-4-106023: Deny tcp src dmz:10.123.123.123/6316 dst outside:10.123.123.123/53 type 3, code 0, by access-group \"acl_dmz\" [0xe3afb522, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -232,6 +241,9 @@
                 "address": "10.123.123.123",
                 "ip": "10.123.123.123"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -269,9 +281,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:06.519281712Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.179413873Z",
                 "original": "%ASA-4-106023: Deny udp src Inside:10.123.123.123/57621(LOCAL\\Elastic) dst Outside:10.123.123.123/57621 by access-group \"Inside_access_in\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -305,6 +317,9 @@
                 "address": "10.123.123.123",
                 "ip": "10.123.123.123"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "SNL-ASA-VPN-A01",
                 "product": "asa",
@@ -328,9 +343,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:41:06.519284155Z",
-                "code": "106017",
+                "ingested": "2021-06-03T06:53:21.179415191Z",
                 "original": "%ASA-2-106017: Deny IP due to Land Attack from 10.123.123.123 to 10.123.123.123",
+                "code": "106017",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-asa.log-config.yml
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-asa.log-config.yml
@@ -1,2 +1,0 @@
-dynamic_fields:
-  event.ingested: ".*"

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-asa.log-expected.json
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-asa.log-expected.json
@@ -18,6 +18,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -56,9 +59,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255258024Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401145166Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1772 to outside:100.66.98.44/8256",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -94,6 +97,9 @@
                 "address": "100.66.205.104",
                 "ip": "100.66.205.104"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -133,9 +139,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255269819Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401152015Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11757 for outside:100.66.205.104/80 (100.66.205.104/80) to inside:172.31.98.44/1772 (172.31.98.44/1772)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -176,6 +182,9 @@
                 "address": "100.66.211.242",
                 "ip": "100.66.211.242"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 38110,
                 "iana_number": "6",
@@ -216,9 +225,9 @@
             "event": {
                 "severity": 6,
                 "duration": 67000000000,
-                "ingested": "2021-05-13T11:41:07.255272591Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401153471Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11749 for outside:100.66.211.242/80 to inside:172.31.98.44/1758 duration 0:01:07 bytes 38110 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:49.000Z",
                 "action": "flow-expiration",
@@ -258,6 +267,9 @@
                 "address": "100.66.211.242",
                 "ip": "100.66.211.242"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 44010,
                 "iana_number": "6",
@@ -298,9 +310,9 @@
             "event": {
                 "severity": 6,
                 "duration": 67000000000,
-                "ingested": "2021-05-13T11:41:07.255275137Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401154795Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11748 for outside:100.66.211.242/80 to inside:172.31.98.44/1757 duration 0:01:07 bytes 44010 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:49.000Z",
                 "action": "flow-expiration",
@@ -340,6 +352,9 @@
                 "address": "100.66.185.90",
                 "ip": "100.66.185.90"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 7652,
                 "iana_number": "6",
@@ -380,9 +395,9 @@
             "event": {
                 "severity": 6,
                 "duration": 67000000000,
-                "ingested": "2021-05-13T11:41:07.255277627Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401156092Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11745 for outside:100.66.185.90/80 to inside:172.31.98.44/1755 duration 0:01:07 bytes 7652 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:49.000Z",
                 "action": "flow-expiration",
@@ -422,6 +437,9 @@
                 "address": "100.66.185.90",
                 "ip": "100.66.185.90"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 7062,
                 "iana_number": "6",
@@ -462,9 +480,9 @@
             "event": {
                 "severity": 6,
                 "duration": 67000000000,
-                "ingested": "2021-05-13T11:41:07.255280131Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401157373Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11744 for outside:100.66.185.90/80 to inside:172.31.98.44/1754 duration 0:01:07 bytes 7062 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:49.000Z",
                 "action": "flow-expiration",
@@ -504,6 +522,9 @@
                 "address": "100.66.160.197",
                 "ip": "100.66.160.197"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 5738,
                 "iana_number": "6",
@@ -544,9 +565,9 @@
             "event": {
                 "severity": 6,
                 "duration": 68000000000,
-                "ingested": "2021-05-13T11:41:07.255282567Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401158641Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11742 for outside:100.66.160.197/80 to inside:172.31.98.44/1752 duration 0:01:08 bytes 5738 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:48.000Z",
                 "action": "flow-expiration",
@@ -586,6 +607,9 @@
                 "address": "100.66.205.14",
                 "ip": "100.66.205.14"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 4176,
                 "iana_number": "6",
@@ -626,9 +650,9 @@
             "event": {
                 "severity": 6,
                 "duration": 68000000000,
-                "ingested": "2021-05-13T11:41:07.255285029Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401159912Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11738 for outside:100.66.205.14/80 to inside:172.31.98.44/1749 duration 0:01:08 bytes 4176 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:48.000Z",
                 "action": "flow-expiration",
@@ -668,6 +692,9 @@
                 "address": "100.66.124.33",
                 "ip": "100.66.124.33"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 1715,
                 "iana_number": "6",
@@ -708,9 +735,9 @@
             "event": {
                 "severity": 6,
                 "duration": 68000000000,
-                "ingested": "2021-05-13T11:41:07.255287519Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401161175Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11739 for outside:100.66.124.33/80 to inside:172.31.98.44/1750 duration 0:01:08 bytes 1715 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:48.000Z",
                 "action": "flow-expiration",
@@ -750,6 +777,9 @@
                 "address": "100.66.35.9",
                 "ip": "100.66.35.9"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 45595,
                 "iana_number": "6",
@@ -790,9 +820,9 @@
             "event": {
                 "severity": 6,
                 "duration": 69000000000,
-                "ingested": "2021-05-13T11:41:07.255290213Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401162460Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11731 for outside:100.66.35.9/80 to inside:172.31.98.44/1747 duration 0:01:09 bytes 45595 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:47.000Z",
                 "action": "flow-expiration",
@@ -832,6 +862,9 @@
                 "address": "100.66.211.242",
                 "ip": "100.66.211.242"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 27359,
                 "iana_number": "6",
@@ -872,9 +905,9 @@
             "event": {
                 "severity": 6,
                 "duration": 69000000000,
-                "ingested": "2021-05-13T11:41:07.255292693Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401163796Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11723 for outside:100.66.211.242/80 to inside:172.31.98.44/1742 duration 0:01:09 bytes 27359 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:47.000Z",
                 "action": "flow-expiration",
@@ -914,6 +947,9 @@
                 "address": "100.66.218.21",
                 "ip": "100.66.218.21"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 4457,
                 "iana_number": "6",
@@ -954,9 +990,9 @@
             "event": {
                 "severity": 6,
                 "duration": 69000000000,
-                "ingested": "2021-05-13T11:41:07.255295404Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401165310Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11715 for outside:100.66.218.21/80 to inside:172.31.98.44/1741 duration 0:01:09 bytes 4457 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:47.000Z",
                 "action": "flow-expiration",
@@ -996,6 +1032,9 @@
                 "address": "100.66.198.27",
                 "ip": "100.66.198.27"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 26709,
                 "iana_number": "6",
@@ -1036,9 +1075,9 @@
             "event": {
                 "severity": 6,
                 "duration": 69000000000,
-                "ingested": "2021-05-13T11:41:07.255297913Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401166630Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11711 for outside:100.66.198.27/80 to inside:172.31.98.44/1739 duration 0:01:09 bytes 26709 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:47.000Z",
                 "action": "flow-expiration",
@@ -1078,6 +1117,9 @@
                 "address": "100.66.198.27",
                 "ip": "100.66.198.27"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 22097,
                 "iana_number": "6",
@@ -1118,9 +1160,9 @@
             "event": {
                 "severity": 6,
                 "duration": 69000000000,
-                "ingested": "2021-05-13T11:41:07.255300411Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401167890Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11712 for outside:100.66.198.27/80 to inside:172.31.98.44/1740 duration 0:01:09 bytes 22097 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:47.000Z",
                 "action": "flow-expiration",
@@ -1160,6 +1202,9 @@
                 "address": "100.66.202.211",
                 "ip": "100.66.202.211"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 2209,
                 "iana_number": "6",
@@ -1200,9 +1245,9 @@
             "event": {
                 "severity": 6,
                 "duration": 70000000000,
-                "ingested": "2021-05-13T11:41:07.255302902Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401169149Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11708 for outside:100.66.202.211/80 to inside:172.31.98.44/1738 duration 0:01:10 bytes 2209 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:46.000Z",
                 "action": "flow-expiration",
@@ -1242,6 +1287,9 @@
                 "address": "100.66.124.15",
                 "ip": "100.66.124.15"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 10404,
                 "iana_number": "6",
@@ -1282,9 +1330,9 @@
             "event": {
                 "severity": 6,
                 "duration": 67000000000,
-                "ingested": "2021-05-13T11:41:07.255305353Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401170475Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11746 for outside:100.66.124.15/80 to inside:172.31.98.44/1756 duration 0:01:07 bytes 10404 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:49.000Z",
                 "action": "flow-expiration",
@@ -1324,6 +1372,9 @@
                 "address": "100.66.124.15",
                 "ip": "100.66.124.15"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 123694,
                 "iana_number": "6",
@@ -1364,9 +1415,9 @@
             "event": {
                 "severity": 6,
                 "duration": 70000000000,
-                "ingested": "2021-05-13T11:41:07.255307920Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401171839Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11706 for outside:100.66.124.15/80 to inside:172.31.98.44/1737 duration 0:01:10 bytes 123694 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:46.000Z",
                 "action": "flow-expiration",
@@ -1406,6 +1457,9 @@
                 "address": "100.66.209.247",
                 "ip": "100.66.209.247"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 35835,
                 "iana_number": "6",
@@ -1446,9 +1500,9 @@
             "event": {
                 "severity": 6,
                 "duration": 71000000000,
-                "ingested": "2021-05-13T11:41:07.255310408Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401173139Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11702 for outside:100.66.209.247/80 to inside:172.31.98.44/1736 duration 0:01:11 bytes 35835 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:33:45.000Z",
                 "action": "flow-expiration",
@@ -1488,6 +1542,9 @@
                 "address": "100.66.35.162",
                 "ip": "100.66.35.162"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 0,
                 "iana_number": "6",
@@ -1528,9 +1585,9 @@
             "event": {
                 "severity": 6,
                 "duration": 30000000000,
-                "ingested": "2021-05-13T11:41:07.255312885Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401174400Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11753 for outside:100.66.35.162/80 to inside:172.31.98.44/1765 duration 0:00:30 bytes 0 SYN Timeout",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:26.000Z",
                 "action": "flow-expiration",
@@ -1570,6 +1627,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -1608,9 +1668,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255315338Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401175688Z",
                 "original": "%ASA-6-305011: Built dynamic UDP translation from inside:172.31.98.44/56132 to outside:100.66.98.44/1188",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1646,6 +1706,9 @@
                 "address": "100.66.80.32",
                 "ip": "100.66.80.32"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -1685,9 +1748,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255317782Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:21.401176978Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11758 for outside:100.66.80.32/53 (100.66.80.32/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1728,6 +1791,9 @@
                 "address": "100.66.80.32",
                 "ip": "100.66.80.32"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 148,
                 "iana_number": "17",
@@ -1768,9 +1834,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255320230Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401180163Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11758 for outside:100.66.80.32/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 148",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -1810,6 +1876,9 @@
                 "address": "100.66.252.6",
                 "ip": "100.66.252.6"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -1849,9 +1918,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255322668Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:21.401181454Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11759 for outside:100.66.252.6/53 (100.66.252.6/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1892,6 +1961,9 @@
                 "address": "100.66.252.6",
                 "ip": "100.66.252.6"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 164,
                 "iana_number": "17",
@@ -1932,9 +2004,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255325256Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401182894Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11759 for outside:100.66.252.6/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 164",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -1974,6 +2046,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2012,9 +2087,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255327713Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401184185Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1773 to outside:100.66.98.44/8257",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2050,6 +2125,9 @@
                 "address": "100.66.252.226",
                 "ip": "100.66.252.226"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -2089,9 +2167,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255330132Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401185480Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11760 for outside:100.66.252.226/80 (100.66.252.226/80) to inside:172.31.98.44/1773 (172.31.98.44/1773)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2132,6 +2210,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2170,9 +2251,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255332554Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401195485Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1774 to outside:100.66.98.44/8258",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2208,6 +2289,9 @@
                 "address": "100.66.252.226",
                 "ip": "100.66.252.226"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -2247,9 +2331,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255340325Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401197268Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11761 for outside:100.66.252.226/80 (100.66.252.226/80) to inside:172.31.98.44/1774 (172.31.98.44/1774)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2290,6 +2374,9 @@
                 "address": "100.66.238.126",
                 "ip": "100.66.238.126"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -2329,9 +2416,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255343048Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:21.401198656Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11762 for outside:100.66.238.126/53 (100.66.238.126/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2372,6 +2459,9 @@
                 "address": "100.66.93.51",
                 "ip": "100.66.93.51"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -2411,9 +2501,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255345536Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:21.401199917Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11763 for outside:100.66.93.51/53 (100.66.93.51/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2454,6 +2544,9 @@
                 "address": "100.66.238.126",
                 "ip": "100.66.238.126"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 111,
                 "iana_number": "17",
@@ -2494,9 +2587,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255348008Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401201170Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11762 for outside:100.66.238.126/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 111",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -2536,6 +2629,9 @@
                 "address": "100.66.93.51",
                 "ip": "100.66.93.51"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 237,
                 "iana_number": "17",
@@ -2576,9 +2672,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255350496Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401202430Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11763 for outside:100.66.93.51/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 237",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -2618,6 +2714,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2656,9 +2755,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255352959Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401203678Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1775 to outside:100.66.98.44/8259",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2694,6 +2793,9 @@
                 "address": "100.66.225.103",
                 "ip": "100.66.225.103"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -2733,9 +2835,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255355419Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401204928Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11764 for outside:100.66.225.103/443 (100.66.225.103/443) to inside:172.31.98.44/1775 (172.31.98.44/1775)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2776,6 +2878,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -2814,9 +2919,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255357978Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401206384Z",
                 "original": "%ASA-6-305011: Built dynamic UDP translation from inside:172.31.98.44/56132 to outside:100.66.98.44/1189",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2852,6 +2957,9 @@
                 "address": "100.66.240.126",
                 "ip": "100.66.240.126"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -2891,9 +2999,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255360447Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:21.401207645Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11772 for outside:100.66.240.126/53 (100.66.240.126/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2934,6 +3042,9 @@
                 "address": "100.66.44.45",
                 "ip": "100.66.44.45"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -2973,9 +3084,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255362903Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:21.401208911Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11773 for outside:100.66.44.45/53 (100.66.44.45/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3016,6 +3127,9 @@
                 "address": "100.66.240.126",
                 "ip": "100.66.240.126"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 87,
                 "iana_number": "17",
@@ -3056,9 +3170,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255365411Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401210220Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11772 for outside:100.66.240.126/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 87",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -3098,6 +3212,9 @@
                 "address": "100.66.44.45",
                 "ip": "100.66.44.45"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 221,
                 "iana_number": "17",
@@ -3138,9 +3255,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255367908Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401211478Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11773 for outside:100.66.44.45/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 221",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -3180,6 +3297,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -3218,9 +3338,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255370406Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401212724Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1452 to outside:100.66.98.44/8265",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3256,6 +3376,9 @@
                 "address": "100.66.179.219",
                 "ip": "100.66.179.219"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -3295,9 +3418,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255372876Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401214004Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11774 for outside:100.66.179.219/80 (100.66.179.219/80) to inside:172.31.98.44/1452 (172.31.98.44/1452)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3338,6 +3461,9 @@
                 "address": "100.66.157.232",
                 "ip": "100.66.157.232"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -3377,9 +3503,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255375321Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:21.401215259Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11775 for outside:100.66.157.232/53 (100.66.157.232/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3420,6 +3546,9 @@
                 "address": "100.66.178.133",
                 "ip": "100.66.178.133"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -3459,9 +3588,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255377786Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:21.401216527Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11776 for outside:100.66.178.133/53 (100.66.178.133/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3502,6 +3631,9 @@
                 "address": "100.66.157.232",
                 "ip": "100.66.157.232"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 101,
                 "iana_number": "17",
@@ -3542,9 +3674,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255380245Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401217788Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11775 for outside:100.66.157.232/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 101",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -3584,6 +3716,9 @@
                 "address": "100.66.178.133",
                 "ip": "100.66.178.133"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 126,
                 "iana_number": "17",
@@ -3624,9 +3759,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255382710Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401219058Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11776 for outside:100.66.178.133/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 126",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -3666,6 +3801,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -3704,9 +3842,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255385203Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401220339Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1453 to outside:100.66.98.44/8266",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3742,6 +3880,9 @@
                 "address": "100.66.133.112",
                 "ip": "100.66.133.112"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -3781,9 +3922,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255387784Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401221587Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11777 for outside:100.66.133.112/80 (100.66.133.112/80) to inside:172.31.98.44/1453 (172.31.98.44/1453)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3824,6 +3965,9 @@
                 "address": "100.66.133.112",
                 "ip": "100.66.133.112"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 862,
                 "iana_number": "6",
@@ -3864,9 +4008,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255390259Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401222876Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11777 for outside:100.66.133.112/80 to inside:172.31.98.44/1453 duration 0:00:00 bytes 862 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -3906,6 +4050,9 @@
                 "address": "100.66.204.197",
                 "ip": "100.66.204.197"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -3945,9 +4092,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255392721Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:21.401224165Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11779 for outside:100.66.204.197/53 (100.66.204.197/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3988,6 +4135,9 @@
                 "address": "100.66.157.232",
                 "ip": "100.66.157.232"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 104,
                 "iana_number": "17",
@@ -4028,9 +4178,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255395177Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401225432Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11778 for outside:100.66.157.232/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 104",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -4070,6 +4220,9 @@
                 "address": "100.66.204.197",
                 "ip": "100.66.204.197"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 176,
                 "iana_number": "17",
@@ -4110,9 +4263,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255397735Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401226873Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11779 for outside:100.66.204.197/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 176",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -4152,6 +4305,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -4190,9 +4346,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255400503Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401228136Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1454 to outside:100.66.98.44/8267",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4228,6 +4384,9 @@
                 "address": "100.66.128.3",
                 "ip": "100.66.128.3"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -4267,9 +4426,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255402992Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401229472Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11780 for outside:100.66.128.3/80 (100.66.128.3/80) to inside:172.31.98.44/1454 (172.31.98.44/1454)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4310,6 +4469,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -4348,9 +4510,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255405498Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401230726Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1455 to outside:100.66.98.44/8268",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4386,6 +4548,9 @@
                 "address": "100.66.128.3",
                 "ip": "100.66.128.3"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -4425,9 +4590,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255407963Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401231977Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11781 for outside:100.66.128.3/80 (100.66.128.3/80) to inside:172.31.98.44/1455 (172.31.98.44/1455)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4468,6 +4633,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -4506,9 +4674,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255410424Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401233227Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1456 to outside:100.66.98.44/8269",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4544,6 +4712,9 @@
                 "address": "100.66.128.3",
                 "ip": "100.66.128.3"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -4583,9 +4754,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255412936Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401234496Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11782 for outside:100.66.128.3/80 (100.66.128.3/80) to inside:172.31.98.44/1456 (172.31.98.44/1456)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4626,6 +4797,9 @@
                 "address": "100.66.100.4",
                 "ip": "100.66.100.4"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -4665,9 +4839,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255415388Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:21.401235806Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11783 for outside:100.66.100.4/53 (100.66.100.4/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4708,6 +4882,9 @@
                 "address": "100.66.100.4",
                 "ip": "100.66.100.4"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 104,
                 "iana_number": "17",
@@ -4748,9 +4925,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255417845Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401237057Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11783 for outside:100.66.100.4/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 104",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -4790,6 +4967,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -4828,9 +5008,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255420304Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401238321Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1457 to outside:100.66.98.44/8270",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4866,6 +5046,9 @@
                 "address": "100.66.198.40",
                 "ip": "100.66.198.40"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -4905,9 +5088,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255422809Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401239569Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11784 for outside:100.66.198.40/80 (100.66.198.40/80) to inside:172.31.98.44/1457 (172.31.98.44/1457)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4948,6 +5131,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -4986,9 +5172,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255425322Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401240823Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1458 to outside:100.66.98.44/8271",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5024,6 +5210,9 @@
                 "address": "100.66.198.40",
                 "ip": "100.66.198.40"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -5063,9 +5252,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255427794Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401242197Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11785 for outside:100.66.198.40/80 (100.66.198.40/80) to inside:172.31.98.44/1458 (172.31.98.44/1458)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5106,6 +5295,9 @@
                 "address": "100.66.1.107",
                 "ip": "100.66.1.107"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -5145,9 +5337,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255432516Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:21.401243455Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11786 for outside:100.66.1.107/53 (100.66.1.107/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5188,6 +5380,9 @@
                 "address": "100.66.198.40",
                 "ip": "100.66.198.40"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 593,
                 "iana_number": "6",
@@ -5228,9 +5423,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255435165Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401249320Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11784 for outside:100.66.198.40/80 to inside:172.31.98.44/1457 duration 0:00:00 bytes 593 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -5270,6 +5465,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -5308,9 +5506,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255437767Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401250661Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1459 to outside:100.66.98.44/8272",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5346,6 +5544,9 @@
                 "address": "100.66.198.40",
                 "ip": "100.66.198.40"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -5385,9 +5586,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255440277Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401251934Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11787 for outside:100.66.198.40/80 (100.66.198.40/80) to inside:172.31.98.44/1459 (172.31.98.44/1459)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5428,6 +5629,9 @@
                 "address": "100.66.1.107",
                 "ip": "100.66.1.107"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 375,
                 "iana_number": "17",
@@ -5468,9 +5672,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255442770Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401253262Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11786 for outside:100.66.1.107/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 375",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -5510,6 +5714,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -5548,9 +5755,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255445278Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401254571Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1460 to outside:100.66.98.44/8273",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5586,6 +5793,9 @@
                 "address": "100.66.192.44",
                 "ip": "100.66.192.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -5625,9 +5835,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255447754Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401255829Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11788 for outside:100.66.192.44/80 (100.66.192.44/80) to inside:172.31.98.44/1460 (172.31.98.44/1460)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5651,15 +5861,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -5670,17 +5886,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255450273Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401257093Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1454 to outside:100.66.98.44/8267 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5714,6 +5927,9 @@
                 "address": "172.31.156.80",
                 "ip": "172.31.156.80"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -5752,9 +5968,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255452728Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401258338Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.156.80/1385 to outside:100.66.98.44/8277",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5790,6 +6006,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -5829,9 +6048,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255455191Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401259588Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11797 for outside:100.66.19.254/80 (100.66.19.254/80) to inside:172.31.156.80/1385 (172.31.156.80/1385)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5855,15 +6074,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -5874,17 +6099,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255457639Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401260863Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1455 to outside:100.66.98.44/8268 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5901,15 +6123,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -5920,17 +6148,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255460310Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401262287Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1456 to outside:100.66.98.44/8269 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5947,15 +6172,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -5966,17 +6197,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255462793Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401263565Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1457 to outside:100.66.98.44/8270 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -5993,15 +6221,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -6012,17 +6246,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255465245Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401264814Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1458 to outside:100.66.98.44/8271 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -6039,15 +6270,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -6058,17 +6295,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255467704Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401266070Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1459 to outside:100.66.98.44/8272 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -6085,15 +6319,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -6104,17 +6344,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255470144Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401267332Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1460 to outside:100.66.98.44/8273 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -6148,6 +6385,9 @@
                 "address": "100.66.115.46",
                 "ip": "100.66.115.46"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 575,
                 "iana_number": "6",
@@ -6188,9 +6428,9 @@
             "event": {
                 "severity": 6,
                 "duration": 325000000000,
-                "ingested": "2021-05-13T11:41:07.255472655Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401268588Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11564 for outside:100.66.115.46/80 to inside:172.31.156.80/1382 duration 0:05:25 bytes 575 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:29:31.000Z",
                 "action": "flow-expiration",
@@ -6230,6 +6470,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 5391,
                 "iana_number": "6",
@@ -6270,9 +6513,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255475099Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401270850Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11797 for outside:100.66.19.254/80 to inside:172.31.156.80/1385 duration 0:00:00 bytes 5391 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -6312,6 +6555,9 @@
                 "address": "172.31.156.80",
                 "ip": "172.31.156.80"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -6350,9 +6596,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255477550Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401272165Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.156.80/1386 to outside:100.66.98.44/8278",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -6388,6 +6634,9 @@
                 "address": "100.66.115.46",
                 "ip": "100.66.115.46"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -6427,9 +6676,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255480029Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401273419Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11798 for outside:100.66.115.46/80 (100.66.115.46/80) to inside:172.31.156.80/1386 (172.31.156.80/1386)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -6470,6 +6719,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -6508,9 +6760,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255482506Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401274670Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -6549,6 +6801,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -6587,9 +6842,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255485026Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401275923Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -6628,6 +6883,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -6666,9 +6924,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255487495Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401277190Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -6707,6 +6965,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -6745,9 +7006,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255489941Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401278450Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -6786,6 +7047,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -6824,9 +7088,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255492388Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401279717Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -6865,6 +7129,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -6903,9 +7170,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255494907Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401280975Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -6944,6 +7211,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -6982,9 +7252,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255497382Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401282235Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -7023,6 +7293,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -7061,9 +7334,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255499865Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401283518Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -7102,6 +7375,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -7140,9 +7416,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255502347Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401284774Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -7181,6 +7457,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -7219,9 +7498,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255504794Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401286057Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -7260,6 +7539,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -7298,9 +7580,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255507295Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401287319Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -7339,6 +7621,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -7377,9 +7662,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255509740Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401288574Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -7418,6 +7703,9 @@
                 "address": "100.66.19.254",
                 "ip": "100.66.19.254"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -7456,9 +7744,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255512191Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401289860Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -7497,6 +7785,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -7535,9 +7826,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255514633Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401291129Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1275 to outside:100.66.98.44/8279",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -7573,6 +7864,9 @@
                 "address": "100.66.205.99",
                 "ip": "100.66.205.99"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -7612,9 +7906,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255517140Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401292400Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11799 for outside:100.66.205.99/80 (100.66.205.99/80) to inside:172.31.98.44/1275 (172.31.98.44/1275)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -7655,6 +7949,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -7693,9 +7990,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255519623Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401293719Z",
                 "original": "%ASA-6-305011: Built dynamic UDP translation from inside:172.31.98.44/56132 to outside:100.66.98.44/1190",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -7731,6 +8028,9 @@
                 "address": "100.66.14.30",
                 "ip": "100.66.14.30"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -7770,9 +8070,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255522072Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:21.401294995Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11800 for outside:100.66.14.30/53 (100.66.14.30/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -7813,6 +8113,9 @@
                 "address": "100.66.14.30",
                 "ip": "100.66.14.30"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 373,
                 "iana_number": "17",
@@ -7853,9 +8156,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255524503Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401296267Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11800 for outside:100.66.14.30/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 373",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -7895,6 +8198,9 @@
                 "address": "100.66.252.210",
                 "ip": "100.66.252.210"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -7934,9 +8240,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255526938Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:21.401297542Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11801 for outside:100.66.252.210/53 (100.66.252.210/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -7977,6 +8283,9 @@
                 "address": "100.66.252.210",
                 "ip": "100.66.252.210"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 207,
                 "iana_number": "17",
@@ -8017,9 +8326,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255529373Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401298799Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11801 for outside:100.66.252.210/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 207",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -8059,6 +8368,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -8097,9 +8409,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255531824Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401300145Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1276 to outside:100.66.98.44/8280",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -8135,6 +8447,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -8174,9 +8489,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255534263Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401301419Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11802 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1276 (172.31.98.44/1276)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -8217,6 +8532,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -8255,9 +8573,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255536731Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401302673Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1277 to outside:100.66.98.44/8281",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -8293,6 +8611,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -8332,9 +8653,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255539173Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401303928Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11803 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1277 (172.31.98.44/1277)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -8375,6 +8696,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 12853,
                 "iana_number": "6",
@@ -8415,9 +8739,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255541663Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401305188Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11802 for outside:100.66.98.165/80 to inside:172.31.98.44/1276 duration 0:00:00 bytes 12853 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -8457,6 +8781,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -8495,9 +8822,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255544109Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401306450Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1278 to outside:100.66.98.44/8282",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -8533,6 +8860,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -8572,9 +8902,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255546585Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401307727Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11804 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1278 (172.31.98.44/1278)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -8615,6 +8945,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 5291,
                 "iana_number": "6",
@@ -8655,9 +8988,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255549174Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401309113Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11803 for outside:100.66.98.165/80 to inside:172.31.98.44/1277 duration 0:00:00 bytes 5291 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -8697,6 +9030,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -8735,9 +9071,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255551727Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401310493Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1279 to outside:100.66.98.44/8283",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -8773,6 +9109,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -8812,9 +9151,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255557175Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401311751Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11805 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1279 (172.31.98.44/1279)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -8855,6 +9194,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 965,
                 "iana_number": "6",
@@ -8895,9 +9237,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255559825Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401313023Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11804 for outside:100.66.98.165/80 to inside:172.31.98.44/1278 duration 0:00:00 bytes 965 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -8937,6 +9279,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 8605,
                 "iana_number": "6",
@@ -8977,9 +9322,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255562316Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401314284Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11805 for outside:100.66.98.165/80 to inside:172.31.98.44/1279 duration 0:00:00 bytes 8605 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -9019,6 +9364,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -9057,9 +9405,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255564794Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401315546Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1280 to outside:100.66.98.44/8284",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -9095,6 +9443,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -9134,9 +9485,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255567310Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401316804Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11806 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1280 (172.31.98.44/1280)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -9177,6 +9528,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 3428,
                 "iana_number": "6",
@@ -9217,9 +9571,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255569798Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401318075Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11806 for outside:100.66.98.165/80 to inside:172.31.98.44/1280 duration 0:00:00 bytes 3428 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -9259,6 +9613,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -9297,9 +9654,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255572277Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401319352Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1281 to outside:100.66.98.44/8285",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -9335,6 +9692,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -9374,9 +9734,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255574754Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401320608Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11807 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1281 (172.31.98.44/1281)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -9417,6 +9777,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -9455,9 +9818,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255577228Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401321866Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1282 to outside:100.66.98.44/8286",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -9493,6 +9856,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -9532,9 +9898,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255579773Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401323144Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11808 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1282 (172.31.98.44/1282)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -9575,6 +9941,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -9613,9 +9982,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255582219Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401324453Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1283 to outside:100.66.98.44/8287",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -9651,6 +10020,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -9690,9 +10062,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255584667Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401325878Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11809 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1283 (172.31.98.44/1283)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -9733,6 +10105,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -9771,9 +10146,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255587104Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401327132Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1284 to outside:100.66.98.44/8288",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -9809,6 +10184,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -9848,9 +10226,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255589553Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401328383Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11810 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1284 (172.31.98.44/1284)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -9891,6 +10269,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 2028,
                 "iana_number": "6",
@@ -9931,9 +10312,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255591999Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401329638Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11807 for outside:100.66.98.165/80 to inside:172.31.98.44/1281 duration 0:00:00 bytes 2028 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -9973,6 +10354,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 1085,
                 "iana_number": "6",
@@ -10013,9 +10397,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255594581Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401330916Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11808 for outside:100.66.98.165/80 to inside:172.31.98.44/1282 duration 0:00:00 bytes 1085 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -10055,6 +10439,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 868,
                 "iana_number": "6",
@@ -10095,9 +10482,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255597049Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401332206Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11809 for outside:100.66.98.165/80 to inside:172.31.98.44/1283 duration 0:00:00 bytes 868 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -10137,6 +10524,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -10175,9 +10565,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255599524Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401333461Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1285 to outside:100.66.98.44/8289",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -10213,6 +10603,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -10252,9 +10645,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255601963Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401334720Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11811 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1285 (172.31.98.44/1285)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -10295,6 +10688,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -10333,9 +10729,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255604407Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401335983Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1286 to outside:100.66.98.44/8290",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -10371,6 +10767,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -10410,9 +10809,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255606864Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401337631Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11812 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1286 (172.31.98.44/1286)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -10453,6 +10852,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 4439,
                 "iana_number": "6",
@@ -10493,9 +10895,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255610792Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401339027Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11810 for outside:100.66.98.165/80 to inside:172.31.98.44/1284 duration 0:00:00 bytes 4439 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -10535,6 +10937,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -10573,9 +10978,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255613406Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401340288Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1287 to outside:100.66.98.44/8291",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -10611,6 +11016,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -10650,9 +11058,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255615875Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401341543Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11813 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1287 (172.31.98.44/1287)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -10693,6 +11101,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 914,
                 "iana_number": "6",
@@ -10733,9 +11144,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255618340Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401342811Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11811 for outside:100.66.98.165/80 to inside:172.31.98.44/1285 duration 0:00:00 bytes 914 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -10775,6 +11186,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 871,
                 "iana_number": "6",
@@ -10815,9 +11229,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255620801Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401344940Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11812 for outside:100.66.98.165/80 to inside:172.31.98.44/1286 duration 0:00:00 bytes 871 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -10857,6 +11271,9 @@
                 "address": "100.66.100.107",
                 "ip": "100.66.100.107"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -10896,9 +11313,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255623291Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:21.401347448Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11814 for outside:100.66.100.107/53 (100.66.100.107/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -10939,6 +11356,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -10977,9 +11397,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255625729Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401348809Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1288 to outside:100.66.98.44/8292",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -11015,6 +11435,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -11054,9 +11477,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255628211Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401350450Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11815 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1288 (172.31.98.44/1288)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -11097,6 +11520,9 @@
                 "address": "100.66.100.107",
                 "ip": "100.66.100.107"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 384,
                 "iana_number": "17",
@@ -11137,9 +11563,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255630662Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401351737Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11814 for outside:100.66.100.107/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 384",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -11179,6 +11605,9 @@
                 "address": "100.66.104.8",
                 "ip": "100.66.104.8"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -11218,9 +11647,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255633127Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:21.401353003Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11816 for outside:100.66.104.8/53 (100.66.104.8/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -11261,6 +11690,9 @@
                 "address": "100.66.104.8",
                 "ip": "100.66.104.8"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 94,
                 "iana_number": "17",
@@ -11301,9 +11733,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255635617Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401354274Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11816 for outside:100.66.104.8/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 94",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -11343,6 +11775,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -11381,9 +11816,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255638089Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401355539Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1289 to outside:100.66.98.44/8293",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -11419,6 +11854,9 @@
                 "address": "100.66.123.191",
                 "ip": "100.66.123.191"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -11458,9 +11896,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255640565Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401356806Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11817 for outside:100.66.123.191/80 (100.66.123.191/80) to inside:172.31.98.44/1289 (172.31.98.44/1289)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -11501,6 +11939,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 945,
                 "iana_number": "6",
@@ -11541,9 +11982,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255643043Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401358065Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11815 for outside:100.66.98.165/80 to inside:172.31.98.44/1288 duration 0:00:00 bytes 945 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -11583,6 +12024,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 13284,
                 "iana_number": "6",
@@ -11623,9 +12067,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255645514Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401359320Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11813 for outside:100.66.98.165/80 to inside:172.31.98.44/1287 duration 0:00:00 bytes 13284 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -11665,6 +12109,9 @@
                 "address": "100.66.100.4",
                 "ip": "100.66.100.4"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -11704,9 +12151,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255647981Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:21.401360591Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11818 for outside:100.66.100.4/53 (100.66.100.4/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -11747,6 +12194,9 @@
                 "address": "100.66.100.4",
                 "ip": "100.66.100.4"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 104,
                 "iana_number": "17",
@@ -11787,9 +12237,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255650529Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401361858Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11818 for outside:100.66.100.4/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 104",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -11829,6 +12279,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -11867,9 +12320,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255653002Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401363123Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1290 to outside:100.66.98.44/8294",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -11905,6 +12358,9 @@
                 "address": "100.66.198.25",
                 "ip": "100.66.198.25"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -11944,9 +12400,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255655475Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401364400Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11819 for outside:100.66.198.25/80 (100.66.198.25/80) to inside:172.31.98.44/1290 (172.31.98.44/1290)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -11987,6 +12443,9 @@
                 "address": "100.66.48.1",
                 "ip": "100.66.48.1"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 58512,
                 "iana_number": "17",
@@ -12027,9 +12486,9 @@
             "event": {
                 "severity": 6,
                 "duration": 3526000000000,
-                "ingested": "2021-05-13T11:41:07.255657946Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401365667Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 9828 for outside:100.66.48.1/67 to NP Identity Ifc:255.255.255.255/68 duration 0:58:46 bytes 58512",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T11:36:10.000Z",
                 "action": "flow-expiration",
@@ -12052,15 +12511,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -12071,17 +12536,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255660415Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401366920Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1272 to outside:100.66.98.44/8276 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -12115,6 +12577,9 @@
                 "address": "100.66.3.39",
                 "ip": "100.66.3.39"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -12154,9 +12619,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255662912Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:21.401368189Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11820 for outside:100.66.3.39/53 (100.66.3.39/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -12197,6 +12662,9 @@
                 "address": "100.66.162.30",
                 "ip": "100.66.162.30"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -12236,9 +12704,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255665349Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:21.401369442Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11821 for outside:100.66.162.30/53 (100.66.162.30/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -12279,6 +12747,9 @@
                 "address": "100.66.3.39",
                 "ip": "100.66.3.39"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 168,
                 "iana_number": "17",
@@ -12319,9 +12790,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255667810Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401370715Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11820 for outside:100.66.3.39/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 168",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -12361,6 +12832,9 @@
                 "address": "100.66.3.39",
                 "ip": "100.66.3.39"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -12400,9 +12874,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255670298Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:21.401371977Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11822 for outside:100.66.3.39/53 (100.66.3.39/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -12443,6 +12917,9 @@
                 "address": "100.66.162.30",
                 "ip": "100.66.162.30"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 198,
                 "iana_number": "17",
@@ -12483,9 +12960,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255672818Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401373233Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11821 for outside:100.66.162.30/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 198",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -12525,6 +13002,9 @@
                 "address": "100.66.3.39",
                 "ip": "100.66.3.39"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 150,
                 "iana_number": "17",
@@ -12565,9 +13045,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255675287Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401374492Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11822 for outside:100.66.3.39/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 150",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -12607,6 +13087,9 @@
                 "address": "100.66.48.186",
                 "ip": "100.66.48.186"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -12646,9 +13129,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255677748Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:21.401375743Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11823 for outside:100.66.48.186/53 (100.66.48.186/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -12689,6 +13172,9 @@
                 "address": "100.66.48.186",
                 "ip": "100.66.48.186"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 84,
                 "iana_number": "17",
@@ -12729,9 +13215,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255680227Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401376989Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11823 for outside:100.66.48.186/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 84",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -12771,6 +13257,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -12809,9 +13298,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255682705Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401378243Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1291 to outside:100.66.98.44/8295",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -12847,6 +13336,9 @@
                 "address": "100.66.54.190",
                 "ip": "100.66.54.190"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -12886,9 +13378,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255685177Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401379503Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11824 for outside:100.66.54.190/80 (100.66.54.190/80) to inside:172.31.98.44/1291 (172.31.98.44/1291)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -12929,6 +13421,9 @@
                 "address": "100.66.254.94",
                 "ip": "100.66.254.94"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -12968,9 +13463,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255687828Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:21.401380925Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11825 for outside:100.66.254.94/53 (100.66.254.94/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -13011,6 +13506,9 @@
                 "address": "100.66.254.94",
                 "ip": "100.66.254.94"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 188,
                 "iana_number": "17",
@@ -13051,9 +13549,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255690604Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401382305Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11825 for outside:100.66.254.94/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 188",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -13093,6 +13591,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -13131,9 +13632,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255693273Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401383625Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1292 to outside:100.66.98.44/8296",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -13169,6 +13670,9 @@
                 "address": "100.66.54.190",
                 "ip": "100.66.54.190"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -13208,9 +13712,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255695737Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401384871Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11826 for outside:100.66.54.190/80 (100.66.54.190/80) to inside:172.31.98.44/1292 (172.31.98.44/1292)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -13251,6 +13755,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -13289,9 +13796,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255698189Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401386127Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1293 to outside:100.66.98.44/8297",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -13327,6 +13834,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -13366,9 +13876,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255700627Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401387394Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11827 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1293 (172.31.98.44/1293)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -13409,6 +13919,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -13447,9 +13960,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255703096Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401388642Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1294 to outside:100.66.98.44/8298",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -13485,6 +13998,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -13524,9 +14040,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255705544Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401389961Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11828 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1294 (172.31.98.44/1294)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -13567,6 +14083,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 5964,
                 "iana_number": "6",
@@ -13607,9 +14126,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255707993Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401391298Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11827 for outside:100.66.98.165/80 to inside:172.31.98.44/1293 duration 0:00:00 bytes 5964 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -13649,6 +14168,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -13687,9 +14209,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255710436Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401392554Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1295 to outside:100.66.98.44/8299",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -13725,6 +14247,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -13764,9 +14289,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255712878Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401393827Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11829 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1295 (172.31.98.44/1295)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -13807,6 +14332,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -13845,9 +14373,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255715303Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401395087Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1296 to outside:100.66.98.44/8300",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -13883,6 +14411,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -13922,9 +14453,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255717748Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401396348Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11830 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1296 (172.31.98.44/1296)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -13965,6 +14496,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 6694,
                 "iana_number": "6",
@@ -14005,9 +14539,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255720185Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401397616Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11828 for outside:100.66.98.165/80 to inside:172.31.98.44/1294 duration 0:00:00 bytes 6694 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -14047,6 +14581,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 1493,
                 "iana_number": "6",
@@ -14087,9 +14624,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255722668Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401398884Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11829 for outside:100.66.98.165/80 to inside:172.31.98.44/1295 duration 0:00:00 bytes 1493 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -14129,6 +14666,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 893,
                 "iana_number": "6",
@@ -14169,9 +14709,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255725116Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401400139Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11830 for outside:100.66.98.165/80 to inside:172.31.98.44/1296 duration 0:00:00 bytes 893 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -14211,6 +14751,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -14249,9 +14792,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255727564Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401401398Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1297 to outside:100.66.98.44/8301",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -14287,6 +14830,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -14326,9 +14872,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255729994Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401402647Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11831 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1297 (172.31.98.44/1297)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -14369,6 +14915,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -14407,9 +14956,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255732449Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401403942Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1298 to outside:100.66.98.44/8302",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -14445,6 +14994,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -14484,9 +15036,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255734893Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401405213Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11832 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1298 (172.31.98.44/1298)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -14527,6 +15079,9 @@
                 "address": "100.66.179.9",
                 "ip": "100.66.179.9"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -14566,9 +15121,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255737336Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:21.401406467Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11833 for outside:100.66.179.9/53 (100.66.179.9/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -14609,6 +15164,9 @@
                 "address": "100.66.179.9",
                 "ip": "100.66.179.9"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 150,
                 "iana_number": "17",
@@ -14649,9 +15207,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255739811Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401408811Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11833 for outside:100.66.179.9/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 150",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -14691,6 +15249,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 2750,
                 "iana_number": "6",
@@ -14731,9 +15292,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255742278Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401410100Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11831 for outside:100.66.98.165/80 to inside:172.31.98.44/1297 duration 0:00:00 bytes 2750 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -14773,6 +15334,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -14811,9 +15375,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255744716Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401411400Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1299 to outside:100.66.98.44/8303",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -14849,6 +15413,9 @@
                 "address": "100.66.247.99",
                 "ip": "100.66.247.99"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -14888,9 +15455,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255747171Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401412662Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11834 for outside:100.66.247.99/80 (100.66.247.99/80) to inside:172.31.98.44/1299 (172.31.98.44/1299)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -14931,6 +15498,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -14969,9 +15539,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255749609Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401413925Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1300 to outside:100.66.98.44/8304",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15007,6 +15577,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -15046,9 +15619,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255752053Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401415195Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11835 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1300 (172.31.98.44/1300)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15089,6 +15662,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 881,
                 "iana_number": "6",
@@ -15129,9 +15705,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255754497Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401416454Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11832 for outside:100.66.98.165/80 to inside:172.31.98.44/1298 duration 0:00:00 bytes 881 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -15171,6 +15747,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 2202,
                 "iana_number": "6",
@@ -15211,9 +15790,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255758624Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401417731Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11835 for outside:100.66.98.165/80 to inside:172.31.98.44/1300 duration 0:00:00 bytes 2202 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -15253,6 +15832,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -15291,9 +15873,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255761372Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401418999Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1301 to outside:100.66.98.44/8305",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15329,6 +15911,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -15368,9 +15953,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255763863Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401420255Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11836 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1301 (172.31.98.44/1301)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15411,6 +15996,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -15449,9 +16037,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255766349Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401421523Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1302 to outside:100.66.98.44/8306",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15487,6 +16075,9 @@
                 "address": "100.66.98.165",
                 "ip": "100.66.98.165"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -15526,9 +16117,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255768805Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401422785Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11837 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1302 (172.31.98.44/1302)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15552,15 +16143,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -15571,17 +16168,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255771238Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401424043Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1276 to outside:100.66.98.44/8280 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15598,15 +16192,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -15617,17 +16217,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255773678Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401425320Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1277 to outside:100.66.98.44/8281 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15644,15 +16241,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -15663,17 +16266,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255776128Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401426578Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1278 to outside:100.66.98.44/8282 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15690,15 +16290,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -15709,17 +16315,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255778588Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401427835Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1279 to outside:100.66.98.44/8283 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15736,15 +16339,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -15755,17 +16364,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255781077Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401429118Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1280 to outside:100.66.98.44/8284 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15782,15 +16388,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -15801,17 +16413,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255783538Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401430383Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1281 to outside:100.66.98.44/8285 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15828,15 +16437,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -15847,17 +16462,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255785997Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401431650Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1282 to outside:100.66.98.44/8286 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15874,15 +16486,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -15893,17 +16511,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255788456Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401432924Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1283 to outside:100.66.98.44/8287 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15920,15 +16535,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -15939,17 +16560,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255790933Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401435269Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1284 to outside:100.66.98.44/8288 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -15966,15 +16584,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -15985,17 +16609,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255793364Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401436695Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1285 to outside:100.66.98.44/8289 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16012,15 +16633,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -16031,17 +16658,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255795802Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401438005Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1286 to outside:100.66.98.44/8290 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16058,15 +16682,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -16077,17 +16707,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255798263Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401439296Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1287 to outside:100.66.98.44/8291 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16104,15 +16731,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -16123,17 +16756,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255800770Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401440561Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1288 to outside:100.66.98.44/8292 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16150,15 +16780,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -16169,17 +16805,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255803217Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401441819Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1293 to outside:100.66.98.44/8297 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16196,15 +16829,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -16215,17 +16854,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255805693Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401443088Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1294 to outside:100.66.98.44/8298 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16259,6 +16895,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -16297,9 +16936,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255808152Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401444458Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1304 to outside:100.66.98.44/8308",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16335,6 +16974,9 @@
                 "address": "100.66.205.99",
                 "ip": "100.66.205.99"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -16374,9 +17016,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255810591Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401445815Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11840 for outside:100.66.205.99/80 (100.66.205.99/80) to inside:172.31.98.44/1304 (172.31.98.44/1304)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16400,15 +17042,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -16419,17 +17067,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255813053Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401447153Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1295 to outside:100.66.98.44/8299 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16446,15 +17091,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -16465,17 +17116,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255815505Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401448428Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1296 to outside:100.66.98.44/8300 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16509,6 +17157,9 @@
                 "address": "100.66.0.124",
                 "ip": "100.66.0.124"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -16548,9 +17199,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255817974Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:21.401449697Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11841 for outside:100.66.0.124/53 (100.66.0.124/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16591,6 +17242,9 @@
                 "address": "100.66.160.2",
                 "ip": "100.66.160.2"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -16630,9 +17284,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255820433Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:21.401450994Z",
                 "original": "%ASA-6-302015: Built outbound UDP connection 11842 for outside:100.66.160.2/53 (100.66.160.2/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16673,6 +17327,9 @@
                 "address": "100.66.0.124",
                 "ip": "100.66.0.124"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 318,
                 "iana_number": "17",
@@ -16713,9 +17370,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255822887Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401452277Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11841 for outside:100.66.0.124/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 318",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -16755,6 +17412,9 @@
                 "address": "100.66.160.2",
                 "ip": "100.66.160.2"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 104,
                 "iana_number": "17",
@@ -16795,9 +17455,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:07.255825386Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:21.401453533Z",
                 "original": "%ASA-6-302016: Teardown UDP connection 11842 for outside:100.66.160.2/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 104",
+                "code": "302016",
                 "kind": "event",
                 "start": "2018-10-10T12:34:56.000Z",
                 "action": "flow-expiration",
@@ -16837,6 +17497,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -16875,9 +17538,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255827833Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401454795Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1305 to outside:100.66.98.44/8309",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16913,6 +17576,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -16952,9 +17618,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255830288Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401456073Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11843 for outside:100.66.124.24/80 (100.66.124.24/80) to inside:172.31.98.44/1305 (172.31.98.44/1305)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -16978,15 +17644,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -16997,17 +17669,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255832724Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401457334Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1297 to outside:100.66.98.44/8301 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17024,15 +17693,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -17043,17 +17718,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255835152Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401458610Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1298 to outside:100.66.98.44/8302 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17070,15 +17742,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -17089,17 +17767,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255837713Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401459880Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1299 to outside:100.66.98.44/8303 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17116,15 +17791,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -17135,17 +17816,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255840217Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401461146Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1300 to outside:100.66.98.44/8304 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17162,15 +17840,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -17181,17 +17865,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255842669Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401462416Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1301 to outside:100.66.98.44/8305 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17208,15 +17889,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -17227,17 +17914,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255845106Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401463685Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1302 to outside:100.66.98.44/8306 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17254,15 +17938,21 @@
             }
         },
         {
+            "process": {
+                "name": "CiscoASA",
+                "pid": 999
+            },
+            "log": {
+                "level": "informational"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "localhost",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "CiscoASA",
-                "pid": 999
             },
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
@@ -17273,17 +17963,14 @@
                     "localhost"
                 ]
             },
-            "log": {
-                "level": "informational"
-            },
             "host": {
                 "hostname": "localhost"
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255847546Z",
-                "code": "305012",
+                "ingested": "2021-06-03T06:53:21.401464956Z",
                 "original": "%ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1303 to outside:100.66.98.44/8307 duration 0:00:30",
+                "code": "305012",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17317,6 +18004,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 410333,
                 "iana_number": "6",
@@ -17357,9 +18047,9 @@
             "event": {
                 "severity": 6,
                 "duration": 4000000000,
-                "ingested": "2021-05-13T11:41:07.255850025Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:21.401466256Z",
                 "original": "%ASA-6-302014: Teardown TCP connection 11843 for outside:100.66.124.24/80 to inside:172.31.98.44/1305 duration 0:00:04 bytes 410333 TCP Reset-I",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-10-10T12:34:52.000Z",
                 "action": "flow-expiration",
@@ -17399,6 +18089,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -17437,9 +18130,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255852464Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401467630Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17478,6 +18171,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -17516,9 +18212,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255854916Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401468900Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17557,6 +18253,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -17595,9 +18294,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255857411Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401470190Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17636,6 +18335,9 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -17674,9 +18376,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255859920Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:21.401471460Z",
                 "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1306 to outside:100.66.98.44/8310",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17712,6 +18414,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -17751,9 +18456,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:07.255862369Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:21.401472808Z",
                 "original": "%ASA-6-302013: Built outbound TCP connection 11844 for outside:100.66.124.24/80 (100.66.124.24/80) to inside:172.31.98.44/1306 (172.31.98.44/1306)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17794,6 +18499,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -17832,9 +18540,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255864807Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401474149Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17873,6 +18581,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -17911,9 +18622,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255867247Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401475405Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -17952,6 +18663,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -17990,9 +18704,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255869703Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401476667Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18031,6 +18745,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18069,9 +18786,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255872239Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401479133Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18110,6 +18827,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18148,9 +18868,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255874720Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401480573Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18189,6 +18909,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18227,9 +18950,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255877173Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401481958Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18268,6 +18991,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18306,9 +19032,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255879614Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401483343Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18347,6 +19073,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18385,9 +19114,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255882065Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401484664Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18426,6 +19155,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18464,9 +19196,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255884542Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401485981Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18505,6 +19237,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18543,9 +19278,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255886982Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401487368Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18584,6 +19319,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18622,9 +19360,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255889690Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401489106Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18663,6 +19401,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18701,9 +19442,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255892202Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401490430Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18742,6 +19483,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18780,9 +19524,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255894654Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401491748Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18821,6 +19565,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18859,9 +19606,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255897102Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401493068Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18900,6 +19647,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18938,9 +19688,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255899559Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401494391Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -18979,6 +19729,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19017,9 +19770,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255902011Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401495778Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -19058,6 +19811,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19096,9 +19852,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255904458Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401497093Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -19137,6 +19893,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19175,9 +19934,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255906932Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401498428Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -19216,6 +19975,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19254,9 +20016,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255909378Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401499769Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -19295,6 +20057,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19333,9 +20098,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255911821Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401501081Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -19374,6 +20139,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19412,9 +20180,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255914351Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401502399Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -19453,6 +20221,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19491,9 +20262,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255916791Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401503764Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -19532,6 +20303,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19570,9 +20344,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255919236Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401505084Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -19611,6 +20385,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19649,9 +20426,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255923190Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401506427Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -19690,6 +20467,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19728,9 +20508,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255925821Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401507743Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -19769,6 +20549,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19807,9 +20590,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255928271Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401509079Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -19848,6 +20631,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19886,9 +20672,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255930750Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401510442Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -19927,6 +20713,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -19965,9 +20754,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255933198Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401511772Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -20006,6 +20795,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -20044,9 +20836,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255935651Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401513084Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -20085,6 +20877,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -20123,9 +20918,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255938089Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401514411Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -20164,6 +20959,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -20202,9 +21000,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255940593Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401515731Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -20243,6 +21041,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -20281,9 +21082,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255943027Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401517101Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -20322,6 +21123,9 @@
                 "address": "100.66.124.24",
                 "ip": "100.66.124.24"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -20360,9 +21164,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:07.255945494Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:21.401518432Z",
                 "original": "%ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-common-config.yml
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-common-config.yml
@@ -1,0 +1,5 @@
+dynamic_fields:
+  event.ingested: ".*"
+fields:
+  tags:
+    - preserve_original_event

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-dns.log-config.yml
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-dns.log-config.yml
@@ -1,2 +1,0 @@
-dynamic_fields:
-  event.ingested: ".*"

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-dns.log-expected.json
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-dns.log-expected.json
@@ -40,6 +40,9 @@
                 "packets": 1,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -84,9 +87,9 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:34.642316914Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:33.100780315Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 57379, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 145, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSRecordType: a host address, DNS_TTL: 70",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-26T23:11:03.000Z",
                 "action": "connection-finished",
@@ -184,6 +187,9 @@
                 "packets": 1,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -228,9 +234,9 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:34.642329465Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:33.100786966Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, AccessControlRuleReason: Intrusion Monitor, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 51389, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, IPSCount: 1, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 193, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSRecordType: IP6 Address, DNS_TTL: 299",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-26T23:11:03.000Z",
                 "action": "connection-finished",
@@ -330,6 +336,9 @@
                 "packets": 1,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -374,9 +383,9 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:34.642332436Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:33.100788497Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 53033, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 166, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSRecordType: the canonical name for an alias, DNS_TTL: 899",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-26T23:11:03.000Z",
                 "action": "connection-finished",
@@ -474,6 +483,9 @@
                 "packets": 1,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -518,9 +530,9 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:34.642335228Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:33.100792493Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, AccessControlRuleReason: Intrusion Monitor, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 55371, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, IPSCount: 1, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 97, ResponderBytes: 200, NAPPolicy: Balanced Security and Connectivity, DNSQuery: www.elastic.co, DNSRecordType: a host address, DNS_TTL: 12",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-26T23:11:03.000Z",
                 "action": "connection-finished",
@@ -620,6 +632,9 @@
                 "packets": 1,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -664,9 +679,9 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:34.642337868Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:33.100794079Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 60441, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 193, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSRecordType: IP6 Address, DNS_TTL: 299, DNSResponseType: No error",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-26T23:11:03.000Z",
                 "action": "connection-finished",
@@ -765,6 +780,9 @@
                 "packets": 1,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -809,9 +827,9 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:34.642340479Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:33.100795441Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 59714, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 166, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSRecordType: the canonical name for an alias, DNS_TTL: 658",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-26T23:11:03.000Z",
                 "action": "connection-finished",
@@ -909,6 +927,9 @@
                 "packets": 1,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -953,9 +974,9 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:34.642343084Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:33.100796809Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, AccessControlRuleReason: Intrusion Monitor, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 55105, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, IPSCount: 1, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 199, NAPPolicy: Balanced Security and Connectivity, DNSResponseType: Non-Existent Domain, DNSQuery: elastic.co, DNSRecordType: mail exchange, DNS_TTL: 299",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-26T23:11:03.000Z",
                 "action": "connection-finished",
@@ -1056,6 +1077,9 @@
                 "packets": 1,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -1100,9 +1124,9 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:34.642345724Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:33.100798199Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 57141, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 221, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSRecordType: an authoritative name server, DNS_TTL: 21599",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-26T23:11:03.000Z",
                 "action": "connection-finished",
@@ -1200,6 +1224,9 @@
                 "packets": 1,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -1244,9 +1271,9 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:34.642348360Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:33.100799517Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 47260, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 166, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSResponseType: Server Failure, DNSRecordType: marks the start of a zone of authority, DNS_TTL: 899",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-26T23:11:03.000Z",
                 "action": "connection-finished",
@@ -1345,6 +1372,9 @@
                 "packets": 1,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -1389,9 +1419,9 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:34.642350984Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:33.100800836Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, AccessControlRuleReason: Intrusion Monitor, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 58082, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, IPSCount: 1, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 722, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSRecordType: text strings, DNS_TTL: 299",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-26T23:11:03.000Z",
                 "action": "connection-finished",
@@ -1494,6 +1524,9 @@
                 "packets": 1,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -1538,9 +1571,9 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:34.642353642Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:33.100802168Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 205.251.196.144, SrcPort: 33973, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 98, ResponderBytes: 75, NAPPolicy: Balanced Security and Connectivity, DNSQuery: refusedthis.com, DNSRecordType: a host address, DNSResponseType: Query Refused",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-26T23:11:03.000Z",
                 "action": "connection-finished",
@@ -1634,6 +1667,9 @@
                 "packets": 6,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "tcp",
@@ -1678,9 +1714,9 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:34.642356506Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:33.100803623Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 39541, DstPort: 53, Protocol: tcp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 6, ResponderPackets: 4, InitiatorBytes: 457, ResponderBytes: 313, NAPPolicy: Balanced Security and Connectivity, DNSResponseType: Server Failure",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-26T23:11:03.000Z",
                 "action": "connection-finished",
@@ -1776,6 +1812,9 @@
                 "packets": 1,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -1820,9 +1859,9 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:34.642359169Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:33.100804950Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 9.9.9.9, SrcPort: 41672, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 107, ResponderBytes: 180, NAPPolicy: Balanced Security and Connectivity, DNSQuery: laskdfjlaksdf.elastic.co, DNSRecordType: a host address, DNSResponseType: Non-Existent Domain, DNS_TTL: 900",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-26T23:11:03.000Z",
                 "action": "connection-finished",
@@ -1921,6 +1960,9 @@
                 "packets": 1,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -1965,9 +2007,9 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:34.642361808Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:33.100806263Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 9.9.9.9, SrcPort: 59577, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 104, ResponderBytes: 108, NAPPolicy: Balanced Security and Connectivity, DNSQuery: ns-1168.awsdns-18.org, DNSRecordType: a host address, DNS_TTL: 31694",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-26T23:11:03.000Z",
                 "action": "connection-finished",
@@ -2065,6 +2107,9 @@
                 "packets": 1,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -2109,9 +2154,9 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:34.642364425Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:33.100807590Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 9.9.9.9, SrcPort: 35998, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 101, ResponderBytes: 162, NAPPolicy: Balanced Security and Connectivity, DNSQuery: _http._tcp.security.ubuntu.com, DNSRecordType: Server Selection, DNSResponseType: Non-Existent Domain, DNS_TTL: 946",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-26T23:11:03.000Z",
                 "action": "connection-finished",
@@ -2210,6 +2255,9 @@
                 "packets": 1,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -2254,9 +2302,9 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:34.642367037Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:33.100808944Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, AccessControlRuleReason: Intrusion Monitor, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 55105, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, IPSCount: 1, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 199, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSRecordType: mail exchange, DNS_TTL: 299",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-26T23:11:03.000Z",
                 "action": "connection-finished",
@@ -2356,6 +2404,9 @@
                 "packets": 1,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -2400,9 +2451,9 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:34.642369723Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:33.100810382Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 47260, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 166, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSRecordType: marks the start of a zone of authority, DNS_TTL: 899",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-26T23:11:03.000Z",
                 "action": "connection-finished",
@@ -2500,6 +2551,9 @@
                 "packets": 1,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -2544,9 +2598,9 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:34.642372426Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:33.100811703Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 53033, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 166, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSRecordType: the canonical name for an alias, DNS_TTL: 899",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-26T23:11:03.000Z",
                 "action": "connection-finished",
@@ -2644,6 +2698,9 @@
                 "packets": 1,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -2688,9 +2745,9 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:34.642375048Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:33.100813028Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 57141, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 221, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSRecordType: an authoritative name server, DNS_TTL: 21599",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-26T23:11:03.000Z",
                 "action": "connection-finished",
@@ -2787,6 +2844,9 @@
                 "packets": 1,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -2831,9 +2891,9 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:34.642377684Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:33.100814387Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 46093, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 131, NAPPolicy: Balanced Security and Connectivity, DNSRecordType: a domain name pointer, DNS_TTL: 59",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-26T23:11:03.000Z",
                 "action": "connection-finished",
@@ -2930,6 +2990,9 @@
                 "packets": 1,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -2974,9 +3037,9 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:34.642380305Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:33.100853454Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, AccessControlRuleReason: Intrusion Monitor, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 58082, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, IPSCount: 1, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 722, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSRecordType: text strings, DNS_TTL: 299",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-26T23:11:03.000Z",
                 "action": "connection-finished",

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-filtered.log-config.yml
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-filtered.log-config.yml
@@ -1,2 +1,0 @@
-dynamic_fields:
-  event.ingested: ".*"

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-filtered.log-expected.json
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-filtered.log-expected.json
@@ -1,15 +1,21 @@
 {
     "expected": [
         {
+            "process": {
+                "name": "asa",
+                "pid": 1234
+            },
+            "log": {
+                "level": "debug"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "beats",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
-            },
-            "process": {
-                "name": "asa",
-                "pid": 1234
             },
             "@timestamp": "2019-01-01T01:00:27.000Z",
             "ecs": {
@@ -20,17 +26,14 @@
                     "beats"
                 ]
             },
-            "log": {
-                "level": "debug"
-            },
             "host": {
                 "hostname": "beats"
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.631368899Z",
-                "code": "999999",
+                "ingested": "2021-06-03T06:53:34.550545963Z",
                 "original": "%FTD-7-999999: This message is not filtered.",
+                "code": "999999",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -66,15 +69,14 @@
                     "beats"
                 ]
             },
-            "log": {},
             "host": {
                 "hostname": "beats"
             },
             "event": {
                 "severity": 8,
-                "ingested": "2021-05-13T11:41:38.631380546Z",
-                "code": "999999",
+                "ingested": "2021-06-03T06:53:34.550594129Z",
                 "original": "%FTD-8-999999: This phony message is dropped due to log level.",
+                "code": "999999",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -88,7 +90,10 @@
                 "ftd": {
                     "message_id": "999999"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-firepower-management.log-config.yml
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-firepower-management.log-config.yml
@@ -1,2 +1,0 @@
-dynamic_fields:
-  event.ingested: ".*"

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-firepower-management.log-expected.json
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-firepower-management.log-expected.json
@@ -26,12 +26,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764483234Z",
+                "ingested": "2021-06-03T06:53:34.607388817Z",
                 "original": "admin@10.0.255.31, System \u003e Configuration \u003e Configuration \u003e /platinum/platformSettingEdit.cgi?type=AuditLog, Page View\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -59,12 +62,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764495080Z",
+                "ingested": "2021-06-03T06:53:34.607395497Z",
                 "original": "admin@10.0.255.31, System \u003e Configuration \u003e Configuration \u003e /platinum/platformSettingEdit.cgi?type=Banner, Page View\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -92,12 +98,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764498131Z",
+                "ingested": "2021-06-03T06:53:34.607397008Z",
                 "original": "admin@10.0.255.31, System \u003e Configuration \u003e Configuration \u003e /platinum/ChangeReconciliation.cgi, Page View\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -125,12 +134,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764500807Z",
+                "ingested": "2021-06-03T06:53:34.607398334Z",
                 "original": "admin@10.0.255.31, System \u003e Configuration \u003e Configuration \u003e /platinum/platformSettingEdit.cgi?type=IntrusionPolicyPrefs, Page View\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -158,12 +170,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764503481Z",
+                "ingested": "2021-06-03T06:53:34.607399636Z",
                 "original": "admin@10.0.255.31, System \u003e Configuration \u003e Configuration \u003e /admin/lights_out_mgmt.cgi, Page View\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -191,12 +206,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764506175Z",
+                "ingested": "2021-06-03T06:53:34.607400900Z",
                 "original": "admin@10.0.255.31, Cloud Services, View url filtering settings\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -224,12 +242,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764508816Z",
+                "ingested": "2021-06-03T06:53:34.607402172Z",
                 "original": "admin@10.0.255.31, Cloud Services, View amp settings\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -257,12 +278,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764511447Z",
+                "ingested": "2021-06-03T06:53:34.607403423Z",
                 "original": "admin@10.0.255.31, System \u003e Monitoring \u003e Syslog, Page View\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -290,12 +314,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764514116Z",
+                "ingested": "2021-06-03T06:53:34.607404683Z",
                 "original": "admin@10.0.255.31, Devices \u003e Device Management, Page View\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -323,12 +350,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764516872Z",
+                "ingested": "2021-06-03T06:53:34.607405938Z",
                 "original": "admin@10.0.255.31, Devices \u003e Device Management \u003e NGFW Interfaces, Page View\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -356,12 +386,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764519641Z",
+                "ingested": "2021-06-03T06:53:34.607410581Z",
                 "original": "admin@10.0.255.31, Devices \u003e Device Management \u003e NGFW Device Summary, Page View\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -389,12 +422,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764522524Z",
+                "ingested": "2021-06-03T06:53:34.607412158Z",
                 "original": "admin@10.0.255.31, Devices \u003e Device Management \u003e NGFW Device Summary, Page View\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -422,12 +458,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764525231Z",
+                "ingested": "2021-06-03T06:53:34.607413541Z",
                 "original": "admin@10.0.255.31, Devices \u003e Platform Settings, Page View\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -455,12 +494,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764527885Z",
+                "ingested": "2021-06-03T06:53:34.607414854Z",
                 "original": "admin@10.0.255.31, Devices \u003e Platform Settings \u003e Platform Settings Editor, Page View\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -488,12 +530,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764530513Z",
+                "ingested": "2021-06-03T06:53:34.607416230Z",
                 "original": "admin@10.0.255.31, Devices \u003e Platform Settings \u003e Platform Settings Editor, Save Policy ftd-policy\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -521,12 +566,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764533166Z",
+                "ingested": "2021-06-03T06:53:34.607417548Z",
                 "original": "admin@10.0.255.31, Devices \u003e Platform Settings \u003e Platform Settings Editor, Modified: Syslog\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -554,12 +602,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764535932Z",
+                "ingested": "2021-06-03T06:53:34.607418969Z",
                 "original": "admin@10.0.255.31, Devices \u003e Platform Settings \u003e Platform Settings Editor, Page View\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -587,12 +638,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764538620Z",
+                "ingested": "2021-06-03T06:53:34.607420290Z",
                 "original": "admin@10.0.255.31, Devices \u003e Platform Settings \u003e Platform Settings Editor, Save Policy ftd-policy\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -620,12 +674,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764541240Z",
+                "ingested": "2021-06-03T06:53:34.607421604Z",
                 "original": "admin@10.0.255.31, Devices \u003e Platform Settings \u003e Platform Settings Editor, Modified: Syslog\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -653,12 +710,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764543901Z",
+                "ingested": "2021-06-03T06:53:34.607422923Z",
                 "original": "admin@10.0.255.31, Devices \u003e Platform Settings \u003e Platform Settings Editor, Page View\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -686,12 +746,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764546533Z",
+                "ingested": "2021-06-03T06:53:34.607424216Z",
                 "original": "csm_processes@Default User IP, Login, Login Success\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -719,12 +782,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764549157Z",
+                "ingested": "2021-06-03T06:53:34.607425522Z",
                 "original": "csm_processes@Default User IP, Login, Login Success\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -752,12 +818,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764551780Z",
+                "ingested": "2021-06-03T06:53:34.607426831Z",
                 "original": "admin@localhost, Task Queue, Successful task completion : Pre-deploy Global Configuration Generation\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -785,12 +854,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764554640Z",
+                "ingested": "2021-06-03T06:53:34.607428249Z",
                 "original": "csm_processes@Default User IP, Login, Login Success\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -818,12 +890,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764566050Z",
+                "ingested": "2021-06-03T06:53:34.607429568Z",
                 "original": "admin@localhost, Task Queue, Successful task completion : Pre-deploy Device Configuration for siem-ftd\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -851,12 +926,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764568843Z",
+                "ingested": "2021-06-03T06:53:34.607430874Z",
                 "original": "admin@10.0.255.31, System \u003e Configuration \u003e Configuration, Page View\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -884,12 +962,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764571447Z",
+                "ingested": "2021-06-03T06:53:34.607432175Z",
                 "original": "admin@localhost, Task Queue, Policy Deployment to siem-ftd - SUCCESS\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -917,12 +998,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764574063Z",
+                "ingested": "2021-06-03T06:53:34.607433482Z",
                 "original": "csm_processes@Default User IP, Login, Login Success\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -950,12 +1034,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764576659Z",
+                "ingested": "2021-06-03T06:53:34.607434790Z",
                 "original": "admin@10.0.255.31, System \u003e Monitoring \u003e Syslog, Page View\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -983,12 +1070,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764579283Z",
+                "ingested": "2021-06-03T06:53:34.607436098Z",
                 "original": "admin@10.0.255.31, System \u003e Monitoring \u003e Audit, Page View\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -1016,12 +1106,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764581885Z",
+                "ingested": "2021-06-03T06:53:34.607437435Z",
                 "original": "admin@10.0.255.31, System \u003e Configuration \u003e Configuration, Page View\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -1049,12 +1142,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764584480Z",
+                "ingested": "2021-06-03T06:53:34.607438754Z",
                 "original": "admin@10.0.255.31, System \u003e Configuration \u003e Configuration \u003e /platinum/platformSettingEdit.cgi?type=AuditLog, Page View\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -1082,12 +1178,15 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764587073Z",
+                "ingested": "2021-06-03T06:53:34.607440057Z",
                 "original": "admin@10.0.255.31, Devices \u003e Platform Settings \u003e Local System Configuration, Save Local System Configuration\u0000x0a\u0000x00"
             },
             "cisco": {
                 "ftd": {}
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -1116,14 +1215,17 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:38.764589677Z",
+                "ingested": "2021-06-03T06:53:34.607441384Z",
                 "original": "admin@10.0.255.31, Devices \u003e Platform Settings \u003e Audit Log Settings \u003e  Modified: Send Audit Log to Syslog enabled \u003e Disabled"
             },
             "cisco": {
                 "ftd": {
                     "security": {}
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-intrusion.log-config.yml
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-intrusion.log-config.yml
@@ -1,2 +1,0 @@
-dynamic_fields:
-  event.ingested: ".*"

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-intrusion.log-expected.json
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-intrusion.log-expected.json
@@ -15,6 +15,9 @@
                 "ip": "10.0.1.20"
             },
             "message": "SERVER-WEBAPP Ipswitch WhatsUp Small Business directory traversal attempt",
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "http",
                 "transport": "tcp",
@@ -61,9 +64,9 @@
             },
             "event": {
                 "severity": 0,
-                "ingested": "2021-05-13T11:41:40.568873142Z",
-                "code": "430001",
+                "ingested": "2021-06-03T06:53:35.381430714Z",
                 "original": "%FTD-0-430001: SrcIP: 10.0.1.20, DstIP: 10.0.100.30, SrcPort: 55644, DstPort: 80, Protocol: tcp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, Priority: 1, GID: 1, SID: 17279, Revision: 12, Message: SERVER-WEBAPP Ipswitch WhatsUp Small Business directory traversal attempt, Classification: Attempted User Privilege Gain, User: No Authentication Required, Client: Firefox, ApplicationProtocol: HTTP, IntrusionPolicy: intrusion-policy, ACPolicy: default, NAPPolicy: Balanced Security and Connectivity",
+                "code": "430001",
                 "kind": "alert",
                 "action": "intrusion-detected",
                 "category": [
@@ -127,6 +130,9 @@
                 "ip": "10.0.1.20"
             },
             "message": "SERVER-WEBAPP Ipswitch WhatsUp Small Business directory traversal attempt",
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "http",
                 "transport": "tcp",
@@ -173,9 +179,9 @@
             },
             "event": {
                 "severity": 0,
-                "ingested": "2021-05-13T11:41:40.568885481Z",
-                "code": "430001",
+                "ingested": "2021-06-03T06:53:35.381442854Z",
                 "original": "%FTD-0-430001: SrcIP: 10.0.1.20, DstIP: 10.0.100.30, SrcPort: 55868, DstPort: 80, Protocol: tcp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, Priority: 1, GID: 1, SID: 17279, Revision: 12, Message: SERVER-WEBAPP Ipswitch WhatsUp Small Business directory traversal attempt, Classification: Attempted User Privilege Gain, User: No Authentication Required, Client: Firefox, ApplicationProtocol: HTTP, IntrusionPolicy: intrusion-policy, ACPolicy: default, NAPPolicy: Balanced Security and Connectivity",
+                "code": "430001",
                 "kind": "alert",
                 "action": "intrusion-detected",
                 "category": [
@@ -239,6 +245,9 @@
                 "ip": "10.0.100.30"
             },
             "message": "APP-DETECT failed FTP login attempt",
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -283,9 +292,9 @@
             },
             "event": {
                 "severity": 0,
-                "ingested": "2021-05-13T11:41:40.568888467Z",
-                "code": "430001",
+                "ingested": "2021-06-03T06:53:35.381445736Z",
                 "original": "%FTD-0-430001: SrcIP: 10.0.100.30, DstIP: 10.0.1.20, SrcPort: 21, DstPort: 39114, Protocol: tcp, IngressInterface: outside, EgressInterface: inside, IngressZone: output-zone, EgressZone: input-zone, Priority: 3, GID: 1, SID: 13360, Revision: 6, Message: APP-DETECT failed FTP login attempt, Classification: Misc Activity, User: No Authentication Required, IntrusionPolicy: intrusion-policy, ACPolicy: default, NAPPolicy: Balanced Security and Connectivity",
+                "code": "430001",
                 "kind": "alert",
                 "action": "intrusion-detected",
                 "category": [
@@ -347,6 +356,9 @@
                 "ip": "10.0.100.30"
             },
             "message": "APP-DETECT failed FTP login attempt",
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -391,9 +403,9 @@
             },
             "event": {
                 "severity": 0,
-                "ingested": "2021-05-13T11:41:40.568891204Z",
-                "code": "430001",
+                "ingested": "2021-06-03T06:53:35.381448230Z",
                 "original": "%FTD-0-430001: SrcIP: 10.0.100.30, DstIP: 10.0.1.20, SrcPort: 21, DstPort: 40740, Protocol: 6, IngressInterface: outside, EgressInterface: inside, IngressZone: output-zone, EgressZone: input-zone, Priority: 3, GID: 1, SID: 13360, Revision: 6, Message: APP-DETECT failed FTP login attempt, Classification: Misc Activity, User: No Authentication Required, IntrusionPolicy: intrusion-policy, ACPolicy: default, NAPPolicy: Balanced Security and Connectivity",
+                "code": "430001",
                 "kind": "alert",
                 "action": "intrusion-detected",
                 "category": [

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-no-type-id.log-config.yml
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-no-type-id.log-config.yml
@@ -1,2 +1,0 @@
-dynamic_fields:
-  event.ingested: ".*"

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-no-type-id.log-expected.json
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-no-type-id.log-expected.json
@@ -17,6 +17,9 @@
                 "ip": "10.1.123.45"
             },
             "message": "Intrusion attempt",
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "application": "webserver",
                 "protocol": "http"
@@ -45,9 +48,9 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:41.145999386Z",
-                "code": "430001",
+                "ingested": "2021-06-03T06:53:35.595184293Z",
                 "original": "ApplicationProtocol: http, Client: webserver, DstIP: 10.8.12.47, SrcIP: 10.1.123.45, Message: Intrusion attempt",
+                "code": "430001",
                 "kind": "alert",
                 "action": "intrusion-detected",
                 "category": [
@@ -79,6 +82,9 @@
                 "level": "debug"
             },
             "message": "Some message here (1:36330:2).",
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "beats",
                 "product": "asa",
@@ -104,9 +110,9 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:41.146011950Z",
-                "code": "430001",
+                "ingested": "2021-06-03T06:53:35.595190391Z",
                 "original": "HTTPResponse: 404, Message: Some message here (1:36330:2).",
+                "code": "430001",
                 "kind": "alert",
                 "action": "intrusion-detected",
                 "category": [
@@ -135,6 +141,9 @@
                 "level": "debug"
             },
             "message": "Some message here (1:36330:2)",
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "beats",
                 "product": "asa",
@@ -160,9 +169,9 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-05-13T11:41:41.146014955Z",
-                "code": "430002",
+                "ingested": "2021-06-03T06:53:35.595191790Z",
                 "original": "HTTPResponse: 404, Message: Some message here (1:36330:2), Empty: ,FileCount:, IngressZone:",
+                "code": "430002",
                 "kind": "event",
                 "action": "connection-started",
                 "category": [
@@ -205,6 +214,9 @@
                 "This one has a type id",
                 "And two messages"
             ],
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "beats",
                 "product": "asa",
@@ -234,9 +246,9 @@
             },
             "event": {
                 "severity": 3,
-                "ingested": "2021-05-13T11:41:41.146017669Z",
-                "code": "430005",
+                "ingested": "2021-06-03T06:53:35.595192969Z",
                 "original": "%ASA-3-430005 Message: This one has a type id, HTTPResponse: 404, Message: And two messages, SrcIP: 127.0.0.1, DstIP: 192.168.3.33, SrcPort: 512, DstPort: 64311",
+                "code": "430005",
                 "kind": "alert",
                 "action": "malware-detected",
                 "category": [

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-not-ip.log-config.yml
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-not-ip.log-config.yml
@@ -1,2 +1,0 @@
-dynamic_fields:
-  event.ingested: ".*"

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-not-ip.log-expected.json
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-not-ip.log-expected.json
@@ -19,6 +19,9 @@
                 "address": "WHAT-IS-THIS-A-HOSTNAME-192.0.2.244",
                 "domain": "WHAT-IS-THIS-A-HOSTNAME-192.0.2.244"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -52,9 +55,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:41:41.535036087Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:35.737836752Z",
                 "original": "%ASA-5-106100: access-list AL-DMZ-LB-IN denied tcp LB-DMZ/WHAT-IS-THIS-A-HOSTNAME-192.0.2.244(27218) -\u003e OUTSIDE/203.0.113.42(53) hit-cnt 1 first hit [0x16847359, 0x00000000]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -87,6 +90,9 @@
                 "address": "192.168.132.46",
                 "ip": "192.168.132.46"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "1",
                 "transport": "icmp"
@@ -115,9 +121,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:41.535048355Z",
-                "code": "302021",
+                "ingested": "2021-06-03T06:53:35.737844012Z",
                 "original": "%ASA-6-302021: Teardown ICMP connection for faddr 172.24.177.29/0 gaddr mydomain.example.net/17233 laddr 192.168.132.46/17233",
+                "code": "302021",
                 "kind": "event",
                 "action": "flow-expiration",
                 "category": [
@@ -156,6 +162,9 @@
                 "port": 1234,
                 "ip": "10.10.10.1"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -195,9 +204,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:41.535051314Z",
-                "code": "338204",
+                "ingested": "2021-06-03T06:53:35.737845599Z",
                 "original": "%ASA-4-338204: Dynamic filter dropped greylisted TCP traffic from eth0:10.10.10.1/1234 (source.example.net/11234) to wan:172.24.177.3/80 (www.example.org/80), destination malicious address resolved from dynamic list: example.org, threat-level: high, category: malware",
+                "code": "338204",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-sample.log-config.yml
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-sample.log-config.yml
@@ -1,2 +1,0 @@
-dynamic_fields:
-  event.ingested: ".*"

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-sample.log-expected.json
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-sample.log-expected.json
@@ -14,6 +14,9 @@
                 "address": "10.1.2.30",
                 "ip": "10.1.2.30"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -45,9 +48,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:41.932570589Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:35.877521935Z",
                 "original": "%FTD-4-106023: Deny tcp src dmz:10.1.2.30/63016 dst outside:192.0.0.8/53 by access-group \"acl_dmz\" [0xe3aab522, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -82,6 +85,9 @@
                 "address": "10.1.2.30",
                 "ip": "10.1.2.30"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -113,9 +119,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:41.932582218Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:35.877526779Z",
                 "original": "%FTD-4-106023: Deny tcp src dmz:10.1.2.30/63016 dst outside:192.0.0.8/53 type 3, code 0, by access-group \"acl_dmz\" [0xe3aab522, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -150,6 +156,9 @@
                 "address": "10.1.2.16",
                 "ip": "10.1.2.16"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -181,9 +190,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:41:41.932585201Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:35.877528249Z",
                 "original": "%FTD-session-5-106100: access-list acl_in permitted tcp inside/10.1.2.16(2241) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -219,6 +228,9 @@
                 "address": "172.29.2.101",
                 "ip": "172.29.2.101"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -257,9 +269,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:41.932587924Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:35.877529559Z",
                 "original": "%FTD-6-106100: access-list inside denied udp inside/172.29.2.101(1039) -\u003e outside/192.0.2.10(53) hit-cnt 1 first hit [0xd820e56a, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -294,6 +306,9 @@
                 "address": "172.29.2.3",
                 "ip": "172.29.2.3"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -332,9 +347,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:41.932590586Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:35.877530827Z",
                 "original": "%FTD-6-106100: access-list inside permitted udp inside/172.29.2.3(1065) -\u003e outside/192.0.2.57(53) hit-cnt 144 300-second interval [0xe982c7a4, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -369,6 +384,9 @@
                 "address": "10.123.3.42",
                 "ip": "10.123.3.42"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -400,9 +418,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:41.932593223Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:35.877532085Z",
                 "original": "%FTD-6-305011: Built dynamic TCP translation from outside:10.123.3.42/4952 to outside:192.0.2.130/12834",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -437,6 +455,9 @@
                 "address": "192.0.2.43",
                 "ip": "192.0.2.43"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -469,9 +490,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:41.932595884Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:35.877533333Z",
                 "original": "%FTD-6-302013: Built outbound TCP connection 89743274 for outside:192.0.2.43/443 (192.0.2.43/443) to outside:10.123.3.42/4952 (10.123.3.42/12834)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -508,6 +529,9 @@
                 "address": "10.123.1.35",
                 "ip": "10.123.1.35"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -539,9 +563,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:41.932598543Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:35.877534604Z",
                 "original": "%FTD-6-305011: Built dynamic UDP translation from outside:10.123.1.35/52925 to outside:192.0.2.130/25882",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -579,6 +603,9 @@
                 "port": 53,
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -611,9 +638,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:41.932601190Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:35.877535878Z",
                 "original": "%FTD-6-302015: Built outbound UDP connection 89743275 for outside:192.0.2.222/53 (192.0.2.43/53) to outside:10.123.1.35/52925 (10.123.1.35/25882)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -650,6 +677,9 @@
                 "address": "10.123.3.42",
                 "ip": "10.123.3.42"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -681,9 +711,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:41.932603817Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:35.877537160Z",
                 "original": "%FTD-6-305011: Built dynamic TCP translation from outside:10.123.3.42/4953 to outside:192.0.2.130/45392",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -719,6 +749,9 @@
                 "address": "192.0.2.1",
                 "ip": "192.0.2.1"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -751,9 +784,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:41.932606463Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:35.877538415Z",
                 "original": "%FTD-6-302013: Built outbound TCP connection 89743276 for outside:192.0.2.1/80 (192.0.2.1/80) to outside:10.123.3.42/4953 (10.123.3.130/45392)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -790,6 +823,9 @@
                 "address": "192.0.2.222",
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 140,
                 "iana_number": "17",
@@ -823,9 +859,9 @@
             "event": {
                 "severity": 6,
                 "duration": 5025000000000,
-                "ingested": "2021-05-13T11:41:41.932609261Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:35.877539841Z",
                 "original": "%FTD-6-302016: Teardown UDP connection 89743275 for outside:192.0.2.222/53 to inside:10.123.1.35/52925 duration 1:23:45 bytes 140",
+                "code": "302016",
                 "kind": "event",
                 "start": "2013-04-29T11:36:05.000Z",
                 "action": "flow-expiration",
@@ -861,6 +897,9 @@
                 "address": "192.0.2.222",
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 9999999,
                 "iana_number": "17",
@@ -894,9 +933,9 @@
             "event": {
                 "severity": 6,
                 "duration": 36000000000000,
-                "ingested": "2021-05-13T11:41:41.932611913Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:35.877541122Z",
                 "original": "%FTD-6-302016: Teardown UDP connection 666 for outside:192.0.2.222/53 user1 to inside:10.123.1.35/52925 user2 duration 10:00:00 bytes 9999999",
+                "code": "302016",
                 "kind": "event",
                 "start": "2013-04-29T02:59:50.000Z",
                 "action": "flow-expiration",
@@ -932,6 +971,9 @@
                 "address": "192.168.132.46",
                 "ip": "192.168.132.46"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "1",
                 "transport": "icmp"
@@ -960,9 +1002,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:41.932614627Z",
-                "code": "302021",
+                "ingested": "2021-06-03T06:53:35.877542379Z",
                 "original": "%FTD-6-302021: Teardown ICMP connection for faddr 172.24.177.29/0 gaddr 192.168.132.46/17233 laddr 192.168.132.46/17233",
+                "code": "302021",
                 "kind": "event",
                 "action": "flow-expiration",
                 "category": [
@@ -994,6 +1036,9 @@
                 "address": "192.168.3.42",
                 "ip": "192.168.3.42"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1025,9 +1070,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:41.932617275Z",
-                "code": "305011",
+                "ingested": "2021-06-03T06:53:35.877543654Z",
                 "original": "%FTD-6-305011: Built dynamic TCP translation from inside:192.168.3.42/4954 to outside:192.0.0.130/10879",
+                "code": "305011",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1063,6 +1108,9 @@
                 "address": "192.0.0.17",
                 "ip": "192.0.0.17"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -1095,9 +1143,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:41.932619905Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:35.877544906Z",
                 "original": "%FTD-6-302013: Built outbound TCP connection 89743277 for outside:192.0.0.17/80 (192.0.0.17/80) to inside:192.168.3.42/4954 (10.0.0.130/10879)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1134,6 +1182,9 @@
                 "address": "192.0.0.66",
                 "ip": "192.0.0.66"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -1157,9 +1208,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:41:41.932622650Z",
-                "code": "106007",
+                "ingested": "2021-06-03T06:53:35.877546387Z",
                 "original": "%FTD-2-106007: Deny inbound UDP from 192.0.0.66/12981 to 10.1.2.60/53 due to DNS Query",
+                "code": "106007",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1191,6 +1242,9 @@
                 "address": "10.0.0.16",
                 "ip": "10.0.0.16"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1222,9 +1276,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:41:41.932625402Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:35.877547657Z",
                 "original": "%FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2006) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1259,6 +1313,9 @@
                 "address": "10.0.0.46",
                 "ip": "10.0.0.46"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1290,9 +1347,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:41:41.932628085Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:35.877548902Z",
                 "original": "%FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49734) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1327,6 +1384,9 @@
                 "address": "10.0.0.46",
                 "ip": "10.0.0.46"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1358,9 +1418,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:41:41.932630715Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:35.877550157Z",
                 "original": "%FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49735) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1395,6 +1455,9 @@
                 "address": "10.0.0.46",
                 "ip": "10.0.0.46"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1426,9 +1489,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:41:41.932633335Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:35.877551432Z",
                 "original": "%FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49736) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1463,6 +1526,9 @@
                 "address": "10.0.0.46",
                 "ip": "10.0.0.46"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1494,9 +1560,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:41:41.932635999Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:35.877552681Z",
                 "original": "%FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49737) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1531,6 +1597,9 @@
                 "address": "10.0.0.46",
                 "ip": "10.0.0.46"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1562,9 +1631,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:41:41.932638700Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:35.877553938Z",
                 "original": "%FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49738) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1599,6 +1668,9 @@
                 "address": "10.0.0.46",
                 "ip": "10.0.0.46"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1630,9 +1702,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:41:41.932641448Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:35.877555361Z",
                 "original": "%FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49746) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1667,6 +1739,9 @@
                 "address": "10.0.0.16",
                 "ip": "10.0.0.16"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1698,9 +1773,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:41:41.932644094Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:35.877556635Z",
                 "original": "%FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2007) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1735,6 +1810,9 @@
                 "address": "10.0.0.13",
                 "ip": "10.0.0.13"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1766,9 +1844,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:41:41.932646732Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:35.877557901Z",
                 "original": "%FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.13(43013) -\u003e dmz/192.168.33.31(25) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1803,6 +1881,9 @@
                 "address": "10.0.0.16",
                 "ip": "10.0.0.16"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1834,9 +1915,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:41:41.932649381Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:35.877559162Z",
                 "original": "%FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2008) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1871,6 +1952,9 @@
                 "address": "192.0.2.66",
                 "ip": "192.0.2.66"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -1898,9 +1982,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:41:41.932656422Z",
-                "code": "106006",
+                "ingested": "2021-06-03T06:53:35.877560412Z",
                 "original": "%FTD-2-106006: Deny inbound UDP from 192.0.2.66/137 to 10.1.2.42/137 on interface inside",
+                "code": "106006",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1933,6 +2017,9 @@
                 "address": "192.0.2.66",
                 "ip": "192.0.2.66"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -1956,9 +2043,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:41:41.932659417Z",
-                "code": "106007",
+                "ingested": "2021-06-03T06:53:35.877561688Z",
                 "original": "%FTD-2-106007: Deny inbound UDP from 192.0.2.66/12981 to 10.1.5.60/53 due to DNS Query",
+                "code": "106007",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -1990,6 +2077,9 @@
                 "address": "10.0.0.16",
                 "ip": "10.0.0.16"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2021,9 +2111,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:41:41.932662173Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:35.877562948Z",
                 "original": "%FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2009) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2058,6 +2148,9 @@
                 "address": "10.0.0.46",
                 "ip": "10.0.0.46"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2089,9 +2182,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:41:41.932664895Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:35.877564198Z",
                 "original": "%FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49776) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2126,6 +2219,9 @@
                 "address": "10.0.0.16",
                 "ip": "10.0.0.16"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2157,9 +2253,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:41:41.932667644Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:35.877565441Z",
                 "original": "%FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2010) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2194,6 +2290,9 @@
                 "address": "10.0.0.16",
                 "ip": "10.0.0.16"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2225,9 +2324,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:41:41.932670329Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:35.877566689Z",
                 "original": "%FTD-5-106100: access-list acl_in denied tcp inside/10.0.0.16(2011) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2262,6 +2361,9 @@
                 "address": "10.0.0.16",
                 "ip": "10.0.0.16"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2293,9 +2395,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:41:41.932673039Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:35.877567946Z",
                 "original": "%FTD-5-106100: access-list acl_in denied tcp inside/10.0.0.16(2012) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2330,6 +2432,9 @@
                 "address": "192.0.2.126",
                 "ip": "192.0.2.126"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2361,9 +2466,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:41.932675879Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:35.877569339Z",
                 "original": "%FTD-4-106023: Deny tcp src outside:192.0.2.126/53638 dst inside:10.0.0.132/8111 by access-group \"acl_out\" [0x71761f18, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2398,6 +2503,9 @@
                 "address": "192.0.2.126",
                 "ip": "192.0.2.126"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2429,9 +2537,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:41.932678592Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:35.877570635Z",
                 "original": "%FTD-4-106023: Deny tcp src outside:192.0.2.126/53638 dst inside:10.0.0.132/8111 by access-group \"acl_out\" [0x71761f18, 0x0]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2466,6 +2574,9 @@
                 "address": "10.0.0.46",
                 "ip": "10.0.0.46"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2497,9 +2608,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:41:41.932681307Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:35.877571897Z",
                 "original": "%FTD-5-106100: access-list acl_in est-allowed tcp inside/10.0.0.46(49840) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2534,6 +2645,9 @@
                 "address": "10.0.0.16",
                 "ip": "10.0.0.16"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2565,9 +2679,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:41:41.932683935Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:35.877573147Z",
                 "original": "%FTD-5-106100: access-list acl_in est-allowed tcp inside/10.0.0.16(2013) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2602,6 +2716,9 @@
                 "address": "10.0.0.16",
                 "ip": "10.0.0.16"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2633,9 +2750,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:41:41.932686578Z",
-                "code": "106100",
+                "ingested": "2021-06-03T06:53:35.877574387Z",
                 "original": "%FTD-session-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2241) -\u003e outside/192.0.0.99(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
+                "code": "106100",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2671,6 +2788,9 @@
                 "address": "192.168.77.12",
                 "ip": "192.168.77.12"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp",
@@ -2710,9 +2830,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:41.932689198Z",
-                "code": "302015",
+                "ingested": "2021-06-03T06:53:35.877575628Z",
                 "original": "%FTD-6-302015: Built outbound UDP connection 447235 for outside:192.168.77.12/11180 (192.168.77.12/11180) to identity:10.0.13.13/80 (10.0.13.13/80)",
+                "code": "302015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2749,6 +2869,9 @@
                 "address": "192.168.1.33",
                 "ip": "192.168.1.33"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -2787,9 +2910,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:41.932691827Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:35.877576867Z",
                 "original": "%FTD-4-106023: Deny udp src dmz:192.168.1.33/5555 dst outside:192.0.0.12/53 by access-group \"dmz\" [0x123a465e, 0x4c7bf613]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2824,6 +2947,9 @@
                 "address": "192.168.1.33",
                 "ip": "192.168.1.33"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -2862,9 +2988,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:41.932694454Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:35.877578125Z",
                 "original": "%FTD-4-106023: Deny udp src dmz:192.168.1.33/5555 dst outside:192.0.0.12/53 by access-group \"dmz\" [0x123a465e, 0x4c7bf613]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2899,6 +3025,9 @@
                 "address": "192.0.2.222",
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -2938,9 +3067,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:41.932697097Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:35.877579366Z",
                 "original": "%FTD-6-302013: Built outbound TCP connection 447236 for outside:192.0.2.222/1234 (192.0.2.222/1234) to dmz:OCSP_Server/5678 (OCSP_Server/5678)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -2977,6 +3106,9 @@
                 "address": "192.0.2.222",
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -3016,9 +3148,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:41.932699735Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:35.877580615Z",
                 "original": "%FTD-6-302013: Built outbound TCP connection 447236 for outside:192.0.2.222/1234 (192.0.2.222/1234) to dmz:OCSP_Server/5678 (OCSP_Server/5678)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3055,6 +3187,9 @@
                 "address": "192.0.2.222",
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 14804,
                 "iana_number": "6",
@@ -3095,9 +3230,9 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:41.932702358Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:35.877581864Z",
                 "original": "%FTD-6-302014: Teardown TCP connection 447236 for outside:192.0.2.222/1234 to dmz:192.168.1.34/5678 duration 0:00:00 bytes 14804 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-12-11T08:01:31.000Z",
                 "action": "flow-expiration",
@@ -3133,6 +3268,9 @@
                 "address": "192.0.2.222",
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 134781,
                 "iana_number": "6",
@@ -3173,9 +3311,9 @@
             "event": {
                 "severity": 6,
                 "duration": 68000000000,
-                "ingested": "2021-05-13T11:41:41.932705280Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:35.877583999Z",
                 "original": "%FTD-6-302014: Teardown TCP connection 447234 for outside:192.0.2.222/1234 to dmz:192.168.1.35/5678 duration 0:01:08 bytes 134781 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-12-11T08:00:30.000Z",
                 "action": "flow-expiration",
@@ -3211,6 +3349,9 @@
                 "address": "192.0.2.222",
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 134781,
                 "iana_number": "6",
@@ -3251,9 +3392,9 @@
             "event": {
                 "severity": 6,
                 "duration": 68000000000,
-                "ingested": "2021-05-13T11:41:41.932707948Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:35.877585418Z",
                 "original": "%FTD-6-302014: Teardown TCP connection 447234 for outside:192.0.2.222/1234 to dmz:192.168.1.35/5678 duration 0:01:08 bytes 134781 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-12-11T08:00:30.000Z",
                 "action": "flow-expiration",
@@ -3289,6 +3430,9 @@
                 "address": "192.0.2.222",
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "transport": "(no"
             },
@@ -3321,9 +3465,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:41.932710611Z",
-                "code": "106015",
+                "ingested": "2021-06-03T06:53:35.877586747Z",
                 "original": "%FTD-6-106015: Deny TCP (no connection) from 192.0.2.222/1234 to 192.168.1.34/5679 flags RST  on interface outside",
+                "code": "106015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3355,6 +3499,9 @@
                 "address": "192.0.2.222",
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "transport": "(no"
             },
@@ -3387,9 +3534,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:41.932713237Z",
-                "code": "106015",
+                "ingested": "2021-06-03T06:53:35.877588079Z",
                 "original": "%FTD-6-106015: Deny TCP (no connection) from 192.0.2.222/1234 to 192.168.1.34/5679 flags RST  on interface outside",
+                "code": "106015",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3421,6 +3568,9 @@
                 "address": "192.168.1.34",
                 "ip": "192.168.1.34"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17",
                 "transport": "udp"
@@ -3459,9 +3609,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:41.932715871Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:35.877589386Z",
                 "original": "%FTD-4-106023: Deny udp src dmz:192.168.1.34/5679 dst outside:192.0.0.12/5000 by access-group \"dmz\" [0x123a465e, 0x8c20f21]",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3496,6 +3646,9 @@
                 "address": "192.0.2.222",
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -3535,9 +3688,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:41.932718635Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:35.877590835Z",
                 "original": "%FTD-6-302013: Built outbound TCP connection 447237 for outside:192.0.2.222/1234 (192.0.2.222/1234) to dmz:192.168.1.34/65000 (192.168.1.34/65000)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3574,6 +3727,9 @@
                 "address": "192.0.2.222",
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp",
@@ -3613,9 +3769,9 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-05-13T11:41:41.932721290Z",
-                "code": "302013",
+                "ingested": "2021-06-03T06:53:35.877592141Z",
                 "original": "%FTD-6-302013: Built outbound TCP connection 447237 for outside:192.0.2.222/1234 (192.0.2.222/1234) to dmz:192.168.1.34/65000 (192.168.1.34/65000)",
+                "code": "302013",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3652,6 +3808,9 @@
                 "address": "192.0.2.222",
                 "ip": "192.0.2.222"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 11420,
                 "iana_number": "6",
@@ -3692,9 +3851,9 @@
             "event": {
                 "severity": 6,
                 "duration": 86399000000000,
-                "ingested": "2021-05-13T11:41:41.932723930Z",
-                "code": "302014",
+                "ingested": "2021-06-03T06:53:35.877593454Z",
                 "original": "%FTD-6-302014: Teardown TCP connection 447237 for outside:192.0.2.222/1234 to dmz:10.10.10.10/1235 duration 23:59:59 bytes 11420 TCP FINs",
+                "code": "302014",
                 "kind": "event",
                 "start": "2018-12-10T08:01:54.000Z",
                 "action": "flow-expiration",
@@ -3730,6 +3889,9 @@
                 "address": "10.44.4.4",
                 "ip": "10.44.4.4"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "bytes": 1416,
                 "iana_number": "17",
@@ -3763,9 +3925,9 @@
             "event": {
                 "severity": 6,
                 "duration": 122000000000,
-                "ingested": "2021-05-13T11:41:41.932726576Z",
-                "code": "302016",
+                "ingested": "2021-06-03T06:53:35.877594770Z",
                 "original": "%FTD-6-302016: Teardown UDP connection 40 for outside:10.44.4.4/500 to inside:10.44.2.2/500 duration 0:02:02 bytes 1416",
+                "code": "302016",
                 "kind": "event",
                 "start": "2012-08-15T23:28:07.000Z",
                 "action": "flow-expiration",
@@ -3799,6 +3961,9 @@
                 "address": "0.0.0.0",
                 "ip": "0.0.0.0"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "GIFRCHN01",
                 "product": "asa",
@@ -3828,9 +3993,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:41:41.932729292Z",
-                "code": "106016",
+                "ingested": "2021-06-03T06:53:35.877596078Z",
                 "original": "%FTD-2-106016: Deny IP spoof from (0.0.0.0) to 192.88.99.47 on interface Mobile_Traffic",
+                "code": "106016",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3861,6 +4026,9 @@
                 "address": "0.0.0.0",
                 "ip": "0.0.0.0"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "GIFRCHN01",
                 "product": "asa",
@@ -3890,9 +4058,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:41:41.932731922Z",
-                "code": "106016",
+                "ingested": "2021-06-03T06:53:35.877597384Z",
                 "original": "%FTD-2-106016: Deny IP spoof from (0.0.0.0) to 192.88.99.57 on interface Mobile_Traffic",
+                "code": "106016",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3923,6 +4091,9 @@
                 "address": "0.0.0.0",
                 "ip": "0.0.0.0"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "GIFRCHN01",
                 "product": "asa",
@@ -3952,9 +4123,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:41:41.932734551Z",
-                "code": "106016",
+                "ingested": "2021-06-03T06:53:35.877598697Z",
                 "original": "%FTD-2-106016: Deny IP spoof from (0.0.0.0) to 192.88.99.47 on interface Mobile_Traffic",
+                "code": "106016",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -3985,6 +4156,9 @@
                 "address": "0.0.0.0",
                 "ip": "0.0.0.0"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "GIFRCHN01",
                 "product": "asa",
@@ -4014,9 +4188,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:41:41.932737173Z",
-                "code": "106016",
+                "ingested": "2021-06-03T06:53:35.877600005Z",
                 "original": "%FTD-2-106016: Deny IP spoof from (0.0.0.0) to 192.88.99.47 on interface Mobile_Traffic",
+                "code": "106016",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4047,6 +4221,9 @@
                 "address": "0.0.0.0",
                 "ip": "0.0.0.0"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "GIFRCHN01",
                 "product": "asa",
@@ -4076,9 +4253,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:41:41.932739810Z",
-                "code": "106016",
+                "ingested": "2021-06-03T06:53:35.877601312Z",
                 "original": "%FTD-2-106016: Deny IP spoof from (0.0.0.0) to 192.88.99.57 on interface Mobile_Traffic",
+                "code": "106016",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4109,6 +4286,9 @@
                 "address": "0.0.0.0",
                 "ip": "0.0.0.0"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "GIFRCHN01",
                 "product": "asa",
@@ -4138,9 +4318,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:41:41.932742438Z",
-                "code": "106016",
+                "ingested": "2021-06-03T06:53:35.877602633Z",
                 "original": "%FTD-2-106016: Deny IP spoof from (0.0.0.0) to 192.88.99.57 on interface Mobile_Traffic",
+                "code": "106016",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4171,6 +4351,9 @@
                 "address": "0.0.0.0",
                 "ip": "0.0.0.0"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "GIFRCHN01",
                 "product": "asa",
@@ -4200,9 +4383,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:41:41.932745070Z",
-                "code": "106016",
+                "ingested": "2021-06-03T06:53:35.877648058Z",
                 "original": "%FTD-2-106016: Deny IP spoof from (0.0.0.0) to 192.168.1.255 on interface Mobile_Traffic",
+                "code": "106016",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4233,6 +4416,9 @@
                 "address": "0.0.0.0",
                 "ip": "0.0.0.0"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "hostname": "GIFRCHN01",
                 "product": "asa",
@@ -4262,9 +4448,9 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-05-13T11:41:41.932747726Z",
-                "code": "106016",
+                "ingested": "2021-06-03T06:53:35.877649862Z",
                 "original": "%FTD-2-106016: Deny IP spoof from (0.0.0.0) to 192.168.1.255 on interface Mobile_Traffic",
+                "code": "106016",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4297,6 +4483,9 @@
                 "address": "192.0.2.95",
                 "ip": "192.0.2.95"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -4335,9 +4524,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:41.932750377Z",
-                "code": "106023",
+                "ingested": "2021-06-03T06:53:35.877651150Z",
                 "original": "%FTD-4-106023: Deny tcp src outside:192.0.2.95/24069 dst inside:10.32.112.125/25 by access-group \"PERMIT_IN\" [0x0, 0x0]\"",
+                "code": "106023",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4366,6 +4555,9 @@
                 "address": "10.2.3.5",
                 "ip": "10.2.3.5"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "1",
                 "transport": "icmp"
@@ -4398,9 +4590,9 @@
             },
             "event": {
                 "severity": 3,
-                "ingested": "2021-05-13T11:41:41.932753017Z",
-                "code": "313001",
+                "ingested": "2021-06-03T06:53:35.877652445Z",
                 "original": "%FTD-3-313001: Denied ICMP type=3, code=3 from 10.2.3.5 on interface Outside",
+                "code": "313001",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4433,6 +4625,9 @@
                 "address": "172.16.30.2",
                 "ip": "172.16.30.2"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "1",
                 "transport": "icmp"
@@ -4459,9 +4654,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:41.932755650Z",
-                "code": "313004",
+                "ingested": "2021-06-03T06:53:35.877653707Z",
                 "original": "%FTD-4-313004: Denied ICMP type=0, from laddr 172.16.30.2 on interface inside to 172.16.1.10: no matching session",
+                "code": "313004",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4503,6 +4698,9 @@
                 "port": 6798,
                 "ip": "10.1.1.45"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -4537,9 +4735,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:41.932758290Z",
-                "code": "338002",
+                "ingested": "2021-06-03T06:53:35.877654977Z",
                 "original": "%FTD-4-338002: Dynamic Filter permitted black listed TCP traffic from inside:10.1.1.45/6798 (192.88.99.1/7890) to outside:192.88.99.129/80 (192.88.99.129/80), destination 192.88.99.129 resolved from dynamic list: bad.example.com",
+                "code": "338002",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4584,6 +4782,9 @@
                 "port": 33340,
                 "ip": "10.1.1.1"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -4615,9 +4816,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:41.932760932Z",
-                "code": "338004",
+                "ingested": "2021-06-03T06:53:35.877656238Z",
                 "original": "%FTD-4-338004: Dynamic Filter monitored blacklisted TCP traffic from inside:10.1.1.1/33340 (10.2.1.1/33340) to outsidet:192.0.2.223/80 (192.0.2.225/80), destination 192.0.2.223 resolved from dynamic list: 192.0.2.223/255.255.255.255, threat-level: very-high, category: Malware",
+                "code": "338004",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4663,6 +4864,9 @@
                 "port": 33340,
                 "ip": "10.1.1.1"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -4694,9 +4898,9 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-05-13T11:41:41.932763561Z",
-                "code": "338008",
+                "ingested": "2021-06-03T06:53:35.877657511Z",
                 "original": "%FTD-4-338008: Dynamic Filter dropped blacklisted TCP traffic from inside:10.1.1.1/33340 (10.2.1.1/33340) to outsidet:192.0.2.223/80 (192.0.2.223/8080), destination 192.0.2.223 resolved from dynamic list: 192.0.2.223/255.255.255.255, threat-level: very-high, category: Malware",
+                "code": "338008",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4738,6 +4942,9 @@
             "url": {
                 "original": "/app"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "type": "firewall",
                 "product": "asa",
@@ -4755,9 +4962,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:41:41.932766237Z",
-                "code": "304001",
+                "ingested": "2021-06-03T06:53:35.877658800Z",
                 "original": "%FTD-5-304001: 10.30.30.30 Accessed URL 192.0.2.1:/app",
+                "code": "304001",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4790,6 +4997,9 @@
             "url": {
                 "original": "http://example.com"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "type": "firewall",
                 "product": "asa",
@@ -4807,9 +5017,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:41:41.932768862Z",
-                "code": "304001",
+                "ingested": "2021-06-03T06:53:35.877661973Z",
                 "original": "%FTD-5-304001: 10.5.111.32 Accessed URL 192.0.2.32:http://example.com",
+                "code": "304001",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [
@@ -4842,6 +5052,9 @@
             "url": {
                 "original": "http://www.example.net/images/favicon.ico"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "product": "asa",
                 "type": "firewall",
@@ -4864,9 +5077,9 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-05-13T11:41:41.932771505Z",
-                "code": "304002",
+                "ingested": "2021-06-03T06:53:35.877663369Z",
                 "original": "%FTD-5-304002: Access denied URL http://www.example.net/images/favicon.ico SRC 10.69.6.39 DEST 192.0.0.19 on interface inside",
+                "code": "304002",
                 "kind": "event",
                 "action": "firewall-rule",
                 "category": [

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-security-connection.log-config.yml
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-security-connection.log-config.yml
@@ -1,2 +1,0 @@
-dynamic_fields:
-  event.ingested: ".*"

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-security-connection.log-expected.json
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-security-connection.log-expected.json
@@ -16,6 +16,9 @@
                 "packets": 1,
                 "ip": "10.0.100.30"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "icmp",
                 "transport": "icmp",
@@ -59,9 +62,9 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-05-13T11:41:49.604314427Z",
-                "code": "430002",
+                "ingested": "2021-06-03T06:53:38.800407479Z",
                 "original": "%FTD-1-430002: AccessControlRuleAction: Allow, SrcIP: 10.0.100.30, DstIP: 10.0.1.20, ICMPType: Echo Request, ICMPCode: No Code, Protocol: icmp, IngressInterface: output, EgressInterface: input, IngressZone: output-zone, EgressZone: input-zone, ACPolicy: default, AccessControlRuleName: Rule-1, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: ICMP client, ApplicationProtocol: ICMP, InitiatorPackets: 1, ResponderPackets: 0, InitiatorBytes: 98, ResponderBytes: 0, NAPPolicy: Balanced Security and Connectivity",
+                "code": "430002",
                 "kind": "event",
                 "action": "connection-started",
                 "category": [
@@ -129,6 +132,9 @@
                 "packets": 1,
                 "ip": "10.0.100.30"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "icmp",
                 "transport": "icmp",
@@ -173,9 +179,9 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:49.604326976Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:38.800421190Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.100.30, DstIP: 10.0.1.20, ICMPType: Echo Request, ICMPCode: No Code, Protocol: icmp, IngressInterface: output, EgressInterface: input, IngressZone: output-zone, EgressZone: input-zone, ACPolicy: default, AccessControlRuleName: Rule-1, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: ICMP client, ApplicationProtocol: ICMP, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 98, ResponderBytes: 98, NAPPolicy: Balanced Security and Connectivity",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-15T16:05:33.000Z",
                 "action": "connection-finished",
@@ -270,6 +276,9 @@
                 "packets": 1,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -313,9 +322,9 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-05-13T11:41:49.604329919Z",
-                "code": "430002",
+                "ingested": "2021-06-03T06:53:38.800422428Z",
                 "original": "%FTD-1-430002: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 50074, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Rule-1, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, InitiatorPackets: 1, ResponderPackets: 0, InitiatorBytes: 106, ResponderBytes: 0, NAPPolicy: Balanced Security and Connectivity, DNSQuery: eu-central-1.ec2.archive.ubuntu.com, DNSRecordType: a host address",
+                "code": "430002",
                 "kind": "event",
                 "action": "connection-started",
                 "category": [
@@ -409,6 +418,9 @@
                 "packets": 2,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "transport": "udp",
@@ -453,9 +465,9 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:49.604332690Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:38.800423513Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 49264, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Rule-1, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 2, ResponderPackets: 2, InitiatorBytes: 164, ResponderBytes: 314, NAPPolicy: Balanced Security and Connectivity, DNSQuery: siem-inside, DNSRecordType: a host address, DNSResponseType: Non-Existent Domain, DNS_TTL: 86395",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-15T16:07:00.000Z",
                 "action": "connection-finished",
@@ -550,6 +562,9 @@
                 "packets": 2,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -591,9 +606,9 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-05-13T11:41:49.604335348Z",
-                "code": "430002",
+                "ingested": "2021-06-03T06:53:38.800424561Z",
                 "original": "%FTD-1-430002: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 52.59.244.233, SrcPort: 43228, DstPort: 80, Protocol: tcp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Rule-1, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, InitiatorPackets: 2, ResponderPackets: 1, InitiatorBytes: 140, ResponderBytes: 74, NAPPolicy: Balanced Security and Connectivity",
+                "code": "430002",
                 "kind": "event",
                 "action": "connection-started",
                 "category": [
@@ -683,6 +698,9 @@
                 "original": "http://eu-central-1.ec2.archive.ubuntu.com/ubuntu/pool/main/m/manpages/manpages-dev_4.15-1_all.deb",
                 "domain": "eu-central-1.ec2.archive.ubuntu.com"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "http",
                 "transport": "tcp",
@@ -735,9 +753,9 @@
             "event": {
                 "severity": 1,
                 "duration": 1000000000,
-                "ingested": "2021-05-13T11:41:49.604338025Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:38.800425607Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 52.59.244.233, SrcPort: 43228, DstPort: 80, Protocol: tcp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Rule-1, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, UserAgent: Debian APT-HTTP/1.3 (1.6.11), Client: Advanced Packaging Tool, ClientVersion: 1.3, ApplicationProtocol: HTTP, WebApplication: Ubuntu, ConnectionDuration: 1, InitiatorPackets: 1359, ResponderPackets: 29001, InitiatorBytes: 97454, ResponderBytes: 41319018, NAPPolicy: Balanced Security and Connectivity, HTTPResponse: 200, ReferencedHost: eu-central-1.ec2.archive.ubuntu.com, URL: http://eu-central-1.ec2.archive.ubuntu.com/ubuntu/pool/main/m/manpages/manpages-dev_4.15-1_all.deb",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-15T16:07:18.000Z",
                 "action": "connection-finished",
@@ -837,6 +855,9 @@
                 "packets": 2,
                 "ip": "10.0.1.20"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "6",
                 "transport": "tcp"
@@ -878,9 +899,9 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-05-13T11:41:49.604340675Z",
-                "code": "430002",
+                "ingested": "2021-06-03T06:53:38.800426617Z",
                 "original": "%FTD-1-430002: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 213.211.198.62, SrcPort: 46000, DstPort: 80, Protocol: tcp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Rule-1, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, InitiatorPackets: 2, ResponderPackets: 1, InitiatorBytes: 140, ResponderBytes: 74, NAPPolicy: Balanced Security and Connectivity",
+                "code": "430002",
                 "kind": "event",
                 "action": "connection-started",
                 "category": [
@@ -970,6 +991,9 @@
                 "original": "http://www.eicar.org/download/eicar_com.zip",
                 "domain": "www.eicar.org"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "http",
                 "transport": "tcp",
@@ -1019,9 +1043,9 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-05-13T11:41:49.604343318Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:38.800427616Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 213.211.198.62, SrcPort: 46000, DstPort: 80, Protocol: tcp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Rule-1, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, UserAgent: curl/7.58.0, Client: cURL, ClientVersion: 7.58.0, ApplicationProtocol: HTTP, ConnectionDuration: 0, InitiatorPackets: 6, ResponderPackets: 4, InitiatorBytes: 503, ResponderBytes: 690, NAPPolicy: Balanced Security and Connectivity, HTTPResponse: 200, ReferencedHost: www.eicar.org, URL: http://www.eicar.org/download/eicar_com.zip",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-16T09:33:15.000Z",
                 "action": "connection-finished",
@@ -1100,6 +1124,9 @@
                 "packets": 0,
                 "ip": "10.0.100.30"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "1",
                 "transport": "icmp"
@@ -1141,9 +1168,9 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-05-13T11:41:49.604345961Z",
-                "code": "430002",
+                "ingested": "2021-06-03T06:53:38.800428629Z",
                 "original": "%FTD-1-430002: AccessControlRuleAction: Block, SrcIP: 10.0.100.30, DstIP: 10.0.1.20, ICMPType: Echo Request, ICMPCode: No Code, Protocol: icmp, IngressInterface: output, EgressInterface: input, IngressZone: output-zone, EgressZone: input-zone, ACPolicy: default, AccessControlRuleName: Block-inbound-ICMP, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, InitiatorPackets: 0, ResponderPackets: 0, InitiatorBytes: 0, ResponderBytes: 0, NAPPolicy: Balanced Security and Connectivity",
+                "code": "430002",
                 "kind": "event",
                 "action": "connection-started",
                 "category": [
@@ -1215,6 +1242,9 @@
                 "original": "http://10.0.100.30:8000/eicar_com.zip",
                 "domain": "10.0.100.30:8000"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "http",
                 "transport": "tcp",
@@ -1264,9 +1294,9 @@
             "event": {
                 "severity": 1,
                 "duration": 1000000000,
-                "ingested": "2021-05-13T11:41:49.604348622Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:38.800429734Z",
                 "original": "%FTD-1-430003: AccessControlRuleAction: Block, AccessControlRuleReason: File Block, SrcIP: 10.0.1.20, DstIP: 10.0.100.30, SrcPort: 41544, DstPort: 8000, Protocol: tcp, IngressInterface: input, EgressInterface: output, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, UserAgent: curl/7.58.0, Client: cURL, ClientVersion: 7.58.0, ApplicationProtocol: HTTP, ConnectionDuration: 1, FileCount: 1, InitiatorPackets: 4, ResponderPackets: 7, InitiatorBytes: 365, ResponderBytes: 1927, NAPPolicy: Balanced Security and Connectivity, HTTPResponse: 200, ReferencedHost: 10.0.100.30:8000, URL: http://10.0.100.30:8000/eicar_com.zip",
+                "code": "430003",
                 "kind": "event",
                 "start": "2019-08-14T15:09:40.000Z",
                 "action": "connection-finished",

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-security-file-malware.log-config.yml
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-security-file-malware.log-config.yml
@@ -1,2 +1,0 @@
-dynamic_fields:
-  event.ingested: ".*"

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-security-file-malware.log-expected.json
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-security-file-malware.log-expected.json
@@ -17,6 +17,9 @@
             "url": {
                 "original": "http://10.0.100.30:8000/exploit.exe"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "http",
                 "transport": "tcp",
@@ -53,9 +56,9 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-05-13T11:41:51.194519149Z",
-                "code": "430004",
+                "ingested": "2021-06-03T06:53:39.427128291Z",
                 "original": "%FTD-1-430004: SrcIP: 10.0.1.20, DstIP: 10.0.100.30, SrcPort: 41522, DstPort: 8000, Protocol: tcp, FileDirection: Download, FileAction: Detect, FileName: exploit.exe, FileType: ELF, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-14T14:54:24Z, FilePolicy: malware-and-file-policy, FileSandboxStatus: File Size Is Too Small, URI: http://10.0.100.30:8000/exploit.exe",
+                "code": "430004",
                 "kind": "alert",
                 "start": "2019-08-14T14:54:24Z",
                 "action": "file-detected",
@@ -112,6 +115,9 @@
             "url": {
                 "original": "http://10.0.100.30:8000/exploit.exe"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "http",
                 "transport": "tcp",
@@ -148,9 +154,9 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-05-13T11:41:51.194531594Z",
-                "code": "430004",
+                "ingested": "2021-06-03T06:53:39.427133268Z",
                 "original": "%FTD-1-430004: SrcIP: 10.0.1.20, DstIP: 10.0.100.30, SrcPort: 41526, DstPort: 8000, Protocol: tcp, FileDirection: Download, FileAction: Detect, FileName: exploit.exe, FileType: ELF, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-14T14:55:01Z, FilePolicy: malware-and-file-policy, FileSandboxStatus: File Size Is Too Small, URI: http://10.0.100.30:8000/exploit.exe",
+                "code": "430004",
                 "kind": "alert",
                 "start": "2019-08-14T14:55:01Z",
                 "action": "file-detected",
@@ -207,6 +213,9 @@
             "url": {
                 "original": "http://10.0.100.30:8000/eicar.com"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "http",
                 "transport": "tcp",
@@ -243,9 +252,9 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-05-13T11:41:51.194534361Z",
-                "code": "430004",
+                "ingested": "2021-06-03T06:53:39.427134722Z",
                 "original": "%FTD-1-430004: SrcIP: 10.0.1.20, DstIP: 10.0.100.30, SrcPort: 41530, DstPort: 8000, Protocol: tcp, FileDirection: Download, FileAction: Detect, FileName: eicar.com, FileType: EICAR, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-14T15:00:27Z, FilePolicy: malware-and-file-policy, FileSandboxStatus: File Size Is Too Small, URI: http://10.0.100.30:8000/eicar.com",
+                "code": "430004",
                 "kind": "alert",
                 "start": "2019-08-14T15:00:27Z",
                 "action": "file-detected",
@@ -302,6 +311,9 @@
             "url": {
                 "original": "http://10.0.100.30:8000/eicar.com.txt"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "http",
                 "transport": "tcp",
@@ -338,9 +350,9 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-05-13T11:41:51.194536886Z",
-                "code": "430004",
+                "ingested": "2021-06-03T06:53:39.427135965Z",
                 "original": "%FTD-1-430004: SrcIP: 10.0.1.20, DstIP: 10.0.100.30, SrcPort: 41534, DstPort: 8000, Protocol: tcp, FileDirection: Download, FileAction: Detect, FileName: eicar.com.txt, FileType: EICAR, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-14T15:01:40Z, FilePolicy: malware-and-file-policy, FileSandboxStatus: File Size Is Too Small, URI: http://10.0.100.30:8000/eicar.com.txt",
+                "code": "430004",
                 "kind": "alert",
                 "start": "2019-08-14T15:01:40Z",
                 "action": "file-detected",
@@ -397,6 +409,9 @@
             "url": {
                 "original": "http://10.0.100.30:8000/eicar_com.zip"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "http",
                 "transport": "tcp",
@@ -440,9 +455,9 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-05-13T11:41:51.194539414Z",
-                "code": "430004",
+                "ingested": "2021-06-03T06:53:39.427137162Z",
                 "original": "%FTD-1-430004: SrcIP: 10.0.1.20, DstIP: 10.0.100.30, SrcPort: 41540, DstPort: 8000, Protocol: tcp, FileDirection: Download, FileAction: Detect, FileSHA256: 2546dcffc5ad854d4ddc64fbf056871cd5a00f2471cb7a5bfd4ac23b6e9eedad, ThreatName: Unknown, FileName: eicar_com.zip, FileType: ZIP, FileSize: 184, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-14T15:03:27Z, FilePolicy: malware-and-file-policy, FileSandboxStatus: File Size Is Too Small, URI: http://10.0.100.30:8000/eicar_com.zip",
+                "code": "430004",
                 "kind": "alert",
                 "start": "2019-08-14T15:03:27Z",
                 "action": "file-detected",
@@ -503,6 +518,9 @@
             "url": {
                 "original": "http://10.0.100.30:8000/eicar_com.zip"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "http",
                 "transport": "tcp",
@@ -546,9 +564,9 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-05-13T11:41:51.194541936Z",
-                "code": "430004",
+                "ingested": "2021-06-03T06:53:39.427138337Z",
                 "original": "%FTD-1-430004: SrcIP: 10.0.1.20, DstIP: 10.0.100.30, SrcPort: 41542, DstPort: 8000, Protocol: tcp, FileDirection: Download, FileAction: Detect, FileSHA256: 2546dcffc5ad854d4ddc64fbf056871cd5a00f2471cb7a5bfd4ac23b6e9eedad, ThreatName: Unknown, FileName: eicar_com.zip, FileType: ZIP, FileSize: 184, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-14T15:03:31Z, FilePolicy: malware-and-file-policy, FileSandboxStatus: File Size Is Too Small, URI: http://10.0.100.30:8000/eicar_com.zip",
+                "code": "430004",
                 "kind": "alert",
                 "start": "2019-08-14T15:03:31Z",
                 "action": "file-detected",
@@ -609,6 +627,9 @@
             "url": {
                 "original": "http://10.0.100.30:8000/eicar_com.zip"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "http",
                 "transport": "tcp",
@@ -652,9 +673,9 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-05-13T11:41:51.194544382Z",
-                "code": "430005",
+                "ingested": "2021-06-03T06:53:39.427139511Z",
                 "original": "%FTD-1-430005: SrcIP: 10.0.1.20, DstIP: 10.0.100.30, SrcPort: 41544, DstPort: 8000, Protocol: tcp, FileDirection: Download, FileAction: Malware Block, FileSHA256: 2546dcffc5ad854d4ddc64fbf056871cd5a00f2471cb7a5bfd4ac23b6e9eedad, SHA_Disposition: Malware, SperoDisposition: Spero detection not performed on file, ThreatName: Win.Ransomware.Eicar::95.sbx.tg, ThreatScore: 76, FileName: eicar_com.zip, FileType: ZIP, FileSize: 184, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-14T15:09:40Z, FilePolicy: malware-and-file-policy, FileSandboxStatus: File Size Is Too Small, URI: http://10.0.100.30:8000/eicar_com.zip",
+                "code": "430005",
                 "kind": "alert",
                 "start": "2019-08-14T15:09:40Z",
                 "action": "malware-detected",
@@ -737,6 +758,9 @@
             "url": {
                 "original": "http://www.eicar.org/download/eicar_com.zip"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "http",
                 "transport": "tcp",
@@ -780,9 +804,9 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-05-13T11:41:51.194546816Z",
-                "code": "430005",
+                "ingested": "2021-06-03T06:53:39.427140688Z",
                 "original": "%FTD-1-430005: SrcIP: 10.0.1.20, DstIP: 213.211.198.62, SrcPort: 46004, DstPort: 80, Protocol: tcp, FileDirection: Download, FileAction: Malware Cloud Lookup, FileSHA256: 2546dcffc5ad854d4ddc64fbf056871cd5a00f2471cb7a5bfd4ac23b6e9eedad, SHA_Disposition: Unavailable, SperoDisposition: Spero detection not performed on file, ThreatName: Win.Ransomware.Eicar::95.sbx.tg, FileName: eicar_com.zip, FileType: ZIP, FileSize: 184, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-16T09:39:02Z, FilePolicy: malware-and-file-policy, FileStorageStatus: Not Stored (Disposition Was Pending), FileSandboxStatus: File Size Is Too Small, URI: http://www.eicar.org/download/eicar_com.zip",
+                "code": "430005",
                 "kind": "alert",
                 "start": "2019-08-16T09:39:02Z",
                 "action": "malware-detected",
@@ -846,6 +870,9 @@
             "url": {
                 "original": "http://10.0.100.30/public/infected/dd3dee576d0cb4abfed00f97f0c71c1d"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "http",
                 "transport": "tcp",
@@ -889,9 +916,9 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-05-13T11:41:51.194549258Z",
-                "code": "430005",
+                "ingested": "2021-06-03T06:53:39.427141884Z",
                 "original": "%FTD-1-430005: SrcIP: 10.0.1.20, DstIP: 10.0.100.30, SrcPort: 55378, DstPort: 80, Protocol: tcp, FileDirection: Download, FileAction: Malware Cloud Lookup, FileSHA256: 9a04a82eb19ad382f9e9dbafa498c6b4291f93cfe98d9e8b2915af99c06ffcd7, SHA_Disposition: Unavailable, SperoDisposition: Spero detection not performed on file, ThreatName: Unknown, FileName: dd3dee576d0cb4abfed00f97f0c71c1d, FileType: PDF, FileSize: 278987, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-16T09:40:45Z, FilePolicy: malware-and-file-policy, FileStorageStatus: Not Stored (Disposition Was Pending), FileSandboxStatus: Sent for Analysis, FileStaticAnalysisStatus: Failed to Send, URI: http://10.0.100.30/public/infected/dd3dee576d0cb4abfed00f97f0c71c1d",
+                "code": "430005",
                 "kind": "alert",
                 "start": "2019-08-16T09:40:45Z",
                 "action": "malware-detected",
@@ -973,6 +1000,9 @@
             "url": {
                 "original": "http://18.197.225.123/public/infected/dd3dee576d0cb4abfed00f97f0c71c1d"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "http",
                 "transport": "tcp",
@@ -1016,9 +1046,9 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-05-13T11:41:51.194551696Z",
-                "code": "430005",
+                "ingested": "2021-06-03T06:53:39.427143048Z",
                 "original": "%FTD-1-430005: SrcIP: 10.0.1.20, DstIP: 18.197.225.123, SrcPort: 47926, DstPort: 80, Protocol: tcp, FileDirection: Download, FileAction: Malware Cloud Lookup, FileSHA256: 9a04a82eb19ad382f9e9dbafa498c6b4291f93cfe98d9e8b2915af99c06ffcd7, SHA_Disposition: Malware, SperoDisposition: Spero detection not performed on file, ThreatName: Pdf.Exploit.Pdfka::100.sbx.tg, ThreatScore: 100, FileName: dd3dee576d0cb4abfed00f97f0c71c1d, FileType: PDF, FileSize: 278987, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-16T09:42:06Z, FilePolicy: malware-and-file-policy, FileSandboxStatus: Failed to Send, URI: http://18.197.225.123/public/infected/dd3dee576d0cb4abfed00f97f0c71c1d",
+                "code": "430005",
                 "kind": "alert",
                 "start": "2019-08-16T09:42:06Z",
                 "action": "malware-detected",

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-security-malware-site.log-config.yml
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-security-malware-site.log-config.yml
@@ -1,2 +1,0 @@
-dynamic_fields:
-  event.ingested: ".*"

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-security-malware-site.log-expected.json
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-security-malware-site.log-expected.json
@@ -52,6 +52,9 @@
                 "original": "http://bad-malwaresite-grr.info/favicon.ico",
                 "domain": "eyedropper-color-pick.info"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "http",
                 "transport": "tcp",
@@ -101,9 +104,9 @@
             "event": {
                 "severity": 0,
                 "duration": 20000000000,
-                "ingested": "2021-05-13T11:41:52.407893295Z",
-                "code": "430003",
+                "ingested": "2021-06-03T06:53:39.990392255Z",
                 "original": "%NGIPS-0-430003: DeviceUUID: 1c8ff662-08f3-11e4-85c0-bc960372972f, AccessControlRuleAction: Allow, AccessControlRuleReason: IP Monitor, SrcIP: 3.3.3.3, DstIP: 2.2.2.2, SrcPort: 65090, DstPort: 80, Protocol: tcp, IngressInterface: s1p1, EgressInterface: s1p2, IngressZone: Inside-DMZ-Interface-Inline, EgressZone: Inside-DMZ-Interface-Inline, ACPolicy: COOL-POLICY-3D, AccessControlRuleName: Inside DMZ-Rule-Inline, Prefilter Policy: Unknown, User: No Authentication Required, UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36, Client: Chrome, ClientVersion: 80.0.3987.87, ApplicationProtocol: HTTP, ConnectionDuration: 20, InitiatorPackets: 4, ResponderPackets: 4, InitiatorBytes: 729, ResponderBytes: 246, NAPPolicy: State-Backbone, SecIntMatchingIP: Destination, IPReputationSICategory: Malware, HTTPReferer: http://eyedropper-color-pick.info/mk?c=1581483445764, ReferencedHost: eyedropper-color-pick.info, URL: http://bad-malwaresite-grr.info/favicon.ico",
+                "code": "430003",
                 "kind": "event",
                 "start": "2020-03-01T01:02:16.000Z",
                 "action": "connection-finished",

--- a/packages/cisco/data_stream/ftd/_dev/test/system/test-logfile-config.yml
+++ b/packages/cisco/data_stream/ftd/_dev/test/system/test-logfile-config.yml
@@ -4,3 +4,4 @@ data_stream:
   vars:
     paths:
       - "{{SERVICE_LOGS_DIR}}/*ftd*.log"
+    preserve_original_event: true

--- a/packages/cisco/data_stream/ftd/_dev/test/system/test-udp-config.yml
+++ b/packages/cisco/data_stream/ftd/_dev/test/system/test-udp-config.yml
@@ -5,3 +5,4 @@ data_stream:
   vars:
     udp_host: 0.0.0.0
     udp_port: 9514
+    preserve_original_event: true

--- a/packages/cisco/data_stream/ftd/agent/stream/stream.yml.hbs
+++ b/packages/cisco/data_stream/ftd/agent/stream/stream.yml.hbs
@@ -3,6 +3,12 @@ paths:
   - {{path}}
 {{/each}}
 exclude_files: [".gz$"]
-tags: {{tags}}
+tags:
+{{#each tags as |tag i|}}
+ - {{tag}}
+{{/each}}
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 processors:
   - add_locale: ~

--- a/packages/cisco/data_stream/ftd/agent/stream/udp.yml.hbs
+++ b/packages/cisco/data_stream/ftd/agent/stream/udp.yml.hbs
@@ -1,4 +1,10 @@
 host: "{{udp_host}}:{{udp_port}}"
-tags: {{tags}}
+tags:
+{{#each tags as |tag i|}}
+ - {{tag}}
+{{/each}}
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 processors:
   - add_locale: ~

--- a/packages/cisco/data_stream/ftd/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco/data_stream/ftd/elasticsearch/ingest_pipeline/default.yml
@@ -16,7 +16,7 @@ processors:
   - grok:
       field: message
       patterns:
-        - "(?:%{SYSLOG_HEADER})?\\s*%{GREEDYDATA:log.original}"
+        - "(?:%{SYSLOG_HEADER})?\\s*%{GREEDYDATA:event.original}"
       pattern_definitions:
         SYSLOG_HEADER: "(?:%{SYSLOGFACILITY}\\s*)?(?:%{FTD_DATE:_temp_.raw_date}:?\\s+)?(?:%{PROCESS_HOST}|%{HOST_PROCESS})(?:{DATA})?%{SYSLOG_END}?"
         SYSLOGFACILITY: "<%{NONNEGINT:log.syslog.facility.code:int}(?:.%{NONNEGINT:log.syslog.priority:int})?>"
@@ -34,7 +34,7 @@ processors:
   #
   # This parses the header of an EMBLEM-style message for FTD and ASA prefixes.
   - grok:
-      field: log.original
+      field: event.original
       patterns:
         - "%{FTD_PREFIX}-(?:%{FTD_SUFFIX:_temp_.cisco.suffix}-)?%{NONNEGINT:event.severity:int}-%{POSINT:_temp_.cisco.message_id}?:?\\s*%{GREEDYDATA:message}"
         # Before version 6.3, messages for connection, security intelligence, and intrusion events didn't include an event type ID in the message header.
@@ -1447,10 +1447,6 @@ processors:
   # Rename some 7.x fields
   #
   - rename:
-      field: log.original
-      target_field: event.original
-      ignore_missing: true
-  - rename:
       field: cisco.ftd.list_id
       target_field: cisco.ftd.rule_name
       ignore_missing: true
@@ -1602,6 +1598,11 @@ processors:
       value: "{{source.domain}}"
       if: ctx.source?.domain != null && ctx.source?.domain != ''
       allow_duplicates: false
+  - remove:
+      field: event.original
+      if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"
+      ignore_failure: true
+      ignore_missing: true
 on_failure:
   # Copy any fields under _temp_.cisco to its final destination. Those can help
   # with diagnosing the failure.

--- a/packages/cisco/data_stream/ftd/fields/ecs.yml
+++ b/packages/cisco/data_stream/ftd/fields/ecs.yml
@@ -105,9 +105,6 @@
 - name: log.level
   type: keyword
   description: Log level of the log event.
-- name: log.original
-  type: keyword
-  description: Original log message with light interpretation only (encoding, newlines).
 - name: network.bytes
   type: long
   description: Total bytes transferred in both directions.

--- a/packages/cisco/data_stream/ftd/manifest.yml
+++ b/packages/cisco/data_stream/ftd/manifest.yml
@@ -29,6 +29,14 @@ streams:
         required: true
         show_user: true
         default: 9003
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
       - name: log_level
         type: integer
         title: Log Level
@@ -49,6 +57,14 @@ streams:
         show_user: true
         default:
           - /var/log/cisco-ftd.log
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
       - name: tags
         type: text
         title: Tags

--- a/packages/cisco/data_stream/ftd/sample_event.json
+++ b/packages/cisco/data_stream/ftd/sample_event.json
@@ -1,0 +1,176 @@
+{
+    "@timestamp": "2019-08-16T09:39:03.000Z",
+    "agent": {
+        "ephemeral_id": "f5535a1f-52da-44d4-a626-f85bbdc25e74",
+        "hostname": "docker-fleet-agent",
+        "id": "37c96a8c-c323-4db5-b898-9ba84c49e2ea",
+        "name": "docker-fleet-agent",
+        "type": "filebeat",
+        "version": "7.14.0"
+    },
+    "cisco": {
+        "ftd": {
+            "message_id": "430005",
+            "rule_name": "malware-and-file-policy",
+            "security": {
+                "application_protocol": "HTTP",
+                "client": "cURL",
+                "dst_ip": "213.211.198.62",
+                "dst_port": "80",
+                "file_action": "Malware Cloud Lookup",
+                "file_direction": "Download",
+                "file_name": "eicar_com.zip",
+                "file_policy": "malware-and-file-policy",
+                "file_sandbox_status": "File Size Is Too Small",
+                "file_sha256": "2546dcffc5ad854d4ddc64fbf056871cd5a00f2471cb7a5bfd4ac23b6e9eedad",
+                "file_size": "184",
+                "file_storage_status": "Not Stored (Disposition Was Pending)",
+                "file_type": "ZIP",
+                "first_packet_second": "2019-08-16T09:39:02Z",
+                "protocol": "tcp",
+                "sha_disposition": "Unavailable",
+                "spero_disposition": "Spero detection not performed on file",
+                "src_ip": "10.0.1.20",
+                "src_port": "46004",
+                "threat_name": "Win.Ransomware.Eicar::95.sbx.tg",
+                "uri": "http://www.eicar.org/download/eicar_com.zip",
+                "user": "No Authentication Required"
+            },
+            "threat_category": "Win.Ransomware.Eicar::95.sbx.tg"
+        }
+    },
+    "data_stream": {
+        "dataset": "cisco.ftd",
+        "namespace": "ep",
+        "type": "logs"
+    },
+    "destination": {
+        "address": "213.211.198.62",
+        "as": {
+            "number": 43341,
+            "organization": {
+                "name": "MDlink online service center GmbH"
+            }
+        },
+        "geo": {
+            "city_name": "Magdeburg",
+            "continent_name": "Europe",
+            "country_iso_code": "DE",
+            "country_name": "Germany",
+            "location": {
+                "lat": 52.1333,
+                "lon": 11.6167
+            },
+            "region_iso_code": "DE-ST",
+            "region_name": "Saxony-Anhalt"
+        },
+        "ip": "213.211.198.62",
+        "port": 80
+    },
+    "ecs": {
+        "version": "1.9.0"
+    },
+    "elastic_agent": {
+        "id": "732b7efe-6d7b-40fc-bbfe-799296be9d11",
+        "snapshot": true,
+        "version": "7.14.0"
+    },
+    "event": {
+        "action": "malware-detected",
+        "category": [
+            "malware"
+        ],
+        "code": "430005",
+        "dataset": "cisco.ftd",
+        "ingested": "2021-06-03T09:24:01.526093450Z",
+        "kind": "alert",
+        "original": "%FTD-1-430005: SrcIP: 10.0.1.20, DstIP: 213.211.198.62, SrcPort: 46004, DstPort: 80, Protocol: tcp, FileDirection: Download, FileAction: Malware Cloud Lookup, FileSHA256: 2546dcffc5ad854d4ddc64fbf056871cd5a00f2471cb7a5bfd4ac23b6e9eedad, SHA_Disposition: Unavailable, SperoDisposition: Spero detection not performed on file, ThreatName: Win.Ransomware.Eicar::95.sbx.tg, FileName: eicar_com.zip, FileType: ZIP, FileSize: 184, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-16T09:39:02Z, FilePolicy: malware-and-file-policy, FileStorageStatus: Not Stored (Disposition Was Pending), FileSandboxStatus: File Size Is Too Small, URI: http://www.eicar.org/download/eicar_com.zip",
+        "severity": 1,
+        "start": "2019-08-16T09:39:02Z",
+        "timezone": "+00:00",
+        "type": [
+            "info"
+        ]
+    },
+    "file": {
+        "hash": {
+            "sha256": "2546dcffc5ad854d4ddc64fbf056871cd5a00f2471cb7a5bfd4ac23b6e9eedad"
+        },
+        "name": "eicar_com.zip",
+        "size": 184
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": true,
+        "hostname": "firepower",
+        "id": "f46ddd9d65ff20633d9c337909855778",
+        "ip": [
+            "172.19.0.7"
+        ],
+        "mac": [
+            "02:42:ac:13:00:07"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+            "codename": "Core",
+            "family": "redhat",
+            "kernel": "5.10.25-linuxkit",
+            "name": "CentOS Linux",
+            "platform": "centos",
+            "type": "linux",
+            "version": "7 (Core)"
+        }
+    },
+    "input": {
+        "type": "udp"
+    },
+    "log": {
+        "level": "alert",
+        "source": {
+            "address": "172.19.0.4:46787"
+        }
+    },
+    "network": {
+        "application": "curl",
+        "iana_number": "6",
+        "protocol": "http",
+        "transport": "tcp"
+    },
+    "observer": {
+        "hostname": "firepower",
+        "product": "asa",
+        "type": "firewall",
+        "vendor": "Cisco"
+    },
+    "related": {
+        "hash": [
+            "2546dcffc5ad854d4ddc64fbf056871cd5a00f2471cb7a5bfd4ac23b6e9eedad"
+        ],
+        "hosts": [
+            "firepower"
+        ],
+        "ip": [
+            "10.0.1.20",
+            "213.211.198.62"
+        ],
+        "user": [
+            "No Authentication Required"
+        ]
+    },
+    "source": {
+        "address": "10.0.1.20",
+        "ip": "10.0.1.20",
+        "port": 46004
+    },
+    "tags": [
+        "cisco-ftd",
+        "preserve_original_event"
+    ],
+    "url": {
+        "original": "http://www.eicar.org/download/eicar_com.zip"
+    },
+    "user": {
+        "id": "No Authentication Required",
+        "name": "No Authentication Required"
+    }
+}

--- a/packages/cisco/data_stream/ios/_dev/test/pipeline/test-cisco-ios.log-config.yml
+++ b/packages/cisco/data_stream/ios/_dev/test/pipeline/test-cisco-ios.log-config.yml
@@ -1,2 +1,0 @@
-dynamic_fields:
-  event.ingested: ".*"

--- a/packages/cisco/data_stream/ios/_dev/test/pipeline/test-cisco-ios.log-expected.json
+++ b/packages/cisco/data_stream/ios/_dev/test/pipeline/test-cisco-ios.log-expected.json
@@ -1,15 +1,6 @@
 {
     "expected": [
         {
-            "ecs": {
-                "version": "1.9.0"
-            },
-            "related": {
-                "ip": [
-                    "198.51.100.197",
-                    "224.0.0.22"
-                ]
-            },
             "log": {
                 "level": "informational",
                 "source": {
@@ -26,10 +17,29 @@
                 "ip": "198.51.100.197"
             },
             "message": "list 177 denied igmp 198.51.100.197 -\u003e 224.0.0.22, 1 packet",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "community_id": "1:Rt5RGlrNED3cg8Wokm4+KGsDz+4=",
+                "transport": "igmp",
+                "type": "ipv4",
+                "packets": 1
+            },
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "related": {
+                "ip": [
+                    "198.51.100.197",
+                    "224.0.0.22"
+                ]
+            },
             "event": {
                 "severity": 6,
                 "sequence": 585917,
-                "ingested": "2021-05-13T11:41:52.773645786Z",
+                "ingested": "2021-06-03T06:53:40.219184164Z",
+                "original": "Feb  8 04:00:48 198.51.100.2 585917: Feb  8 04:00:47.272: %SEC-6-IPACCESSLOGRP: list 177 denied igmp 198.51.100.197 -\u003e 224.0.0.22, 1 packet",
                 "code": "IPACCESSLOGRP",
                 "provider": "firewall",
                 "action": "deny",
@@ -41,12 +51,6 @@
                     "facility": "SEC",
                     "access_list": "177"
                 }
-            },
-            "network": {
-                "community_id": "1:Rt5RGlrNED3cg8Wokm4+KGsDz+4=",
-                "transport": "igmp",
-                "type": "ipv4",
-                "packets": 1
             }
         },
         {
@@ -66,6 +70,9 @@
                 "ip": "198.51.100.2"
             },
             "message": "list INBOUND-ON-F11 denied igmp 198.51.100.2 -\u003e 224.0.0.2 (20), 1 packet",
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "community_id": "1:gg8i3117u+0XZ7S0E0dl04HE4qw=",
                 "transport": "igmp",
@@ -87,7 +94,8 @@
             "event": {
                 "severity": 6,
                 "sequence": 585918,
-                "ingested": "2021-05-13T11:41:52.773657091Z",
+                "ingested": "2021-06-03T06:53:40.219188906Z",
+                "original": "Feb  9 04:00:48 198.51.100.2 585918: Feb  9 04:00:47.272: %SEC-6-IPACCESSLOGSP: list INBOUND-ON-F11 denied igmp 198.51.100.2 -\u003e 224.0.0.2 (20), 1 packet",
                 "code": "IPACCESSLOGSP",
                 "provider": "firewall",
                 "action": "deny",
@@ -102,15 +110,6 @@
             }
         },
         {
-            "ecs": {
-                "version": "1.9.0"
-            },
-            "related": {
-                "ip": [
-                    "198.51.100.1",
-                    "255.255.255.255"
-                ]
-            },
             "log": {
                 "level": "informational",
                 "source": {
@@ -127,10 +126,28 @@
                 "ip": "198.51.100.1"
             },
             "message": "list 171 denied 0 198.51.100.1 -\u003e 255.255.255.255, 1 packet",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "type": "ipv4",
+                "iana_number": "0",
+                "packets": 1
+            },
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "related": {
+                "ip": [
+                    "198.51.100.1",
+                    "255.255.255.255"
+                ]
+            },
             "event": {
                 "severity": 6,
                 "sequence": 585919,
-                "ingested": "2021-05-13T11:41:52.773660107Z",
+                "ingested": "2021-06-03T06:53:40.219190244Z",
+                "original": "Feb 10 04:00:48 198.51.100.2 585919: Feb 10 04:00:47.272: %SEC-6-IPACCESSLOGNP: list 171 denied 0 198.51.100.1 -\u003e 255.255.255.255, 1 packet",
                 "code": "IPACCESSLOGNP",
                 "provider": "firewall",
                 "action": "deny",
@@ -142,23 +159,9 @@
                     "facility": "SEC",
                     "access_list": "171"
                 }
-            },
-            "network": {
-                "type": "ipv4",
-                "iana_number": "0",
-                "packets": 1
             }
         },
         {
-            "ecs": {
-                "version": "1.9.0"
-            },
-            "related": {
-                "ip": [
-                    "2001:DB8::3",
-                    "2001:DB8:1000::1"
-                ]
-            },
             "log": {
                 "level": "informational",
                 "source": {
@@ -177,10 +180,29 @@
                 "ip": "2001:DB8::3"
             },
             "message": "list ACL-IPv6-E0/0-IN/10 permitted tcp 2001:DB8::3(1027) -\u003e 2001:DB8:1000::1(22), 9 packets",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "community_id": "1:MFLZEQR2gBCpxJEXRvaB0jjkxNA=",
+                "transport": "tcp",
+                "type": "ipv6",
+                "packets": 9
+            },
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "related": {
+                "ip": [
+                    "2001:DB8::3",
+                    "2001:DB8:1000::1"
+                ]
+            },
             "event": {
                 "severity": 6,
                 "sequence": 585920,
-                "ingested": "2021-05-13T11:41:52.773662792Z",
+                "ingested": "2021-06-03T06:53:40.219191472Z",
+                "original": "May  3 19:11:33 198.51.100.2 585920: May  3 19:11:32.619: %IPV6-6-ACCESSLOGP: list ACL-IPv6-E0/0-IN/10 permitted tcp 2001:DB8::3(1027) -\u003e 2001:DB8:1000::1(22), 9 packets",
                 "code": "ACCESSLOGP",
                 "provider": "firewall",
                 "action": "allow",
@@ -192,24 +214,9 @@
                     "facility": "IPV6",
                     "access_list": "ACL-IPv6-E0/0-IN/10"
                 }
-            },
-            "network": {
-                "community_id": "1:MFLZEQR2gBCpxJEXRvaB0jjkxNA=",
-                "transport": "tcp",
-                "type": "ipv6",
-                "packets": 9
             }
         },
         {
-            "ecs": {
-                "version": "1.9.0"
-            },
-            "related": {
-                "ip": [
-                    "198.51.100.195",
-                    "198.51.100.255"
-                ]
-            },
             "log": {
                 "level": "informational",
                 "source": {
@@ -228,10 +235,29 @@
                 "ip": "198.51.100.195"
             },
             "message": "list 177 denied udp 198.51.100.195(55250) -\u003e 198.51.100.255(15600), 1 packet",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "community_id": "1:7qvTEOLkmhTrK1y9mKNwCENQbeU=",
+                "transport": "udp",
+                "type": "ipv4",
+                "packets": 1
+            },
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "related": {
+                "ip": [
+                    "198.51.100.195",
+                    "198.51.100.255"
+                ]
+            },
             "event": {
                 "severity": 6,
                 "sequence": 1663303,
-                "ingested": "2021-05-13T11:41:52.773665451Z",
+                "ingested": "2021-06-03T06:53:40.219192695Z",
+                "original": "Jun 20 02:41:40 198.51.100.2 1663303: Jun 20 02:41:39.326: %SEC-6-IPACCESSLOGP: list 177 denied udp 198.51.100.195(55250) -\u003e 198.51.100.255(15600), 1 packet",
                 "code": "IPACCESSLOGP",
                 "provider": "firewall",
                 "action": "deny",
@@ -243,12 +269,6 @@
                     "facility": "SEC",
                     "access_list": "177"
                 }
-            },
-            "network": {
-                "community_id": "1:7qvTEOLkmhTrK1y9mKNwCENQbeU=",
-                "transport": "udp",
-                "type": "ipv4",
-                "packets": 1
             }
         },
         {
@@ -272,6 +292,9 @@
                 "type": "3",
                 "code": "4"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "community_id": "1:9lO0Kj0TpXAVNWuiPRAyFAGtCqM=",
                 "transport": "icmp",
@@ -290,7 +313,8 @@
             "event": {
                 "severity": 6,
                 "sequence": 1663304,
-                "ingested": "2021-05-13T11:41:52.773668094Z",
+                "ingested": "2021-06-03T06:53:40.219193857Z",
+                "original": "Jun 20 02:41:45 198.51.100.2 1663304: Jun 20 02:41:44.921: %SEC-6-IPACCESSLOGDP: list 151 denied icmp 198.51.100.1 -\u003e 198.51.100.2 (3/4), 1 packet",
                 "code": "IPACCESSLOGDP",
                 "provider": "firewall",
                 "action": "deny",
@@ -305,15 +329,6 @@
             }
         },
         {
-            "ecs": {
-                "version": "1.9.0"
-            },
-            "related": {
-                "ip": [
-                    "198.51.100.195",
-                    "198.51.100.255"
-                ]
-            },
             "log": {
                 "level": "informational",
                 "source": {
@@ -332,10 +347,29 @@
                 "ip": "198.51.100.195"
             },
             "message": "list 177 denied udp 198.51.100.195(54309) -\u003e 198.51.100.255(15600), 1 packet",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "community_id": "1:UaC2rOjKSQBEmX+jEyiQatg9eGI=",
+                "transport": "udp",
+                "type": "ipv4",
+                "packets": 1
+            },
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "related": {
+                "ip": [
+                    "198.51.100.195",
+                    "198.51.100.255"
+                ]
+            },
             "event": {
                 "severity": 6,
                 "sequence": 1663312,
-                "ingested": "2021-05-13T11:41:52.773670719Z",
+                "ingested": "2021-06-03T06:53:40.219195040Z",
+                "original": "Jun 20 02:42:28 198.51.100.2 1663312: Jun 20 02:42:27.342: %SEC-6-IPACCESSLOGP: list 177 denied udp 198.51.100.195(54309) -\u003e 198.51.100.255(15600), 1 packet",
                 "code": "IPACCESSLOGP",
                 "provider": "firewall",
                 "action": "deny",
@@ -347,12 +381,6 @@
                     "facility": "SEC",
                     "access_list": "177"
                 }
-            },
-            "network": {
-                "community_id": "1:UaC2rOjKSQBEmX+jEyiQatg9eGI=",
-                "transport": "udp",
-                "type": "ipv4",
-                "packets": 1
             }
         },
         {
@@ -368,7 +396,8 @@
             "event": {
                 "severity": 6,
                 "sequence": 1663313,
-                "ingested": "2021-05-13T11:41:52.773673453Z",
+                "ingested": "2021-06-03T06:53:40.219196195Z",
+                "original": "Jun 20 02:42:28 198.51.100.2 1663313: Jun 20 02:42:28.374: %SEC-6-IPACCESSLOGRL: access-list logging rate-limited or missed 18 packets",
                 "code": "IPACCESSLOGRL",
                 "provider": "firewall",
                 "category": "network",
@@ -379,18 +408,12 @@
                 "ios": {
                     "facility": "SEC"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
-            "ecs": {
-                "version": "1.9.0"
-            },
-            "related": {
-                "ip": [
-                    "198.51.100.195",
-                    "198.51.100.255"
-                ]
-            },
             "log": {
                 "level": "informational",
                 "source": {
@@ -409,10 +432,29 @@
                 "ip": "198.51.100.195"
             },
             "message": "list 177 denied udp 198.51.100.195(43989) -\u003e 198.51.100.255(15600), 1 packet",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "community_id": "1:CdrzBOQ6Cohqy+Mgg9EZnl1nHFs=",
+                "transport": "udp",
+                "type": "ipv4",
+                "packets": 1
+            },
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "related": {
+                "ip": [
+                    "198.51.100.195",
+                    "198.51.100.255"
+                ]
+            },
             "event": {
                 "severity": 6,
                 "sequence": 1663314,
-                "ingested": "2021-05-13T11:41:52.773676138Z",
+                "ingested": "2021-06-03T06:53:40.219197354Z",
+                "original": "Jun 20 02:42:34 198.51.100.2 1663314: Jun 20 02:42:33.340: %SEC-6-IPACCESSLOGP: list 177 denied udp 198.51.100.195(43989) -\u003e 198.51.100.255(15600), 1 packet",
                 "code": "IPACCESSLOGP",
                 "provider": "firewall",
                 "action": "deny",
@@ -424,24 +466,9 @@
                     "facility": "SEC",
                     "access_list": "177"
                 }
-            },
-            "network": {
-                "community_id": "1:CdrzBOQ6Cohqy+Mgg9EZnl1nHFs=",
-                "transport": "udp",
-                "type": "ipv4",
-                "packets": 1
             }
         },
         {
-            "ecs": {
-                "version": "1.9.0"
-            },
-            "related": {
-                "ip": [
-                    "198.51.100.12",
-                    "172.217.10.46"
-                ]
-            },
             "log": {
                 "level": "informational",
                 "source": {
@@ -475,10 +502,29 @@
                 "ip": "198.51.100.12"
             },
             "message": "list 150 denied tcp 198.51.100.12(59832) -\u003e 172.217.10.46(80), 1 packet",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "community_id": "1:VrawQ+fBZ7zfHStQfvTOW1zQANA=",
+                "transport": "tcp",
+                "type": "ipv4",
+                "packets": 1
+            },
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "related": {
+                "ip": [
+                    "198.51.100.12",
+                    "172.217.10.46"
+                ]
+            },
             "event": {
                 "severity": 6,
                 "sequence": 1663321,
-                "ingested": "2021-05-13T11:41:52.773678777Z",
+                "ingested": "2021-06-03T06:53:40.219198575Z",
+                "original": "Jun 20 02:43:09 198.51.100.2 1663321: Jun 20 02:43:08.454: %SEC-6-IPACCESSLOGP: list 150 denied tcp 198.51.100.12(59832) -\u003e 172.217.10.46(80), 1 packet",
                 "code": "IPACCESSLOGP",
                 "provider": "firewall",
                 "action": "deny",
@@ -490,12 +536,6 @@
                     "facility": "SEC",
                     "access_list": "150"
                 }
-            },
-            "network": {
-                "community_id": "1:VrawQ+fBZ7zfHStQfvTOW1zQANA=",
-                "transport": "tcp",
-                "type": "ipv4",
-                "packets": 1
             }
         },
         {
@@ -511,7 +551,8 @@
             "event": {
                 "severity": 6,
                 "sequence": 1663325,
-                "ingested": "2021-05-13T11:41:52.773681413Z",
+                "ingested": "2021-06-03T06:53:40.219199726Z",
+                "original": "Jun 20 02:43:29 198.51.100.2 1663325: Jun 20 02:43:28.403: %SEC-6-IPACCESSLOGRL: access-list logging rate-limited or missed 23 packets",
                 "code": "IPACCESSLOGRL",
                 "provider": "firewall",
                 "category": "network",
@@ -522,7 +563,10 @@
                 "ios": {
                     "facility": "SEC"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "log": {
@@ -545,6 +589,9 @@
                 "type": "3",
                 "code": "3"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "community_id": "1:huj4hjTG/rbN+R5GhpV6YHP1sYM=",
                 "transport": "icmp",
@@ -563,7 +610,8 @@
             "event": {
                 "severity": 6,
                 "sequence": 1663326,
-                "ingested": "2021-05-13T11:41:52.773684217Z",
+                "ingested": "2021-06-03T06:53:40.219201053Z",
+                "original": "Jun 20 02:43:29 198.51.100.2 1663326: Jun 20 02:43:28.403: %SEC-6-IPACCESSLOGDP: list 150 denied icmp 198.51.100.12 -\u003e 198.51.100.1 (3/3), 32 packets",
                 "code": "IPACCESSLOGDP",
                 "provider": "firewall",
                 "action": "deny",
@@ -578,15 +626,6 @@
             }
         },
         {
-            "ecs": {
-                "version": "1.9.0"
-            },
-            "related": {
-                "ip": [
-                    "198.51.100.12",
-                    "172.217.10.46"
-                ]
-            },
             "log": {
                 "level": "informational",
                 "source": {
@@ -620,10 +659,29 @@
                 "ip": "198.51.100.12"
             },
             "message": "list 150 denied tcp 198.51.100.12(59834) -\u003e 172.217.10.46(80), 1 packet",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "community_id": "1:5enMmUgQViWG28IC5W6/9cYJ6EA=",
+                "transport": "tcp",
+                "type": "ipv4",
+                "packets": 1
+            },
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "related": {
+                "ip": [
+                    "198.51.100.12",
+                    "172.217.10.46"
+                ]
+            },
             "event": {
                 "severity": 6,
                 "sequence": 1663327,
-                "ingested": "2021-05-13T11:41:52.773686914Z",
+                "ingested": "2021-06-03T06:53:40.219202221Z",
+                "original": "Jun 20 02:43:30 198.51.100.2 1663327: Jun 20 02:43:29.451: %SEC-6-IPACCESSLOGP: list 150 denied tcp 198.51.100.12(59834) -\u003e 172.217.10.46(80), 1 packet",
                 "code": "IPACCESSLOGP",
                 "provider": "firewall",
                 "action": "deny",
@@ -635,26 +693,9 @@
                     "facility": "SEC",
                     "access_list": "150"
                 }
-            },
-            "network": {
-                "community_id": "1:5enMmUgQViWG28IC5W6/9cYJ6EA=",
-                "transport": "tcp",
-                "type": "ipv4",
-                "packets": 1
             }
         },
         {
-            "ecs": {
-                "version": "1.9.0"
-            },
-            "related": {
-                "user": [
-                    "john.smith"
-                ],
-                "ip": [
-                    "10.2.55.3"
-                ]
-            },
             "log": {
                 "level": "notification",
                 "source": {
@@ -672,10 +713,28 @@
                 "ip": "10.2.55.3"
             },
             "message": "Login Success [user: john.smith] [Source: 10.2.55.3] [localport: 22] at 12:06:03 MST Wed Mar 24 2021",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "type": "ipv4"
+            },
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "related": {
+                "user": [
+                    "john.smith"
+                ],
+                "ip": [
+                    "10.2.55.3"
+                ]
+            },
             "event": {
                 "severity": 5,
                 "sequence": 1991219,
-                "ingested": "2021-05-13T11:41:52.773689575Z",
+                "ingested": "2021-06-03T06:53:40.219203363Z",
+                "original": "Mar 24 18:06:03 198.51.100.2 1991219: Mar 24 18:06:03.424 UTC: %SEC_LOGIN-5-LOGIN_SUCCESS: Login Success [user: john.smith] [Source: 10.2.55.3] [localport: 22] at 12:06:03 MST Wed Mar 24 2021",
                 "code": "LOGIN_SUCCESS",
                 "provider": "firewall",
                 "category": "network",
@@ -686,9 +745,6 @@
                     "action": "Login",
                     "facility": "SEC_LOGIN"
                 }
-            },
-            "network": {
-                "type": "ipv4"
             }
         },
         {
@@ -716,16 +772,17 @@
                 "address": "10.5.36.9",
                 "ip": "10.5.36.9"
             },
+            "message": "User john.smith has exited tty session 5(10.5.36.9)",
             "event": {
                 "severity": 6,
                 "sequence": 1991220,
-                "ingested": "2021-05-13T11:41:52.773692219Z",
+                "ingested": "2021-06-03T06:53:40.219204507Z",
+                "original": "Mar 24 18:06:00 198.51.100.2 1991220: Mar 24 18:06:00.364 UTC: %SYS-6-LOGOUT: User john.smith has exited tty session 5(10.5.36.9)",
                 "code": "LOGOUT",
                 "provider": "firewall",
                 "category": "network",
                 "type": "info"
             },
-            "message": "User john.smith has exited tty session 5(10.5.36.9)",
             "cisco": {
                 "ios": {
                     "action": "exited",
@@ -736,20 +793,14 @@
                     }
                 }
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "type": "ipv4"
             }
         },
         {
-            "ecs": {
-                "version": "1.9.0"
-            },
-            "related": {
-                "ip": [
-                    "10.4.5.66",
-                    "10.3.66.3"
-                ]
-            },
             "log": {
                 "level": "informational",
                 "source": {
@@ -765,11 +816,27 @@
                 "ip": "10.4.5.66"
             },
             "message": "Received (*, 10.36.2.78) Join from 10.4.5.66 for invalid RP 10.3.66.3",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "type": "ipv4"
+            },
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "related": {
+                "ip": [
+                    "10.4.5.66",
+                    "10.3.66.3"
+                ]
+            },
             "event": {
                 "severity": 6,
                 "sequence": 1991221,
                 "reason": "Invalid RP",
-                "ingested": "2021-05-13T11:41:52.773694889Z",
+                "ingested": "2021-06-03T06:53:40.219205649Z",
+                "original": "Mar 24 17:37:39 198.51.100.2 1991221: Mar 24 17:37:39 UTC: %PIM-SW1-6-INVALID_RP_JOIN: Received (*, 10.36.2.78) Join from 10.4.5.66 for invalid RP 10.3.66.3",
                 "code": "INVALID_RP_JOIN",
                 "provider": "firewall",
                 "action": "multicast-join",
@@ -788,21 +855,9 @@
                     "facility": "PIM-SW1",
                     "outcome": "invalid RP"
                 }
-            },
-            "network": {
-                "type": "ipv4"
             }
         },
         {
-            "ecs": {
-                "version": "1.9.0"
-            },
-            "related": {
-                "ip": [
-                    "10.4.5.66",
-                    "10.3.66.3"
-                ]
-            },
             "log": {
                 "level": "informational",
                 "source": {
@@ -818,11 +873,27 @@
                 "ip": "10.4.5.66"
             },
             "message": "Received (10.50.22.5, 10.36.2.78) Join from 10.4.5.66 for invalid RP 10.3.66.3",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "type": "ipv4"
+            },
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "related": {
+                "ip": [
+                    "10.4.5.66",
+                    "10.3.66.3"
+                ]
+            },
             "event": {
                 "severity": 6,
                 "sequence": 1991221,
                 "reason": "Invalid RP",
-                "ingested": "2021-05-13T11:41:52.773697656Z",
+                "ingested": "2021-06-03T06:53:40.219206882Z",
+                "original": "Mar 24 17:37:39 198.51.100.2 1991221: Mar 24 17:37:39 UTC: %PIM-SW1-6-INVALID_RP_JOIN: Received (10.50.22.5, 10.36.2.78) Join from 10.4.5.66 for invalid RP 10.3.66.3",
                 "code": "INVALID_RP_JOIN",
                 "provider": "firewall",
                 "action": "multicast-join",
@@ -844,9 +915,6 @@
                     "facility": "PIM-SW1",
                     "outcome": "invalid RP"
                 }
-            },
-            "network": {
-                "type": "ipv4"
             }
         },
         {
@@ -862,7 +930,8 @@
             "event": {
                 "severity": 4,
                 "sequence": 1991217,
-                "ingested": "2021-05-13T11:41:52.773700350Z",
+                "ingested": "2021-06-03T06:53:40.219208053Z",
+                "original": "Mar 24 12:09:35 198.51.100.2 1991217: Mar 24 12:09:35.367: %OSPF-4-NOVALIDKEY: No valid authentication send key is available on interface eth0",
                 "code": "NOVALIDKEY",
                 "provider": "firewall",
                 "category": "network",
@@ -873,7 +942,10 @@
                 "ios": {
                     "facility": "OSPF"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "ecs": {
@@ -888,7 +960,8 @@
             "event": {
                 "severity": 6,
                 "sequence": 1991218,
-                "ingested": "2021-05-13T11:41:52.773703009Z",
+                "ingested": "2021-06-03T06:53:40.219209207Z",
+                "original": "Mar 24 12:06:47 198.51.100.2 1991218: Mar 24 12:06:47.099: %CCH323-6-CALL_PRESERVED: cch323_h225_handle_conn_loss: H.323 call preserved due to socket closure or error, Call Id = 6527, fd = 19",
                 "code": "CALL_PRESERVED",
                 "provider": "firewall",
                 "category": "network",
@@ -899,7 +972,10 @@
                 "ios": {
                     "facility": "CCH323"
                 }
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco/data_stream/ios/_dev/test/pipeline/test-common-config.yml
+++ b/packages/cisco/data_stream/ios/_dev/test/pipeline/test-common-config.yml
@@ -1,0 +1,5 @@
+dynamic_fields:
+  event.ingested: ".*"
+fields:
+  tags:
+    - preserve_original_event

--- a/packages/cisco/data_stream/ios/_dev/test/system/test-logfile-config.yml
+++ b/packages/cisco/data_stream/ios/_dev/test/system/test-logfile-config.yml
@@ -4,3 +4,4 @@ data_stream:
   vars:
     paths:
       - "{{SERVICE_LOGS_DIR}}/*ios*.log"
+    preserve_original_event: true

--- a/packages/cisco/data_stream/ios/_dev/test/system/test-udp-config.yml
+++ b/packages/cisco/data_stream/ios/_dev/test/system/test-udp-config.yml
@@ -5,3 +5,4 @@ data_stream:
   vars:
     syslog_host: 0.0.0.0
     syslog_port: 9514
+    preserve_original_event: true

--- a/packages/cisco/data_stream/ios/agent/stream/stream.yml.hbs
+++ b/packages/cisco/data_stream/ios/agent/stream/stream.yml.hbs
@@ -3,6 +3,12 @@ paths:
   - {{path}}
 {{/each}}
 exclude_files: [".gz$"]
-tags: {{this.tags}}
+tags:
+{{#each tags as |tag i|}}
+ - {{tag}}
+{{/each}}
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 processors:
   - add_locale: ~

--- a/packages/cisco/data_stream/ios/agent/stream/udp.yml.hbs
+++ b/packages/cisco/data_stream/ios/agent/stream/udp.yml.hbs
@@ -3,6 +3,9 @@ tags:
 {{#each tags as |tag i|}}
  - {{tag}}
 {{/each}}
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 {{#contains tags "forwarded"}}
 publisher_pipeline.disable_host: true
 {{/contains}}

--- a/packages/cisco/data_stream/ios/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco/data_stream/ios/elasticsearch/ingest_pipeline/default.yml
@@ -17,12 +17,12 @@ processors:
   - set:
       field: event.type
       value: info
+  - rename:
+      field: message
+      target_field: event.original
   - dissect:
-      field: message
+      field: event.original
       pattern: "%{_temp_.ts->} %{+_temp_.ts} %{+_temp_.ts->} %{log.source.address} %{event.sequence}: %{_temp_.timestamp}: %{_temp_.message}"
-  - remove:
-      field: message
-      ignore_missing: true
   - grok:
       field: _temp_.message
       patterns:
@@ -223,6 +223,11 @@ processors:
       ignore_failure: true
   - remove:
       field: _temp_
+      ignore_missing: true
+  - remove:
+      field: event.original
+      if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"
+      ignore_failure: true
       ignore_missing: true
 
 on_failure:

--- a/packages/cisco/data_stream/ios/fields/ecs.yml
+++ b/packages/cisco/data_stream/ios/fields/ecs.yml
@@ -96,9 +96,6 @@
 - name: log.level
   type: keyword
   description: Log level of the log event.
-- name: log.original
-  type: keyword
-  description: Original log message with light interpretation only (encoding, newlines).
 - name: network.community_id
   type: keyword
   description: A hash of source and destination IPs and ports.

--- a/packages/cisco/data_stream/ios/manifest.yml
+++ b/packages/cisco/data_stream/ios/manifest.yml
@@ -29,6 +29,14 @@ streams:
         required: true
         show_user: true
         default: 9002
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
   - input: logfile
     enabled: false
     title: Cisco IOS logs
@@ -42,6 +50,14 @@ streams:
         show_user: true
         default:
           - /var/log/cisco-ios.log
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
       - name: tags
         type: text
         title: Tags

--- a/packages/cisco/data_stream/ios/sample_event.json
+++ b/packages/cisco/data_stream/ios/sample_event.json
@@ -1,0 +1,99 @@
+{
+    "@timestamp": "2021-06-03T09:25:42.537Z",
+    "agent": {
+        "ephemeral_id": "f5535a1f-52da-44d4-a626-f85bbdc25e74",
+        "hostname": "docker-fleet-agent",
+        "id": "37c96a8c-c323-4db5-b898-9ba84c49e2ea",
+        "name": "docker-fleet-agent",
+        "type": "filebeat",
+        "version": "7.14.0"
+    },
+    "cisco": {
+        "ios": {
+            "access_list": "177",
+            "facility": "SEC"
+        }
+    },
+    "data_stream": {
+        "dataset": "cisco.ios",
+        "namespace": "ep",
+        "type": "logs"
+    },
+    "destination": {
+        "address": "224.0.0.22",
+        "ip": "224.0.0.22"
+    },
+    "ecs": {
+        "version": "1.9.0"
+    },
+    "elastic_agent": {
+        "id": "732b7efe-6d7b-40fc-bbfe-799296be9d11",
+        "snapshot": true,
+        "version": "7.14.0"
+    },
+    "event": {
+        "action": "deny",
+        "category": "network",
+        "code": "IPACCESSLOGRP",
+        "dataset": "cisco.ios",
+        "ingested": "2021-06-03T09:25:43.560570635Z",
+        "original": "Feb  8 04:00:48 198.51.100.2 585917: Feb  8 04:00:47.272: %SEC-6-IPACCESSLOGRP: list 177 denied igmp 198.51.100.197 -\u003e 224.0.0.22, 1 packet\n",
+        "provider": "firewall",
+        "sequence": 585917,
+        "severity": 6,
+        "type": "info"
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": true,
+        "hostname": "docker-fleet-agent",
+        "id": "f46ddd9d65ff20633d9c337909855778",
+        "ip": [
+            "172.19.0.7"
+        ],
+        "mac": [
+            "02:42:ac:13:00:07"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+            "codename": "Core",
+            "family": "redhat",
+            "kernel": "5.10.25-linuxkit",
+            "name": "CentOS Linux",
+            "platform": "centos",
+            "type": "linux",
+            "version": "7 (Core)"
+        }
+    },
+    "input": {
+        "type": "udp"
+    },
+    "log": {
+        "level": "informational",
+        "source": {
+            "address": "198.51.100.2"
+        }
+    },
+    "message": "list 177 denied igmp 198.51.100.197 -\u003e 224.0.0.22, 1 packet",
+    "network": {
+        "community_id": "1:Rt5RGlrNED3cg8Wokm4+KGsDz+4=",
+        "packets": 1,
+        "transport": "igmp",
+        "type": "ipv4"
+    },
+    "related": {
+        "ip": [
+            "198.51.100.197",
+            "224.0.0.22"
+        ]
+    },
+    "source": {
+        "address": "198.51.100.197",
+        "ip": "198.51.100.197",
+        "packets": 1
+    },
+    "tags": [
+        "cisco-ios",
+        "preserve_original_event"
+    ]
+}

--- a/packages/cisco/data_stream/meraki/_dev/test/system/test-logfile-config.yml
+++ b/packages/cisco/data_stream/meraki/_dev/test/system/test-logfile-config.yml
@@ -4,3 +4,4 @@ data_stream:
   vars:
     paths:
       - "{{SERVICE_LOGS_DIR}}/*meraki*.log"
+    preserve_original_event: true

--- a/packages/cisco/data_stream/meraki/_dev/test/system/test-tcp-config.yml
+++ b/packages/cisco/data_stream/meraki/_dev/test/system/test-tcp-config.yml
@@ -5,3 +5,4 @@ data_stream:
   vars:
     tcp_host: 0.0.0.0
     tcp_port: 9514
+    preserve_original_event: true

--- a/packages/cisco/data_stream/meraki/_dev/test/system/test-udp-config.yml
+++ b/packages/cisco/data_stream/meraki/_dev/test/system/test-udp-config.yml
@@ -5,3 +5,4 @@ data_stream:
   vars:
     udp_host: 0.0.0.0
     udp_port: 9514
+    preserve_original_event: true

--- a/packages/cisco/data_stream/meraki/agent/stream/stream.yml.hbs
+++ b/packages/cisco/data_stream/meraki/agent/stream/stream.yml.hbs
@@ -7,6 +7,9 @@ tags:
 {{#each tags as |tag i|}}
  - {{tag}}
 {{/each}}
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 fields_under_root: true
 fields:
     observer:
@@ -3249,7 +3252,3 @@ processors:
     target_subdomain_field: url.subdomain
     target_etld_field: url.top_level_domain
 - add_locale: ~
-- add_fields:
-    target: ''
-    fields:
-        ecs.version: 1.9.0

--- a/packages/cisco/data_stream/meraki/agent/stream/tcp.yml.hbs
+++ b/packages/cisco/data_stream/meraki/agent/stream/tcp.yml.hbs
@@ -4,6 +4,9 @@ tags:
 {{#each tags as |tag i|}}
  - {{tag}}
 {{/each}}
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 fields_under_root: true
 fields:
     observer:
@@ -3246,7 +3249,3 @@ processors:
     target_subdomain_field: url.subdomain
     target_etld_field: url.top_level_domain
 - add_locale: ~
-- add_fields:
-    target: ''
-    fields:
-        ecs.version: 1.9.0

--- a/packages/cisco/data_stream/meraki/agent/stream/udp.yml.hbs
+++ b/packages/cisco/data_stream/meraki/agent/stream/udp.yml.hbs
@@ -4,6 +4,9 @@ tags:
 {{#each tags as |tag i|}}
  - {{tag}}
 {{/each}}
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 fields_under_root: true
 fields:
     observer:
@@ -3246,7 +3249,3 @@ processors:
     target_subdomain_field: url.subdomain
     target_etld_field: url.top_level_domain
 - add_locale: ~
-- add_fields:
-    target: ''
-    fields:
-        ecs.version: 1.9.0

--- a/packages/cisco/data_stream/meraki/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco/data_stream/meraki/elasticsearch/ingest_pipeline/default.yml
@@ -6,6 +6,9 @@ processors:
   - set:
         field: event.ingested
         value: '{{_ingest.timestamp}}'
+  - set:
+        field: ecs.version
+        value: 1.9.0      
   # User agent
   - user_agent:
         field: user_agent.original
@@ -58,6 +61,11 @@ processors:
         value: '{{host.name}}'
         allow_duplicates: false
         if: ctx.host?.name != null && ctx.host?.name != ''
+  - remove:
+        field: event.original
+        if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"
+        ignore_failure: true
+        ignore_missing: true
 on_failure:
   - append:
         field: error.message

--- a/packages/cisco/data_stream/meraki/manifest.yml
+++ b/packages/cisco/data_stream/meraki/manifest.yml
@@ -42,6 +42,14 @@ streams:
         required: false
         show_user: true
         default: true
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
       - name: keep_raw_fields
         type: bool
         title: Keep raw parser fields
@@ -94,6 +102,14 @@ streams:
         required: false
         show_user: true
         default: true
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
       - name: keep_raw_fields
         type: bool
         title: Keep raw parser fields
@@ -140,6 +156,14 @@ streams:
         required: false
         show_user: true
         default: true
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
       - name: keep_raw_fields
         type: bool
         title: Keep raw parser fields

--- a/packages/cisco/data_stream/meraki/sample_event.json
+++ b/packages/cisco/data_stream/meraki/sample_event.json
@@ -1,0 +1,96 @@
+{
+    "@timestamp": "2016-01-29T06:09:59.000Z",
+    "agent": {
+        "ephemeral_id": "f5535a1f-52da-44d4-a626-f85bbdc25e74",
+        "hostname": "docker-fleet-agent",
+        "id": "37c96a8c-c323-4db5-b898-9ba84c49e2ea",
+        "name": "docker-fleet-agent",
+        "type": "filebeat",
+        "version": "7.14.0"
+    },
+    "data_stream": {
+        "dataset": "cisco.meraki",
+        "namespace": "ep",
+        "type": "logs"
+    },
+    "destination": {
+        "ip": [
+            "10.193.124.51"
+        ],
+        "port": 5293
+    },
+    "ecs": {
+        "version": "1.9.0"
+    },
+    "elastic_agent": {
+        "id": "732b7efe-6d7b-40fc-bbfe-799296be9d11",
+        "snapshot": true,
+        "version": "7.14.0"
+    },
+    "event": {
+        "action": "deny\n",
+        "code": "security_event",
+        "dataset": "cisco.meraki",
+        "ingested": "2021-06-03T09:28:46.590942659Z",
+        "original": "modtempo 1454047799.olab nto_ security_event olaborissecurity_event tur url=https://example.org/odoco/ria.jpg?ritin=uredolor#tatemac src=10.15.44.253:5078 dst=10.193.124.51:5293 mac=01:00:5e:28:ae:7d name=psa sha256=umq disposition=ntium action=deny\n",
+        "timezone": "+00:00"
+    },
+    "host": {
+        "name": "docker-fleet-agent"
+    },
+    "input": {
+        "type": "udp"
+    },
+    "log": {
+        "source": {
+            "address": "172.19.0.4:37952"
+        }
+    },
+    "observer": {
+        "product": "Meraki",
+        "type": "Wireless",
+        "vendor": "Cisco"
+    },
+    "related": {
+        "hosts": [
+            "docker-fleet-agent"
+        ],
+        "ip": [
+            "10.15.44.253",
+            "10.193.124.51"
+        ]
+    },
+    "rsa": {
+        "internal": {
+            "event_desc": "olaborissecurity_event tur",
+            "messageid": "security_event"
+        },
+        "misc": {
+            "action": [
+                "deny\n"
+            ],
+            "disposition": "ntium",
+            "event_type": "security_event",
+            "node": "nto_",
+            "sensor": "nto_"
+        },
+        "time": {
+            "event_time": "2016-01-29T06:09:59.000Z"
+        }
+    },
+    "source": {
+        "ip": [
+            "10.15.44.253"
+        ],
+        "mac": "01:00:5e:28:ae:7d",
+        "port": 5078
+    },
+    "tags": [
+        "cisco-meraki",
+        "forwarded",
+        "preserve_original_event"
+    ],
+    "url": {
+        "original": "https://example.org/odoco/ria.jpg?ritin=uredolor#tatemac"
+    }
+}

--- a/packages/cisco/data_stream/nexus/_dev/test/system/test-logfile-config.yml
+++ b/packages/cisco/data_stream/nexus/_dev/test/system/test-logfile-config.yml
@@ -4,3 +4,4 @@ data_stream:
   vars:
     paths:
       - "{{SERVICE_LOGS_DIR}}/*nexus*.log"
+    preserve_original_event: true

--- a/packages/cisco/data_stream/nexus/_dev/test/system/test-tcp-config.yml
+++ b/packages/cisco/data_stream/nexus/_dev/test/system/test-tcp-config.yml
@@ -5,3 +5,4 @@ data_stream:
   vars:
     tcp_host: 0.0.0.0
     tcp_port: 9514
+    preserve_original_event: true

--- a/packages/cisco/data_stream/nexus/_dev/test/system/test-udp-config.yml
+++ b/packages/cisco/data_stream/nexus/_dev/test/system/test-udp-config.yml
@@ -5,3 +5,4 @@ data_stream:
   vars:
     udp_host: 0.0.0.0
     udp_port: 9514
+    preserve_original_event: true

--- a/packages/cisco/data_stream/nexus/agent/stream/stream.yml.hbs
+++ b/packages/cisco/data_stream/nexus/agent/stream/stream.yml.hbs
@@ -7,6 +7,9 @@ tags:
 {{#each tags as |tag i|}}
  - {{tag}}
 {{/each}}
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 fields_under_root: true
 fields:
     observer:
@@ -7172,7 +7175,3 @@ processors:
     target_subdomain_field: url.subdomain
     target_etld_field: url.top_level_domain
 - add_locale: ~
-- add_fields:
-    target: ''
-    fields:
-        ecs.version: 1.9.0

--- a/packages/cisco/data_stream/nexus/agent/stream/tcp.yml.hbs
+++ b/packages/cisco/data_stream/nexus/agent/stream/tcp.yml.hbs
@@ -4,6 +4,9 @@ tags:
 {{#each tags as |tag i|}}
  - {{tag}}
 {{/each}}
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 fields_under_root: true
 fields:
     observer:
@@ -7169,7 +7172,3 @@ processors:
     target_subdomain_field: url.subdomain
     target_etld_field: url.top_level_domain
 - add_locale: ~
-- add_fields:
-    target: ''
-    fields:
-        ecs.version: 1.9.0

--- a/packages/cisco/data_stream/nexus/agent/stream/udp.yml.hbs
+++ b/packages/cisco/data_stream/nexus/agent/stream/udp.yml.hbs
@@ -4,6 +4,9 @@ tags:
 {{#each tags as |tag i|}}
  - {{tag}}
 {{/each}}
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 fields_under_root: true
 fields:
     observer:
@@ -7169,7 +7172,3 @@ processors:
     target_subdomain_field: url.subdomain
     target_etld_field: url.top_level_domain
 - add_locale: ~
-- add_fields:
-    target: ''
-    fields:
-        ecs.version: 1.9.0

--- a/packages/cisco/data_stream/nexus/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco/data_stream/nexus/elasticsearch/ingest_pipeline/default.yml
@@ -6,6 +6,9 @@ processors:
   - set:
         field: event.ingested
         value: '{{_ingest.timestamp}}'
+  - set:
+        field: ecs.version
+        value: 1.9.0
   # User agent
   - user_agent:
         field: user_agent.original
@@ -58,6 +61,11 @@ processors:
         value: '{{host.name}}'
         allow_duplicates: false
         if: ctx.host?.name != null && ctx.host?.name != ''
+  - remove:
+        field: event.original
+        if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"
+        ignore_failure: true
+        ignore_missing: true
 on_failure:
   - append:
         field: error.message

--- a/packages/cisco/data_stream/nexus/manifest.yml
+++ b/packages/cisco/data_stream/nexus/manifest.yml
@@ -42,6 +42,14 @@ streams:
         required: false
         show_user: true
         default: true
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
       - name: keep_raw_fields
         type: bool
         title: Keep raw parser fields
@@ -94,6 +102,14 @@ streams:
         required: false
         show_user: true
         default: true
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
       - name: keep_raw_fields
         type: bool
         title: Keep raw parser fields
@@ -140,6 +156,14 @@ streams:
         required: false
         show_user: true
         default: true
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
       - name: keep_raw_fields
         type: bool
         title: Keep raw parser fields

--- a/packages/cisco/data_stream/nexus/sample_event.json
+++ b/packages/cisco/data_stream/nexus/sample_event.json
@@ -1,0 +1,65 @@
+{
+    "@timestamp": "2021-06-03T09:31:40.532Z",
+    "agent": {
+        "ephemeral_id": "f5535a1f-52da-44d4-a626-f85bbdc25e74",
+        "hostname": "docker-fleet-agent",
+        "id": "37c96a8c-c323-4db5-b898-9ba84c49e2ea",
+        "name": "docker-fleet-agent",
+        "type": "filebeat",
+        "version": "7.14.0"
+    },
+    "data_stream": {
+        "dataset": "cisco.nexus",
+        "namespace": "ep",
+        "type": "logs"
+    },
+    "ecs": {
+        "version": "1.9.0"
+    },
+    "elastic_agent": {
+        "id": "732b7efe-6d7b-40fc-bbfe-799296be9d11",
+        "snapshot": true,
+        "version": "7.14.0"
+    },
+    "event": {
+        "code": "pam_aaa",
+        "dataset": "cisco.nexus",
+        "ingested": "2021-06-03T09:31:41.553114054Z",
+        "original": "2012 Dec 18 14:51:08 Nexus5010-B %AUTHPRIV-3-SYSTEM_MSG: pam_aaa:Authentication failed for user en from 2.2.2.1 - login\n",
+        "timezone": "+00:00"
+    },
+    "host": {
+        "name": "docker-fleet-agent"
+    },
+    "input": {
+        "type": "udp"
+    },
+    "log": {
+        "source": {
+            "address": "172.19.0.4:46985"
+        }
+    },
+    "observer": {
+        "product": "Nexus",
+        "type": "Switches",
+        "vendor": "Cisco"
+    },
+    "related": {
+        "hosts": [
+            "docker-fleet-agent"
+        ]
+    },
+    "rsa": {
+        "internal": {
+            "messageid": "pam_aaa"
+        },
+        "time": {
+            "timezone": "Nexus5010-B %AUTHPRIV-3-SYSTEM_MSG"
+        }
+    },
+    "tags": [
+        "cisco-nexus",
+        "forwarded",
+        "preserve_original_event"
+    ]
+}

--- a/packages/cisco/docs/README.md
+++ b/packages/cisco/docs/README.md
@@ -17,6 +17,136 @@ datasets for receiving logs over syslog or read from a file:
 
 The `asa` dataset collects the Cisco firewall logs.
 
+An example event for `asa` looks as following:
+
+```$json
+{
+    "@timestamp": "2018-10-10T12:34:56.000Z",
+    "agent": {
+        "ephemeral_id": "f5535a1f-52da-44d4-a626-f85bbdc25e74",
+        "hostname": "docker-fleet-agent",
+        "id": "37c96a8c-c323-4db5-b898-9ba84c49e2ea",
+        "name": "docker-fleet-agent",
+        "type": "filebeat",
+        "version": "7.14.0"
+    },
+    "cisco": {
+        "asa": {
+            "destination_interface": "outside",
+            "message_id": "305011",
+            "source_interface": "inside"
+        }
+    },
+    "data_stream": {
+        "dataset": "cisco.asa",
+        "namespace": "ep",
+        "type": "logs"
+    },
+    "destination": {
+        "address": "100.66.98.44",
+        "ip": "100.66.98.44",
+        "port": 8256
+    },
+    "ecs": {
+        "version": "1.9.0"
+    },
+    "elastic_agent": {
+        "id": "732b7efe-6d7b-40fc-bbfe-799296be9d11",
+        "snapshot": true,
+        "version": "7.14.0"
+    },
+    "event": {
+        "action": "firewall-rule",
+        "category": [
+            "network"
+        ],
+        "code": "305011",
+        "dataset": "cisco.asa",
+        "ingested": "2021-06-03T09:22:20.519428820Z",
+        "kind": "event",
+        "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1772 to outside:100.66.98.44/8256",
+        "severity": 6,
+        "timezone": "+00:00",
+        "type": [
+            "info"
+        ]
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": true,
+        "hostname": "localhost",
+        "id": "f46ddd9d65ff20633d9c337909855778",
+        "ip": [
+            "172.19.0.7"
+        ],
+        "mac": [
+            "02:42:ac:13:00:07"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+            "codename": "Core",
+            "family": "redhat",
+            "kernel": "5.10.25-linuxkit",
+            "name": "CentOS Linux",
+            "platform": "centos",
+            "type": "linux",
+            "version": "7 (Core)"
+        }
+    },
+    "input": {
+        "type": "udp"
+    },
+    "log": {
+        "level": "informational",
+        "source": {
+            "address": "172.19.0.4:47315"
+        }
+    },
+    "network": {
+        "iana_number": "6",
+        "transport": "tcp"
+    },
+    "observer": {
+        "egress": {
+            "interface": {
+                "name": "inside"
+            }
+        },
+        "hostname": "localhost",
+        "ingress": {
+            "interface": {
+                "name": "outside"
+            }
+        },
+        "product": "asa",
+        "type": "firewall",
+        "vendor": "Cisco"
+    },
+    "process": {
+        "name": "CiscoASA",
+        "pid": 999
+    },
+    "related": {
+        "hosts": [
+            "localhost"
+        ],
+        "ip": [
+            "172.31.98.44",
+            "100.66.98.44"
+        ]
+    },
+    "source": {
+        "address": "172.31.98.44",
+        "ip": "172.31.98.44",
+        "port": 1772
+    },
+    "tags": [
+        "cisco-asa",
+        "preserve_original_event"
+    ]
+}
+```
+
 **Exported fields**
 
 | Field | Description | Type |
@@ -124,7 +254,6 @@ The `asa` dataset collects the Cisco firewall logs.
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.level | Log level of the log event. | keyword |
 | log.offset | Offset of the entry in the log file. | long |
-| log.original | Original log message with light interpretation only (encoding, newlines). | keyword |
 | log.source.address | Source address from which the log event was read / sent from. | keyword |
 | log.syslog.facility.code | Syslog numeric facility of the event. | long |
 | log.syslog.priority | Syslog priority of the event. | long |
@@ -178,6 +307,187 @@ The `asa` dataset collects the Cisco firewall logs.
 ### FTD
 
 The `ftd` dataset collects the Firepower Threat Defense logs.
+
+An example event for `ftd` looks as following:
+
+```$json
+{
+    "@timestamp": "2019-08-16T09:39:03.000Z",
+    "agent": {
+        "ephemeral_id": "f5535a1f-52da-44d4-a626-f85bbdc25e74",
+        "hostname": "docker-fleet-agent",
+        "id": "37c96a8c-c323-4db5-b898-9ba84c49e2ea",
+        "name": "docker-fleet-agent",
+        "type": "filebeat",
+        "version": "7.14.0"
+    },
+    "cisco": {
+        "ftd": {
+            "message_id": "430005",
+            "rule_name": "malware-and-file-policy",
+            "security": {
+                "application_protocol": "HTTP",
+                "client": "cURL",
+                "dst_ip": "213.211.198.62",
+                "dst_port": "80",
+                "file_action": "Malware Cloud Lookup",
+                "file_direction": "Download",
+                "file_name": "eicar_com.zip",
+                "file_policy": "malware-and-file-policy",
+                "file_sandbox_status": "File Size Is Too Small",
+                "file_sha256": "2546dcffc5ad854d4ddc64fbf056871cd5a00f2471cb7a5bfd4ac23b6e9eedad",
+                "file_size": "184",
+                "file_storage_status": "Not Stored (Disposition Was Pending)",
+                "file_type": "ZIP",
+                "first_packet_second": "2019-08-16T09:39:02Z",
+                "protocol": "tcp",
+                "sha_disposition": "Unavailable",
+                "spero_disposition": "Spero detection not performed on file",
+                "src_ip": "10.0.1.20",
+                "src_port": "46004",
+                "threat_name": "Win.Ransomware.Eicar::95.sbx.tg",
+                "uri": "http://www.eicar.org/download/eicar_com.zip",
+                "user": "No Authentication Required"
+            },
+            "threat_category": "Win.Ransomware.Eicar::95.sbx.tg"
+        }
+    },
+    "data_stream": {
+        "dataset": "cisco.ftd",
+        "namespace": "ep",
+        "type": "logs"
+    },
+    "destination": {
+        "address": "213.211.198.62",
+        "as": {
+            "number": 43341,
+            "organization": {
+                "name": "MDlink online service center GmbH"
+            }
+        },
+        "geo": {
+            "city_name": "Magdeburg",
+            "continent_name": "Europe",
+            "country_iso_code": "DE",
+            "country_name": "Germany",
+            "location": {
+                "lat": 52.1333,
+                "lon": 11.6167
+            },
+            "region_iso_code": "DE-ST",
+            "region_name": "Saxony-Anhalt"
+        },
+        "ip": "213.211.198.62",
+        "port": 80
+    },
+    "ecs": {
+        "version": "1.9.0"
+    },
+    "elastic_agent": {
+        "id": "732b7efe-6d7b-40fc-bbfe-799296be9d11",
+        "snapshot": true,
+        "version": "7.14.0"
+    },
+    "event": {
+        "action": "malware-detected",
+        "category": [
+            "malware"
+        ],
+        "code": "430005",
+        "dataset": "cisco.ftd",
+        "ingested": "2021-06-03T09:24:01.526093450Z",
+        "kind": "alert",
+        "original": "%FTD-1-430005: SrcIP: 10.0.1.20, DstIP: 213.211.198.62, SrcPort: 46004, DstPort: 80, Protocol: tcp, FileDirection: Download, FileAction: Malware Cloud Lookup, FileSHA256: 2546dcffc5ad854d4ddc64fbf056871cd5a00f2471cb7a5bfd4ac23b6e9eedad, SHA_Disposition: Unavailable, SperoDisposition: Spero detection not performed on file, ThreatName: Win.Ransomware.Eicar::95.sbx.tg, FileName: eicar_com.zip, FileType: ZIP, FileSize: 184, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-16T09:39:02Z, FilePolicy: malware-and-file-policy, FileStorageStatus: Not Stored (Disposition Was Pending), FileSandboxStatus: File Size Is Too Small, URI: http://www.eicar.org/download/eicar_com.zip",
+        "severity": 1,
+        "start": "2019-08-16T09:39:02Z",
+        "timezone": "+00:00",
+        "type": [
+            "info"
+        ]
+    },
+    "file": {
+        "hash": {
+            "sha256": "2546dcffc5ad854d4ddc64fbf056871cd5a00f2471cb7a5bfd4ac23b6e9eedad"
+        },
+        "name": "eicar_com.zip",
+        "size": 184
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": true,
+        "hostname": "firepower",
+        "id": "f46ddd9d65ff20633d9c337909855778",
+        "ip": [
+            "172.19.0.7"
+        ],
+        "mac": [
+            "02:42:ac:13:00:07"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+            "codename": "Core",
+            "family": "redhat",
+            "kernel": "5.10.25-linuxkit",
+            "name": "CentOS Linux",
+            "platform": "centos",
+            "type": "linux",
+            "version": "7 (Core)"
+        }
+    },
+    "input": {
+        "type": "udp"
+    },
+    "log": {
+        "level": "alert",
+        "source": {
+            "address": "172.19.0.4:46787"
+        }
+    },
+    "network": {
+        "application": "curl",
+        "iana_number": "6",
+        "protocol": "http",
+        "transport": "tcp"
+    },
+    "observer": {
+        "hostname": "firepower",
+        "product": "asa",
+        "type": "firewall",
+        "vendor": "Cisco"
+    },
+    "related": {
+        "hash": [
+            "2546dcffc5ad854d4ddc64fbf056871cd5a00f2471cb7a5bfd4ac23b6e9eedad"
+        ],
+        "hosts": [
+            "firepower"
+        ],
+        "ip": [
+            "10.0.1.20",
+            "213.211.198.62"
+        ],
+        "user": [
+            "No Authentication Required"
+        ]
+    },
+    "source": {
+        "address": "10.0.1.20",
+        "ip": "10.0.1.20",
+        "port": 46004
+    },
+    "tags": [
+        "cisco-ftd",
+        "preserve_original_event"
+    ],
+    "url": {
+        "original": "http://www.eicar.org/download/eicar_com.zip"
+    },
+    "user": {
+        "id": "No Authentication Required",
+        "name": "No Authentication Required"
+    }
+}
+```
 
 **Exported fields**
 
@@ -296,7 +606,6 @@ The `ftd` dataset collects the Firepower Threat Defense logs.
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.level | Log level of the log event. | keyword |
 | log.offset | Offset of the entry in the log file. | long |
-| log.original | Original log message with light interpretation only (encoding, newlines). | keyword |
 | log.source.address | Source address from which the log event was read / sent from. | keyword |
 | log.syslog.facility.code | Syslog numeric facility of the event. | long |
 | log.syslog.priority | Syslog priority of the event. | long |
@@ -357,6 +666,110 @@ The `ftd` dataset collects the Firepower Threat Defense logs.
 ### IOS
 
 The `ios` dataset collects the Cisco IOS router and switch logs.
+
+An example event for `ios` looks as following:
+
+```$json
+{
+    "@timestamp": "2021-06-03T09:25:42.537Z",
+    "agent": {
+        "ephemeral_id": "f5535a1f-52da-44d4-a626-f85bbdc25e74",
+        "hostname": "docker-fleet-agent",
+        "id": "37c96a8c-c323-4db5-b898-9ba84c49e2ea",
+        "name": "docker-fleet-agent",
+        "type": "filebeat",
+        "version": "7.14.0"
+    },
+    "cisco": {
+        "ios": {
+            "access_list": "177",
+            "facility": "SEC"
+        }
+    },
+    "data_stream": {
+        "dataset": "cisco.ios",
+        "namespace": "ep",
+        "type": "logs"
+    },
+    "destination": {
+        "address": "224.0.0.22",
+        "ip": "224.0.0.22"
+    },
+    "ecs": {
+        "version": "1.9.0"
+    },
+    "elastic_agent": {
+        "id": "732b7efe-6d7b-40fc-bbfe-799296be9d11",
+        "snapshot": true,
+        "version": "7.14.0"
+    },
+    "event": {
+        "action": "deny",
+        "category": "network",
+        "code": "IPACCESSLOGRP",
+        "dataset": "cisco.ios",
+        "ingested": "2021-06-03T09:25:43.560570635Z",
+        "original": "Feb  8 04:00:48 198.51.100.2 585917: Feb  8 04:00:47.272: %SEC-6-IPACCESSLOGRP: list 177 denied igmp 198.51.100.197 -\u003e 224.0.0.22, 1 packet\n",
+        "provider": "firewall",
+        "sequence": 585917,
+        "severity": 6,
+        "type": "info"
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": true,
+        "hostname": "docker-fleet-agent",
+        "id": "f46ddd9d65ff20633d9c337909855778",
+        "ip": [
+            "172.19.0.7"
+        ],
+        "mac": [
+            "02:42:ac:13:00:07"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+            "codename": "Core",
+            "family": "redhat",
+            "kernel": "5.10.25-linuxkit",
+            "name": "CentOS Linux",
+            "platform": "centos",
+            "type": "linux",
+            "version": "7 (Core)"
+        }
+    },
+    "input": {
+        "type": "udp"
+    },
+    "log": {
+        "level": "informational",
+        "source": {
+            "address": "198.51.100.2"
+        }
+    },
+    "message": "list 177 denied igmp 198.51.100.197 -\u003e 224.0.0.22, 1 packet",
+    "network": {
+        "community_id": "1:Rt5RGlrNED3cg8Wokm4+KGsDz+4=",
+        "packets": 1,
+        "transport": "igmp",
+        "type": "ipv4"
+    },
+    "related": {
+        "ip": [
+            "198.51.100.197",
+            "224.0.0.22"
+        ]
+    },
+    "source": {
+        "address": "198.51.100.197",
+        "ip": "198.51.100.197",
+        "packets": 1
+    },
+    "tags": [
+        "cisco-ios",
+        "preserve_original_event"
+    ]
+}
+```
 
 **Exported fields**
 
@@ -438,7 +851,6 @@ The `ios` dataset collects the Cisco IOS router and switch logs.
 | log.file.path | Full path to the log file this event came from. | keyword |
 | log.level | Log level of the log event. | keyword |
 | log.offset |  | long |
-| log.original | Original log message with light interpretation only (encoding, newlines). | keyword |
 | log.source.address |  | keyword |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. | text |
 | network.community_id | A hash of source and destination IPs and ports. | keyword |
@@ -460,6 +872,76 @@ The `ios` dataset collects the Cisco IOS router and switch logs.
 ### Nexus
 
 The `nexus` dataset collects Cisco Nexus logs.
+
+An example event for `nexus` looks as following:
+
+```$json
+{
+    "@timestamp": "2021-06-03T09:31:40.532Z",
+    "agent": {
+        "ephemeral_id": "f5535a1f-52da-44d4-a626-f85bbdc25e74",
+        "hostname": "docker-fleet-agent",
+        "id": "37c96a8c-c323-4db5-b898-9ba84c49e2ea",
+        "name": "docker-fleet-agent",
+        "type": "filebeat",
+        "version": "7.14.0"
+    },
+    "data_stream": {
+        "dataset": "cisco.nexus",
+        "namespace": "ep",
+        "type": "logs"
+    },
+    "ecs": {
+        "version": "1.9.0"
+    },
+    "elastic_agent": {
+        "id": "732b7efe-6d7b-40fc-bbfe-799296be9d11",
+        "snapshot": true,
+        "version": "7.14.0"
+    },
+    "event": {
+        "code": "pam_aaa",
+        "dataset": "cisco.nexus",
+        "ingested": "2021-06-03T09:31:41.553114054Z",
+        "original": "2012 Dec 18 14:51:08 Nexus5010-B %AUTHPRIV-3-SYSTEM_MSG: pam_aaa:Authentication failed for user en from 2.2.2.1 - login\n",
+        "timezone": "+00:00"
+    },
+    "host": {
+        "name": "docker-fleet-agent"
+    },
+    "input": {
+        "type": "udp"
+    },
+    "log": {
+        "source": {
+            "address": "172.19.0.4:46985"
+        }
+    },
+    "observer": {
+        "product": "Nexus",
+        "type": "Switches",
+        "vendor": "Cisco"
+    },
+    "related": {
+        "hosts": [
+            "docker-fleet-agent"
+        ]
+    },
+    "rsa": {
+        "internal": {
+            "messageid": "pam_aaa"
+        },
+        "time": {
+            "timezone": "Nexus5010-B %AUTHPRIV-3-SYSTEM_MSG"
+        }
+    },
+    "tags": [
+        "cisco-nexus",
+        "forwarded",
+        "preserve_original_event"
+    ]
+}
+```
 
 **Exported fields**
 
@@ -1294,6 +1776,107 @@ The `nexus` dataset collects Cisco Nexus logs.
 ### Meraki
 
 The `meraki` dataset collects Cisco Meraki logs.
+
+An example event for `meraki` looks as following:
+
+```$json
+{
+    "@timestamp": "2016-01-29T06:09:59.000Z",
+    "agent": {
+        "ephemeral_id": "f5535a1f-52da-44d4-a626-f85bbdc25e74",
+        "hostname": "docker-fleet-agent",
+        "id": "37c96a8c-c323-4db5-b898-9ba84c49e2ea",
+        "name": "docker-fleet-agent",
+        "type": "filebeat",
+        "version": "7.14.0"
+    },
+    "data_stream": {
+        "dataset": "cisco.meraki",
+        "namespace": "ep",
+        "type": "logs"
+    },
+    "destination": {
+        "ip": [
+            "10.193.124.51"
+        ],
+        "port": 5293
+    },
+    "ecs": {
+        "version": "1.9.0"
+    },
+    "elastic_agent": {
+        "id": "732b7efe-6d7b-40fc-bbfe-799296be9d11",
+        "snapshot": true,
+        "version": "7.14.0"
+    },
+    "event": {
+        "action": "deny\n",
+        "code": "security_event",
+        "dataset": "cisco.meraki",
+        "ingested": "2021-06-03T09:28:46.590942659Z",
+        "original": "modtempo 1454047799.olab nto_ security_event olaborissecurity_event tur url=https://example.org/odoco/ria.jpg?ritin=uredolor#tatemac src=10.15.44.253:5078 dst=10.193.124.51:5293 mac=01:00:5e:28:ae:7d name=psa sha256=umq disposition=ntium action=deny\n",
+        "timezone": "+00:00"
+    },
+    "host": {
+        "name": "docker-fleet-agent"
+    },
+    "input": {
+        "type": "udp"
+    },
+    "log": {
+        "source": {
+            "address": "172.19.0.4:37952"
+        }
+    },
+    "observer": {
+        "product": "Meraki",
+        "type": "Wireless",
+        "vendor": "Cisco"
+    },
+    "related": {
+        "hosts": [
+            "docker-fleet-agent"
+        ],
+        "ip": [
+            "10.15.44.253",
+            "10.193.124.51"
+        ]
+    },
+    "rsa": {
+        "internal": {
+            "event_desc": "olaborissecurity_event tur",
+            "messageid": "security_event"
+        },
+        "misc": {
+            "action": [
+                "deny\n"
+            ],
+            "disposition": "ntium",
+            "event_type": "security_event",
+            "node": "nto_",
+            "sensor": "nto_"
+        },
+        "time": {
+            "event_time": "2016-01-29T06:09:59.000Z"
+        }
+    },
+    "source": {
+        "ip": [
+            "10.15.44.253"
+        ],
+        "mac": "01:00:5e:28:ae:7d",
+        "port": 5078
+    },
+    "tags": [
+        "cisco-meraki",
+        "forwarded",
+        "preserve_original_event"
+    ],
+    "url": {
+        "original": "https://example.org/odoco/ria.jpg?ritin=uredolor#tatemac"
+    }
+}
+```
 
 **Exported fields**
 

--- a/packages/cisco/manifest.yml
+++ b/packages/cisco/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco
 title: Cisco
-version: 0.9.1
+version: 0.9.2
 license: basic
 description: Cisco Integration
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

- Makes event.original optional 
- Updates README with sample events.
- Unifies pipeline tests configs.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #777 
- Relates #961 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
