### PR TITLE
[fortinet] Make event.original optional in fortinet

### DIFF
--- a/packages/fortinet/_dev/build/docs/README.md
+++ b/packages/fortinet/_dev/build/docs/README.md
@@ -17,11 +17,15 @@ This integration has been tested against FortiOS version 6.0.x and 6.2.x. Versio
 
 Contains log entries from Fortinet FortiGate applicances.
 
+{{event "firewall"}}
+
 {{fields "firewall"}}
 
 ### Clientendpoint
 
 The `clientendpoint` dataset collects Fortinet FortiClient Endpoint Security logs.
+
+{{event "clientendpoint"}}
 
 {{fields "clientendpoint"}}
 
@@ -29,10 +33,14 @@ The `clientendpoint` dataset collects Fortinet FortiClient Endpoint Security log
 
 The `fortimail` dataset collects Fortinet FortiMail logs.
 
+{{event "fortimail"}}
+
 {{fields "fortimail"}}
 
 ### Fortimanager
 
 The `fortimanager` dataset collects Fortinet Manager/Analyzer logs.
+
+{{event "fortimanager"}}
 
 {{fields "fortimanager"}}

--- a/packages/fortinet/changelog.yml
+++ b/packages/fortinet/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.8.2"
+  changes:
+    - description: make event.original optional
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1075
 - version: "0.8.1"
   changes:
     - description: update to ECS 1.9.0

--- a/packages/fortinet/data_stream/clientendpoint/_dev/test/system/test-logfile-config.yml
+++ b/packages/fortinet/data_stream/clientendpoint/_dev/test/system/test-logfile-config.yml
@@ -4,3 +4,4 @@ data_stream:
   vars:
     paths:
       - "{{SERVICE_LOGS_DIR}}/*clientendpoint*.log"
+    preserve_original_event: true

--- a/packages/fortinet/data_stream/clientendpoint/_dev/test/system/test-tcp-config.yml
+++ b/packages/fortinet/data_stream/clientendpoint/_dev/test/system/test-tcp-config.yml
@@ -5,3 +5,4 @@ data_stream:
   vars:
     tcp_host: 0.0.0.0
     tcp_port: 9514
+    preserve_original_event: true

--- a/packages/fortinet/data_stream/clientendpoint/_dev/test/system/test-udp-config.yml
+++ b/packages/fortinet/data_stream/clientendpoint/_dev/test/system/test-udp-config.yml
@@ -5,3 +5,4 @@ data_stream:
   vars:
     udp_host: 0.0.0.0
     udp_port: 9515
+    preserve_original_event: true

--- a/packages/fortinet/data_stream/clientendpoint/agent/stream/log.yml.hbs
+++ b/packages/fortinet/data_stream/clientendpoint/agent/stream/log.yml.hbs
@@ -7,6 +7,9 @@ tags:
 {{#each tags as |tag i|}}
  - {{tag}}
 {{/each}}
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 fields_under_root: true
 fields:
     observer:
@@ -2767,7 +2770,3 @@ processors:
     target_subdomain_field: url.subdomain
     target_etld_field: url.top_level_domain
 - add_locale: ~
-- add_fields:
-    target: ''
-    fields:
-        ecs.version: 1.9.0

--- a/packages/fortinet/data_stream/clientendpoint/agent/stream/tcp.yml.hbs
+++ b/packages/fortinet/data_stream/clientendpoint/agent/stream/tcp.yml.hbs
@@ -4,6 +4,9 @@ tags:
 {{#each tags as |tag i|}}
  - {{tag}}
 {{/each}}
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 fields_under_root: true
 fields:
     observer:
@@ -2764,7 +2767,3 @@ processors:
     target_subdomain_field: url.subdomain
     target_etld_field: url.top_level_domain
 - add_locale: ~
-- add_fields:
-    target: ''
-    fields:
-        ecs.version: 1.9.0

--- a/packages/fortinet/data_stream/clientendpoint/agent/stream/udp.yml.hbs
+++ b/packages/fortinet/data_stream/clientendpoint/agent/stream/udp.yml.hbs
@@ -4,6 +4,9 @@ tags:
 {{#each tags as |tag i|}}
  - {{tag}}
 {{/each}}
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 fields_under_root: true
 fields:
     observer:
@@ -2764,7 +2767,3 @@ processors:
     target_subdomain_field: url.subdomain
     target_etld_field: url.top_level_domain
 - add_locale: ~
-- add_fields:
-    target: ''
-    fields:
-        ecs.version: 1.9.0

--- a/packages/fortinet/data_stream/clientendpoint/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fortinet/data_stream/clientendpoint/elasticsearch/ingest_pipeline/default.yml
@@ -6,6 +6,9 @@ processors:
   - set:
         field: event.ingested
         value: '{{_ingest.timestamp}}'
+  - set:
+        field: ecs.version
+        value: 1.9.0
   # User agent
   - user_agent:
         field: user_agent.original
@@ -58,6 +61,11 @@ processors:
         value: '{{host.name}}'
         allow_duplicates: false
         if: ctx.host?.name != null && ctx.host?.name != ''
+  - remove:
+        field: event.original
+        if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"
+        ignore_failure: true
+        ignore_missing: true
 on_failure:
   - append:
         field: error.message

--- a/packages/fortinet/data_stream/clientendpoint/manifest.yml
+++ b/packages/fortinet/data_stream/clientendpoint/manifest.yml
@@ -43,6 +43,14 @@ streams:
         required: false
         show_user: true
         default: true
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
       - name: keep_raw_fields
         type: bool
         title: Keep raw parser fields
@@ -96,6 +104,14 @@ streams:
         required: false
         show_user: true
         default: true
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
       - name: keep_raw_fields
         type: bool
         title: Keep raw parser fields
@@ -143,6 +159,14 @@ streams:
         required: false
         show_user: true
         default: true
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
       - name: keep_raw_fields
         type: bool
         title: Keep raw parser fields

--- a/packages/fortinet/data_stream/clientendpoint/sample_event.json
+++ b/packages/fortinet/data_stream/clientendpoint/sample_event.json
@@ -1,0 +1,125 @@
+{
+    "@timestamp": "2020-06-05T21:33:08.000Z",
+    "agent": {
+        "ephemeral_id": "74b27709-c288-4314-b386-659dbc5a62ea",
+        "hostname": "docker-fleet-agent",
+        "id": "2164018d-05cd-45b4-979d-4032bdd775f6",
+        "name": "docker-fleet-agent",
+        "type": "filebeat",
+        "version": "7.14.0"
+    },
+    "data_stream": {
+        "dataset": "fortinet.clientendpoint",
+        "namespace": "ep",
+        "type": "logs"
+    },
+    "destination": {
+        "ip": [
+            "10.203.5.162"
+        ],
+        "port": 7290
+    },
+    "ecs": {
+        "version": "1.9.0"
+    },
+    "elastic_agent": {
+        "id": "7cc48d16-ebf0-44b1-9094-fe2082d8f5a4",
+        "snapshot": true,
+        "version": "7.14.0"
+    },
+    "event": {
+        "action": "deny",
+        "code": "pop3",
+        "dataset": "fortinet.clientendpoint",
+        "ingested": "2021-06-03T12:35:28.382730111Z",
+        "original": "June 5 21:33:08 tatno4987.www5.localhost proto=ggp service=pop3 status=deny src=10.54.231.100 dst=10.203.5.162 src_port=5616 dst_port=7290 server_app=iam pid=6096 app_name=ciati traff_direct=unknown block_count=3162 logon_user=umdolore@eniam7007.api.invalid msg=success\n",
+        "outcome": "failure",
+        "timezone": "+00:00"
+    },
+    "host": {
+        "name": "tatno4987.www5.localhost"
+    },
+    "input": {
+        "type": "udp"
+    },
+    "log": {
+        "source": {
+            "address": "192.168.240.4:43222"
+        }
+    },
+    "network": {
+        "direction": "unknown",
+        "protocol": "ggp"
+    },
+    "observer": {
+        "product": "FortiClient",
+        "type": "Anti-Virus",
+        "vendor": "Fortinet"
+    },
+    "process": {
+        "pid": 6096
+    },
+    "related": {
+        "hosts": [
+            "eniam7007.api.invalid",
+            "tatno4987.www5.localhost"
+        ],
+        "ip": [
+            "10.54.231.100",
+            "10.203.5.162"
+        ],
+        "user": [
+            "umdolore"
+        ]
+    },
+    "rsa": {
+        "counters": {
+            "dclass_c1": 3162,
+            "dclass_c1_str": "block_count"
+        },
+        "internal": {
+            "messageid": "pop3"
+        },
+        "investigations": {
+            "ec_outcome": "Failure",
+            "ec_subject": "NetworkComm",
+            "ec_theme": "ALM"
+        },
+        "misc": {
+            "action": [
+                "deny"
+            ],
+            "result": "success\n"
+        },
+        "network": {
+            "alias_host": [
+                "tatno4987.www5.localhost"
+            ],
+            "domain": "eniam7007.api.invalid",
+            "network_service": "pop3"
+        },
+        "time": {
+            "event_time": "2020-06-05T21:33:08.000Z"
+        }
+    },
+    "server": {
+        "domain": "eniam7007.api.invalid",
+        "registered_domain": "api.invalid",
+        "subdomain": "eniam7007",
+        "top_level_domain": "invalid"
+    },
+    "source": {
+        "ip": [
+            "10.54.231.100"
+        ],
+        "port": 5616
+    },
+    "tags": [
+        "fortinet-clientendpoint",
+        "forwarded",
+        "preserve_original_event"
+    ],
+    "user": {
+        "name": "umdolore"
+    }
+}

--- a/packages/fortinet/data_stream/firewall/_dev/test/pipeline/test-common-config.yml
+++ b/packages/fortinet/data_stream/firewall/_dev/test/pipeline/test-common-config.yml
@@ -1,0 +1,5 @@
+dynamic_fields:
+  event.ingested: ".*"
+fields:
+  tags:
+    - preserve_original_event

--- a/packages/fortinet/data_stream/firewall/_dev/test/pipeline/test-fortinet.log-config.yml
+++ b/packages/fortinet/data_stream/firewall/_dev/test/pipeline/test-fortinet.log-config.yml
@@ -1,2 +1,0 @@
-dynamic_fields:
-  event.ingested: ".*"

--- a/packages/fortinet/data_stream/firewall/_dev/test/pipeline/test-fortinet.log-expected.json
+++ b/packages/fortinet/data_stream/firewall/_dev/test/pipeline/test-fortinet.log-expected.json
@@ -45,6 +45,9 @@
                 "path": "/config/",
                 "domain": "elastic.co"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "https",
                 "bytes": 2282,
@@ -69,6 +72,9 @@
                 }
             },
             "@timestamp": "2020-04-23T12:17:48.000-05:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "user": [
                     "elasticuser"
@@ -94,7 +100,8 @@
                 }
             },
             "event": {
-                "ingested": "2021-04-23T12:53:35.715470959Z",
+                "ingested": "2021-06-03T08:20:55.393436727Z",
+                "original": "\u003c188\u003edate=2020-04-23 time=12:17:48 devname=\"testswitch1\" devid=\"somerouterid\" logid=\"0316013056\" type=\"utm\" subtype=\"webfilter\" eventtype=\"ftgd_blk\" level=\"warning\" vd=\"root\" eventtime=1587230269052907555 tz=\"-0500\" policyid=100602 sessionid=1234 user=\"elasticuser\" group=\"elasticgroup\" authserver=\"elasticauth\" srcip=192.168.2.1 srcport=61930 srcintf=\"port1\" srcintfrole=\"lan\" dstip=8.8.8.8 dstport=443 dstintf=\"wan1\" dstintfrole=\"wan\" proto=6 service=\"HTTPS\" hostname=\"elastic.co\" profile=\"elasticruleset\" action=\"blocked\" reqtype=\"direct\" url=\"/config/\" sentbyte=1152 rcvdbyte=1130 direction=\"outgoing\" msg=\"URL belongs to a denied category in policy\" method=\"domain\" cat=76 catdesc=\"Internet Telephony\"",
                 "code": "0316013056",
                 "timezone": "-0500",
                 "kind": "event",
@@ -146,6 +153,9 @@
                 "packets": 0,
                 "ip": "10.10.10.10"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "snmp",
                 "bytes": 0,
@@ -169,6 +179,9 @@
                 }
             },
             "@timestamp": "2020-04-23T01:16:08.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "ip": [
                     "10.10.10.10",
@@ -194,7 +207,8 @@
             },
             "event": {
                 "duration": 0,
-                "ingested": "2021-04-23T12:53:35.715477295Z",
+                "ingested": "2021-06-03T08:20:55.393445744Z",
+                "original": "\u003c189\u003edate=2020-04-23 time=01:16:08 devname=\"testswitch1\" devid=\"somerouterid\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"OPERATIONAL\" eventtime=1592961368 srcip=10.10.10.10 srcport=60899 srcintf=\"srcintfname\" srcintfrole=\"lan\" dstip=8.8.8.8 dstport=161 dstintf=\"dstintfname\" dstintfrole=\"lan\" sessionid=155313 proto=17 action=\"deny\" policyid=0 policytype=\"policy\" service=\"SNMP\" dstcountry=\"Reserved\" srccountry=\"Reserved\" trandisp=\"noop\" duration=0 sentbyte=0 rcvdbyte=0 sentpkt=0 appcat=\"unscanned\" crscore=30 craction=131072 crlevel=\"high\"",
                 "code": "0000000013",
                 "kind": "event",
                 "module": "fortinet",
@@ -256,6 +270,9 @@
                 "path": "/",
                 "domain": "elastic.co"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "https",
                 "bytes": 10357,
@@ -280,6 +297,9 @@
                 }
             },
             "@timestamp": "2020-04-23T12:17:45.000-05:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "user": [
                     "elasticuser"
@@ -305,7 +325,8 @@
                 }
             },
             "event": {
-                "ingested": "2021-04-23T12:53:35.715478820Z",
+                "ingested": "2021-06-03T08:20:55.393448583Z",
+                "original": "\u003c189\u003edate=2020-04-23 time=12:17:45 devname=\"testswitch1\" devid=\"somerouterid\" logid=\"0317013312\" type=\"utm\" subtype=\"webfilter\" eventtype=\"ftgd_allow\" level=\"notice\" vd=\"root\" eventtime=1587230266314799756 tz=\"-0500\" policyid=38 sessionid=543234 user=\"elasticuser\" group=\"elasticgroup\" authserver=\"elasticauth\" srcip=192.168.2.1 srcport=65236 srcintf=\"port1\" srcintfrole=\"lan\" dstip=8.8.8.8 dstport=443 dstintf=\"wan1\" dstintfrole=\"wan\" proto=6 service=\"HTTPS\" hostname=\"elastic.co\" profile=\"elasticruleset\" action=\"passthrough\" reqtype=\"direct\" url=\"/\" sentbyte=3545 rcvdbyte=6812 direction=\"outgoing\" msg=\"URL belongs to an allowed category in policy\" method=\"domain\" cat=23 catdesc=\"Web-based Email\"",
                 "code": "0317013312",
                 "timezone": "-0500",
                 "kind": "event",
@@ -365,6 +386,9 @@
                 "path": "/",
                 "domain": "elastic.co"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "ssl",
                 "application": "HTTPS.BROWSER",
@@ -389,6 +413,9 @@
                 }
             },
             "@timestamp": "2020-04-23T13:17:35.000-04:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "user": [
                     "elasticuser"
@@ -423,7 +450,8 @@
                 }
             },
             "event": {
-                "ingested": "2021-04-23T12:53:35.715480084Z",
+                "ingested": "2021-06-03T08:20:55.393451204Z",
+                "original": "\u003c190\u003edate=2020-04-23 time=13:17:35 devname=\"testswitch1\" devid=\"somerouterid\" logid=\"1059028704\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"signature\" level=\"information\" vd=\"root\" eventtime=1587230255061492894 tz=\"-0400\" appid=40568 user=\"elasticuser\" group=\"elasticgroup\" authserver=\"elasticauth\" srcip=192.168.2.1 dstip=8.8.8.8 srcport=59790 dstport=443 srcintf=\"LAN\" srcintfrole=\"lan\" dstintf=\"wan1\" dstintfrole=\"wan\" proto=6 service=\"SSL\" direction=\"outgoing\" policyid=12 sessionid=453234 applist=\"elasticruleset\" action=\"pass\" appcat=\"Web.Client\" app=\"HTTPS.BROWSER\" hostname=\"elastic.co\" incidentserialno=23465 url=\"/\" msg=\"Web.Client: HTTPS.BROWSER,\" apprisk=\"medium\" scertcname=\"test.elastic.co\"",
                 "code": "1059028704",
                 "timezone": "-0400",
                 "kind": "event",
@@ -483,6 +511,9 @@
                 "path": "/",
                 "domain": "elastic.co"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "ssl",
                 "application": "HTTPS.BROWSER",
@@ -507,6 +538,9 @@
                 }
             },
             "@timestamp": "2020-04-23T13:17:35.000-04:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "user": [
                     "elasticuser"
@@ -541,7 +575,8 @@
                 }
             },
             "event": {
-                "ingested": "2021-04-23T12:53:35.715481362Z",
+                "ingested": "2021-06-03T08:20:55.393453639Z",
+                "original": "\u003c190\u003edate=2020-04-23 time=13:17:35 devname=\"testswitch1\" devid=\"somerouterid\" logid=\"1059028704\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"signature\" level=\"information\" vd=\"root\" eventtime=1591788391 tz=\"-0400\" appid=40568 user=\"elasticuser\" group=\"elasticgroup\" authserver=\"elasticauth\" srcip=192.168.2.1 dstip=8.8.8.8 srcport=59790 dstport=443 srcintf=\"LAN\" srcintfrole=\"lan\" dstintf=\"wan1\" dstintfrole=\"wan\" proto=6 service=\"SSL\" direction=\"outgoing\" policyid=12 sessionid=453234 applist=\"elasticruleset\" action=\"pass\" appcat=\"Web.Client\" app=\"HTTPS.BROWSER\" hostname=\"elastic.co\" incidentserialno=23465 url=\"/\" msg=\"Web.Client: HTTPS.BROWSER,\" apprisk=\"medium\" scertcname=\"test.elastic.co\"",
                 "code": "1059028704",
                 "timezone": "-0400",
                 "kind": "event",
@@ -602,6 +637,9 @@
                 "ip": "192.168.2.1"
             },
             "message": "Domain is monitored",
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17"
             },
@@ -623,6 +661,9 @@
                 }
             },
             "@timestamp": "2020-04-23T12:17:29.000-05:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "hosts": [
                     "elastic.example.com"
@@ -646,7 +687,8 @@
                 }
             },
             "event": {
-                "ingested": "2021-04-23T12:53:35.715482601Z",
+                "ingested": "2021-06-03T08:20:55.393456041Z",
+                "original": "\u003c189\u003edate=2020-04-23 time=12:17:29 devname=\"testswitch1\" devid=\"somerouterid\" logid=\"1501054802\" type=\"utm\" subtype=\"dns\" eventtype=\"dns-response\" level=\"notice\" vd=\"root\" eventtime=1587230249360109339 tz=\"-0500\" policyid=26 sessionid=543234 srcip=192.168.2.1 srcport=53430 srcintf=\"port1\" srcintfrole=\"lan\" dstip=8.8.8.8 dstport=53 dstintf=\"wan1\" dstintfrole=\"wan\" proto=17 profile=\"test\" xid=2234 qname=\"elastic.example.com\" qtype=\"A\" qtypeval=1 qclass=\"IN\" ipaddr=\"8.8.8.8\" msg=\"Domain is monitored\" action=\"pass\" cat=23 catdesc=\"Web-based Email\"",
                 "code": "1501054802",
                 "timezone": "-0500",
                 "kind": "event",
@@ -709,6 +751,9 @@
                 "ip": "192.168.2.1"
             },
             "message": "Domain is monitored",
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17"
             },
@@ -730,6 +775,9 @@
                 }
             },
             "@timestamp": "2020-04-23T12:17:29.000-05:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "hosts": [
                     "elastic.example.com"
@@ -754,7 +802,8 @@
                 }
             },
             "event": {
-                "ingested": "2021-04-23T12:53:35.715483848Z",
+                "ingested": "2021-06-03T08:20:55.393458406Z",
+                "original": "\u003c189\u003edate=2020-04-23 time=12:17:29 devname=\"testswitch1\" devid=\"somerouterid\" logid=\"1501054802\" type=\"utm\" subtype=\"dns\" eventtype=\"dns-response\" level=\"notice\" vd=\"root\" eventtime=1587230249360109339 tz=\"-0500\" policyid=26 sessionid=543234 srcip=192.168.2.1 srcport=53430 srcintf=\"port1\" srcintfrole=\"lan\" dstip=8.8.8.8 dstport=53 dstintf=\"wan1\" dstintfrole=\"wan\" proto=17 profile=\"test\" xid=2234 qname=\"elastic.example.com\" qtype=\"A\" qtypeval=1 qclass=\"IN\" ipaddr=\"8.8.8.8, 8.8.4.4\" msg=\"Domain is monitored\" action=\"pass\" cat=23 catdesc=\"Web-based Email\"",
                 "code": "1501054802",
                 "timezone": "-0500",
                 "kind": "event",
@@ -815,6 +864,9 @@
                 "path": "/",
                 "domain": "elastic.no"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "ssl",
                 "application": "HTTPS.BROWSER",
@@ -839,6 +891,9 @@
                 }
             },
             "@timestamp": "2020-04-23T12:17:11.000-05:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "user": [
                     "elasticuser"
@@ -864,7 +919,8 @@
                 }
             },
             "event": {
-                "ingested": "2021-04-23T12:53:35.715485098Z",
+                "ingested": "2021-06-03T08:20:55.393461035Z",
+                "original": "\u003c190\u003edate=2020-04-23 time=12:17:11 devname=\"testswitch1\" devid=\"somerouterid\" logid=\"1059028704\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"signature\" level=\"information\" vd=\"root\" eventtime=1587230232148674303 tz=\"-0500\" appid=40568 user=\"elasticuser\" group=\"elasticgroup\" authserver=\"elasticauth\" srcip=192.168.2.1 dstip=8.8.8.8 srcport=63012 dstport=443 srcintf=\"port1\" srcintfrole=\"lan\" dstintf=\"wan1\" dstintfrole=\"wan\" proto=6 service=\"SSL\" direction=\"outgoing\" policyid=100602 sessionid=543234 applist=\"elasticruleset\" action=\"pass\" appcat=\"Web.Client\" app=\"HTTPS.BROWSER\" hostname=\"elastic.no\" incidentserialno=54323 url=\"/\" msg=\"Web.Client: HTTPS.BROWSER,\" apprisk=\"medium\"",
                 "code": "1059028704",
                 "timezone": "-0500",
                 "kind": "event",
@@ -925,6 +981,9 @@
                 "ip": "192.168.2.1"
             },
             "message": "Domain is monitored",
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17"
             },
@@ -946,6 +1005,9 @@
                 }
             },
             "@timestamp": "2020-04-23T12:17:04.000-05:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "hosts": [
                     "elastic.co"
@@ -969,7 +1031,8 @@
                 }
             },
             "event": {
-                "ingested": "2021-04-23T12:53:35.715486364Z",
+                "ingested": "2021-06-03T08:20:55.393464561Z",
+                "original": "\u003c189\u003edate=2020-04-23 time=12:17:04 devname=\"testswitch1\" devid=\"somerouterid\" logid=\"1501054802\" type=\"utm\" subtype=\"dns\" eventtype=\"dns-response\" level=\"notice\" vd=\"root\" eventtime=1587230224712900694 tz=\"-0500\" policyid=26 sessionid=5432 srcip=192.168.2.1 srcport=54438 srcintf=\"port1\" srcintfrole=\"lan\" dstip=8.8.8.8 dstport=53 dstintf=\"wan1\" dstintfrole=\"wan\" proto=17 profile=\"elastictest\" xid=2352 qname=\"elastic.co\" qtype=\"A\" qtypeval=1 qclass=\"IN\" ipaddr=\"8.8.8.8\" msg=\"Domain is monitored\" action=\"pass\" cat=93 catdesc=\"Remote Access\"",
                 "code": "1501054802",
                 "timezone": "-0500",
                 "kind": "event",
@@ -1026,6 +1089,9 @@
                 "port": 54788,
                 "ip": "192.168.2.1"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "iana_number": "17"
             },
@@ -1047,6 +1113,9 @@
                 }
             },
             "@timestamp": "2020-04-23T12:17:12.000-05:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "hosts": [
                     "elastic.co"
@@ -1068,7 +1137,8 @@
                 }
             },
             "event": {
-                "ingested": "2021-04-23T12:53:35.715487588Z",
+                "ingested": "2021-06-03T08:20:55.393467201Z",
+                "original": "\u003c190\u003edate=2020-04-23 time=12:17:12 devname=\"testswitch1\" devid=\"somerouterid\" logid=\"1500054000\" type=\"utm\" subtype=\"dns\" eventtype=\"dns-query\" level=\"information\" vd=\"root\" eventtime=1587230232658642672 tz=\"-0500\" policyid=26 sessionid=543234 srcip=192.168.2.1 srcport=54788 srcintf=\"port1\" srcintfrole=\"lan\" dstip=8.8.8.8 dstport=53 dstintf=\"wan1\" dstintfrole=\"wan\" proto=17 profile=\"elastictest\" xid=235 qname=\"elastic.co\" qtype=\"A\" qtypeval=1 qclass=\"IN\"",
                 "code": "1500054000",
                 "timezone": "-0500",
                 "kind": "event",
@@ -1122,6 +1192,9 @@
                 "ip": "192.168.2.1"
             },
             "message": "Server certificate passed",
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "https",
                 "iana_number": "6"
@@ -1144,6 +1217,9 @@
                 }
             },
             "@timestamp": "2020-04-23T13:15:18.000-04:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "user": [
                     "elasticuser2"
@@ -1166,7 +1242,8 @@
                 }
             },
             "event": {
-                "ingested": "2021-04-23T12:53:35.715488835Z",
+                "ingested": "2021-06-03T08:20:55.393473857Z",
+                "original": "\u003c189\u003edate=2020-04-23 time=13:15:18 devname=\"testswitch2\" devid=\"someotherid\" logid=\"1700062001\" type=\"utm\" subtype=\"ssl\" eventtype=\"ssl-anomalies\" level=\"notice\" vd=\"root\" eventtime=1587230118838592454 tz=\"-0400\" policyid=12 sessionid=42346234 service=\"HTTPS\" user=\"elasticuser2\" group=\"elasticgroup2\" profile=\"somecerts\" srcip=192.168.2.1 srcport=59726 dstip=8.8.4.4 dstport=443 srcintf=\"LAN\" srcintfrole=\"lan\" dstintf=\"wan1\" dstintfrole=\"wan\" proto=6 action=\"passthrough\" msg=\"Server certificate passed\" reason=\"untrusted-cert\"",
                 "code": "1700062001",
                 "timezone": "-0400",
                 "kind": "event",
@@ -1184,33 +1261,8 @@
             }
         },
         {
-            "observer": {
-                "name": "testswitch3",
-                "product": "Fortigate",
-                "serial_number": "someotherrouteridagain",
-                "type": "firewall",
-                "vendor": "Fortinet"
-            },
-            "@timestamp": "2020-04-23T12:32:48.000-05:00",
-            "related": {
-                "user": [
-                    "elasticouser"
-                ],
-                "ip": [
-                    "10.10.10.10"
-                ]
-            },
             "log": {
                 "level": "notice"
-            },
-            "fortinet": {
-                "firewall": {
-                    "server": "elasticserver",
-                    "action": "FSSO-logon",
-                    "type": "event",
-                    "subtype": "user",
-                    "vd": "root"
-                }
             },
             "rule": {
                 "description": "FSSO logon authentication status"
@@ -1221,8 +1273,41 @@
                 },
                 "ip": "10.10.10.10"
             },
+            "message": "FSSO-logon event from FSSO_elasticserver: user elasticouser logged on 10.10.10.10",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "observer": {
+                "name": "testswitch3",
+                "product": "Fortigate",
+                "serial_number": "someotherrouteridagain",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
+            "@timestamp": "2020-04-23T12:32:48.000-05:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "related": {
+                "user": [
+                    "elasticouser"
+                ],
+                "ip": [
+                    "10.10.10.10"
+                ]
+            },
+            "fortinet": {
+                "firewall": {
+                    "server": "elasticserver",
+                    "action": "FSSO-logon",
+                    "type": "event",
+                    "subtype": "user",
+                    "vd": "root"
+                }
+            },
             "event": {
-                "ingested": "2021-04-23T12:53:35.715490269Z",
+                "ingested": "2021-06-03T08:20:55.393476688Z",
+                "original": "\u003c189\u003edate=2020-04-23 time=12:32:48 devname=\"testswitch3\" devid=\"someotherrouteridagain\" logid=\"0102043014\" type=\"event\" subtype=\"user\" level=\"notice\" vd=\"root\" eventtime=1587231168439640874 tz=\"-0500\" logdesc=\"FSSO logon authentication status\" srcip=10.10.10.10 user=\"elasticouser\" server=\"elasticserver\" action=\"FSSO-logon\" msg=\"FSSO-logon event from FSSO_elasticserver: user elasticouser logged on 10.10.10.10\"",
                 "code": "0102043014",
                 "timezone": "-0500",
                 "kind": "event",
@@ -1237,8 +1322,7 @@
                 ],
                 "dataset": "fortinet.firewall",
                 "outcome": "success"
-            },
-            "message": "FSSO-logon event from FSSO_elasticserver: user elasticouser logged on 10.10.10.10"
+            }
         },
         {
             "log": {
@@ -1286,6 +1370,9 @@
                 "ip": "8.8.8.8"
             },
             "message": "IPsec phase 1 error",
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "name": "testswitch3",
                 "product": "Fortigate",
@@ -1294,6 +1381,9 @@
                 "vendor": "Fortinet"
             },
             "@timestamp": "2020-04-23T12:32:47.000-05:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "ip": [
                     "8.8.8.8",
@@ -1314,7 +1404,8 @@
                 }
             },
             "event": {
-                "ingested": "2021-04-23T12:53:35.715491501Z",
+                "ingested": "2021-06-03T08:20:55.393479066Z",
+                "original": "\u003c187\u003edate=2020-04-23 time=12:32:47 devname=\"testswitch3\" devid=\"someotherrouteridagain\" logid=\"0101037124\" type=\"event\" subtype=\"vpn\" level=\"error\" vd=\"root\" eventtime=1587231168339114138 tz=\"-0500\" logdesc=\"IPsec phase 1 error\" msg=\"IPsec phase 1 error\" action=\"negotiate\" remip=8.8.4.4 locip=8.8.8.8 remport=500 locport=500 outintf=\"wan2\" cookies=\"345hkjhdrs87/0000000000000000\" user=\"N/A\" group=\"N/A\" xauthuser=\"N/A\" xauthgroup=\"N/A\" assignip=N/A vpntunnel=\"N/A\" status=\"negotiate_error\" reason=\"peer SA proposal not match local policy\" peer_notif=\"NOT-APPLICABLE\"",
                 "code": "0101037124",
                 "timezone": "-0500",
                 "kind": "event",
@@ -1376,6 +1467,9 @@
                 "ip": "9.9.9.9"
             },
             "message": "progress IPsec phase 1",
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "direction": "outbound"
             },
@@ -1387,6 +1481,9 @@
                 "vendor": "Fortinet"
             },
             "@timestamp": "2020-04-23T12:32:31.000-05:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "ip": [
                     "9.9.9.9",
@@ -1411,7 +1508,8 @@
                 }
             },
             "event": {
-                "ingested": "2021-04-23T12:53:35.715492718Z",
+                "ingested": "2021-06-03T08:20:55.393481357Z",
+                "original": "\u003c189\u003edate=2020-04-23 time=12:32:31 devname=\"testswitch3\" devid=\"someotherrouteridagain\" logid=\"0101037127\" type=\"event\" subtype=\"vpn\" level=\"notice\" vd=\"root\" eventtime=1587231151628960857 tz=\"-0500\" logdesc=\"Progress IPsec phase 1\" msg=\"progress IPsec phase 1\" action=\"negotiate\" remip=8.4.5.4 locip=9.9.9.9 remport=500 locport=500 outintf=\"wan1\" cookies=\"df868dsg876d/0000000000000000\" user=\"N/A\" group=\"N/A\" xauthuser=\"N/A\" xauthgroup=\"N/A\" assignip=N/A vpntunnel=\"elasticvpn\" status=\"success\" init=\"local\" mode=\"main\" dir=\"outbound\" stage=1 role=\"initiator\" result=\"OK\"",
                 "code": "0101037127",
                 "timezone": "-0500",
                 "kind": "event",
@@ -1436,6 +1534,9 @@
                 "vendor": "Fortinet"
             },
             "@timestamp": "2020-04-23T14:32:09.000-03:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "log": {
                 "level": "notice"
             },
@@ -1460,8 +1561,10 @@
             "rule": {
                 "description": "System performance statistics"
             },
+            "message": "Performance statistics: average CPU: 0, memory:  23, concurrent sessions:  20, setup-rate: 0",
             "event": {
-                "ingested": "2021-04-23T12:53:35.715493937Z",
+                "ingested": "2021-06-03T08:20:55.393483662Z",
+                "original": "\u003c189\u003edate=2020-04-23 time=14:32:09 devname=\"testswitch3\" devid=\"someotherrouteridagain\" logid=\"0100040704\" type=\"event\" subtype=\"system\" level=\"notice\" vd=\"root\" eventtime=1587231129938795255 tz=\"-0300\" logdesc=\"System performance statistics\" action=\"perf-stats\" cpu=0 mem=10 totalsession=23 disk=0 bandwidth=\"23/4\" setuprate=0 disklograte=0 fazlograte=0 freediskstorage=331 sysuptime=25170 msg=\"Performance statistics: average CPU: 0, memory:  23, concurrent sessions:  20, setup-rate: 0\"",
                 "code": "0100040704",
                 "timezone": "-0300",
                 "kind": "event",
@@ -1475,9 +1578,27 @@
                 ],
                 "dataset": "fortinet.firewall"
             },
-            "message": "Performance statistics: average CPU: 0, memory:  23, concurrent sessions:  20, setup-rate: 0"
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
+            "log": {
+                "level": "notice"
+            },
+            "rule": {
+                "description": "Authentication logon"
+            },
+            "source": {
+                "user": {
+                    "name": "elastiiiuser"
+                },
+                "ip": "10.10.10.10"
+            },
+            "message": "User elastiiiuser added to auth logon",
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "name": "testswitch3",
                 "product": "Fortigate",
@@ -1486,6 +1607,9 @@
                 "vendor": "Fortinet"
             },
             "@timestamp": "2020-04-23T12:32:09.000-05:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "user": [
                     "elastiiiuser"
@@ -1493,9 +1617,6 @@
                 "ip": [
                     "10.10.10.10"
                 ]
-            },
-            "log": {
-                "level": "notice"
             },
             "fortinet": {
                 "firewall": {
@@ -1507,17 +1628,9 @@
                     "status": "logon"
                 }
             },
-            "rule": {
-                "description": "Authentication logon"
-            },
-            "source": {
-                "user": {
-                    "name": "elastiiiuser"
-                },
-                "ip": "10.10.10.10"
-            },
             "event": {
-                "ingested": "2021-04-23T12:53:35.715495181Z",
+                "ingested": "2021-06-03T08:20:55.393485943Z",
+                "original": "\u003c189\u003edate=2020-04-23 time=12:32:09 devname=\"testswitch3\" devid=\"someotherrouteridagain\" logid=\"0102043039\" type=\"event\" subtype=\"user\" level=\"notice\" vd=\"root\" eventtime=1587231130109462858 tz=\"-0500\" logdesc=\"Authentication logon\" srcip=10.10.10.10 user=\"elastiiiuser\" authserver=\"FSSO_elastiauth\" action=\"auth-logon\" status=\"logon\" msg=\"User elastiiiuser added to auth logon\"",
                 "code": "0102043039",
                 "timezone": "-0500",
                 "kind": "event",
@@ -1532,8 +1645,7 @@
                 ],
                 "dataset": "fortinet.firewall",
                 "outcome": "success"
-            },
-            "message": "User elastiiiuser added to auth logon"
+            }
         },
         {
             "log": {
@@ -1575,6 +1687,9 @@
                 "ip": "7.6.3.4"
             },
             "message": "progress IPsec phase 1",
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "direction": "outbound"
             },
@@ -1586,6 +1701,9 @@
                 "vendor": "Fortinet"
             },
             "@timestamp": "2020-04-23T12:32:00.000-05:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "ip": [
                     "7.6.3.4",
@@ -1610,7 +1728,8 @@
                 }
             },
             "event": {
-                "ingested": "2021-04-23T12:53:35.715499665Z",
+                "ingested": "2021-06-03T08:20:55.393488453Z",
+                "original": "\u003c189\u003edate=2020-04-23 time=12:32:00 devname=\"testswitch3\" devid=\"someotherrouteridagain\" logid=\"0101037127\" type=\"event\" subtype=\"vpn\" level=\"notice\" vd=\"root\" eventtime=1587231120608961118 tz=\"-0500\" logdesc=\"Progress IPsec phase 1\" msg=\"progress IPsec phase 1\" action=\"negotiate\" remip=8.8.5.4 locip=7.6.3.4 remport=500 locport=500 outintf=\"wan1\" cookies=\"345khj34566/0000000000000000\" user=\"N/A\" group=\"N/A\" xauthuser=\"N/A\" xauthgroup=\"N/A\" assignip=N/A vpntunnel=\"testvpn\" status=\"success\" init=\"local\" mode=\"main\" dir=\"outbound\" stage=1 role=\"initiator\" result=\"OK\"",
                 "code": "0101037127",
                 "timezone": "-0500",
                 "kind": "event",
@@ -1635,6 +1754,9 @@
                 "vendor": "Fortinet"
             },
             "@timestamp": "2020-04-23T14:24:13.000-03:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "log": {
                 "level": "notice"
             },
@@ -1649,8 +1771,10 @@
             "rule": {
                 "description": "FortiSandbox AV database updated"
             },
+            "message": "FortiSandbox AV database updated",
             "event": {
-                "ingested": "2021-04-23T12:53:35.715500902Z",
+                "ingested": "2021-06-03T08:20:55.393490718Z",
+                "original": "\u003c189\u003edate=2020-04-23 time=14:24:13 devname=\"testswitch3\" devid=\"someotherrouteridagain\" logid=\"0100041006\" type=\"event\" subtype=\"system\" level=\"notice\" vd=\"root\" eventtime=1587230655301863513 tz=\"-0300\" logdesc=\"FortiSandbox AV database updated\" version=\"1.522479\" msg=\"FortiSandbox AV database updated\"",
                 "code": "0100041006",
                 "timezone": "-0300",
                 "kind": "event",
@@ -1658,9 +1782,26 @@
                 "start": "2020-04-18T14:24:15.301-03:00",
                 "dataset": "fortinet.firewall"
             },
-            "message": "FortiSandbox AV database updated"
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
+            "log": {
+                "level": "information"
+            },
+            "rule": {
+                "description": "FortiClient connection added"
+            },
+            "source": {
+                "user": {
+                    "name": "elastico"
+                }
+            },
+            "message": "Add a FortiClient Connection.",
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "name": "testswitch3",
                 "product": "Fortigate",
@@ -1669,13 +1810,13 @@
                 "vendor": "Fortinet"
             },
             "@timestamp": "2020-04-23T12:23:47.000-05:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "user": [
                     "elastico"
                 ]
-            },
-            "log": {
-                "level": "information"
             },
             "fortinet": {
                 "firewall": {
@@ -1693,51 +1834,20 @@
                     "status": "success"
                 }
             },
-            "rule": {
-                "description": "FortiClient connection added"
-            },
-            "source": {
-                "user": {
-                    "name": "elastico"
-                }
-            },
             "event": {
-                "ingested": "2021-04-23T12:53:35.715502117Z",
+                "ingested": "2021-06-03T08:20:55.393493047Z",
+                "original": "\u003c190\u003edate=2020-04-23 time=12:23:47 devname=\"testswitch3\" devid=\"someotherrouteridagain\" logid=\"0107045057\" type=\"event\" subtype=\"endpoint\" level=\"information\" vd=\"root\" eventtime=1587230627558979735 tz=\"-0500\" logdesc=\"FortiClient connection added\" action=\"add\" status=\"success\" license_limit=\"unlimited\" used_for_type=3 connection_type=\"sslvpn\" count=2 user=\"elastico\" ip=172.16.0.2 name=\"somerouter\" fctuid=\"645234fdd01F885824F764\" msg=\"Add a FortiClient Connection.\"",
                 "code": "0107045057",
                 "timezone": "-0500",
                 "kind": "event",
                 "module": "fortinet",
                 "start": "2020-04-18T12:23:47.558-05:00",
                 "dataset": "fortinet.firewall"
-            },
-            "message": "Add a FortiClient Connection."
+            }
         },
         {
-            "observer": {
-                "name": "testswitch3",
-                "product": "Fortigate",
-                "serial_number": "someotherrouteridagain",
-                "type": "firewall",
-                "vendor": "Fortinet"
-            },
-            "@timestamp": "2020-04-23T12:23:47.000-05:00",
-            "related": {
-                "ip": [
-                    "8.8.8.6"
-                ]
-            },
             "log": {
                 "level": "information"
-            },
-            "fortinet": {
-                "firewall": {
-                    "action": "ssl-new-con",
-                    "type": "event",
-                    "tunneltype": "ssl",
-                    "subtype": "vpn",
-                    "vd": "root",
-                    "tunnelid": "2"
-                }
             },
             "destination": {
                 "geo": {
@@ -1760,8 +1870,39 @@
             "rule": {
                 "description": "SSL VPN new connection"
             },
+            "message": "SSL new connection",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "observer": {
+                "name": "testswitch3",
+                "product": "Fortigate",
+                "serial_number": "someotherrouteridagain",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
+            "@timestamp": "2020-04-23T12:23:47.000-05:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "related": {
+                "ip": [
+                    "8.8.8.6"
+                ]
+            },
+            "fortinet": {
+                "firewall": {
+                    "action": "ssl-new-con",
+                    "type": "event",
+                    "tunneltype": "ssl",
+                    "subtype": "vpn",
+                    "vd": "root",
+                    "tunnelid": "2"
+                }
+            },
             "event": {
-                "ingested": "2021-04-23T12:53:35.715503343Z",
+                "ingested": "2021-06-03T08:20:55.393495311Z",
+                "original": "\u003c190\u003edate=2020-04-23 time=12:23:47 devname=\"testswitch3\" devid=\"someotherrouteridagain\" logid=\"0101039943\" type=\"event\" subtype=\"vpn\" level=\"information\" vd=\"root\" eventtime=1587230627334405765 tz=\"-0500\" logdesc=\"SSL VPN new connection\" action=\"ssl-new-con\" tunneltype=\"ssl\" tunnelid=2 remip=8.8.8.6 user=\"N/A\" group=\"N/A\" dst_host=\"N/A\" reason=\"N/A\" msg=\"SSL new connection\"",
                 "code": "0101039943",
                 "timezone": "-0500",
                 "kind": "event",
@@ -1774,8 +1915,7 @@
                     "network"
                 ],
                 "dataset": "fortinet.firewall"
-            },
-            "message": "SSL new connection"
+            }
         },
         {
             "log": {
@@ -1811,6 +1951,9 @@
                 }
             },
             "message": "SSL tunnel established",
+            "tags": [
+                "preserve_original_event"
+            ],
             "observer": {
                 "name": "testswitch3",
                 "product": "Fortigate",
@@ -1819,6 +1962,9 @@
                 "vendor": "Fortinet"
             },
             "@timestamp": "2020-04-23T12:23:47.000-05:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "user": [
                     "someuser"
@@ -1840,7 +1986,8 @@
                 }
             },
             "event": {
-                "ingested": "2021-04-23T12:53:35.715504567Z",
+                "ingested": "2021-06-03T08:20:55.393497572Z",
+                "original": "\u003c190\u003edate=2020-04-23 time=12:23:47 devname=\"testswitch3\" devid=\"someotherrouteridagain\" logid=\"0101039947\" type=\"event\" subtype=\"vpn\" level=\"information\" vd=\"root\" eventtime=1587230627698970007 tz=\"-0500\" logdesc=\"SSL VPN tunnel up\" action=\"tunnel-up\" tunneltype=\"ssl-tunnel\" tunnelid=2345 remip=8.8.5.4 tunnelip=10.10.10.10 user=\"someuser\" group=\"somegroup\" dst_host=\"N/A\" reason=\"tunnel established\" msg=\"SSL tunnel established\"",
                 "code": "0101039947",
                 "timezone": "-0500",
                 "kind": "event",
@@ -1856,33 +2003,8 @@
             }
         },
         {
-            "observer": {
-                "name": "testswitch3",
-                "product": "Fortigate",
-                "serial_number": "someotherrouteridagain",
-                "type": "firewall",
-                "vendor": "Fortinet"
-            },
-            "@timestamp": "2020-04-23T14:16:42.000-03:00",
-            "related": {
-                "user": [
-                    "elasticadmin"
-                ],
-                "ip": [
-                    "192.168.1.1"
-                ]
-            },
             "log": {
                 "level": "notice"
-            },
-            "fortinet": {
-                "firewall": {
-                    "server": "FSSO_somefssoserver",
-                    "action": "FSSO-logoff",
-                    "type": "event",
-                    "subtype": "user",
-                    "vd": "root"
-                }
             },
             "rule": {
                 "description": "FSSO log off authentication status"
@@ -1893,8 +2015,41 @@
                 },
                 "ip": "192.168.1.1"
             },
+            "message": "FSSO-logoff event from FSSO_somefssoserver: user elasticuser logged off 1192.168.1.1",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "observer": {
+                "name": "testswitch3",
+                "product": "Fortigate",
+                "serial_number": "someotherrouteridagain",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
+            "@timestamp": "2020-04-23T14:16:42.000-03:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
+            "related": {
+                "user": [
+                    "elasticadmin"
+                ],
+                "ip": [
+                    "192.168.1.1"
+                ]
+            },
+            "fortinet": {
+                "firewall": {
+                    "server": "FSSO_somefssoserver",
+                    "action": "FSSO-logoff",
+                    "type": "event",
+                    "subtype": "user",
+                    "vd": "root"
+                }
+            },
             "event": {
-                "ingested": "2021-04-23T12:53:35.715505801Z",
+                "ingested": "2021-06-03T08:20:55.393499866Z",
+                "original": "\u003c189\u003edate=2020-04-23 time=14:16:42 devname=\"testswitch3\" devid=\"someotherrouteridagain\" logid=\"0102043015\" type=\"event\" subtype=\"user\" level=\"notice\" vd=\"root\" eventtime=1587230204674924332 tz=\"-0300\" logdesc=\"FSSO log off authentication status\" srcip=192.168.1.1 user=\"elasticadmin\" server=\"FSSO_somefssoserver\" action=\"FSSO-logoff\" msg=\"FSSO-logoff event from FSSO_somefssoserver: user elasticuser logged off 1192.168.1.1\"",
                 "code": "0102043015",
                 "timezone": "-0300",
                 "kind": "event",
@@ -1909,8 +2064,7 @@
                 ],
                 "dataset": "fortinet.firewall",
                 "outcome": "success"
-            },
-            "message": "FSSO-logoff event from FSSO_somefssoserver: user elasticuser logged off 1192.168.1.1"
+            }
         },
         {
             "observer": {
@@ -1921,6 +2075,9 @@
                 "vendor": "Fortinet"
             },
             "@timestamp": "2020-04-23T12:16:02.000-05:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "log": {
                 "level": "notice"
             },
@@ -1936,8 +2093,10 @@
             "rule": {
                 "description": "FortiCloud server connected"
             },
+            "message": "FortiCloud 9.9.9.9 server is connected",
             "event": {
-                "ingested": "2021-04-23T12:53:35.715507071Z",
+                "ingested": "2021-06-03T08:20:55.393502192Z",
+                "original": "\u003c189\u003edate=2020-04-23 time=12:16:02 devname=\"testswitch3\" devid=\"someotherrouteridagain\" logid=\"0100022915\" type=\"event\" subtype=\"system\" level=\"notice\" vd=\"root\" eventtime=1587230163121116383 tz=\"-0500\" logdesc=\"FortiCloud server connected\" server=\"9.9.9.9\" action=\"connect\" msg=\"FortiCloud 9.9.9.9 server is connected\"",
                 "code": "0100022915",
                 "timezone": "-0500",
                 "kind": "event",
@@ -1945,7 +2104,9 @@
                 "start": "2020-04-18T12:16:03.121-05:00",
                 "dataset": "fortinet.firewall"
             },
-            "message": "FortiCloud 9.9.9.9 server is connected"
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "observer": {
@@ -1956,6 +2117,9 @@
                 "vendor": "Fortinet"
             },
             "@timestamp": "2020-04-23T12:16:02.000-05:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "log": {
                 "level": "notice"
             },
@@ -1972,8 +2136,10 @@
             "rule": {
                 "description": "FortiCloud server disconnected"
             },
+            "message": "FortiCloud 4.4.4.4 server is disconnected",
             "event": {
-                "ingested": "2021-04-23T12:53:35.715509409Z",
+                "ingested": "2021-06-03T08:20:55.393504644Z",
+                "original": "\u003c189\u003edate=2020-04-23 time=12:16:02 devname=\"testswitch3\" devid=\"someotherrouteridagain\" logid=\"0100022913\" type=\"event\" subtype=\"system\" level=\"notice\" vd=\"root\" eventtime=1587230163375149856 tz=\"-0500\" logdesc=\"FortiCloud server disconnected\" server=\"4.4.4.4\" action=\"disconnect\" reason=\"connection reset\" msg=\"FortiCloud 4.4.4.4 server is disconnected\"",
                 "code": "0100022913",
                 "timezone": "-0500",
                 "kind": "event",
@@ -1981,7 +2147,9 @@
                 "start": "2020-04-18T12:16:03.375-05:00",
                 "dataset": "fortinet.firewall"
             },
-            "message": "FortiCloud 4.4.4.4 server is disconnected"
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "log": {
@@ -2017,6 +2185,9 @@
                 "port": 53438,
                 "ip": "192.168.1.6"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "dns",
                 "iana_number": "17"
@@ -2039,6 +2210,9 @@
                 }
             },
             "@timestamp": "2020-04-23T12:14:09.000-05:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "ip": [
                     "192.168.1.6",
@@ -2062,7 +2236,8 @@
                 }
             },
             "event": {
-                "ingested": "2021-04-23T12:53:35.715510671Z",
+                "ingested": "2021-06-03T08:20:55.393507011Z",
+                "original": "\u003c188\u003edate=2020-04-23 time=12:14:09 devname=\"newfirewall\" devid=\"newrouterid\" logid=\"0000000011\" type=\"traffic\" subtype=\"forward\" level=\"warning\" vd=\"root\" eventtime=1587230049761513222 tz=\"-0500\" srcip=192.168.1.6 srcport=53438 srcintf=\"port1\" srcintfrole=\"lan\" dstip=8.8.8.8 dstport=53 dstintf=\"wan1\" dstintfrole=\"wan\" sessionid=435234 proto=17 action=\"dns\" policyid=26 policytype=\"policy\" poluuid=\"2345de-b143-52134d8-6654f-4654sdfg16f431\" policyname=\"elasticnewruleset\" service=\"DNS\" dstcountry=\"Netherlands\" srccountry=\"Reserved\" appcat=\"unscanned\" crscore=5 craction=54144 crlevel=\"low\"",
                 "code": "0000000011",
                 "timezone": "-0500",
                 "kind": "event",
@@ -2141,6 +2316,9 @@
                 "ip": "192.168.10.10",
                 "packets": 723417
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "portname",
                 "bytes": 504096,
@@ -2165,6 +2343,9 @@
                 }
             },
             "@timestamp": "2020-04-23T12:11:51.000-05:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "ip": [
                     "192.168.10.10",
@@ -2190,21 +2371,22 @@
                 }
             },
             "event": {
-                "duration": 5462000000000,
-                "ingested": "2021-04-23T12:53:35.715511909Z",
+                "original": "\u003c189\u003edate=2020-04-23 time=12:11:51 devname=\"newfirewall\" devid=\"newrouterid\" logid=\"0000000020\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" eventtime=1587229911390385486 tz=\"-0500\" srcip=192.168.10.10 srcport=6000 srcintf=\"port1\" srcintfrole=\"lan\" dstip=8.6.4.7 dstport=6000 dstintf=\"wan1\" dstintfrole=\"wan\" sessionid=4352 proto=17 action=\"accept\" policyid=3426 policytype=\"policy\" poluuid=\"1765de8-5a13-765da73fdsfa1c\" policyname=\"newruleelastic\" service=\"portname\" dstcountry=\"Netherlands\" srccountry=\"Reserved\" trandisp=\"snat\" transip=123.123.123.123 transport=60964 appcat=\"unknown\" applist=\"policylist\" duration=5462 sentbyte=438650 rcvdbyte=65446 sentpkt=723417 rcvdpkt=1045601 vwlid=0 sentdelta=576 rcvddelta=728",
                 "code": "0000000020",
                 "timezone": "-0500",
                 "kind": "event",
                 "module": "fortinet",
                 "start": "2020-04-18T12:11:51.390-05:00",
-                "action": "accept",
-                "category": [
-                    "network"
-                ],
                 "type": [
                     "connection",
                     "end",
                     "allowed"
+                ],
+                "duration": 5462000000000,
+                "ingested": "2021-06-03T08:20:55.393509289Z",
+                "action": "accept",
+                "category": [
+                    "network"
                 ],
                 "dataset": "fortinet.firewall",
                 "outcome": "success"
@@ -2259,6 +2441,9 @@
                 "packets": 4,
                 "ip": "2001:4860:4860::8888"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "icmp6/1/0",
                 "application": "icmp6/25/0",
@@ -2284,6 +2469,9 @@
                 }
             },
             "@timestamp": "2020-04-23T12:11:48.000-05:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "ip": [
                     "2001:4860:4860::8888"
@@ -2303,22 +2491,23 @@
                 }
             },
             "event": {
-                "duration": 42000000000,
-                "ingested": "2021-04-23T12:53:35.715513133Z",
+                "original": "\u003c189\u003edate=2020-04-23 time=12:11:48 devname=\"newfirewall\" devid=\"newrouterid\" logid=\"0001000014\" type=\"traffic\" subtype=\"local\" level=\"notice\" vd=\"root\" eventtime=1587229908751434997 tz=\"-0500\" srcip=2001:4860:4860::8888 identifier=0 srcintf=\"port1\" srcintfrole=\"lan\" dstip=2001:4860:4860::8888 dstintf=\"unknown0\" dstintfrole=\"undefined\" sessionid=6542345 proto=58 action=\"accept\" policyid=0 policytype=\"someotherpolicy\" service=\"icmp6/1/0\" trandisp=\"noop\" app=\"icmp6/25/0\" duration=42 sentbyte=3014 rcvdbyte=20 sentpkt=4 rcvdpkt=0 appcat=\"unscanned\"",
                 "code": "0001000014",
                 "timezone": "-0500",
                 "kind": "event",
                 "module": "fortinet",
                 "start": "2020-04-18T12:11:48.751-05:00",
-                "action": "accept",
-                "category": [
-                    "network"
-                ],
                 "type": [
                     "connection",
                     "end",
                     "protocol",
                     "allowed"
+                ],
+                "duration": 42000000000,
+                "ingested": "2021-06-03T08:20:55.393511564Z",
+                "action": "accept",
+                "category": [
+                    "network"
                 ],
                 "dataset": "fortinet.firewall",
                 "outcome": "success"
@@ -2367,6 +2556,9 @@
                 "packets": 0,
                 "ip": "9.7.7.7"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "ping",
                 "application": "PING",
@@ -2392,6 +2584,9 @@
                 }
             },
             "@timestamp": "2020-04-23T13:10:57.000-04:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "ip": [
                     "9.7.7.7",
@@ -2414,22 +2609,23 @@
                 }
             },
             "event": {
-                "duration": 20000000000,
-                "ingested": "2021-04-23T12:53:35.715514349Z",
+                "original": "\u003c189\u003edate=2020-04-23 time=13:10:57 devname=\"newfirewall\" devid=\"newrouterid\" logid=\"0001000014\" type=\"traffic\" subtype=\"local\" level=\"notice\" vd=\"root\" eventtime=1587229857509058693 tz=\"-0400\" srcip=9.7.7.7 identifier=61 srcintf=\"wan1\" srcintfrole=\"wan\" dstip=8.8.8.8 dstintf=\"unknown0\" dstintfrole=\"undefined\" sessionid=123 proto=1 action=\"accept\" policyid=0 policytype=\"rulepolicy\" service=\"PING\" dstcountry=\"Norway\" srccountry=\"Netherlands\" trandisp=\"noop\" app=\"PING\" duration=20 sentbyte=0 rcvdbyte=10 sentpkt=0 rcvdpkt=40 appcat=\"unscanned\"",
                 "code": "0001000014",
                 "timezone": "-0400",
                 "kind": "event",
                 "module": "fortinet",
                 "start": "2020-04-18T13:10:57.509-04:00",
-                "action": "accept",
-                "category": [
-                    "network"
-                ],
                 "type": [
                     "connection",
                     "end",
                     "protocol",
                     "allowed"
+                ],
+                "duration": 20000000000,
+                "ingested": "2021-06-03T08:20:55.393513829Z",
+                "action": "accept",
+                "category": [
+                    "network"
                 ],
                 "dataset": "fortinet.firewall",
                 "outcome": "success"
@@ -2457,6 +2653,9 @@
                 },
                 "ip": "192.168.1.1"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "udp/12302",
                 "iana_number": "17"
@@ -2479,6 +2678,9 @@
                 }
             },
             "@timestamp": "2020-04-23T12:14:39.000-05:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "user": [
                     "elasticsuper"
@@ -2506,7 +2708,8 @@
                 }
             },
             "event": {
-                "ingested": "2021-04-23T12:53:35.715515563Z",
+                "ingested": "2021-06-03T08:20:55.393516125Z",
+                "original": "\u003c188\u003edate=2020-04-23 time=12:14:39 devname=\"firewall3\" devid=\"oldfwid\" logid=\"0000000011\" type=\"traffic\" subtype=\"forward\" level=\"warning\" vd=\"root\" eventtime=1587230079841464445 tz=\"-0500\" srcip=192.168.1.1 srcport=62493 srcintf=\"port1\" srcintfrole=\"lan\" dstip=192.168.100.100 dstport=1235 dstintf=\"newinterface\" dstintfrole=\"undefined\" sessionid=54234 proto=17 action=\"ip-conn\" policyid=49 policytype=\"policy\" poluuid=\"654cc-b6542-53467u8-e45234-1566casd35f7836\" policyname=\"oldpolicyname\" user=\"elasticsuper\" authserver=\"FSSO_newfsso\" service=\"udp/12302\" dstcountry=\"Reserved\" srccountry=\"Reserved\" appcat=\"unscanned\" crscore=5 craction=63332144 crlevel=\"low\"",
                 "code": "0000000011",
                 "timezone": "-0500",
                 "kind": "event",
@@ -2591,6 +2794,9 @@
                 },
                 "packets": 113
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "https",
                 "application": "Skype.Portals",
@@ -2616,6 +2822,9 @@
                 }
             },
             "@timestamp": "2020-04-23T12:14:28.000-05:00",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "user": [
                     "elasticuser"
@@ -2657,22 +2866,23 @@
                 }
             },
             "event": {
-                "duration": 126000000000,
-                "ingested": "2021-04-23T12:53:35.715516805Z",
+                "original": "\u003c189\u003edate=2020-04-23 time=12:14:28 devname=\"firewall3\" devid=\"oldfwid\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" eventtime=1587230069291463928 tz=\"-0500\" srcip=192.168.50.50 srcport=56603 srcintf=\"port1\" srcintfrole=\"lan\" dstip=8.8.8.8 dstport=442 dstintf=\"wan1\" dstintfrole=\"wan\" sessionid=2345 proto=6 action=\"close\" policyid=2365 policytype=\"policy\" poluuid=\"654644c-b064-fdgdf3425-f003-1234ghdf682e05f\" policyname=\"someoldpolicyname\" user=\"elasticuser\" group=\"testgroup\" authserver=\"FSSO_something\" service=\"HTTPS\" dstcountry=\"Netherlands\" srccountry=\"Reserved\" trandisp=\"snat\" transip=23.23.23.23 transport=603 appid=43540 app=\"Skype.Portals\" appcat=\"Collaboration\" apprisk=\"elevated\" applist=\"someapplist\" appact=\"detected\" duration=126 sentbyte=923 rcvdbyte=77654 sentpkt=113 rcvdpkt=70 vwlid=4 vwlquality=\"Seq_num(3), alive, selected\" wanin=1130 wanout=6671 lanin=1406 lanout=146506 utmaction=\"block\" countweb=1 countapp=1 crscore=5 craction=6144 crlevel=\"low\"",
                 "code": "0000000013",
                 "timezone": "-0500",
                 "kind": "event",
                 "module": "fortinet",
                 "start": "2020-04-18T12:14:29.291-05:00",
-                "action": "close",
-                "category": [
-                    "network"
-                ],
                 "type": [
                     "connection",
                     "end",
                     "protocol",
                     "denied"
+                ],
+                "duration": 126000000000,
+                "ingested": "2021-06-03T08:20:55.393519172Z",
+                "action": "close",
+                "category": [
+                    "network"
                 ],
                 "dataset": "fortinet.firewall",
                 "outcome": "success"
@@ -2715,6 +2925,9 @@
                 "path": "/",
                 "domain": "www.dailymotion.com"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "protocol": "https",
                 "application": "HTTPS.BROWSER",
@@ -2737,6 +2950,9 @@
                 }
             },
             "@timestamp": "2019-05-15T18:03:36.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "ip": [
                     "10.1.100.22",
@@ -2771,7 +2987,8 @@
                 }
             },
             "event": {
-                "ingested": "2021-04-23T12:53:35.715518014Z",
+                "ingested": "2021-06-03T08:20:55.393521592Z",
+                "original": "\u003c190\u003edate=2019-05-15 time=18:03:36 logid=\"1059028704\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"app-ctrl-all\" level=\"information\" vd=\"root\" eventtime=1557968615 appid=40568 srcip=10.1.100.22 dstip=195.8.215.136 srcport=50798 dstport=443 srcintf=\"port10\" srcintfrole=\"lan\" dstintf=\"port9\" dstintfrole=\"wan\" proto=6 service=\"HTTPS\" direction=\"outgoing\" policyid=1 sessionid=4414 applist=\"block-social.media\" appcat=\"Web.Client\" app=\"HTTPS.BROWSER\" action=\"pass\" hostname=\"www.dailymotion.com\" incidentserialno=1962906680 url=\"/\" msg=\"Web.Client: HTTPS.BROWSER,\" apprisk=\"medium\" scertcname=\"*.dailymotion.com\" scertissuer=\"DigiCert SHA2 High Assurance Server CA\"",
                 "code": "1059028704",
                 "kind": "event",
                 "module": "fortinet",
@@ -2818,6 +3035,9 @@
                 "ip": "10.10.10.10"
             },
             "message": "progress IPsec phase 1",
+            "tags": [
+                "preserve_original_event"
+            ],
             "network": {
                 "direction": "outbound"
             },
@@ -2829,6 +3049,9 @@
                 "vendor": "Fortinet"
             },
             "@timestamp": "2020-11-02T08:11:38.000Z",
+            "ecs": {
+                "version": "1.9.0"
+            },
             "related": {
                 "ip": [
                     "10.10.10.10",
@@ -2853,7 +3076,8 @@
                 }
             },
             "event": {
-                "ingested": "2021-04-23T12:53:35.715519227Z",
+                "ingested": "2021-06-03T08:20:55.393523890Z",
+                "original": "\u003c190\u003edate=2020-11-02 time=08:11:38 devname=testfirewall devid=newrouterid logid=0101037127 type=\"event\" subtype=vpn level=notice vd=root logdesc=\"Progress IPsec phase 1\" msg=\"progress IPsec phase 1\" action=negotiate remip=8.8.8.8 locip=10.10.10.10 remport=500 locport=500 outintf=\"port1\" cookies=\"125cbf9ee8349965/0000000000000000\" user=\"N/A\" group=\"N/A\" xauthuser=\"N/A\" xauthgroup=\"N/A\" assignip=N/A vpntunnel=\"P1_Test\" status=success init=local mode=aggressive dir=outbound stage=1 role=initiator result=OK",
                 "code": "0101037127",
                 "kind": "event",
                 "module": "fortinet",

--- a/packages/fortinet/data_stream/firewall/_dev/test/system/test-logfile-config.yml
+++ b/packages/fortinet/data_stream/firewall/_dev/test/system/test-logfile-config.yml
@@ -4,3 +4,4 @@ data_stream:
   vars:
     paths:
       - "{{SERVICE_LOGS_DIR}}/*firewall*.log"
+    preserve_original_event: true

--- a/packages/fortinet/data_stream/firewall/_dev/test/system/test-tcp-config.yml
+++ b/packages/fortinet/data_stream/firewall/_dev/test/system/test-tcp-config.yml
@@ -5,3 +5,4 @@ data_stream:
   vars:
     syslog_host: 0.0.0.0
     syslog_port: 9514
+    preserve_original_event: true

--- a/packages/fortinet/data_stream/firewall/_dev/test/system/test-udp-config.yml
+++ b/packages/fortinet/data_stream/firewall/_dev/test/system/test-udp-config.yml
@@ -5,3 +5,4 @@ data_stream:
   vars:
     syslog_host: 0.0.0.0
     syslog_port: 9515
+    preserve_original_event: true

--- a/packages/fortinet/data_stream/firewall/agent/stream/log.yml.hbs
+++ b/packages/fortinet/data_stream/firewall/agent/stream/log.yml.hbs
@@ -7,9 +7,18 @@ tags:
 {{#each tags as |tag i|}}
  - {{tag}}
 {{/each}}
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 publisher_pipeline.disable_host: true
+{{#if internal_interfaces.length}}
 processors:
-  {{#if internal_interfaces.length}}
+{{else}}
+  {{#if external_interfaces.length}}
+processors:
+  {{/if}}
+{{/if}}
+{{#if internal_interfaces.length}}
   - add_fields:
       target: _temp
       fields:
@@ -17,8 +26,8 @@ processors:
           {{#each internal_interfaces as |interface i|}}
           - {{interface}}
           {{/each}}
-  {{/if}}
-  {{#if external_interfaces.length}}
+{{/if}}
+{{#if external_interfaces.length}}
   - add_fields:
       target: _temp
       fields:
@@ -26,8 +35,4 @@ processors:
           {{#each external_interfaces as |interface i|}}
           - {{interface}}
           {{/each}}
-  {{/if}}
-  - add_fields:
-      target: ''
-      fields:
-        ecs.version: 1.9.0
+{{/if}}

--- a/packages/fortinet/data_stream/firewall/agent/stream/tcp.yml.hbs
+++ b/packages/fortinet/data_stream/firewall/agent/stream/tcp.yml.hbs
@@ -3,9 +3,18 @@ tags:
 {{#each tags as |tag i|}}
  - {{tag}}
 {{/each}}
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 publisher_pipeline.disable_host: true
+{{#if internal_interfaces.length}}
 processors:
-  {{#if internal_interfaces.length}}
+{{else}}
+  {{#if external_interfaces.length}}
+processors:
+  {{/if}}
+{{/if}}
+{{#if internal_interfaces.length}}
   - add_fields:
       target: _temp
       fields:
@@ -13,8 +22,8 @@ processors:
           {{#each internal_interfaces as |interface i|}}
           - {{interface}}
           {{/each}}
-  {{/if}}
-  {{#if external_interfaces.length}}
+{{/if}}
+{{#if external_interfaces.length}}
   - add_fields:
       target: _temp
       fields:
@@ -22,8 +31,4 @@ processors:
           {{#each external_interfaces as |interface i|}}
           - {{interface}}
           {{/each}}
-  {{/if}}
-  - add_fields:
-      target: ''
-      fields:
-        ecs.version: 1.9.0
+{{/if}}

--- a/packages/fortinet/data_stream/firewall/agent/stream/udp.yml.hbs
+++ b/packages/fortinet/data_stream/firewall/agent/stream/udp.yml.hbs
@@ -3,9 +3,18 @@ tags:
 {{#each tags as |tag i|}}
  - {{tag}}
 {{/each}}
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 publisher_pipeline.disable_host: true
+{{#if internal_interfaces.length}}
 processors:
-  {{#if internal_interfaces.length}}
+{{else}}
+  {{#if external_interfaces.length}}
+processors:
+  {{/if}}
+{{/if}}
+{{#if internal_interfaces.length}}
   - add_fields:
       target: _temp
       fields:
@@ -13,8 +22,8 @@ processors:
           {{#each internal_interfaces as |interface i|}}
           - {{interface}}
           {{/each}}
-  {{/if}}
-  {{#if external_interfaces.length}}
+{{/if}}
+{{#if external_interfaces.length}}
   - add_fields:
       target: _temp
       fields:
@@ -22,8 +31,4 @@ processors:
           {{#each external_interfaces as |interface i|}}
           - {{interface}}
           {{/each}}
-  {{/if}}
-  - add_fields:
-      target: ''
-      fields:
-        ecs.version: 1.9.0
+{{/if}}

--- a/packages/fortinet/data_stream/firewall/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fortinet/data_stream/firewall/elasticsearch/ingest_pipeline/default.yml
@@ -4,8 +4,14 @@ processors:
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
-  - grok:
+  - set:
+      field: ecs.version
+      value: 1.9.0
+  - rename:
       field: message
+      target_field: event.original
+  - grok:
+      field: event.original
       patterns:
         - "%{SYSLOG5424PRI}%{GREEDYDATA:syslog5424_sd}$"
   - kv:
@@ -197,7 +203,6 @@ processors:
       field:
         - _temp.time
         - _temp
-        - message
         - syslog5424_sd
         - syslog5424_pri
         - fortinet.firewall.tz
@@ -386,6 +391,11 @@ processors:
             }
           }
         }
+  - remove:
+      field: event.original
+      if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"
+      ignore_failure: true
+      ignore_missing: true
 on_failure:
   - set:
       field: error.message

--- a/packages/fortinet/data_stream/firewall/manifest.yml
+++ b/packages/fortinet/data_stream/firewall/manifest.yml
@@ -18,6 +18,14 @@ streams:
         required: true
         show_user: true
         default: 9004
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
       - name: tags
         type: text
         title: Tags
@@ -46,6 +54,14 @@ streams:
         required: true
         show_user: true
         default: 9004
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
       - name: tags
         type: text
         title: Tags
@@ -69,6 +85,14 @@ streams:
         show_user: true
         default:
           - /var/log/fortinet-firewall.log
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
       - name: tags
         type: text
         title: Tags

--- a/packages/fortinet/data_stream/firewall/sample_event.json
+++ b/packages/fortinet/data_stream/firewall/sample_event.json
@@ -1,0 +1,142 @@
+{
+    "@timestamp": "2019-05-15T18:03:36.000Z",
+    "agent": {
+        "ephemeral_id": "74b27709-c288-4314-b386-659dbc5a62ea",
+        "hostname": "docker-fleet-agent",
+        "id": "2164018d-05cd-45b4-979d-4032bdd775f6",
+        "name": "docker-fleet-agent",
+        "type": "filebeat",
+        "version": "7.14.0"
+    },
+    "data_stream": {
+        "dataset": "fortinet.firewall",
+        "namespace": "ep",
+        "type": "logs"
+    },
+    "destination": {
+        "as": {
+            "number": 41690,
+            "organization": {
+                "name": "Dailymotion S.A."
+            }
+        },
+        "geo": {
+            "continent_name": "Europe",
+            "country_iso_code": "FR",
+            "country_name": "France",
+            "location": {
+                "lat": 48.8582,
+                "lon": 2.3387
+            }
+        },
+        "ip": "195.8.215.136",
+        "port": 443
+    },
+    "ecs": {
+        "version": "1.9.0"
+    },
+    "elastic_agent": {
+        "id": "7cc48d16-ebf0-44b1-9094-fe2082d8f5a4",
+        "snapshot": true,
+        "version": "7.14.0"
+    },
+    "event": {
+        "action": "app-ctrl-all",
+        "category": [
+            "network"
+        ],
+        "code": "1059028704",
+        "dataset": "fortinet.firewall",
+        "ingested": "2021-06-03T12:38:44.458586716Z",
+        "kind": "event",
+        "module": "fortinet",
+        "original": "\u003c190\u003edate=2019-05-15 time=18:03:36 logid=\"1059028704\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"app-ctrl-all\" level=\"information\" vd=\"root\" eventtime=1557968615 appid=40568 srcip=10.1.100.22 dstip=195.8.215.136 srcport=50798 dstport=443 srcintf=\"port10\" srcintfrole=\"lan\" dstintf=\"port9\" dstintfrole=\"wan\" proto=6 service=\"HTTPS\" direction=\"outgoing\" policyid=1 sessionid=4414 applist=\"block-social.media\" appcat=\"Web.Client\" app=\"HTTPS.BROWSER\" action=\"pass\" hostname=\"www.dailymotion.com\" incidentserialno=1962906680 url=\"/\" msg=\"Web.Client: HTTPS.BROWSER,\" apprisk=\"medium\" scertcname=\"*.dailymotion.com\" scertissuer=\"DigiCert SHA2 High Assurance Server CA\"\n",
+        "outcome": "success",
+        "start": "2019-05-16T01:03:35.000Z",
+        "type": [
+            "allowed"
+        ]
+    },
+    "fortinet": {
+        "firewall": {
+            "action": "pass",
+            "appid": "40568",
+            "apprisk": "medium",
+            "dstintfrole": "wan",
+            "incidentserialno": "1962906680",
+            "sessionid": "4414",
+            "srcintfrole": "lan",
+            "subtype": "app-ctrl",
+            "type": "utm",
+            "vd": "root"
+        }
+    },
+    "input": {
+        "type": "udp"
+    },
+    "log": {
+        "level": "information",
+        "source": {
+            "address": "192.168.240.4:54617"
+        }
+    },
+    "message": "Web.Client: HTTPS.BROWSER,",
+    "network": {
+        "application": "HTTPS.BROWSER",
+        "direction": "outbound",
+        "iana_number": "6",
+        "protocol": "https"
+    },
+    "observer": {
+        "egress": {
+            "interface": {
+                "name": "port9"
+            }
+        },
+        "ingress": {
+            "interface": {
+                "name": "port10"
+            }
+        },
+        "product": "Fortigate",
+        "type": "firewall",
+        "vendor": "Fortinet"
+    },
+    "related": {
+        "ip": [
+            "10.1.100.22",
+            "195.8.215.136"
+        ]
+    },
+    "rule": {
+        "category": "Web-Client",
+        "id": "1",
+        "ruleset": "block-social.media"
+    },
+    "source": {
+        "ip": "10.1.100.22",
+        "port": 50798
+    },
+    "tags": [
+        "fortinet-firewall",
+        "forwarded",
+        "preserve_original_event"
+    ],
+    "tls": {
+        "server": {
+            "issuer": "DigiCert SHA2 High Assurance Server CA",
+            "x509": {
+                "issuer": {
+                    "common_name": "DigiCert SHA2 High Assurance Server CA"
+                },
+                "subject": {
+                    "common_name": "*.dailymotion.com"
+                }
+            }
+        }
+    },
+    "url": {
+        "domain": "www.dailymotion.com",
+        "path": "/"
+    }
+}

--- a/packages/fortinet/data_stream/fortimail/_dev/test/system/test-logfile-config.yml
+++ b/packages/fortinet/data_stream/fortimail/_dev/test/system/test-logfile-config.yml
@@ -4,3 +4,4 @@ data_stream:
   vars:
     paths:
       - "{{SERVICE_LOGS_DIR}}/*fortimail*.log"
+    preserve_original_event: true

--- a/packages/fortinet/data_stream/fortimail/_dev/test/system/test-tcp-config.yml
+++ b/packages/fortinet/data_stream/fortimail/_dev/test/system/test-tcp-config.yml
@@ -5,3 +5,4 @@ data_stream:
   vars:
     tcp_host: 0.0.0.0
     tcp_port: 9514
+    preserve_original_event: true

--- a/packages/fortinet/data_stream/fortimail/_dev/test/system/test-udp-config.yml
+++ b/packages/fortinet/data_stream/fortimail/_dev/test/system/test-udp-config.yml
@@ -5,3 +5,4 @@ data_stream:
   vars:
     udp_host: 0.0.0.0
     udp_port: 9515
+    preserve_original_event: true

--- a/packages/fortinet/data_stream/fortimail/agent/stream/log.yml.hbs
+++ b/packages/fortinet/data_stream/fortimail/agent/stream/log.yml.hbs
@@ -7,6 +7,9 @@ tags:
 {{#each tags as |tag i|}}
  - {{tag}}
 {{/each}}
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 fields_under_root: true
 fields:
     observer:
@@ -4293,7 +4296,3 @@ processors:
     target_subdomain_field: url.subdomain
     target_etld_field: url.top_level_domain
 - add_locale: ~
-- add_fields:
-    target: ''
-    fields:
-        ecs.version: 1.9.0

--- a/packages/fortinet/data_stream/fortimail/agent/stream/tcp.yml.hbs
+++ b/packages/fortinet/data_stream/fortimail/agent/stream/tcp.yml.hbs
@@ -4,6 +4,9 @@ tags:
 {{#each tags as |tag i|}}
  - {{tag}}
 {{/each}}
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 fields_under_root: true
 fields:
     observer:
@@ -4290,7 +4293,3 @@ processors:
     target_subdomain_field: url.subdomain
     target_etld_field: url.top_level_domain
 - add_locale: ~
-- add_fields:
-    target: ''
-    fields:
-        ecs.version: 1.9.0

--- a/packages/fortinet/data_stream/fortimail/agent/stream/udp.yml.hbs
+++ b/packages/fortinet/data_stream/fortimail/agent/stream/udp.yml.hbs
@@ -4,6 +4,9 @@ tags:
 {{#each tags as |tag i|}}
  - {{tag}}
 {{/each}}
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 fields_under_root: true
 fields:
     observer:
@@ -4290,7 +4293,3 @@ processors:
     target_subdomain_field: url.subdomain
     target_etld_field: url.top_level_domain
 - add_locale: ~
-- add_fields:
-    target: ''
-    fields:
-        ecs.version: 1.9.0

--- a/packages/fortinet/data_stream/fortimail/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fortinet/data_stream/fortimail/elasticsearch/ingest_pipeline/default.yml
@@ -6,6 +6,9 @@ processors:
   - set:
         field: event.ingested
         value: '{{_ingest.timestamp}}'
+  - set:
+        field: ecs.version
+        value: 1.9.0
   # User agent
   - user_agent:
         field: user_agent.original
@@ -58,6 +61,11 @@ processors:
         value: '{{host.name}}'
         allow_duplicates: false
         if: ctx.host?.name != null && ctx.host?.name != ''
+  - remove:
+        field: event.original
+        if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"
+        ignore_failure: true
+        ignore_missing: true
 on_failure:
   - append:
         field: error.message

--- a/packages/fortinet/data_stream/fortimail/manifest.yml
+++ b/packages/fortinet/data_stream/fortimail/manifest.yml
@@ -42,6 +42,14 @@ streams:
         required: false
         show_user: true
         default: true
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
       - name: keep_raw_fields
         type: bool
         title: Keep raw parser fields
@@ -94,6 +102,14 @@ streams:
         required: false
         show_user: true
         default: true
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
       - name: keep_raw_fields
         type: bool
         title: Keep raw parser fields
@@ -141,6 +157,14 @@ streams:
         required: false
         show_user: true
         default: true
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
       - name: keep_raw_fields
         type: bool
         title: Keep raw parser fields

--- a/packages/fortinet/data_stream/fortimail/sample_event.json
+++ b/packages/fortinet/data_stream/fortimail/sample_event.json
@@ -1,0 +1,78 @@
+{
+    "@timestamp": "2016-01-29T06:09:59.000Z",
+    "agent": {
+        "ephemeral_id": "74b27709-c288-4314-b386-659dbc5a62ea",
+        "hostname": "docker-fleet-agent",
+        "id": "2164018d-05cd-45b4-979d-4032bdd775f6",
+        "name": "docker-fleet-agent",
+        "type": "filebeat",
+        "version": "7.14.0"
+    },
+    "data_stream": {
+        "dataset": "fortinet.fortimail",
+        "namespace": "ep",
+        "type": "logs"
+    },
+    "ecs": {
+        "version": "1.9.0"
+    },
+    "elastic_agent": {
+        "id": "7cc48d16-ebf0-44b1-9094-fe2082d8f5a4",
+        "snapshot": true,
+        "version": "7.14.0"
+    },
+    "event": {
+        "action": "event",
+        "code": "nes",
+        "dataset": "fortinet.fortimail",
+        "ingested": "2021-06-03T12:42:09.362670647Z",
+        "original": "date=2016-1-29 time=06:09:59 device_id=pexe log_id=nes log_part=eab type=event subtype=update pri=high msg=\"boNemoe\"\n",
+        "timezone": "+00:00"
+    },
+    "host": {
+        "name": "docker-fleet-agent"
+    },
+    "input": {
+        "type": "udp"
+    },
+    "log": {
+        "level": "high",
+        "source": {
+            "address": "192.168.240.4:60044"
+        }
+    },
+    "observer": {
+        "product": "FortiMail",
+        "type": "Firewall",
+        "vendor": "Fortinet"
+    },
+    "related": {
+        "hosts": [
+            "docker-fleet-agent"
+        ]
+    },
+    "rsa": {
+        "internal": {
+            "event_desc": "boNemoe",
+            "messageid": "event_update"
+        },
+        "misc": {
+            "category": "update",
+            "event_type": "event",
+            "hardware_id": "pexe",
+            "msgIdPart1": "event",
+            "msgIdPart2": "update",
+            "reference_id": "nes",
+            "reference_id1": "eab",
+            "severity": "high"
+        },
+        "time": {
+            "event_time": "2016-01-29T06:09:59.000Z"
+        }
+    },
+    "tags": [
+        "fortinet-fortimail",
+        "forwarded",
+        "preserve_original_event"
+    ]
+}

--- a/packages/fortinet/data_stream/fortimanager/_dev/test/system/test-logfile-config.yml
+++ b/packages/fortinet/data_stream/fortimanager/_dev/test/system/test-logfile-config.yml
@@ -4,3 +4,4 @@ data_stream:
   vars:
     paths:
       - "{{SERVICE_LOGS_DIR}}/*fortimanager*.log"
+    preserve_original_event: true

--- a/packages/fortinet/data_stream/fortimanager/_dev/test/system/test-tcp-config.yml
+++ b/packages/fortinet/data_stream/fortimanager/_dev/test/system/test-tcp-config.yml
@@ -5,3 +5,4 @@ data_stream:
   vars:
     tcp_host: 0.0.0.0
     tcp_port: 9514
+    preserve_original_event: true

--- a/packages/fortinet/data_stream/fortimanager/_dev/test/system/test-udp-config.yml
+++ b/packages/fortinet/data_stream/fortimanager/_dev/test/system/test-udp-config.yml
@@ -5,3 +5,4 @@ data_stream:
   vars:
     udp_host: 0.0.0.0
     udp_port: 9515
+    preserve_original_event: true

--- a/packages/fortinet/data_stream/fortimanager/agent/stream/log.yml.hbs
+++ b/packages/fortinet/data_stream/fortimanager/agent/stream/log.yml.hbs
@@ -7,6 +7,9 @@ tags:
 {{#each tags as |tag i|}}
  - {{tag}}
 {{/each}}
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 fields_under_root: true
 fields:
     observer:
@@ -3093,7 +3096,3 @@ processors:
     target_subdomain_field: url.subdomain
     target_etld_field: url.top_level_domain
 - add_locale: ~
-- add_fields:
-    target: ''
-    fields:
-        ecs.version: 1.9.0

--- a/packages/fortinet/data_stream/fortimanager/agent/stream/tcp.yml.hbs
+++ b/packages/fortinet/data_stream/fortimanager/agent/stream/tcp.yml.hbs
@@ -4,6 +4,9 @@ tags:
 {{#each tags as |tag i|}}
  - {{tag}}
 {{/each}}
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 fields_under_root: true
 fields:
     observer:
@@ -3090,7 +3093,3 @@ processors:
     target_subdomain_field: url.subdomain
     target_etld_field: url.top_level_domain
 - add_locale: ~
-- add_fields:
-    target: ''
-    fields:
-        ecs.version: 1.9.0

--- a/packages/fortinet/data_stream/fortimanager/agent/stream/udp.yml.hbs
+++ b/packages/fortinet/data_stream/fortimanager/agent/stream/udp.yml.hbs
@@ -4,6 +4,9 @@ tags:
 {{#each tags as |tag i|}}
  - {{tag}}
 {{/each}}
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 fields_under_root: true
 fields:
     observer:
@@ -3090,7 +3093,3 @@ processors:
     target_subdomain_field: url.subdomain
     target_etld_field: url.top_level_domain
 - add_locale: ~
-- add_fields:
-    target: ''
-    fields:
-        ecs.version: 1.9.0

--- a/packages/fortinet/data_stream/fortimanager/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fortinet/data_stream/fortimanager/elasticsearch/ingest_pipeline/default.yml
@@ -6,6 +6,9 @@ processors:
   - set:
         field: event.ingested
         value: '{{_ingest.timestamp}}'
+  - set:
+        field: ecs.version
+        value: 1.9.0
   # User agent
   - user_agent:
         field: user_agent.original
@@ -58,6 +61,11 @@ processors:
         value: '{{host.name}}'
         allow_duplicates: false
         if: ctx.host?.name != null && ctx.host?.name != ''
+  - remove:
+        field: event.original
+        if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"
+        ignore_failure: true
+        ignore_missing: true
 on_failure:
   - append:
         field: error.message

--- a/packages/fortinet/data_stream/fortimanager/manifest.yml
+++ b/packages/fortinet/data_stream/fortimanager/manifest.yml
@@ -42,6 +42,14 @@ streams:
         required: false
         show_user: true
         default: true
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
       - name: keep_raw_fields
         type: bool
         title: Keep raw parser fields
@@ -94,6 +102,14 @@ streams:
         required: false
         show_user: true
         default: true
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
       - name: keep_raw_fields
         type: bool
         title: Keep raw parser fields
@@ -141,6 +157,14 @@ streams:
         required: false
         show_user: true
         default: true
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
       - name: keep_raw_fields
         type: bool
         title: Keep raw parser fields

--- a/packages/fortinet/data_stream/fortimanager/sample_event.json
+++ b/packages/fortinet/data_stream/fortimanager/sample_event.json
@@ -1,0 +1,135 @@
+{
+    "@timestamp": "2016-01-29T06:09:59.000Z",
+    "agent": {
+        "ephemeral_id": "74b27709-c288-4314-b386-659dbc5a62ea",
+        "hostname": "docker-fleet-agent",
+        "id": "2164018d-05cd-45b4-979d-4032bdd775f6",
+        "name": "docker-fleet-agent",
+        "type": "filebeat",
+        "version": "7.14.0"
+    },
+    "data_stream": {
+        "dataset": "fortinet.fortimanager",
+        "namespace": "ep",
+        "type": "logs"
+    },
+    "destination": {
+        "bytes": 449,
+        "geo": {
+            "country_name": "sequa"
+        },
+        "ip": [
+            "10.44.173.44"
+        ],
+        "nat": {
+            "ip": "10.189.58.145",
+            "port": 5273
+        },
+        "port": 6125
+    },
+    "ecs": {
+        "version": "1.9.0"
+    },
+    "elastic_agent": {
+        "id": "7cc48d16-ebf0-44b1-9094-fe2082d8f5a4",
+        "snapshot": true,
+        "version": "7.14.0"
+    },
+    "event": {
+        "action": "allow",
+        "code": "sse",
+        "dataset": "fortinet.fortimanager",
+        "ingested": "2021-06-03T12:45:50.284271932Z",
+        "original": "logver=iusm devname=\"modtempo\" devid=\"olab\" vd=nto date=2016-1-29 time=6:09:59 logid=sse type=exercita subtype=der level=very-high eventtime=odoco logtime=ria srcip=10.20.234.169 srcport=1001 srcintf=eth5722 srcintfrole=vol dstip=10.44.173.44 dstport=6125 dstintf=enp0s3068 dstintfrole=nseq poluuid=itinvol sessionid=psa proto=21 action=allow policyid=ntium policytype=psaq crscore=13.800000 craction=eab crlevel=aliqu appcat=Ute service=lupt srccountry=dolore dstcountry=sequa trandisp=abo tranip=10.189.58.145 tranport=5273 duration=14.119000 sentbyte=7880 rcvdbyte=449 sentpkt=mqui app=nci\n",
+        "timezone": "+00:00"
+    },
+    "host": {
+        "name": "docker-fleet-agent"
+    },
+    "input": {
+        "type": "udp"
+    },
+    "log": {
+        "level": "very-high",
+        "source": {
+            "address": "192.168.240.4:36529"
+        }
+    },
+    "network": {
+        "bytes": 8329
+    },
+    "observer": {
+        "egress": {
+            "interface": {
+                "name": "enp0s3068"
+            }
+        },
+        "ingress": {
+            "interface": {
+                "name": "eth5722"
+            }
+        },
+        "product": "FortiManager",
+        "type": "Configuration",
+        "vendor": "Fortinet"
+    },
+    "related": {
+        "hosts": [
+            "modtempo",
+            "docker-fleet-agent"
+        ],
+        "ip": [
+            "10.44.173.44",
+            "10.20.234.169",
+            "10.189.58.145"
+        ]
+    },
+    "rsa": {
+        "internal": {
+            "messageid": "generic_fortinetmgr_1"
+        },
+        "misc": {
+            "action": [
+                "allow"
+            ],
+            "category": "der",
+            "context": "abo",
+            "event_source": "modtempo",
+            "event_type": "exercita",
+            "hardware_id": "olab",
+            "log_session_id": "psa",
+            "policy_id": "ntium",
+            "reference_id": "sse",
+            "severity": "very-high",
+            "vsys": "nto"
+        },
+        "network": {
+            "dinterface": "enp0s3068",
+            "network_service": "lupt",
+            "sinterface": "eth5722"
+        },
+        "time": {
+            "duration_time": 14.119,
+            "event_time": "2016-01-29T06:09:59.000Z",
+            "event_time_str": "odoco"
+        },
+        "web": {
+            "reputation_num": 13.8
+        }
+    },
+    "source": {
+        "bytes": 7880,
+        "geo": {
+            "country_name": "dolore"
+        },
+        "ip": [
+            "10.20.234.169"
+        ],
+        "port": 1001
+    },
+    "tags": [
+        "fortinet-fortimanager",
+        "forwarded",
+        "preserve_original_event"
+    ]
+}

--- a/packages/fortinet/docs/README.md
+++ b/packages/fortinet/docs/README.md
@@ -17,6 +17,153 @@ This integration has been tested against FortiOS version 6.0.x and 6.2.x. Versio
 
 Contains log entries from Fortinet FortiGate applicances.
 
+An example event for `firewall` looks as following:
+
+```$json
+{
+    "@timestamp": "2019-05-15T18:03:36.000Z",
+    "agent": {
+        "ephemeral_id": "74b27709-c288-4314-b386-659dbc5a62ea",
+        "hostname": "docker-fleet-agent",
+        "id": "2164018d-05cd-45b4-979d-4032bdd775f6",
+        "name": "docker-fleet-agent",
+        "type": "filebeat",
+        "version": "7.14.0"
+    },
+    "data_stream": {
+        "dataset": "fortinet.firewall",
+        "namespace": "ep",
+        "type": "logs"
+    },
+    "destination": {
+        "as": {
+            "number": 41690,
+            "organization": {
+                "name": "Dailymotion S.A."
+            }
+        },
+        "geo": {
+            "continent_name": "Europe",
+            "country_iso_code": "FR",
+            "country_name": "France",
+            "location": {
+                "lat": 48.8582,
+                "lon": 2.3387
+            }
+        },
+        "ip": "195.8.215.136",
+        "port": 443
+    },
+    "ecs": {
+        "version": "1.9.0"
+    },
+    "elastic_agent": {
+        "id": "7cc48d16-ebf0-44b1-9094-fe2082d8f5a4",
+        "snapshot": true,
+        "version": "7.14.0"
+    },
+    "event": {
+        "action": "app-ctrl-all",
+        "category": [
+            "network"
+        ],
+        "code": "1059028704",
+        "dataset": "fortinet.firewall",
+        "ingested": "2021-06-03T12:38:44.458586716Z",
+        "kind": "event",
+        "module": "fortinet",
+        "original": "\u003c190\u003edate=2019-05-15 time=18:03:36 logid=\"1059028704\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"app-ctrl-all\" level=\"information\" vd=\"root\" eventtime=1557968615 appid=40568 srcip=10.1.100.22 dstip=195.8.215.136 srcport=50798 dstport=443 srcintf=\"port10\" srcintfrole=\"lan\" dstintf=\"port9\" dstintfrole=\"wan\" proto=6 service=\"HTTPS\" direction=\"outgoing\" policyid=1 sessionid=4414 applist=\"block-social.media\" appcat=\"Web.Client\" app=\"HTTPS.BROWSER\" action=\"pass\" hostname=\"www.dailymotion.com\" incidentserialno=1962906680 url=\"/\" msg=\"Web.Client: HTTPS.BROWSER,\" apprisk=\"medium\" scertcname=\"*.dailymotion.com\" scertissuer=\"DigiCert SHA2 High Assurance Server CA\"\n",
+        "outcome": "success",
+        "start": "2019-05-16T01:03:35.000Z",
+        "type": [
+            "allowed"
+        ]
+    },
+    "fortinet": {
+        "firewall": {
+            "action": "pass",
+            "appid": "40568",
+            "apprisk": "medium",
+            "dstintfrole": "wan",
+            "incidentserialno": "1962906680",
+            "sessionid": "4414",
+            "srcintfrole": "lan",
+            "subtype": "app-ctrl",
+            "type": "utm",
+            "vd": "root"
+        }
+    },
+    "input": {
+        "type": "udp"
+    },
+    "log": {
+        "level": "information",
+        "source": {
+            "address": "192.168.240.4:54617"
+        }
+    },
+    "message": "Web.Client: HTTPS.BROWSER,",
+    "network": {
+        "application": "HTTPS.BROWSER",
+        "direction": "outbound",
+        "iana_number": "6",
+        "protocol": "https"
+    },
+    "observer": {
+        "egress": {
+            "interface": {
+                "name": "port9"
+            }
+        },
+        "ingress": {
+            "interface": {
+                "name": "port10"
+            }
+        },
+        "product": "Fortigate",
+        "type": "firewall",
+        "vendor": "Fortinet"
+    },
+    "related": {
+        "ip": [
+            "10.1.100.22",
+            "195.8.215.136"
+        ]
+    },
+    "rule": {
+        "category": "Web-Client",
+        "id": "1",
+        "ruleset": "block-social.media"
+    },
+    "source": {
+        "ip": "10.1.100.22",
+        "port": 50798
+    },
+    "tags": [
+        "fortinet-firewall",
+        "forwarded",
+        "preserve_original_event"
+    ],
+    "tls": {
+        "server": {
+            "issuer": "DigiCert SHA2 High Assurance Server CA",
+            "x509": {
+                "issuer": {
+                    "common_name": "DigiCert SHA2 High Assurance Server CA"
+                },
+                "subject": {
+                    "common_name": "*.dailymotion.com"
+                }
+            }
+        }
+    },
+    "url": {
+        "domain": "www.dailymotion.com",
+        "path": "/"
+    }
+}
+```
+
 **Exported fields**
 
 | Field | Description | Type |
@@ -595,6 +742,136 @@ Contains log entries from Fortinet FortiGate applicances.
 ### Clientendpoint
 
 The `clientendpoint` dataset collects Fortinet FortiClient Endpoint Security logs.
+
+An example event for `clientendpoint` looks as following:
+
+```$json
+{
+    "@timestamp": "2020-06-05T21:33:08.000Z",
+    "agent": {
+        "ephemeral_id": "74b27709-c288-4314-b386-659dbc5a62ea",
+        "hostname": "docker-fleet-agent",
+        "id": "2164018d-05cd-45b4-979d-4032bdd775f6",
+        "name": "docker-fleet-agent",
+        "type": "filebeat",
+        "version": "7.14.0"
+    },
+    "data_stream": {
+        "dataset": "fortinet.clientendpoint",
+        "namespace": "ep",
+        "type": "logs"
+    },
+    "destination": {
+        "ip": [
+            "10.203.5.162"
+        ],
+        "port": 7290
+    },
+    "ecs": {
+        "version": "1.9.0"
+    },
+    "elastic_agent": {
+        "id": "7cc48d16-ebf0-44b1-9094-fe2082d8f5a4",
+        "snapshot": true,
+        "version": "7.14.0"
+    },
+    "event": {
+        "action": "deny",
+        "code": "pop3",
+        "dataset": "fortinet.clientendpoint",
+        "ingested": "2021-06-03T12:35:28.382730111Z",
+        "original": "June 5 21:33:08 tatno4987.www5.localhost proto=ggp service=pop3 status=deny src=10.54.231.100 dst=10.203.5.162 src_port=5616 dst_port=7290 server_app=iam pid=6096 app_name=ciati traff_direct=unknown block_count=3162 logon_user=umdolore@eniam7007.api.invalid msg=success\n",
+        "outcome": "failure",
+        "timezone": "+00:00"
+    },
+    "host": {
+        "name": "tatno4987.www5.localhost"
+    },
+    "input": {
+        "type": "udp"
+    },
+    "log": {
+        "source": {
+            "address": "192.168.240.4:43222"
+        }
+    },
+    "network": {
+        "direction": "unknown",
+        "protocol": "ggp"
+    },
+    "observer": {
+        "product": "FortiClient",
+        "type": "Anti-Virus",
+        "vendor": "Fortinet"
+    },
+    "process": {
+        "pid": 6096
+    },
+    "related": {
+        "hosts": [
+            "eniam7007.api.invalid",
+            "tatno4987.www5.localhost"
+        ],
+        "ip": [
+            "10.54.231.100",
+            "10.203.5.162"
+        ],
+        "user": [
+            "umdolore"
+        ]
+    },
+    "rsa": {
+        "counters": {
+            "dclass_c1": 3162,
+            "dclass_c1_str": "block_count"
+        },
+        "internal": {
+            "messageid": "pop3"
+        },
+        "investigations": {
+            "ec_outcome": "Failure",
+            "ec_subject": "NetworkComm",
+            "ec_theme": "ALM"
+        },
+        "misc": {
+            "action": [
+                "deny"
+            ],
+            "result": "success\n"
+        },
+        "network": {
+            "alias_host": [
+                "tatno4987.www5.localhost"
+            ],
+            "domain": "eniam7007.api.invalid",
+            "network_service": "pop3"
+        },
+        "time": {
+            "event_time": "2020-06-05T21:33:08.000Z"
+        }
+    },
+    "server": {
+        "domain": "eniam7007.api.invalid",
+        "registered_domain": "api.invalid",
+        "subdomain": "eniam7007",
+        "top_level_domain": "invalid"
+    },
+    "source": {
+        "ip": [
+            "10.54.231.100"
+        ],
+        "port": 5616
+    },
+    "tags": [
+        "fortinet-clientendpoint",
+        "forwarded",
+        "preserve_original_event"
+    ],
+    "user": {
+        "name": "umdolore"
+    }
+}
+```
 
 **Exported fields**
 
@@ -1430,6 +1707,89 @@ The `clientendpoint` dataset collects Fortinet FortiClient Endpoint Security log
 
 The `fortimail` dataset collects Fortinet FortiMail logs.
 
+An example event for `fortimail` looks as following:
+
+```$json
+{
+    "@timestamp": "2016-01-29T06:09:59.000Z",
+    "agent": {
+        "ephemeral_id": "74b27709-c288-4314-b386-659dbc5a62ea",
+        "hostname": "docker-fleet-agent",
+        "id": "2164018d-05cd-45b4-979d-4032bdd775f6",
+        "name": "docker-fleet-agent",
+        "type": "filebeat",
+        "version": "7.14.0"
+    },
+    "data_stream": {
+        "dataset": "fortinet.fortimail",
+        "namespace": "ep",
+        "type": "logs"
+    },
+    "ecs": {
+        "version": "1.9.0"
+    },
+    "elastic_agent": {
+        "id": "7cc48d16-ebf0-44b1-9094-fe2082d8f5a4",
+        "snapshot": true,
+        "version": "7.14.0"
+    },
+    "event": {
+        "action": "event",
+        "code": "nes",
+        "dataset": "fortinet.fortimail",
+        "ingested": "2021-06-03T12:42:09.362670647Z",
+        "original": "date=2016-1-29 time=06:09:59 device_id=pexe log_id=nes log_part=eab type=event subtype=update pri=high msg=\"boNemoe\"\n",
+        "timezone": "+00:00"
+    },
+    "host": {
+        "name": "docker-fleet-agent"
+    },
+    "input": {
+        "type": "udp"
+    },
+    "log": {
+        "level": "high",
+        "source": {
+            "address": "192.168.240.4:60044"
+        }
+    },
+    "observer": {
+        "product": "FortiMail",
+        "type": "Firewall",
+        "vendor": "Fortinet"
+    },
+    "related": {
+        "hosts": [
+            "docker-fleet-agent"
+        ]
+    },
+    "rsa": {
+        "internal": {
+            "event_desc": "boNemoe",
+            "messageid": "event_update"
+        },
+        "misc": {
+            "category": "update",
+            "event_type": "event",
+            "hardware_id": "pexe",
+            "msgIdPart1": "event",
+            "msgIdPart2": "update",
+            "reference_id": "nes",
+            "reference_id1": "eab",
+            "severity": "high"
+        },
+        "time": {
+            "event_time": "2016-01-29T06:09:59.000Z"
+        }
+    },
+    "tags": [
+        "fortinet-fortimail",
+        "forwarded",
+        "preserve_original_event"
+    ]
+}
+```
+
 **Exported fields**
 
 | Field | Description | Type |
@@ -2263,6 +2623,146 @@ The `fortimail` dataset collects Fortinet FortiMail logs.
 ### Fortimanager
 
 The `fortimanager` dataset collects Fortinet Manager/Analyzer logs.
+
+An example event for `fortimanager` looks as following:
+
+```$json
+{
+    "@timestamp": "2016-01-29T06:09:59.000Z",
+    "agent": {
+        "ephemeral_id": "74b27709-c288-4314-b386-659dbc5a62ea",
+        "hostname": "docker-fleet-agent",
+        "id": "2164018d-05cd-45b4-979d-4032bdd775f6",
+        "name": "docker-fleet-agent",
+        "type": "filebeat",
+        "version": "7.14.0"
+    },
+    "data_stream": {
+        "dataset": "fortinet.fortimanager",
+        "namespace": "ep",
+        "type": "logs"
+    },
+    "destination": {
+        "bytes": 449,
+        "geo": {
+            "country_name": "sequa"
+        },
+        "ip": [
+            "10.44.173.44"
+        ],
+        "nat": {
+            "ip": "10.189.58.145",
+            "port": 5273
+        },
+        "port": 6125
+    },
+    "ecs": {
+        "version": "1.9.0"
+    },
+    "elastic_agent": {
+        "id": "7cc48d16-ebf0-44b1-9094-fe2082d8f5a4",
+        "snapshot": true,
+        "version": "7.14.0"
+    },
+    "event": {
+        "action": "allow",
+        "code": "sse",
+        "dataset": "fortinet.fortimanager",
+        "ingested": "2021-06-03T12:45:50.284271932Z",
+        "original": "logver=iusm devname=\"modtempo\" devid=\"olab\" vd=nto date=2016-1-29 time=6:09:59 logid=sse type=exercita subtype=der level=very-high eventtime=odoco logtime=ria srcip=10.20.234.169 srcport=1001 srcintf=eth5722 srcintfrole=vol dstip=10.44.173.44 dstport=6125 dstintf=enp0s3068 dstintfrole=nseq poluuid=itinvol sessionid=psa proto=21 action=allow policyid=ntium policytype=psaq crscore=13.800000 craction=eab crlevel=aliqu appcat=Ute service=lupt srccountry=dolore dstcountry=sequa trandisp=abo tranip=10.189.58.145 tranport=5273 duration=14.119000 sentbyte=7880 rcvdbyte=449 sentpkt=mqui app=nci\n",
+        "timezone": "+00:00"
+    },
+    "host": {
+        "name": "docker-fleet-agent"
+    },
+    "input": {
+        "type": "udp"
+    },
+    "log": {
+        "level": "very-high",
+        "source": {
+            "address": "192.168.240.4:36529"
+        }
+    },
+    "network": {
+        "bytes": 8329
+    },
+    "observer": {
+        "egress": {
+            "interface": {
+                "name": "enp0s3068"
+            }
+        },
+        "ingress": {
+            "interface": {
+                "name": "eth5722"
+            }
+        },
+        "product": "FortiManager",
+        "type": "Configuration",
+        "vendor": "Fortinet"
+    },
+    "related": {
+        "hosts": [
+            "modtempo",
+            "docker-fleet-agent"
+        ],
+        "ip": [
+            "10.44.173.44",
+            "10.20.234.169",
+            "10.189.58.145"
+        ]
+    },
+    "rsa": {
+        "internal": {
+            "messageid": "generic_fortinetmgr_1"
+        },
+        "misc": {
+            "action": [
+                "allow"
+            ],
+            "category": "der",
+            "context": "abo",
+            "event_source": "modtempo",
+            "event_type": "exercita",
+            "hardware_id": "olab",
+            "log_session_id": "psa",
+            "policy_id": "ntium",
+            "reference_id": "sse",
+            "severity": "very-high",
+            "vsys": "nto"
+        },
+        "network": {
+            "dinterface": "enp0s3068",
+            "network_service": "lupt",
+            "sinterface": "eth5722"
+        },
+        "time": {
+            "duration_time": 14.119,
+            "event_time": "2016-01-29T06:09:59.000Z",
+            "event_time_str": "odoco"
+        },
+        "web": {
+            "reputation_num": 13.8
+        }
+    },
+    "source": {
+        "bytes": 7880,
+        "geo": {
+            "country_name": "dolore"
+        },
+        "ip": [
+            "10.20.234.169"
+        ],
+        "port": 1001
+    },
+    "tags": [
+        "fortinet-fortimanager",
+        "forwarded",
+        "preserve_original_event"
+    ]
+}
+```
 
 **Exported fields**
 

--- a/packages/fortinet/manifest.yml
+++ b/packages/fortinet/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet
 title: Fortinet
-version: 0.8.1
+version: 0.8.2
 release: experimental
 description: Fortinet Integration
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Makes event.original optional

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~- [] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #777 
- Relates #961 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
