### PR TITLE
Add aws.cloudwatch.namespace field

### DIFF
--- a/packages/aws/data_stream/ec2_metrics/fields/fields.yml
+++ b/packages/aws/data_stream/ec2_metrics/fields/fields.yml
@@ -159,3 +159,9 @@
           type: integer
           description: |
             The number of threads per CPU core.
+    - name: cloudwatch
+      type: group
+      fields:
+        - name: namespace
+          type: keyword
+          description: The namespace specified when query cloudwatch api.

--- a/packages/aws/data_stream/rds/fields/fields.yml
+++ b/packages/aws/data_stream/rds/fields/fields.yml
@@ -343,3 +343,9 @@
           type: long
           description: |
             The remaining available space for the cluster volume, measured in bytes.
+    - name: cloudwatch
+      type: group
+      fields:
+        - name: namespace
+          type: keyword
+          description: The namespace specified when query cloudwatch api.

--- a/packages/aws/data_stream/sqs/fields/fields.yml
+++ b/packages/aws/data_stream/sqs/fields/fields.yml
@@ -52,3 +52,9 @@
           type: keyword
           description: |
             SQS queue name
+    - name: cloudwatch
+      type: group
+      fields:
+        - name: namespace
+          type: keyword
+          description: The namespace specified when query cloudwatch api.

--- a/packages/aws/docs/README.md
+++ b/packages/aws/docs/README.md
@@ -1264,6 +1264,7 @@ An example event for `ec2` looks as following:
 |---|---|---|
 | @timestamp | Event timestamp. | date |
 | aws.*.metrics.*.* | Metrics that returned from Cloudwatch API query. | object |
+| aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |
 | aws.dimensions.* | Metric dimensions. | object |
 | aws.dimensions.AutoScalingGroupName | An Auto Scaling group is a collection of instances you define if you're using Auto Scaling. | keyword |
 | aws.dimensions.ImageId | This dimension filters the data you request for all instances running this Amazon EC2 Amazon Machine Image (AMI) | keyword |
@@ -1910,6 +1911,7 @@ An example event for `rds` looks as following:
 |---|---|---|
 | @timestamp | Event timestamp. | date |
 | aws.*.metrics.*.* | Metrics that returned from Cloudwatch API query. | object |
+| aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |
 | aws.dimensions.* | Metric dimensions. | object |
 | aws.dimensions.DBClusterIdentifier | This dimension filters the data that you request for a specific Amazon Aurora DB cluster. | keyword |
 | aws.dimensions.DBClusterIdentifier,Role | This dimension filters the data that you request for a specific Aurora DB cluster, aggregating the metric by instance role (WRITER/READER). | keyword |
@@ -2468,6 +2470,7 @@ An example event for `sqs` looks as following:
 |---|---|---|
 | @timestamp | Event timestamp. | date |
 | aws.*.metrics.*.* | Metrics that returned from Cloudwatch API query. | object |
+| aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |
 | aws.dimensions.* | Metric dimensions. | object |
 | aws.dimensions.QueueName | SQS queue name | keyword |
 | aws.s3.bucket.name | Name of a S3 bucket. | keyword |


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR is to add `aws.cloudwatch.namespace` field into `rds`, `ec2_metrics` and `sqs`.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
