### PR TITLE
Skip apache/status system test

### DIFF
--- a/packages/apache/data_stream/status/_dev/test/system/test-default-config.yml
+++ b/packages/apache/data_stream/status/_dev/test/system/test-default-config.yml
@@ -1,3 +1,6 @@
+skip:
+  reason: apache/status metricset no longer adjusts fields as expected in fleet mode
+  link: https://github.com/elastic/beats/issues/26120
 vars:
   hosts:
     - http://{{Hostname}}:{{Port}}


### PR DESCRIPTION
## What does this PR do?

This PR temporarily skips the `apache/status` data stream's system test. This test should be un-skipped once https://github.com/elastic/beats/issues/26120 is resolved.