### PR TITLE
Add support for CloudTrail Digest and Insight Logs

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.1"
+  changes:
+    - description: Add support for CloudTrail Digest & Insight logs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1079
 - version: "0.6.0"
   changes:
     - description: Update ECS version, add event.original and preparing for package GA

--- a/packages/aws/data_stream/cloudtrail/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/cloudtrail/agent/stream/aws-s3.yml.hbs
@@ -1,4 +1,16 @@
 queue_url: {{queue_url}}
+file_selectors:
+{{#if cloudtrail_regex}}
+  - regex: {{cloudtrail_regex}}
+    expand_event_list_from_field: 'Records'
+{{/if}}
+{{#if cloudtrail_digest_regex}}
+  - regex: {{cloudtrail_digest_regex}}
+{{/if}}
+{{#if cloudtrail_insight_regex}}
+  - regex: {{cloudtrail_insight_regex}}
+    expand_event_list_from_field: 'Records'
+{{/if}}
 expand_event_list_from_field: Records
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}

--- a/packages/aws/data_stream/cloudtrail/manifest.yml
+++ b/packages/aws/data_stream/cloudtrail/manifest.yml
@@ -47,6 +47,33 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: cloudtrail_regex
+        type: text
+        title: CloudTrail Logs regex
+        default: '/CloudTrail/'
+        required: false
+        show_user: false
+        description: |
+          Regex to match path of CloudTrail S3 Objects.  If blank
+          CloudTrail logs will be skipped.
+      - name: cloudtrail_digest_regex
+        type: text
+        title: CloudTrail Digest Logs regex
+        default: '/CloudTrail-Digest/'
+        required: false
+        show_user: false
+        description: |
+          Regex to match path of CloudTrail Digest S3 Objects.  If
+          blank CloudTrail Digest logs will be skipped.
+      - name: cloudtrail_insight_regex
+        type: text
+        title: CloudTrail Insight Logs regex
+        default: '/CloudTrail-Insight/'
+        required: false
+        show_user: false
+        description: |
+          Regex to match path of CloudTrail Insight S3 Objects.  If
+          blank CloudTrail Insight logs will be skipped.
   - input: httpjson
     title: AWS CloudTrail logs via Splunk Enterprise REST API
     description: Collect AWS CloudTrail logs via Splunk Enterprise REST API

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 0.6.0
+version: 0.6.1
 license: basic
 description: AWS Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?

Adds support for AWS CloudTrail Digest and AWS CloudTrail Insight Logs

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana
version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## How to test this PR locally

Setup CloudTrail with Insight logs.

## Related issues

- Closes #1022

## Screenshots

![Screen Shot 2021-06-02 at 17 04 46](https://user-images.githubusercontent.com/57081003/120685160-28316980-c465-11eb-801c-00a35013c235.png)
