### PR TITLE
Fixing data types of scalar fields

### DIFF
--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.1"
+  changes:
+    - description: Fix data types of some fields in the `cpu` data stream
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1081
 - version: "0.2.0"
   changes:
     - description: Render units and metric types in exported fields table

--- a/packages/docker/data_stream/cpu/fields/fields.yml
+++ b/packages/docker/data_stream/cpu/fields/fields.yml
@@ -79,20 +79,21 @@
       description: |
         Total CPU usage normalized by the number of CPU cores.
     - name: core.*.pct
-      type: object
+      type: scaled_float
       format: percent
       unit: percent
       metric_type: gauge
       description: |
         Percentage of CPU time in this core.
     - name: core.*.norm.pct
-      type: object
+      type: scaled_float
       format: percent
       unit: percent
       metric_type: gauge
       description: |
         Percentage of CPU time in this core, normalized by the number of CPU cores.
     - name: core.*.ticks
-      type: object
+      type: long
+      metric_type: counter
       description: |
         Number of CPU ticks in this core.

--- a/packages/docker/docs/README.md
+++ b/packages/docker/docs/README.md
@@ -154,9 +154,9 @@ The Docker `cpu` data stream collects runtime CPU metrics.
 | data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
 | data_stream.type | Data stream type. | constant_keyword |  |  |
 | docker.container.labels.* | Container labels | object |  |  |
-| docker.cpu.core.*.norm.pct | Percentage of CPU time in this core, normalized by the number of CPU cores. | object | percent | gauge |
-| docker.cpu.core.*.pct | Percentage of CPU time in this core. | object | percent | gauge |
-| docker.cpu.core.*.ticks | Number of CPU ticks in this core. | object |  |  |
+| docker.cpu.core.*.norm.pct | Percentage of CPU time in this core, normalized by the number of CPU cores. | scaled_float | percent | gauge |
+| docker.cpu.core.*.pct | Percentage of CPU time in this core. | scaled_float | percent | gauge |
+| docker.cpu.core.*.ticks | Number of CPU ticks in this core. | long |  | counter |
 | docker.cpu.kernel.norm.pct | Percentage of time in kernel space normalized by the number of CPU cores. | scaled_float | percent | gauge |
 | docker.cpu.kernel.pct | Percentage of time in kernel space. | scaled_float | percent | gauge |
 | docker.cpu.kernel.ticks | CPU ticks in kernel space. | long |  | counter |

--- a/packages/docker/manifest.yml
+++ b/packages/docker/manifest.yml
@@ -1,6 +1,6 @@
 name: docker
 title: Docker
-version: 0.2.0
+version: 0.2.1
 release: beta
 description: Docker Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?

This PR fixes the Elasticsearch mapping data types for the following fields:
- `docker.cpu.core.*.norm.pct`
- `docker.cpu.core.*.pct`
- `docker.cpu.core.*.ticks`

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] ~If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~

## Related issues
- Fixes #1080 
