### PR TITLE
[Radware] update radware ECS version and adding event.original options

### DIFF
--- a/packages/radware/changelog.yml
+++ b/packages/radware/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.5"
+  changes:
+    - description: update to ECS 1.10.0 and adding event.original options
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1098
 - version: "0.1.4"
   changes:
     - description: update to ECS 1.9.0

--- a/packages/radware/data_stream/defensepro/agent/stream/stream.yml.hbs
+++ b/packages/radware/data_stream/defensepro/agent/stream/stream.yml.hbs
@@ -4,8 +4,11 @@ paths:
 {{/each}}
 exclude_files: [".gz$"]
 tags:
+{{#if preserve_original_event}}
+  - preserve_original_event
+{{/if}}
 {{#each tags as |tag i|}}
- - {{tag}}
+  - {{tag}}
 {{/each}}
 fields_under_root: true
 fields:
@@ -18,6 +21,9 @@ publisher_pipeline.disable_host: true
 {{/contains}}
 
 processors:
+{{#if processors}}
+{{processors}}
+{{/if}}
 - script:
     lang: javascript
     params:
@@ -3507,7 +3513,3 @@ processors:
     target_subdomain_field: url.subdomain
     target_etld_field: url.top_level_domain
 - add_locale: ~
-- add_fields:
-    target: ''
-    fields:
-        ecs.version: 1.9.0

--- a/packages/radware/data_stream/defensepro/agent/stream/tcp.yml.hbs
+++ b/packages/radware/data_stream/defensepro/agent/stream/tcp.yml.hbs
@@ -1,8 +1,11 @@
 tcp:
 host: "{{tcp_host}}:{{tcp_port}}"
 tags:
+{{#if preserve_original_event}}
+  - preserve_original_event
+{{/if}}
 {{#each tags as |tag i|}}
- - {{tag}}
+  - {{tag}}
 {{/each}}
 fields_under_root: true
 fields:
@@ -15,6 +18,9 @@ publisher_pipeline.disable_host: true
 {{/contains}}
 
 processors:
+{{#if processors}}
+{{processors}}
+{{/if}}
 - script:
     lang: javascript
     params:
@@ -3504,7 +3510,3 @@ processors:
     target_subdomain_field: url.subdomain
     target_etld_field: url.top_level_domain
 - add_locale: ~
-- add_fields:
-    target: ''
-    fields:
-        ecs.version: 1.9.0

--- a/packages/radware/data_stream/defensepro/agent/stream/udp.yml.hbs
+++ b/packages/radware/data_stream/defensepro/agent/stream/udp.yml.hbs
@@ -1,8 +1,11 @@
 udp:
 host: "{{udp_host}}:{{udp_port}}"
 tags:
+{{#if preserve_original_event}}
+  - preserve_original_event
+{{/if}}
 {{#each tags as |tag i|}}
- - {{tag}}
+  - {{tag}}
 {{/each}}
 fields_under_root: true
 fields:
@@ -15,6 +18,9 @@ publisher_pipeline.disable_host: true
 {{/contains}}
 
 processors:
+{{#if processors}}
+{{processors}}
+{{/if}}
 - script:
     lang: javascript
     params:
@@ -3504,7 +3510,3 @@ processors:
     target_subdomain_field: url.subdomain
     target_etld_field: url.top_level_domain
 - add_locale: ~
-- add_fields:
-    target: ''
-    fields:
-        ecs.version: 1.9.0

--- a/packages/radware/data_stream/defensepro/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/radware/data_stream/defensepro/elasticsearch/ingest_pipeline/default.yml
@@ -4,61 +4,64 @@ description: Pipeline for Radware DefensePro
 processors:
   # ECS event.ingested
   - set:
-        field: event.ingested
-        value: '{{_ingest.timestamp}}'
+      field: event.ingested
+      value: '{{_ingest.timestamp}}'
+  - set:
+      field: ecs.version
+      value: "1.10.0"
   # User agent
   - user_agent:
-        field: user_agent.original
-        ignore_missing: true
+      field: user_agent.original
+      ignore_missing: true
   # IP Geolocation Lookup
   - geoip:
-        field: source.ip
-        target_field: source.geo
-        ignore_missing: true
+      field: source.ip
+      target_field: source.geo
+      ignore_missing: true
   - geoip:
-        field: destination.ip
-        target_field: destination.geo
-        ignore_missing: true
+      field: destination.ip
+      target_field: destination.geo
+      ignore_missing: true
 
   # IP Autonomous System (AS) Lookup
   - geoip:
-        database_file: GeoLite2-ASN.mmdb
-        field: source.ip
-        target_field: source.as
-        properties:
-            - asn
-            - organization_name
-        ignore_missing: true
+      database_file: GeoLite2-ASN.mmdb
+      field: source.ip
+      target_field: source.as
+      properties:
+          - asn
+          - organization_name
+      ignore_missing: true
   - geoip:
-        database_file: GeoLite2-ASN.mmdb
-        field: destination.ip
-        target_field: destination.as
-        properties:
-            - asn
-            - organization_name
-        ignore_missing: true
+      database_file: GeoLite2-ASN.mmdb
+      field: destination.ip
+      target_field: destination.as
+      properties:
+          - asn
+          - organization_name
+      ignore_missing: true
   - rename:
-        field: source.as.asn
-        target_field: source.as.number
-        ignore_missing: true
+      field: source.as.asn
+      target_field: source.as.number
+      ignore_missing: true
   - rename:
-        field: source.as.organization_name
-        target_field: source.as.organization.name
-        ignore_missing: true
+      field: source.as.organization_name
+      target_field: source.as.organization.name
+      ignore_missing: true
   - rename:
-        field: destination.as.asn
-        target_field: destination.as.number
-        ignore_missing: true
+      field: destination.as.asn
+      target_field: destination.as.number
+      ignore_missing: true
   - rename:
-        field: destination.as.organization_name
-        target_field: destination.as.organization.name
-        ignore_missing: true
+      field: destination.as.organization_name
+      target_field: destination.as.organization.name
+      ignore_missing: true
   - append:
-        field: related.hosts
-        value: '{{host.name}}'
-        allow_duplicates: false
-        if: ctx.host?.name != null && ctx.host?.name != ''
+      field: related.hosts
+      value: '{{host.name}}'
+      allow_duplicates: false
+      if: ctx.host?.name != null && ctx.host?.name != ''
 on_failure:
   - append:
-        field: error.message
-        value: "{{ _ingest.on_failure_message }}"
+      field: error.message
+      value: "{{ _ingest.on_failure_message }}"

--- a/packages/radware/data_stream/defensepro/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/radware/data_stream/defensepro/elasticsearch/ingest_pipeline/default.yml
@@ -61,6 +61,11 @@ processors:
       value: '{{host.name}}'
       allow_duplicates: false
       if: ctx.host?.name != null && ctx.host?.name != ''
+  - remove:
+      field: event.original
+      if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"
+      ignore_failure: true
+      ignore_missing: true
 on_failure:
   - append:
       field: error.message

--- a/packages/radware/data_stream/defensepro/manifest.yml
+++ b/packages/radware/data_stream/defensepro/manifest.yml
@@ -54,6 +54,22 @@ streams:
         required: false
         show_user: false
         default: false
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
   - input: tcp
     title: Radware DefensePro logs
     description: Collect Radware DefensePro logs
@@ -106,6 +122,22 @@ streams:
         required: false
         show_user: false
         default: false
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
   - input: logfile
     enabled: false
     title: Radware DefensePro logs
@@ -152,3 +184,19 @@ streams:
         required: false
         show_user: false
         default: false
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.

--- a/packages/radware/data_stream/defensepro/manifest.yml
+++ b/packages/radware/data_stream/defensepro/manifest.yml
@@ -70,6 +70,7 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
   - input: tcp
     title: Radware DefensePro logs
     description: Collect Radware DefensePro logs
@@ -138,6 +139,7 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
   - input: logfile
     enabled: false
     title: Radware DefensePro logs
@@ -198,5 +200,5 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: >
+        description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.

--- a/packages/radware/manifest.yml
+++ b/packages/radware/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: radware
 title: Radware DefensePro
-version: 0.1.4
+version: 0.1.5
 description: Radware DefensePro Integration
 categories: ["security"]
 release: experimental


### PR DESCRIPTION
## What does this PR do?

Updates package ECS version to 1.10.
Sync module changes to packages if any.
Adds Preserve Raw event functionality if not already exists.
Adds pipeline tests if missing.
Adds missing tags + moving tags to advanced settings.
Adds possibility to add custom processors.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Related issues

- Relates #994 