### PR TITLE
Add support for Splunk authentication tokens to third party REST API

### DIFF
--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.8.1"
+  changes:
+    - description: Add support for Splunk authorization tokens
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1147
 - version: "0.8.0"
   changes:
     - description: Set event.module and event.dataset

--- a/packages/apache/data_stream/access/agent/stream/httpjson.yml.hbs
+++ b/packages/apache/data_stream/access/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: "2"
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -28,6 +34,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/apache/data_stream/error/agent/stream/httpjson.yml.hbs
+++ b/packages/apache/data_stream/error/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -28,6 +34,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -46,17 +46,11 @@ policy_templates:
           - name: username
             type: text
             title: Splunk REST API Username
-            description: |
-              Password must also be provided and Authorization Token
-              must be empty.
             show_user: true
             required: false
           - name: password
             type: password
             title: Splunk REST API Password
-            description: |
-              Username must also be provided and Authorization Token
-              must be empty.
             show_user: true
             required: false
           - name: token
@@ -64,8 +58,8 @@ policy_templates:
             title: Splunk Authorization Token
             description: |
               Bearer Token or Session Key, e.g. "Bearer eyJFd3e46..."
-              or "Splunk 192fd3e...".  Username and password must be
-              empty.
+              or "Splunk 192fd3e...".  Cannot be used with username
+              and password.
             show_user: true
             required: false
           - name: ssl

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: apache
 title: Apache
-version: 0.8.0
+version: 0.8.1
 license: basic
 description: Apache Integration
 type: integration
@@ -46,13 +46,28 @@ policy_templates:
           - name: username
             type: text
             title: Splunk REST API Username
+            description: |
+              Password must also be provided and Authorization Token
+              must be empty.
             show_user: true
-            required: true
+            required: false
           - name: password
             type: password
             title: Splunk REST API Password
-            required: true
+            description: |
+              Username must also be provided and Authorization Token
+              must be empty.
             show_user: true
+            required: false
+          - name: token
+            type: password
+            title: Splunk Authorization Token
+            description: |
+              Bearer Token or Session Key, e.g. "Bearer eyJFd3e46..."
+              or "Splunk 192fd3e...".  Username and password must be
+              empty.
+            show_user: true
+            required: false
           - name: ssl
             type: yaml
             title: SSL Configuration
@@ -60,6 +75,28 @@ policy_templates:
             multi: false
             required: false
             show_user: false
+            default: |
+              #certificate_authorities:
+              #  - |
+              #    -----BEGIN CERTIFICATE-----
+              #    MIIDCjCCAfKgAwIBAgITJ706Mu2wJlKckpIvkWxEHvEyijANBgkqhkiG9w0BAQsF
+              #    ADAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwIBcNMTkwNzIyMTkyOTA0WhgPMjExOTA2
+              #    MjgxOTI5MDRaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEB
+              #    BQADggEPADCCAQoCggEBANce58Y/JykI58iyOXpxGfw0/gMvF0hUQAcUrSMxEO6n
+              #    fZRA49b4OV4SwWmA3395uL2eB2NB8y8qdQ9muXUdPBWE4l9rMZ6gmfu90N5B5uEl
+              #    94NcfBfYOKi1fJQ9i7WKhTjlRkMCgBkWPkUokvBZFRt8RtF7zI77BSEorHGQCk9t
+              #    /D7BS0GJyfVEhftbWcFEAG3VRcoMhF7kUzYwp+qESoriFRYLeDWv68ZOvG7eoWnP
+              #    PsvZStEVEimjvK5NSESEQa9xWyJOmlOKXhkdymtcUd/nXnx6UTCFgnkgzSdTWV41
+              #    CI6B6aJ9svCTI2QuoIq2HxX/ix7OvW1huVmcyHVxyUECAwEAAaNTMFEwHQYDVR0O
+              #    BBYEFPwN1OceFGm9v6ux8G+DZ3TUDYxqMB8GA1UdIwQYMBaAFPwN1OceFGm9v6ux
+              #    8G+DZ3TUDYxqMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAG5D
+              #    874A4YI7YUwOVsVAdbWtgp1d0zKcPRR+r2OdSbTAV5/gcS3jgBJ3i1BN34JuDVFw
+              #    3DeJSYT3nxy2Y56lLnxDeF8CUTUtVQx3CuGkRg1ouGAHpO/6OqOhwLLorEmxi7tA
+              #    H2O8mtT0poX5AnOAhzVy7QW0D/k4WaoLyckM5hUa6RtvgvLxOwA0U+VGurCDoctu
+              #    8F4QOgTAWyh8EZIwaKCliFRSynDpv3JTUwtfZkxo6K6nce1RhCWFAsMvDZL8Dgc0
+              #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
+              #    sxSmbIUfc2SGJGCJD4I=
+              #    -----END CERTIFICATE-----
       - type: apache/metrics
         title: Collect metrics from Apache instances
         description: Collecting Apache status metrics

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.4"
+  changes:
+    - description: Add support for Splunk authorization tokens
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1147
 - version: "0.6.3"
   changes:
     - description: Fix bug in Third Party ingest pipeline

--- a/packages/aws/data_stream/cloudtrail/agent/stream/httpjson.yml.hbs
+++ b/packages/aws/data_stream/cloudtrail/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 0.6.3
+version: 0.6.4
 license: basic
 description: AWS Integration
 type: integration
@@ -254,12 +254,21 @@ policy_templates:
             type: text
             title: Splunk REST API Username
             show_user: true
-            required: true
+            required: false
           - name: password
             type: password
             title: Splunk REST API Password
-            required: true
             show_user: true
+            required: false
+          - name: token
+            type: password
+            title: Splunk Authorization Token
+            description: |
+              Bearer Token or Session Key, e.g. "Bearer eyJFd3e46..."
+              or "Splunk 192fd3e...".  Cannot be used with username
+              and password.
+            show_user: true
+            required: false
           - name: ssl
             type: yaml
             title: SSL Configuration
@@ -267,5 +276,27 @@ policy_templates:
             required: false
             show_user: false
             description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            default: |
+              #certificate_authorities:
+              #  - |
+              #    -----BEGIN CERTIFICATE-----
+              #    MIIDCjCCAfKgAwIBAgITJ706Mu2wJlKckpIvkWxEHvEyijANBgkqhkiG9w0BAQsF
+              #    ADAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwIBcNMTkwNzIyMTkyOTA0WhgPMjExOTA2
+              #    MjgxOTI5MDRaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEB
+              #    BQADggEPADCCAQoCggEBANce58Y/JykI58iyOXpxGfw0/gMvF0hUQAcUrSMxEO6n
+              #    fZRA49b4OV4SwWmA3395uL2eB2NB8y8qdQ9muXUdPBWE4l9rMZ6gmfu90N5B5uEl
+              #    94NcfBfYOKi1fJQ9i7WKhTjlRkMCgBkWPkUokvBZFRt8RtF7zI77BSEorHGQCk9t
+              #    /D7BS0GJyfVEhftbWcFEAG3VRcoMhF7kUzYwp+qESoriFRYLeDWv68ZOvG7eoWnP
+              #    PsvZStEVEimjvK5NSESEQa9xWyJOmlOKXhkdymtcUd/nXnx6UTCFgnkgzSdTWV41
+              #    CI6B6aJ9svCTI2QuoIq2HxX/ix7OvW1huVmcyHVxyUECAwEAAaNTMFEwHQYDVR0O
+              #    BBYEFPwN1OceFGm9v6ux8G+DZ3TUDYxqMB8GA1UdIwQYMBaAFPwN1OceFGm9v6ux
+              #    8G+DZ3TUDYxqMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAG5D
+              #    874A4YI7YUwOVsVAdbWtgp1d0zKcPRR+r2OdSbTAV5/gcS3jgBJ3i1BN34JuDVFw
+              #    3DeJSYT3nxy2Y56lLnxDeF8CUTUtVQx3CuGkRg1ouGAHpO/6OqOhwLLorEmxi7tA
+              #    H2O8mtT0poX5AnOAhzVy7QW0D/k4WaoLyckM5hUa6RtvgvLxOwA0U+VGurCDoctu
+              #    8F4QOgTAWyh8EZIwaKCliFRSynDpv3JTUwtfZkxo6K6nce1RhCWFAsMvDZL8Dgc0
+              #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
+              #    sxSmbIUfc2SGJGCJD4I=
+              #    -----END CERTIFICATE-----
 owner:
   github: elastic/integrations

--- a/packages/nginx/changelog.yml
+++ b/packages/nginx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.2"
+  changes:
+    - description: Add support for Splunk authorization tokens
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1147
 - version: "0.6.1"
   changes:
     - description: Fix bug in Third Party REST API ingest pipeline

--- a/packages/nginx/data_stream/access/agent/stream/httpjson.yml.hbs
+++ b/packages/nginx/data_stream/access/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/nginx/data_stream/error/agent/stream/httpjson.yml.hbs
+++ b/packages/nginx/data_stream/error/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: nginx
 title: Nginx
-version: 0.6.1
+version: 0.6.2
 license: basic
 description: Nginx Integration
 type: integration
@@ -52,12 +52,21 @@ policy_templates:
             type: text
             title: Splunk REST API Username
             show_user: true
-            required: true
+            required: false
           - name: password
             type: password
             title: Splunk REST API Password
-            required: true
             show_user: true
+            required: false
+          - name: token
+            type: password
+            title: Splunk Authorization Token
+            description: |
+              Bearer Token or Session Key, e.g. "Bearer eyJFd3e46..."
+              or "Splunk 192fd3e...".  Cannot be used with username
+              and password.
+            show_user: true
+            required: false
           - name: ssl
             type: yaml
             title: SSL Configuration
@@ -65,6 +74,28 @@ policy_templates:
             multi: false
             required: false
             show_user: false
+            default: |
+              #certificate_authorities:
+              #  - |
+              #    -----BEGIN CERTIFICATE-----
+              #    MIIDCjCCAfKgAwIBAgITJ706Mu2wJlKckpIvkWxEHvEyijANBgkqhkiG9w0BAQsF
+              #    ADAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwIBcNMTkwNzIyMTkyOTA0WhgPMjExOTA2
+              #    MjgxOTI5MDRaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEB
+              #    BQADggEPADCCAQoCggEBANce58Y/JykI58iyOXpxGfw0/gMvF0hUQAcUrSMxEO6n
+              #    fZRA49b4OV4SwWmA3395uL2eB2NB8y8qdQ9muXUdPBWE4l9rMZ6gmfu90N5B5uEl
+              #    94NcfBfYOKi1fJQ9i7WKhTjlRkMCgBkWPkUokvBZFRt8RtF7zI77BSEorHGQCk9t
+              #    /D7BS0GJyfVEhftbWcFEAG3VRcoMhF7kUzYwp+qESoriFRYLeDWv68ZOvG7eoWnP
+              #    PsvZStEVEimjvK5NSESEQa9xWyJOmlOKXhkdymtcUd/nXnx6UTCFgnkgzSdTWV41
+              #    CI6B6aJ9svCTI2QuoIq2HxX/ix7OvW1huVmcyHVxyUECAwEAAaNTMFEwHQYDVR0O
+              #    BBYEFPwN1OceFGm9v6ux8G+DZ3TUDYxqMB8GA1UdIwQYMBaAFPwN1OceFGm9v6ux
+              #    8G+DZ3TUDYxqMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAG5D
+              #    874A4YI7YUwOVsVAdbWtgp1d0zKcPRR+r2OdSbTAV5/gcS3jgBJ3i1BN34JuDVFw
+              #    3DeJSYT3nxy2Y56lLnxDeF8CUTUtVQx3CuGkRg1ouGAHpO/6OqOhwLLorEmxi7tA
+              #    H2O8mtT0poX5AnOAhzVy7QW0D/k4WaoLyckM5hUa6RtvgvLxOwA0U+VGurCDoctu
+              #    8F4QOgTAWyh8EZIwaKCliFRSynDpv3JTUwtfZkxo6K6nce1RhCWFAsMvDZL8Dgc0
+              #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
+              #    sxSmbIUfc2SGJGCJD4I=
+              #    -----END CERTIFICATE-----
       - type: nginx/metrics
         vars:
           - name: hosts

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.13.5"
+  changes:
+    - description: Add support for Splunk authorization tokens
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1147
 - version: "0.13.4"
   changes:
     - description: Use `wildcard` type for relevant ECS fields in `security` stream.

--- a/packages/system/data_stream/application/agent/stream/httpjson.yml.hbs
+++ b/packages/system/data_stream/application/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: "2"
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -28,6 +34,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 tags:
 {{#each tags as |tag i|}}

--- a/packages/system/data_stream/security/agent/stream/httpjson.yml.hbs
+++ b/packages/system/data_stream/security/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: "2"
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -28,6 +34,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 tags:
 {{#each tags as |tag i|}}

--- a/packages/system/data_stream/system/agent/stream/httpjson.yml.hbs
+++ b/packages/system/data_stream/system/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: "2"
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -28,6 +34,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 tags:
 {{#each tags as |tag i|}}

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 0.13.4
+version: 0.13.5
 license: basic
 description: System Integration
 type: integration
@@ -71,12 +71,21 @@ policy_templates:
             type: text
             title: Splunk REST API Username
             show_user: true
-            required: true
+            required: false
           - name: password
             type: password
             title: Splunk REST API Password
-            required: true
             show_user: true
+            required: false
+          - name: token
+            type: password
+            title: Splunk Authorization Token
+            description: |
+              Bearer Token or Session Key, e.g. "Bearer eyJFd3e46..."
+              or "Splunk 192fd3e...".  Cannot be used with username
+              and password.
+            show_user: true
+            required: false
           - name: preserve_original_event
             required: true
             show_user: true
@@ -92,5 +101,27 @@ policy_templates:
             multi: false
             required: false
             show_user: false
+            default: |
+              #certificate_authorities:
+              #  - |
+              #    -----BEGIN CERTIFICATE-----
+              #    MIIDCjCCAfKgAwIBAgITJ706Mu2wJlKckpIvkWxEHvEyijANBgkqhkiG9w0BAQsF
+              #    ADAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwIBcNMTkwNzIyMTkyOTA0WhgPMjExOTA2
+              #    MjgxOTI5MDRaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEB
+              #    BQADggEPADCCAQoCggEBANce58Y/JykI58iyOXpxGfw0/gMvF0hUQAcUrSMxEO6n
+              #    fZRA49b4OV4SwWmA3395uL2eB2NB8y8qdQ9muXUdPBWE4l9rMZ6gmfu90N5B5uEl
+              #    94NcfBfYOKi1fJQ9i7WKhTjlRkMCgBkWPkUokvBZFRt8RtF7zI77BSEorHGQCk9t
+              #    /D7BS0GJyfVEhftbWcFEAG3VRcoMhF7kUzYwp+qESoriFRYLeDWv68ZOvG7eoWnP
+              #    PsvZStEVEimjvK5NSESEQa9xWyJOmlOKXhkdymtcUd/nXnx6UTCFgnkgzSdTWV41
+              #    CI6B6aJ9svCTI2QuoIq2HxX/ix7OvW1huVmcyHVxyUECAwEAAaNTMFEwHQYDVR0O
+              #    BBYEFPwN1OceFGm9v6ux8G+DZ3TUDYxqMB8GA1UdIwQYMBaAFPwN1OceFGm9v6ux
+              #    8G+DZ3TUDYxqMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAG5D
+              #    874A4YI7YUwOVsVAdbWtgp1d0zKcPRR+r2OdSbTAV5/gcS3jgBJ3i1BN34JuDVFw
+              #    3DeJSYT3nxy2Y56lLnxDeF8CUTUtVQx3CuGkRg1ouGAHpO/6OqOhwLLorEmxi7tA
+              #    H2O8mtT0poX5AnOAhzVy7QW0D/k4WaoLyckM5hUa6RtvgvLxOwA0U+VGurCDoctu
+              #    8F4QOgTAWyh8EZIwaKCliFRSynDpv3JTUwtfZkxo6K6nce1RhCWFAsMvDZL8Dgc0
+              #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
+              #    sxSmbIUfc2SGJGCJD4I=
+              #    -----END CERTIFICATE-----
 owner:
   github: elastic/integrations

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.9.2"
+  changes:
+    - description: Add support for Splunk authorization tokens
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1147
 - version: "0.9.1"
   changes:
     - description: Use new `wildcard` type.

--- a/packages/windows/data_stream/forwarded/agent/stream/httpjson.yml.hbs
+++ b/packages/windows/data_stream/forwarded/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: "2"
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -28,6 +34,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 {{#if tags.length}}
 tags:

--- a/packages/windows/data_stream/powershell/agent/stream/httpjson.yml.hbs
+++ b/packages/windows/data_stream/powershell/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: "2"
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -28,6 +34,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 {{#if tags.length}}
 tags:

--- a/packages/windows/data_stream/powershell_operational/agent/stream/httpjson.yml.hbs
+++ b/packages/windows/data_stream/powershell_operational/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: "2"
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -28,6 +34,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 {{#if tags.length}}
 tags:

--- a/packages/windows/data_stream/sysmon_operational/agent/stream/httpjson.yml.hbs
+++ b/packages/windows/data_stream/sysmon_operational/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: "2"
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -28,6 +34,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 {{#if tags.length}}
 tags:

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 0.9.1
+version: 0.9.2
 description: Windows Integration
 type: integration
 categories:
@@ -47,12 +47,21 @@ policy_templates:
             type: text
             title: Splunk REST API Username
             show_user: true
-            required: true
+            required: false
           - name: password
             type: password
             title: Splunk REST API Password
-            required: true
             show_user: true
+            required: false
+          - name: token
+            type: password
+            title: Splunk Authorization Token
+            description: |
+              Bearer Token or Session Key, e.g. "Bearer eyJFd3e46..."
+              or "Splunk 192fd3e...".  Cannot be used with username
+              and password.
+            show_user: true
+            required: false
           - name: ssl
             type: yaml
             title: SSL Configuration
@@ -60,5 +69,27 @@ policy_templates:
             multi: false
             required: false
             show_user: false
+            default: |
+              #certificate_authorities:
+              #  - |
+              #    -----BEGIN CERTIFICATE-----
+              #    MIIDCjCCAfKgAwIBAgITJ706Mu2wJlKckpIvkWxEHvEyijANBgkqhkiG9w0BAQsF
+              #    ADAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwIBcNMTkwNzIyMTkyOTA0WhgPMjExOTA2
+              #    MjgxOTI5MDRaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEB
+              #    BQADggEPADCCAQoCggEBANce58Y/JykI58iyOXpxGfw0/gMvF0hUQAcUrSMxEO6n
+              #    fZRA49b4OV4SwWmA3395uL2eB2NB8y8qdQ9muXUdPBWE4l9rMZ6gmfu90N5B5uEl
+              #    94NcfBfYOKi1fJQ9i7WKhTjlRkMCgBkWPkUokvBZFRt8RtF7zI77BSEorHGQCk9t
+              #    /D7BS0GJyfVEhftbWcFEAG3VRcoMhF7kUzYwp+qESoriFRYLeDWv68ZOvG7eoWnP
+              #    PsvZStEVEimjvK5NSESEQa9xWyJOmlOKXhkdymtcUd/nXnx6UTCFgnkgzSdTWV41
+              #    CI6B6aJ9svCTI2QuoIq2HxX/ix7OvW1huVmcyHVxyUECAwEAAaNTMFEwHQYDVR0O
+              #    BBYEFPwN1OceFGm9v6ux8G+DZ3TUDYxqMB8GA1UdIwQYMBaAFPwN1OceFGm9v6ux
+              #    8G+DZ3TUDYxqMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAG5D
+              #    874A4YI7YUwOVsVAdbWtgp1d0zKcPRR+r2OdSbTAV5/gcS3jgBJ3i1BN34JuDVFw
+              #    3DeJSYT3nxy2Y56lLnxDeF8CUTUtVQx3CuGkRg1ouGAHpO/6OqOhwLLorEmxi7tA
+              #    H2O8mtT0poX5AnOAhzVy7QW0D/k4WaoLyckM5hUa6RtvgvLxOwA0U+VGurCDoctu
+              #    8F4QOgTAWyh8EZIwaKCliFRSynDpv3JTUwtfZkxo6K6nce1RhCWFAsMvDZL8Dgc0
+              #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
+              #    sxSmbIUfc2SGJGCJD4I=
+              #    -----END CERTIFICATE-----
 owner:
   github: elastic/integrations

--- a/packages/winlog/changelog.yml
+++ b/packages/winlog/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.2"
+  changes:
+    - description: Add support for Splunk authorization tokens
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1147
 - version: "0.2.1"
   changes:
     - description: Change Splunk input to use the decode_xml_wineventlog processor.

--- a/packages/winlog/data_stream/winlog/agent/stream/httpjson.yml.hbs
+++ b/packages/winlog/data_stream/winlog/agent/stream/httpjson.yml.hbs
@@ -2,8 +2,14 @@ data_stream:
   dataset: {{data_stream.dataset}}
 config_version: "2"
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -30,6 +36,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 tags:
 {{#each tags as |tag i|}}

--- a/packages/winlog/manifest.yml
+++ b/packages/winlog/manifest.yml
@@ -4,7 +4,7 @@ title: Custom Windows event logs
 description: |-
   Collect your custom Windows event logs.
 type: integration
-version: 0.2.1
+version: 0.2.2
 release: experimental
 conditions:
   kibana.version: '^7.13.0'
@@ -35,12 +35,21 @@ policy_templates:
             type: text
             title: Splunk REST API Username
             show_user: true
-            required: true
+            required: false
           - name: password
             type: password
             title: Splunk REST API Password
-            required: true
             show_user: true
+            required: false
+          - name: token
+            type: password
+            title: Splunk Authorization Token
+            description: |
+              Bearer Token or Session Key, e.g. "Bearer eyJFd3e46..."
+              or "Splunk 192fd3e...".  Cannot be used with username
+              and password.
+            show_user: true
+            required: false
           - name: ssl
             type: yaml
             title: SSL Configuration
@@ -48,6 +57,28 @@ policy_templates:
             multi: false
             required: false
             show_user: false
+            default: |
+              #certificate_authorities:
+              #  - |
+              #    -----BEGIN CERTIFICATE-----
+              #    MIIDCjCCAfKgAwIBAgITJ706Mu2wJlKckpIvkWxEHvEyijANBgkqhkiG9w0BAQsF
+              #    ADAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwIBcNMTkwNzIyMTkyOTA0WhgPMjExOTA2
+              #    MjgxOTI5MDRaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEB
+              #    BQADggEPADCCAQoCggEBANce58Y/JykI58iyOXpxGfw0/gMvF0hUQAcUrSMxEO6n
+              #    fZRA49b4OV4SwWmA3395uL2eB2NB8y8qdQ9muXUdPBWE4l9rMZ6gmfu90N5B5uEl
+              #    94NcfBfYOKi1fJQ9i7WKhTjlRkMCgBkWPkUokvBZFRt8RtF7zI77BSEorHGQCk9t
+              #    /D7BS0GJyfVEhftbWcFEAG3VRcoMhF7kUzYwp+qESoriFRYLeDWv68ZOvG7eoWnP
+              #    PsvZStEVEimjvK5NSESEQa9xWyJOmlOKXhkdymtcUd/nXnx6UTCFgnkgzSdTWV41
+              #    CI6B6aJ9svCTI2QuoIq2HxX/ix7OvW1huVmcyHVxyUECAwEAAaNTMFEwHQYDVR0O
+              #    BBYEFPwN1OceFGm9v6ux8G+DZ3TUDYxqMB8GA1UdIwQYMBaAFPwN1OceFGm9v6ux
+              #    8G+DZ3TUDYxqMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAG5D
+              #    874A4YI7YUwOVsVAdbWtgp1d0zKcPRR+r2OdSbTAV5/gcS3jgBJ3i1BN34JuDVFw
+              #    3DeJSYT3nxy2Y56lLnxDeF8CUTUtVQx3CuGkRg1ouGAHpO/6OqOhwLLorEmxi7tA
+              #    H2O8mtT0poX5AnOAhzVy7QW0D/k4WaoLyckM5hUa6RtvgvLxOwA0U+VGurCDoctu
+              #    8F4QOgTAWyh8EZIwaKCliFRSynDpv3JTUwtfZkxo6K6nce1RhCWFAsMvDZL8Dgc0
+              #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
+              #    sxSmbIUfc2SGJGCJD4I=
+              #    -----END CERTIFICATE-----
 icons:
   - src: "/img/logo_windows.svg"
     type: "image/svg+xml"

--- a/packages/zeek/changelog.yml
+++ b/packages/zeek/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.8.4"
+  changes:
+    - description: Add support for Splunk authorization tokens
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1147
 - version: "0.8.3"
   changes:
     - description: Fix Third Party Api ingest pipeline

--- a/packages/zeek/data_stream/capture_loss/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/capture_loss/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/connection/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/connection/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/dce_rpc/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/dce_rpc/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/dhcp/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/dhcp/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/dnp3/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/dnp3/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/dns/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/dns/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/dpd/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/dpd/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/files/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/files/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/ftp/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/ftp/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/http/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/http/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/intel/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/intel/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/irc/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/irc/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/kerberos/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/kerberos/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/modbus/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/modbus/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/mysql/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/mysql/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/notice/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/notice/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/ntlm/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/ntlm/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/ocsp/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/ocsp/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/pe/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/pe/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/radius/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/radius/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/rdp/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/rdp/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/rfb/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/rfb/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/sip/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/sip/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/smb_cmd/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/smb_cmd/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/smb_files/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/smb_files/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/smb_mapping/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/smb_mapping/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/smtp/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/smtp/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/snmp/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/snmp/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/socks/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/socks/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/ssh/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/ssh/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/ssl/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/ssl/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/stats/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/stats/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/syslog/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/syslog/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/traceroute/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/traceroute/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/tunnel/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/tunnel/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/weird/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/weird/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/data_stream/x509/agent/stream/httpjson.yml.hbs
+++ b/packages/zeek/data_stream/x509/agent/stream/httpjson.yml.hbs
@@ -1,7 +1,13 @@
 config_version: 2
 interval: {{interval}}
+{{#unless token}}
+{{#if username}}
+{{#if password}}
 auth.basic.user: {{username}}
 auth.basic.password: {{password}}
+{{/if}}
+{{/if}}
+{{/unless}}
 cursor:
   index_earliest:
     value: '[[.last_event.result.max_indextime]]'
@@ -27,6 +33,15 @@ request.transforms:
   - set:
       target: header.Content-Type
       value: application/x-www-form-urlencoded
+{{#unless username}}
+{{#unless password}}
+{{#if token}}
+  - set:
+      target: header.Authorization
+      value: {{token}}
+{{/if}}
+{{/unless}}
+{{/unless}}
 response.decode_as: application/x-ndjson
 response.split:
   target: body.result._raw

--- a/packages/zeek/manifest.yml
+++ b/packages/zeek/manifest.yml
@@ -1,6 +1,6 @@
 name: zeek
 title: Zeek
-version: 0.8.3
+version: 0.8.4
 release: beta
 description: Zeek Integration
 type: integration
@@ -54,12 +54,21 @@ policy_templates:
             type: text
             title: Splunk REST API Username
             show_user: true
-            required: true
+            required: false
           - name: password
             type: password
             title: Splunk REST API Password
-            required: true
             show_user: true
+            required: false
+          - name: token
+            type: password
+            title: Splunk Authorization Token
+            description: |
+              Bearer Token or Session Key, e.g. "Bearer eyJFd3e46..."
+              or "Splunk 192fd3e...".  Cannot be used with username
+              and password.
+            show_user: true
+            required: false
           - name: ssl
             type: yaml
             title: SSL Configuration
@@ -67,5 +76,27 @@ policy_templates:
             multi: false
             required: false
             show_user: false
+            default: |
+              #certificate_authorities:
+              #  - |
+              #    -----BEGIN CERTIFICATE-----
+              #    MIIDCjCCAfKgAwIBAgITJ706Mu2wJlKckpIvkWxEHvEyijANBgkqhkiG9w0BAQsF
+              #    ADAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwIBcNMTkwNzIyMTkyOTA0WhgPMjExOTA2
+              #    MjgxOTI5MDRaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEB
+              #    BQADggEPADCCAQoCggEBANce58Y/JykI58iyOXpxGfw0/gMvF0hUQAcUrSMxEO6n
+              #    fZRA49b4OV4SwWmA3395uL2eB2NB8y8qdQ9muXUdPBWE4l9rMZ6gmfu90N5B5uEl
+              #    94NcfBfYOKi1fJQ9i7WKhTjlRkMCgBkWPkUokvBZFRt8RtF7zI77BSEorHGQCk9t
+              #    /D7BS0GJyfVEhftbWcFEAG3VRcoMhF7kUzYwp+qESoriFRYLeDWv68ZOvG7eoWnP
+              #    PsvZStEVEimjvK5NSESEQa9xWyJOmlOKXhkdymtcUd/nXnx6UTCFgnkgzSdTWV41
+              #    CI6B6aJ9svCTI2QuoIq2HxX/ix7OvW1huVmcyHVxyUECAwEAAaNTMFEwHQYDVR0O
+              #    BBYEFPwN1OceFGm9v6ux8G+DZ3TUDYxqMB8GA1UdIwQYMBaAFPwN1OceFGm9v6ux
+              #    8G+DZ3TUDYxqMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAG5D
+              #    874A4YI7YUwOVsVAdbWtgp1d0zKcPRR+r2OdSbTAV5/gcS3jgBJ3i1BN34JuDVFw
+              #    3DeJSYT3nxy2Y56lLnxDeF8CUTUtVQx3CuGkRg1ouGAHpO/6OqOhwLLorEmxi7tA
+              #    H2O8mtT0poX5AnOAhzVy7QW0D/k4WaoLyckM5hUa6RtvgvLxOwA0U+VGurCDoctu
+              #    8F4QOgTAWyh8EZIwaKCliFRSynDpv3JTUwtfZkxo6K6nce1RhCWFAsMvDZL8Dgc0
+              #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
+              #    sxSmbIUfc2SGJGCJD4I=
+              #    -----END CERTIFICATE-----
 owner:
   github: elastic/security-external-integrations


### PR DESCRIPTION
## What does this PR do?

Adds support for Splunk Authentication tokens to third party
REST API source.

- apache
- aws
- system
- windows
- winlog
- zeek

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## How to test this PR locally

https://docs.splunk.com/Documentation/Splunk/8.2.0/Security/CreateAuthTokens
https://docs.splunk.com/Documentation/Splunk/8.2.0/RESTUM/RESTusing

Need to make tokens then try configuring tokens and ingesting data

## Related issues

- Relates #1135


## Screenshots
![Screen Shot 2021-06-23 at 14 34 17](https://user-images.githubusercontent.com/57081003/123157682-77e5ce00-d430-11eb-8839-1b7642977a11.png)

