### PR TITLE
Store structured attributes from MongoDB logs in JSON format

### DIFF
--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -4,8 +4,6 @@
     - description: Store log attributes included in JSON logs
       type: enhancement
       link: https://github.com/elastic/integrations/pull/1153
-- version: "0.4.0"
-  changes:
     - description: Add support for logs in JSON format
       type: enhancement
       link: https://github.com/elastic/integrations/pull/1138

--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -1,6 +1,11 @@
 # newer versions go on top
 - version: "0.4.0"
   changes:
+    - description: Store log attributes included in JSON logs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1153
+- version: "0.4.0"
+  changes:
     - description: Add support for logs in JSON format
       type: enhancement
       link: https://github.com/elastic/integrations/pull/1138

--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -1,12 +1,12 @@
 # newer versions go on top
 - version: "0.4.0"
   changes:
-    - description: Store log attributes included in JSON logs
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/1153
     - description: Add support for logs in JSON format
       type: enhancement
       link: https://github.com/elastic/integrations/pull/1138
+    - description: Store log attributes included in JSON logs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1153
 - version: "0.3.0"
   changes:
     - description: update to ECS 1.10.0 and add event.original option

--- a/packages/mongodb/data_stream/log/_dev/test/pipeline/test-mongodb-debian.log-expected.json
+++ b/packages/mongodb/data_stream/log/_dev/test/pipeline/test-mongodb-debian.log-expected.json
@@ -7,7 +7,7 @@
             },
             "message": "git version: 009580ad490190ba33d1c6253ebd8d91808923e4",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812084646Z",
+                "ingested": "2021-06-18T15:22:30.432591083Z",
                 "type": [
                     "info"
                 ],
@@ -34,7 +34,7 @@
             },
             "message": "modules: none",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812088978Z",
+                "ingested": "2021-06-18T15:22:30.432594589Z",
                 "type": [
                     "info"
                 ],
@@ -61,7 +61,7 @@
             },
             "message": "OpenSSL version: OpenSSL 1.0.2l  25 May 2017",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812090853Z",
+                "ingested": "2021-06-18T15:22:30.432595709Z",
                 "type": [
                     "info"
                 ],
@@ -88,7 +88,7 @@
             },
             "message": "wiredtiger_open config: create,cache_size=8G,session_max=20000,eviction=(threads_max=4),config_base=false,statistics=(fast),log=(enabled=true,archive=true,path=journal,compressor=snappy),file_manager=(close_idle_time=100000),checkpoint=(wait=60,log_size=2GB),statistics_log=(wait=0),",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812092720Z",
+                "ingested": "2021-06-18T15:22:30.432596878Z",
                 "type": [
                     "info"
                 ],
@@ -115,7 +115,7 @@
             },
             "message": "Initializing full-time diagnostic data capture with directory '/var/lib/mongodb/diagnostic.data'",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812094420Z",
+                "ingested": "2021-06-18T15:22:30.432597538Z",
                 "type": [
                     "info"
                 ],
@@ -142,7 +142,7 @@
             },
             "message": "Starting hostname canonicalization worker",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812096116Z",
+                "ingested": "2021-06-18T15:22:30.432598393Z",
                 "type": [
                     "info"
                 ],
@@ -169,7 +169,7 @@
             },
             "message": "waiting for connections on port 27017",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812097795Z",
+                "ingested": "2021-06-18T15:22:30.432599004Z",
                 "type": [
                     "info"
                 ],
@@ -196,7 +196,7 @@
             },
             "message": "end connection 127.0.0.1:55404 (0 connections now open)",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812099461Z",
+                "ingested": "2021-06-18T15:22:30.432599943Z",
                 "type": [
                     "info"
                 ],
@@ -223,7 +223,7 @@
             },
             "message": "connection accepted from 127.0.0.1:55406 #2 (1 connection now open)",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812101148Z",
+                "ingested": "2021-06-18T15:22:30.432600551Z",
                 "type": [
                     "info"
                 ],
@@ -250,7 +250,7 @@
             },
             "message": "now exiting",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812102827Z",
+                "ingested": "2021-06-18T15:22:30.432601205Z",
                 "type": [
                     "info"
                 ],
@@ -277,7 +277,7 @@
             },
             "message": "closing listening socket: 7",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812104511Z",
+                "ingested": "2021-06-18T15:22:30.432601760Z",
                 "type": [
                     "info"
                 ],
@@ -304,7 +304,7 @@
             },
             "message": "removing socket file: /run/mongodb/mongodb-27017.sock",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812106466Z",
+                "ingested": "2021-06-18T15:22:30.432602697Z",
                 "type": [
                     "info"
                 ],
@@ -331,7 +331,7 @@
             },
             "message": "shutdown: going to flush diaglog...",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812108148Z",
+                "ingested": "2021-06-18T15:22:30.432603367Z",
                 "type": [
                     "info"
                 ],
@@ -358,7 +358,7 @@
             },
             "message": "shutdown: going to close sockets...",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812109910Z",
+                "ingested": "2021-06-18T15:22:30.432603900Z",
                 "type": [
                     "info"
                 ],
@@ -385,7 +385,7 @@
             },
             "message": "shutdown: removing fs lock...",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812111624Z",
+                "ingested": "2021-06-18T15:22:30.432604488Z",
                 "type": [
                     "info"
                 ],
@@ -412,7 +412,7 @@
             },
             "message": "db version v3.2.11",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812113280Z",
+                "ingested": "2021-06-18T15:22:30.432605366Z",
                 "type": [
                     "info"
                 ],
@@ -439,7 +439,7 @@
             },
             "message": "build environment:",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812115548Z",
+                "ingested": "2021-06-18T15:22:30.432606201Z",
                 "type": [
                     "info"
                 ],
@@ -466,7 +466,7 @@
             },
             "message": "distarch: x86_64",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812118348Z",
+                "ingested": "2021-06-18T15:22:30.432606898Z",
                 "type": [
                     "info"
                 ],
@@ -493,7 +493,7 @@
             },
             "message": "options: { config: \"/etc/mongodb.conf\", net: { bindIp: \"127.0.0.1\", unixDomainSocket: { pathPrefix: \"/run/mongodb\" } }, storage: { dbPath: \"/var/lib/mongodb\", journal: { enabled: true } }, systemLog: { destination: \"file\", logAppend: true, path: \"/var/log/mongodb/mongodb.log\" } }",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812120999Z",
+                "ingested": "2021-06-18T15:22:30.432607686Z",
                 "type": [
                     "info"
                 ],
@@ -520,7 +520,7 @@
             },
             "message": "connection accepted from 127.0.0.1:55404 #1 (1 connection now open)",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812123109Z",
+                "ingested": "2021-06-18T15:22:30.432608484Z",
                 "type": [
                     "info"
                 ],
@@ -547,7 +547,7 @@
             },
             "message": "end connection 127.0.0.1:55414 (0 connections now open)",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812124846Z",
+                "ingested": "2021-06-18T15:22:30.432609299Z",
                 "type": [
                     "info"
                 ],
@@ -574,7 +574,7 @@
             },
             "message": "end connection 127.0.0.1:58336 (0 connections now open)",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812126591Z",
+                "ingested": "2021-06-18T15:22:30.432609754Z",
                 "type": [
                     "info"
                 ],
@@ -601,7 +601,7 @@
             },
             "message": "shutdown: going to close listening sockets...",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812128346Z",
+                "ingested": "2021-06-18T15:22:30.432610173Z",
                 "type": [
                     "info"
                 ],
@@ -628,7 +628,7 @@
             },
             "message": "WiredTigerKVEngine shutting down",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812130151Z",
+                "ingested": "2021-06-18T15:22:30.432610963Z",
                 "type": [
                     "info"
                 ],
@@ -655,7 +655,7 @@
             },
             "message": "dbexit:  rc: 0",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812131856Z",
+                "ingested": "2021-06-18T15:22:30.432611394Z",
                 "type": [
                     "info"
                 ],
@@ -682,7 +682,7 @@
             },
             "message": "MongoDB starting : pid=29803 port=27017 dbpath=/var/lib/mongodb 64-bit host=sleipnir",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812133558Z",
+                "ingested": "2021-06-18T15:22:30.432611811Z",
                 "type": [
                     "info"
                 ],
@@ -709,7 +709,7 @@
             },
             "message": "allocator: tcmalloc",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812135229Z",
+                "ingested": "2021-06-18T15:22:30.432612238Z",
                 "type": [
                     "info"
                 ],
@@ -736,7 +736,7 @@
             },
             "message": "target_arch: x86_64",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812136905Z",
+                "ingested": "2021-06-18T15:22:30.432612660Z",
                 "type": [
                     "info"
                 ],
@@ -763,7 +763,7 @@
             },
             "message": "end connection 127.0.0.1:55406 (0 connections now open)",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812138594Z",
+                "ingested": "2021-06-18T15:22:30.432613079Z",
                 "type": [
                     "info"
                 ],
@@ -790,7 +790,7 @@
             },
             "message": "connection accepted from 127.0.0.1:55414 #3 (1 connection now open)",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812140354Z",
+                "ingested": "2021-06-18T15:22:30.432613501Z",
                 "type": [
                     "info"
                 ],
@@ -817,7 +817,7 @@
             },
             "message": "connection accepted from 127.0.0.1:58336 #4 (1 connection now open)",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812142074Z",
+                "ingested": "2021-06-18T15:22:30.432613928Z",
                 "type": [
                     "info"
                 ],
@@ -844,7 +844,7 @@
             },
             "message": "got signal 15 (Terminated), will terminate after current cmd ends",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812143769Z",
+                "ingested": "2021-06-18T15:22:30.432614414Z",
                 "type": [
                     "info"
                 ],
@@ -871,7 +871,7 @@
             },
             "message": "Shutting down full-time diagnostic data capture",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812145497Z",
+                "ingested": "2021-06-18T15:22:30.432614891Z",
                 "type": [
                     "info"
                 ],
@@ -898,7 +898,7 @@
             },
             "message": "closing listening socket: 6",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812147163Z",
+                "ingested": "2021-06-18T15:22:30.432615311Z",
                 "type": [
                     "info"
                 ],
@@ -925,7 +925,7 @@
             },
             "message": "Successfully connected to dbbox7:27017, took 10ms (1 connections now open to dbbox7:27017)",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812148999Z",
+                "ingested": "2021-06-18T15:22:30.432615931Z",
                 "type": [
                     "info"
                 ],
@@ -952,7 +952,7 @@
             },
             "message": "** ERROR: A write operation resulted in an error. E11000 duplicate key error index: test.people.$_id_ dup key: { : 0 }",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812150688Z",
+                "ingested": "2021-06-18T15:22:30.432616348Z",
                 "type": [
                     "change",
                     "error"
@@ -980,7 +980,7 @@
             },
             "message": "** ERROR: No connection could be made because the target machine actively refused it 127.0.0.1:27017 at System.Net.Sockets.Socket.EndConnect",
             "event": {
-                "ingested": "2021-06-17T09:12:47.812152429Z",
+                "ingested": "2021-06-18T15:22:30.432616766Z",
                 "type": [
                     "info",
                     "error"

--- a/packages/mongodb/data_stream/log/_dev/test/pipeline/test-mongodb-ubuntu-4-4-4.log-expected.json
+++ b/packages/mongodb/data_stream/log/_dev/test/pipeline/test-mongodb-ubuntu-4-4-4.log-expected.json
@@ -6,7 +6,7 @@
                 "level": "I"
             },
             "event": {
-                "ingested": "2021-06-17T09:12:48.524854135Z",
+                "ingested": "2021-06-18T15:22:30.892272700Z",
                 "original": "{\"t\":{\"$date\":\"2021-03-22T21:21:20.349+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":4615611, \"ctx\":\"initandlisten\",\"msg\":\"MongoDB starting\",\"attr\":{\"pid\":1,\"port\":27017,\"dbPath\":\"/data/db\",\"architecture\":\"64-bit\",\"host\":\"6150fe65a89c\"}}",
                 "type": [
                     "info"
@@ -22,7 +22,14 @@
                 "log": {
                     "context": "initandlisten",
                     "component": "STORAGE",
-                    "id": 4615611
+                    "id": 4615611,
+                    "attr": {
+                        "host": "6150fe65a89c",
+                        "pid": 1,
+                        "dbPath": "/data/db",
+                        "port": 27017,
+                        "architecture": "64-bit"
+                    }
                 }
             },
             "tags": [
@@ -35,7 +42,7 @@
                 "level": "I"
             },
             "event": {
-                "ingested": "2021-06-17T09:12:48.524861128Z",
+                "ingested": "2021-06-18T15:22:30.892275764Z",
                 "original": "{\"t\":{\"$date\":\"2021-03-22T21:21:20.350+00:00\"},\"s\":\"I\",  \"c\":\"CONTROL\",  \"id\":23403,   \"ctx\":\"initandlisten\",\"msg\":\"Build Info\",\"attr\":{\"buildInfo\":{\"version\":\"4.4.4\",\"gitVersion\":\"8db30a63db1a9d84bdcad0c83369623f708e0397\",\"openSSLVersion\":\"OpenSSL 1.1.1  11 Sep 2018\",\"modules\":[],\"allocator\":\"tcmalloc\",\"environment\":{\"distmod\":\"ubuntu1804\",\"distarch\":\"x86_64\",\"target_arch\":\"x86_64\"}}}}",
                 "type": [
                     "info"
@@ -51,7 +58,21 @@
                 "log": {
                     "context": "initandlisten",
                     "component": "CONTROL",
-                    "id": 23403
+                    "id": 23403,
+                    "attr": {
+                        "buildInfo": {
+                            "openSSLVersion": "OpenSSL 1.1.1  11 Sep 2018",
+                            "gitVersion": "8db30a63db1a9d84bdcad0c83369623f708e0397",
+                            "environment": {
+                                "distarch": "x86_64",
+                                "distmod": "ubuntu1804",
+                                "target_arch": "x86_64"
+                            },
+                            "allocator": "tcmalloc",
+                            "version": "4.4.4",
+                            "modules": []
+                        }
+                    }
                 }
             },
             "tags": [
@@ -64,7 +85,7 @@
                 "level": "I"
             },
             "event": {
-                "ingested": "2021-06-17T09:12:48.524885169Z",
+                "ingested": "2021-06-18T15:22:30.892276323Z",
                 "original": "{\"t\":{\"$date\":\"2021-03-22T21:21:26.240+00:00\"},\"s\":\"I\",  \"c\":\"RECOVERY\", \"id\":23987,   \"ctx\":\"initandlisten\",\"msg\":\"WiredTiger recoveryTimestamp\",\"attr\":{\"recoveryTimestamp\":{\"$timestamp\":{\"t\":0,\"i\":0}}}}",
                 "type": [
                     "info"
@@ -80,7 +101,15 @@
                 "log": {
                     "context": "initandlisten",
                     "component": "RECOVERY",
-                    "id": 23987
+                    "id": 23987,
+                    "attr": {
+                        "recoveryTimestamp": {
+                            "$timestamp": {
+                                "t": 0,
+                                "i": 0
+                            }
+                        }
+                    }
                 }
             },
             "tags": [
@@ -93,7 +122,7 @@
                 "level": "I"
             },
             "event": {
-                "ingested": "2021-06-17T09:12:48.524888351Z",
+                "ingested": "2021-06-18T15:22:30.892276804Z",
                 "original": "{\"t\":{\"$date\":\"2021-03-22T21:21:26.363+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":20320,   \"ctx\":\"initandlisten\",\"msg\":\"createCollection\",\"attr\":{\"namespace\":\"admin.system.version\",\"uuidDisposition\":\"provided\",\"uuid\":{\"uuid\":{\"$uuid\":\"b383f03c-b97c-4584-87ae-ab1b8ea399c3\"}},\"options\":{\"uuid\":{\"$uuid\":\"b383f03c-b97c-4584-87ae-ab1b8ea399c3\"}}}}",
                 "type": [
                     "info"
@@ -109,7 +138,21 @@
                 "log": {
                     "context": "initandlisten",
                     "component": "STORAGE",
-                    "id": 20320
+                    "id": 20320,
+                    "attr": {
+                        "namespace": "admin.system.version",
+                        "options": {
+                            "uuid": {
+                                "$uuid": "b383f03c-b97c-4584-87ae-ab1b8ea399c3"
+                            }
+                        },
+                        "uuidDisposition": "provided",
+                        "uuid": {
+                            "uuid": {
+                                "$uuid": "b383f03c-b97c-4584-87ae-ab1b8ea399c3"
+                            }
+                        }
+                    }
                 }
             },
             "tags": [
@@ -122,7 +165,7 @@
                 "level": "I"
             },
             "event": {
-                "ingested": "2021-06-17T09:12:48.524891317Z",
+                "ingested": "2021-06-18T15:22:30.892277263Z",
                 "original": "{\"t\":{\"$date\":\"2021-03-22T21:21:26.410+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"initandlisten\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"namespace\":\"admin.system.version\",\"index\":\"_id_\",\"commitTimestamp\":{\"$timestamp\":{\"t\":0,\"i\":0}}}}",
                 "type": [
                     "info"
@@ -138,7 +181,18 @@
                 "log": {
                     "context": "initandlisten",
                     "component": "INDEX",
-                    "id": 20345
+                    "id": 20345,
+                    "attr": {
+                        "namespace": "admin.system.version",
+                        "index": "_id_",
+                        "commitTimestamp": {
+                            "$timestamp": {
+                                "t": 0,
+                                "i": 0
+                            }
+                        },
+                        "buildUUID": null
+                    }
                 }
             },
             "tags": [
@@ -151,7 +205,7 @@
                 "level": "I"
             },
             "event": {
-                "ingested": "2021-06-17T09:12:48.524894043Z",
+                "ingested": "2021-06-18T15:22:30.892277720Z",
                 "original": "{\"t\":{\"$date\":\"2021-03-22T21:21:26.412+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":20459,   \"ctx\":\"initandlisten\",\"msg\":\"Setting featureCompatibilityVersion\",\"attr\":{\"newVersion\":\"4.4\"}}",
                 "type": [
                     "info"
@@ -167,7 +221,10 @@
                 "log": {
                     "context": "initandlisten",
                     "component": "COMMAND",
-                    "id": 20459
+                    "id": 20459,
+                    "attr": {
+                        "newVersion": "4.4"
+                    }
                 }
             },
             "tags": [
@@ -180,7 +237,7 @@
                 "level": "I"
             },
             "event": {
-                "ingested": "2021-06-17T09:12:48.524896808Z",
+                "ingested": "2021-06-18T15:22:30.892278173Z",
                 "original": "{\"t\":{\"$date\":\"2021-03-22T21:21:26.451+00:00\"},\"s\":\"I\",  \"c\":\"FTDC\",     \"id\":20625,   \"ctx\":\"initandlisten\",\"msg\":\"Initializing full-time diagnostic data capture\",\"attr\":{\"dataDirectory\":\"/data/db/diagnostic.data\"}}",
                 "type": [
                     "info"
@@ -196,7 +253,10 @@
                 "log": {
                     "context": "initandlisten",
                     "component": "FTDC",
-                    "id": 20625
+                    "id": 20625,
+                    "attr": {
+                        "dataDirectory": "/data/db/diagnostic.data"
+                    }
                 }
             },
             "tags": [

--- a/packages/mongodb/data_stream/log/elasticsearch/ingest_pipeline/pipeline-json.yml
+++ b/packages/mongodb/data_stream/log/elasticsearch/ingest_pipeline/pipeline-json.yml
@@ -43,7 +43,6 @@ processors:
 - remove:
     field:
       - mongodb.log.t
-      - mongodb.log.attr
       - mongodb.log.tags
       - mongodb.log.truncated
       - mongodb.log.size

--- a/packages/mongodb/data_stream/log/fields/fields.yml
+++ b/packages/mongodb/data_stream/log/fields/fields.yml
@@ -14,3 +14,7 @@
         Integer representing the unique identifier of the log statement
       example: 4615611
       type: long
+    - name: attr
+      description: |
+        Attributes related to the log message.
+      type: flattened

--- a/packages/mongodb/docs/README.md
+++ b/packages/mongodb/docs/README.md
@@ -85,6 +85,7 @@ The `log` dataset collects the MongoDB logs.
 | log.file.path | Full path to the log file this event came from, including the file name. | keyword |
 | log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
+| mongodb.log.attr | Attributes related to the log message. | flattened |
 | mongodb.log.component | Functional categorization of message | keyword |
 | mongodb.log.context | Context of message | keyword |
 | mongodb.log.id | Integer representing the unique identifier of the log statement | long |


### PR DESCRIPTION
## What does this PR do?

Store the structured attributes included in JSON logs, using the `flattened` type for that.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Related issues

- JSON logs support added in #1138.
