### PR TITLE
Remove unimplemented "Log Level" parameter from Cisco ASA/FTD

### DIFF
--- a/packages/cisco/changelog.yml
+++ b/packages/cisco/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.9.5"
+  changes:
+    - description: Remove unimplemented "Log Level" parameter from ASA/FTD.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1159
 - version: "0.9.4"
   changes:
     - description: use `wildcard` field type for relevant ECS fields

--- a/packages/cisco/data_stream/asa/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco/data_stream/asa/elasticsearch/ingest_pipeline/default.yml
@@ -61,8 +61,6 @@ processors:
   #
   # This value is read from the EMBLEM header and won't be present if this is not
   # an emblem message (firewalls can be configured to report other kinds of events)
-  # This has no effect unless var.log_level is above 7 (default) to filter some
-  # messages.
   - set:
       field: event.severity
       value: 7

--- a/packages/cisco/data_stream/asa/manifest.yml
+++ b/packages/cisco/data_stream/asa/manifest.yml
@@ -30,13 +30,6 @@ streams:
         required: true
         show_user: true
         default: 9001
-      - name: log_level
-        type: integer
-        title: Log Level
-        multi: false
-        required: true
-        show_user: false
-        default: 7
       - name: preserve_original_event
         required: true
         show_user: true
@@ -76,13 +69,6 @@ streams:
         default:
           - cisco-asa
           - forwarded
-      - name: log_level
-        type: integer
-        title: Log Level
-        multi: false
-        required: true
-        show_user: false
-        default: 7
       - name: preserve_original_event
         required: true
         show_user: true

--- a/packages/cisco/data_stream/ftd/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco/data_stream/ftd/elasticsearch/ingest_pipeline/default.yml
@@ -61,8 +61,6 @@ processors:
   #
   # This value is read from the EMBLEM header and won't be present if this is not
   # an emblem message (firewalls can be configured to report other kinds of events)
-  # This has no effect unless var.log_level is above 7 (default) to filter some
-  # messages.
   - set:
       field: event.severity
       value: 7

--- a/packages/cisco/data_stream/ftd/manifest.yml
+++ b/packages/cisco/data_stream/ftd/manifest.yml
@@ -30,13 +30,6 @@ streams:
         required: true
         show_user: true
         default: 9003
-      - name: log_level
-        type: integer
-        title: Log Level
-        multi: false
-        required: true
-        show_user: false
-        default: 7
       - name: preserve_original_event
         required: true
         show_user: true
@@ -76,13 +69,6 @@ streams:
         default:
           - cisco-ftd
           - forwarded
-      - name: log_level
-        type: integer
-        title: Log Level
-        multi: false
-        required: true
-        show_user: false
-        default: 7
       - name: preserve_original_event
         required: true
         show_user: true

--- a/packages/cisco/manifest.yml
+++ b/packages/cisco/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco
 title: Cisco
-version: 0.9.4
+version: 0.9.5
 license: basic
 description: Cisco Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?

This removes the log level config option. I recommend configuring the device to
only send the log level you want (e.g. `logging trap <severity>`).

When these data streams were ported over from Beats they had a log_level
parameter, but that was never implemented for Fleet because it required a mutable
Ingest Node pipeline in order to inject the level into the pipeline.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.

## Related issues

- Closes #799
