### PR TITLE
[suricata] Use wildcard type

### DIFF
--- a/packages/suricata/changelog.yml
+++ b/packages/suricata/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.3"
+  changes:
+    - description: Use `wildcard` field type.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1162
 - version: "0.6.2"
   changes:
     - description: Modify event.original and update ECS version to 1.10.0

--- a/packages/suricata/data_stream/eve/fields/ecs.yml
+++ b/packages/suricata/data_stream/eve/fields/ecs.yml
@@ -193,7 +193,7 @@
       ignore_above: 1024
     - name: original
       level: extended
-      type: keyword
+      type: wildcard
       description: |-
         Unmodified original url as seen in the event source.
         Note that in network monitoring, the observed URL may be a full URL, whereas in access logs, the URL is often just represented as a path.

--- a/packages/suricata/docs/README.md
+++ b/packages/suricata/docs/README.md
@@ -341,7 +341,7 @@ with other versions of Suricata.
 | tls.version | Numeric part of the version parsed from the original string. | keyword |
 | tls.version_protocol | Normalized lowercase protocol name parsed from original string. | keyword |
 | url.domain | Domain of the url, such as "www.elastic.co". In some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `domain` field. | keyword |
-| url.original | Unmodified original url as seen in the event source. Note that in network monitoring, the observed URL may be a full URL, whereas in access logs, the URL is often just represented as a path. This field is meant to represent the URL as it was observed, complete or not. | keyword |
+| url.original | Unmodified original url as seen in the event source. Note that in network monitoring, the observed URL may be a full URL, whereas in access logs, the URL is often just represented as a path. This field is meant to represent the URL as it was observed, complete or not. | wildcard |
 | url.path | Path of the request, such as "/search". | keyword |
 | url.query | The query field describes the query string of the request, such as "q=elasticsearch". | keyword |
 | user_agent.device.name | Name of the device. | keyword |

--- a/packages/suricata/manifest.yml
+++ b/packages/suricata/manifest.yml
@@ -1,6 +1,6 @@
 name: suricata
 title: Suricata
-version: 0.6.2
+version: 0.6.3
 release: experimental
 description: Suricata Integration
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->
Uses `wildcard` field type instead of `keyword` for relevant ECS fields.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~
