### PR TITLE
[system] Use wildcard type for security stream

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.13.4"
+  changes:
+    - description: Use `wildcard` type for relevant ECS fields in `security` stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1185
 - version: "0.13.3"
   changes:
     - description: Fix unneeded unit and metric type for field groups

--- a/packages/system/data_stream/security/fields/ecs.yml
+++ b/packages/system/data_stream/security/fields/ecs.yml
@@ -82,7 +82,7 @@
       description: 'Length of the process.args array.'
       default_field: false
     - name: command_line
-      type: keyword
+      type: wildcard
       ignore_above: 1024
       multi_fields:
         - name: text

--- a/packages/system/docs/README.md
+++ b/packages/system/docs/README.md
@@ -538,7 +538,7 @@ An example event for `security` looks as following:
 | log.level | Original log level of the log event. | keyword |
 | process.args | Array of process arguments, starting with the absolute path to the executable. | keyword |
 | process.args_count | Length of the process.args array. | long |
-| process.command_line | Full command line that started the process, including the absolute path to the executable, and all arguments. | keyword |
+| process.command_line | Full command line that started the process, including the absolute path to the executable, and all arguments. | wildcard |
 | process.entity_id | Unique identifier for the process. | keyword |
 | process.executable | Absolute path to the process executable. | keyword |
 | process.name | Process name. | keyword |

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 0.13.3
+version: 0.13.4
 license: basic
 description: System Integration
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Uses wildcard field type in the relevant ECS fields of the security stream

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~
