### PR TITLE
Fix bug in Third Party REST API ingest pipeline

### DIFF
--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.7.1"
+  changes:
+    - description: Fix bug in Third Party REST API ingest pipeline
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1201
 - version: "0.7.0"
   changes:
     - description: Update to ECS 1.10.0 and adding items that all packages should have

--- a/packages/apache/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apache/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -1,60 +1,15 @@
 ---
 description: "Pipeline for parsing Apache HTTP Server access logs. Requires the geoip and user_agent plugins."
-
 processors:
+  - pipeline:
+      if: ctx.message.startsWith('{')
+      name: '{{ IngestPipeline "third-party" }}'
   - set:
       field: event.ingested
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
       value: '1.10.0'
-   # Splunk specific parsing start
-  - set:
-      field: _temp_.isSplunk
-      value: true
-      if: ctx.message.startsWith('{')
-  - json:
-      field: message
-      target_field: json
-      if: ctx._temp_?.isSplunk == true
-  - drop:
-      if: 'ctx._temp_?.isSplunk == true && ctx.json?.result == null'
-  - fingerprint:
-      fields: 
-        - json.result._cd
-        - json.result._indextime
-        - json.result._raw
-        - json.result._time
-        - json.result.host
-        - json.result.source
-      target_field: '_id'
-      if: 'ctx._temp_?.isSplunk == true && ctx?.json?.result != null'
-  - remove:
-      field: message
-      ignore_missing: true
-      if: ctx._temp_?.isSplunk == true
-  - rename:
-      field: json.result._raw
-      target_field: message
-      ignore_missing: true
-      if: ctx._temp_?.isSplunk == true
-  - rename:
-      field: json.result.host
-      target_field: host.name
-      ignore_missing: true
-      if: ctx._temp_?.isSplunk == true
-  - rename:
-      field: json.result.source
-      target_field: file.path
-      ignore_missing: true
-      if: ctx._temp_?.isSplunk == true
-  - remove:
-      field: 
-        - json
-        - _temp_
-      ignore_missing: true
-      if: ctx._temp_?.isSplunk == 1
-# Splunk specific parsing end
   - rename:
       field: message
       target_field: event.original

--- a/packages/apache/data_stream/access/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/apache/data_stream/access/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,42 @@
+---
+description: Pipeline for parsing Apache HTTP Server logs from third party api
+processors:
+  - json:
+      field: message
+      target_field: json
+  - drop:
+      if: ctx.json?.result == null
+  - fingerprint:
+      fields:
+        - json.result._cd
+        - json.result._indextime
+        - json.result._raw
+        - json.result._time
+        - json.result.host
+        - json.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      copy_from: json.result._raw
+      field: message
+      ignore_empty_value: true
+  - set:
+      copy_from: json.result.host
+      field: host.name
+      ignore_empty_value: true
+  - set:
+      copy_from: json.result.source
+      field: file.path
+      ignore_empty_value: true
+  - remove:
+      field:
+        - json
+      ignore_missing: true
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third-party pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/apache/data_stream/error/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apache/data_stream/error/elasticsearch/ingest_pipeline/default.yml
@@ -1,59 +1,15 @@
 ---
 description: Pipeline for parsing apache error logs
 processors:
+  - pipeline:
+      if: ctx.message.startsWith('{')
+      name: '{{ IngestPipeline "third-party" }}'
   - set:
       field: event.ingested
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
       value: "1.10.0"
-  # Splunk specific parsing start
-  - set:
-      field: _temp_.isSplunk
-      value: true
-      if: ctx.message.startsWith('{')
-  - json:
-      field: message
-      target_field: json
-      if: ctx._temp_?.isSplunk == true
-  - drop:
-      if: 'ctx._temp_?.isSplunk == true && ctx.json?.result == null'
-  - fingerprint:
-      fields: 
-        - json.result._cd
-        - json.result._indextime
-        - json.result._raw
-        - json.result._time
-        - json.result.host
-        - json.result.source
-      target_field: '_id'
-      if: 'ctx._temp_?.isSplunk == true && ctx?.json?.result != null'
-  - remove:
-      field: message
-      ignore_missing: true
-      if: ctx._temp_?.isSplunk == true
-  - rename:
-      field: json.result._raw
-      target_field: message
-      ignore_missing: true
-      if: ctx._temp_?.isSplunk == true
-  - rename:
-      field: json.result.host
-      target_field: host.name
-      ignore_missing: true
-      if: ctx._temp_?.isSplunk == true
-  - rename:
-      field: json.result.source
-      target_field: file.path
-      ignore_missing: true
-      if: ctx._temp_?.isSplunk == true
-  - remove:
-      field: 
-        - json
-        - _temp_
-      ignore_missing: true
-      if: ctx._temp_?.isSplunk == 1
-  # Splunk specific parsing end
   - rename:
       field: message
       target_field: event.original

--- a/packages/apache/data_stream/error/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/apache/data_stream/error/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,42 @@
+---
+description: Pipeline for parsing Apache HTTP Server logs from third party api
+processors:
+  - json:
+      field: message
+      target_field: json
+  - drop:
+      if: ctx.json?.result == null
+  - fingerprint:
+      fields:
+        - json.result._cd
+        - json.result._indextime
+        - json.result._raw
+        - json.result._time
+        - json.result.host
+        - json.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      copy_from: json.result._raw
+      field: message
+      ignore_empty_value: true
+  - set:
+      copy_from: json.result.host
+      field: host.name
+      ignore_empty_value: true
+  - set:
+      copy_from: json.result.source
+      field: file.path
+      ignore_empty_value: true
+  - remove:
+      field:
+        - json
+      ignore_missing: true
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third-party pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: apache
 title: Apache
-version: 0.7.0
+version: 0.7.1
 license: basic
 description: Apache Integration
 type: integration

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.3"
+  changes:
+    - description: Fix bug in Third Party ingest pipeline
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1201
 - version: "0.6.2"
   changes:
     - description: Removed incorrect `http.request.referrer` field from elb logs

--- a/packages/aws/data_stream/cloudtrail/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/cloudtrail/elasticsearch/ingest_pipeline/default.yml
@@ -1,53 +1,21 @@
 ---
 description: Pipeline for AWS CloudTrail Logs
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: json
+  - pipeline:
+      if: ctx?.json?.preview != null
+      name: '{{ IngestPipeline "third-party" }}'
   - set:
       field: event.ingested
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
       value: '1.10.0'
-  - rename:
-      field: message
-      target_field: event.original
-      ignore_missing: true
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  #Splunk specific parsing start
-  - drop:
-      if: 'ctx._temp_?.json?.result == null && ctx._temp_?.json?.preview != null'
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-      target_field: '_id'
-      if: 'ctx._temp_?.json?.result != null && ctx._temp_?.json?.preview != null'
-  - remove:
-      field: event.original
-      if: ctx._temp_?.json?.result?._raw != null
-  - rename:
-      field: _temp_.json.result._raw
-      target_field: event.original
-      ignore_missing: true
-      if: ctx._temp_?.json?.result?._raw != null
-  - json:
-      field: event.original
-      target_field: json
-      if: ctx._temp_?.json?.result?._raw != null
-  # Rename if this is not splunk data
-  - rename:
-      field: _temp_.json
-      target_field: json
-      ignore_missing: true
-      if: ctx._temp_?.json?.result?._raw == null
-  - remove:
-      field: 
-        - _temp_
-      ignore_missing: true
-  #Splunk specific parsing end
   - date:
       field: json.eventTime
       target_field: "@timestamp"

--- a/packages/aws/data_stream/cloudtrail/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/aws/data_stream/cloudtrail/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,32 @@
+---
+description: Pipeline for parsing CloudTrail logs from third party api
+processors:
+  - drop:
+      if: ctx?.json?._raw == null
+      description: JSON doesn't have CloudTrail data
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: json.result._raw
+      ignore_empty_value: true
+  - remove:
+      field: json
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: json
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 0.6.2
+version: 0.6.3
 license: basic
 description: AWS Integration
 type: integration

--- a/packages/nginx/changelog.yml
+++ b/packages/nginx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.1"
+  changes:
+    - description: Fix bug in Third Party REST API ingest pipeline
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1201
 - version: "0.6.0"
   changes:
     - description: update to ECS 1.10.0 and add event.original options

--- a/packages/nginx/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nginx/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -2,59 +2,15 @@
 description: Pipeline for parsing Nginx access logs. Requires the geoip and user_agent
   plugins.
 processors:
+  - pipeline:
+      if: ctx.message.startsWith('{')
+      name: '{{ IngestPipeline "third-party" }}'
   - set:
       field: event.ingested
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
       value: "1.10.0"
- # Splunk specific parsing start
-  - set:
-      field: _temp_.isSplunk
-      value: true
-      if: ctx.message.startsWith('{')
-  - json:
-      field: message
-      target_field: json
-      if: ctx._temp_?.isSplunk == true
-  - drop:
-      if: 'ctx._temp_?.isSplunk == true && ctx.json?.result == null'
-  - fingerprint:
-      fields: 
-        - json.result._cd
-        - json.result._indextime
-        - json.result._raw
-        - json.result._time
-        - json.result.host
-        - json.result.source
-      target_field: '_id'
-      if: 'ctx._temp_?.isSplunk == true && ctx?.json?.result != null'
-  - remove:
-      field: message
-      ignore_missing: true
-      if: ctx._temp_?.isSplunk == true
-  - rename:
-      field: json.result._raw
-      target_field: message
-      ignore_missing: true
-      if: ctx._temp_?.isSplunk == true
-  - rename:
-      field: json.result.host
-      target_field: host.name
-      ignore_missing: true
-      if: ctx._temp_?.isSplunk == true
-  - rename:
-      field: json.result.source
-      target_field: file.path
-      ignore_missing: true
-      if: ctx._temp_?.isSplunk == true
-  - remove:
-      field: 
-        - json
-        - _temp_
-      ignore_missing: true
-      if: ctx._temp_?.isSplunk == 1
-  # Splunk specific parsing end
   - rename:
       field: message
       target_field: event.original

--- a/packages/nginx/data_stream/access/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/nginx/data_stream/access/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,42 @@
+---
+description: Pipeline for parsing nginx logs from third party api
+processors:
+  - json:
+      field: message
+      target_field: json
+  - drop:
+      if: ctx.json?.result == null
+  - fingerprint:
+      fields:
+        - json.result._cd
+        - json.result._indextime
+        - json.result._raw
+        - json.result._time
+        - json.result.host
+        - json.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      copy_from: json.result._raw
+      field: message
+      ignore_empty_value: true
+  - set:
+      copy_from: json.result.host
+      field: host.name
+      ignore_empty_value: true
+  - set:
+      copy_from: json.result.source
+      field: file.path
+      ignore_empty_value: true
+  - remove:
+      field:
+        - json
+      ignore_missing: true
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third-party pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/nginx/data_stream/error/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nginx/data_stream/error/elasticsearch/ingest_pipeline/default.yml
@@ -1,59 +1,15 @@
 ---
 description: Pipeline for parsing the Nginx error logs
 processors:
+  - pipeline:
+      if: ctx.message.startsWith('{')
+      name: '{{ IngestPipeline "third-party" }}'
   - set:
       field: event.ingested
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
       value: "1.10.0"
- # Splunk specific parsing start
-  - set:
-      field: _temp_.isSplunk
-      value: true
-      if: ctx.message.startsWith('{')
-  - json:
-      field: message
-      target_field: json
-      if: ctx._temp_?.isSplunk == true
-  - drop:
-      if: 'ctx._temp_?.isSplunk == true && ctx.json?.result == null'
-  - fingerprint:
-      fields: 
-        - json.result._cd
-        - json.result._indextime
-        - json.result._raw
-        - json.result._time
-        - json.result.host
-        - json.result.source
-      target_field: '_id'
-      if: 'ctx._temp_?.isSplunk == true && ctx?.json?.result != null'
-  - remove:
-      field: message
-      ignore_missing: true
-      if: ctx._temp_?.isSplunk == true
-  - rename:
-      field: json.result._raw
-      target_field: message
-      ignore_missing: true
-      if: ctx._temp_?.isSplunk == true
-  - rename:
-      field: json.result.host
-      target_field: host.name
-      ignore_missing: true
-      if: ctx._temp_?.isSplunk == true
-  - rename:
-      field: json.result.source
-      target_field: file.path
-      ignore_missing: true
-      if: ctx._temp_?.isSplunk == true
-  - remove:
-      field: 
-        - json
-        - _temp_
-      ignore_missing: true
-      if: ctx._temp_?.isSplunk == 1
-  # Splunk specific parsing end
   - rename:
       field: message
       target_field: event.original

--- a/packages/nginx/data_stream/error/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/nginx/data_stream/error/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,42 @@
+---
+description: Pipeline for parsing nginx logs from third party api
+processors:
+  - json:
+      field: message
+      target_field: json
+  - drop:
+      if: ctx.json?.result == null
+  - fingerprint:
+      fields:
+        - json.result._cd
+        - json.result._indextime
+        - json.result._raw
+        - json.result._time
+        - json.result.host
+        - json.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      copy_from: json.result._raw
+      field: message
+      ignore_empty_value: true
+  - set:
+      copy_from: json.result.host
+      field: host.name
+      ignore_empty_value: true
+  - set:
+      copy_from: json.result.source
+      field: file.path
+      ignore_empty_value: true
+  - remove:
+      field:
+        - json
+      ignore_missing: true
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third-party pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: nginx
 title: Nginx
-version: 0.6.0
+version: 0.6.1
 license: basic
 description: Nginx Integration
 type: integration

--- a/packages/zeek/changelog.yml
+++ b/packages/zeek/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.8.3"
+  changes:
+    - description: Fix Third Party Api ingest pipeline
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1201
 - version: "0.8.2"
   changes:
     - description: Use `wildcard` field type.

--- a/packages/zeek/data_stream/capture_loss/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/capture_loss/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek capture_loss.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      target_field: zeek.capture_loss
+      field: _temp_
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -11,53 +26,6 @@ processors:
   - set:
       field: ecs.version
       value: '1.10.0'
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.capture_loss
-      ignore_failure: true
   - date:
       field: zeek.capture_loss.ts
       formats:
@@ -76,8 +44,6 @@ processors:
   - remove:
       field: 
         - zeek.capture_loss.ts
-        - message
-        - json
       ignore_missing: true
   - remove:
       field: event.original

--- a/packages/zeek/data_stream/capture_loss/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/capture_loss/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/connection/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/connection/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,22 @@
 ---
 description: Pipeline for normalizing Zeek conn.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.connection
+      ignore_failure: true
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -17,53 +33,6 @@ processors:
   - set:
       field: event.category
       value: network
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.connection
-      ignore_failure: true
   - dot_expander:
       path: zeek.connection
       field: id.orig_p

--- a/packages/zeek/data_stream/connection/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/connection/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/dce_rpc/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/dce_rpc/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek dce_rpc.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.dce_rpc
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -32,54 +47,6 @@ processors:
   - set:
       field: network.protocol
       value: dce_rpc
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.dce_rpc
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.dce_rpc
       field: id.orig_p
@@ -191,8 +158,6 @@ processors:
       target_field: network.community_id
   - remove:
       field: 
-        - message
-        - json
         - zeek.dce_rpc.id
       ignore_missing: true
   - remove:

--- a/packages/zeek/data_stream/dce_rpc/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/dce_rpc/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/dhcp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/dhcp/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek dhcp.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.dhcp
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -32,54 +47,6 @@ processors:
   - set:
       field: network.protocol
       value: dhcp
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.dhcp
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - rename:
       field: zeek.dhcp.uids
       target_field: zeek.session_id
@@ -211,11 +178,6 @@ processors:
       allow_duplicates: false
   - community_id:
       target_field: network.community_id
-  - remove:
-      field: 
-        - message
-        - json
-      ignore_missing: true
   - remove:
       field: event.original
       if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"

--- a/packages/zeek/data_stream/dhcp/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/dhcp/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/dnp3/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/dnp3/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek dnp3.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.dnp3
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -32,54 +47,6 @@ processors:
   - set:
       field: network.protocol
       value: dnp3
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.dnp3
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.dnp3
       field: id.orig_p
@@ -210,8 +177,6 @@ processors:
       target_field: network.community_id
   - remove:
       field: 
-        - message
-        - json
         - zeek.dnp3.id
       ignore_missing: true
   - remove:

--- a/packages/zeek/data_stream/dnp3/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/dnp3/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for Filebeat Zeek dns.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.dns
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -29,54 +44,6 @@ processors:
   - set:
       field: network.protocol
       value: dns
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.dns
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.dns
       field: id.orig_p
@@ -319,12 +286,10 @@ processors:
       if: ctx?.event?.original == null
   - remove:
       field: 
-        - json
         - zeek.dns.Z
         - zeek.dns.auth
         - zeek.dns.addl
         - zeek.dns.id
-        - message
       ignore_missing: true
   - remove:
       field: event.original

--- a/packages/zeek/data_stream/dns/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/dns/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/dpd/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/dpd/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek dpd.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.dpd
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -23,54 +38,6 @@ processors:
   - append:
       field: event.type
       value: info
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.dpd
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.dpd
       field: id.orig_p
@@ -184,8 +151,6 @@ processors:
       target_field: network.community_id
   - remove:
       field: 
-        - message
-        - json
         - zeek.dpd.id
       ignore_missing: true
   - remove:

--- a/packages/zeek/data_stream/dpd/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/dpd/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/files/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/files/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek files.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.files
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -20,54 +35,6 @@ processors:
   - append:
       field: event.type
       value: info
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.files
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - rename:
       field: zeek.files.conn_uids
       target_field: zeek.files.session_ids
@@ -159,8 +126,6 @@ processors:
       allow_duplicates: false
   - remove:
       field: 
-        - message
-        - json
         - zeek.files.x509
       ignore_missing: true
   - remove:

--- a/packages/zeek/data_stream/files/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/files/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/ftp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/ftp/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek ftp.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.ftp
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -32,54 +47,6 @@ processors:
   - set:
       field: network.protocol
       value: ftp
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.ftp
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.ftp
       field: id.orig_p
@@ -255,8 +222,6 @@ processors:
       target_field: network.community_id
   - remove:
       field: 
-        - message
-        - json
         - zeek.ftp.id
       ignore_missing: true
   - remove:

--- a/packages/zeek/data_stream/ftp/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/ftp/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/http/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/http/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek http.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.http
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -32,54 +47,6 @@ processors:
   - set:
       field: network.transport
       value: tcp
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.http
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.http
       field: id.orig_p
@@ -266,8 +233,6 @@ processors:
       target_field: network.community_id
   - remove:
       field: 
-        - message
-        - json
         - zeek.http.id
       ignore_missing: true
   - remove:

--- a/packages/zeek/data_stream/http/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/http/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/intel/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/intel/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek intel.log.
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.intel
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -20,54 +35,6 @@ processors:
   - append:
       field: event.type
       value: indicator
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.intel
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.intel
       field: id.orig_p
@@ -239,8 +206,6 @@ processors:
       if: ctx?.event?.original == null
   - remove:
       field:
-        - message
-        - json
         - zeek.intel.id
       ignore_missing: true
   - remove:

--- a/packages/zeek/data_stream/intel/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/intel/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/irc/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/irc/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek irc.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.irc
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -32,54 +47,6 @@ processors:
   - set:
       field: network.protocol
       value: irc
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.irc
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.irc
       field: id.orig_p
@@ -212,8 +179,6 @@ processors:
       target_field: network.community_id
   - remove:
       field: 
-        - message
-        - json
         - zeek.irc.id
       ignore_missing: true
   - remove:

--- a/packages/zeek/data_stream/irc/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/irc/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/kerberos/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/kerberos/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek kerberos.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.kerberos
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -32,54 +47,6 @@ processors:
   - set:
       field: network.protocol
       value: kerberos
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.kerberos
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.kerberos
       field: id.orig_p

--- a/packages/zeek/data_stream/kerberos/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/kerberos/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/modbus/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/modbus/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek modbus.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.modbus
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -29,54 +44,6 @@ processors:
   - set:
       field: network.protocol
       value: modbus
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.modbus
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.modbus
       field: id.orig_p
@@ -202,8 +169,6 @@ processors:
       target_field: network.community_id
   - remove:
       field: 
-        - message
-        - json
         - zeek.modbus.id
       ignore_missing: true
   - remove:

--- a/packages/zeek/data_stream/modbus/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/modbus/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/mysql/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/mysql/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek mysql.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.mysql
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -32,54 +47,6 @@ processors:
   - set:
       field: network.protocol
       value: mysql
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.mysql
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.mysql
       field: id.orig_p
@@ -225,8 +192,6 @@ processors:
       target_field: network.community_id
   - remove:
       field: 
-        - message
-        - json
         - zeek.mysql.id
       ignore_missing: true
   - remove:

--- a/packages/zeek/data_stream/mysql/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/mysql/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/notice/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/notice/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek notice.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.notice
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -20,54 +35,6 @@ processors:
   - append:
       field: event.type
       value: info
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.notice
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.notice
       field: id.orig_p
@@ -292,8 +259,6 @@ processors:
       target_field: network.community_id
   - remove:
       field: 
-        - message
-        - json
         - zeek.notice.action
         - zeek.notice.remote_location
         - zeek.notice.f

--- a/packages/zeek/data_stream/notice/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/notice/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/ntlm/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/ntlm/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek ntlm.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.ntlm
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -32,54 +47,6 @@ processors:
   - set:
       field: network.protocol
       value: ntlm
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.ntlm
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.ntlm
       field: id.orig_p

--- a/packages/zeek/data_stream/ntlm/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/ntlm/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/ocsp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/ocsp/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek ocsp.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.ocsp
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -17,54 +32,6 @@ processors:
   - set:
       field: network.transport
       value: tcp
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.ocsp
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - rename:
       field: zeek.ocsp.id
       target_field: zeek.ocsp.file_id
@@ -143,11 +110,6 @@ processors:
       value: "{{zeek.ocsp.issuerKeyHash}}"
       if: "ctx?.zeek?.ocsp?.issuerKeyHash != null"
       allow_duplicates: false
-  - remove:
-      field: 
-        - message
-        - json
-      ignore_missing: true
   - remove:
       field: event.original
       if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"

--- a/packages/zeek/data_stream/ocsp/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/ocsp/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/pe/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/pe/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek pe.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.pe
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -21,54 +36,6 @@ processors:
       field: event.type
       value: info
   - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.pe
-      ignore_failure: true
-      if: ctx?.event?.original != null
-  - rename:
       field: zeek.pe.compile_ts
       target_field: zeek.pe.compile_time
       ignore_missing: true
@@ -86,11 +53,6 @@ processors:
         - UNIX
         - ISO8601
       if: ctx.zeek.pe.compile_time != null
-  - remove:
-      field: 
-        - message
-        - json
-      ignore_missing: true
   - remove:
       field: event.original
       if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"

--- a/packages/zeek/data_stream/pe/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/pe/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/radius/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/radius/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek radius.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.radius
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -32,54 +47,6 @@ processors:
   - set:
       field: network.protocol
       value: radius
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.radius
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.radius
       field: id.orig_p
@@ -202,8 +169,6 @@ processors:
       target_field: network.community_id
   - remove:
       field: 
-        - message
-        - json
         - zeek.radius.id
       ignore_missing: true
   - remove:

--- a/packages/zeek/data_stream/radius/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/radius/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/rdp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/rdp/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek rdp.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.rdp
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -29,54 +44,6 @@ processors:
   - set:
       field: network.protocol
       value: rdp
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.rdp
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.rdp
       field: id.orig_p
@@ -235,8 +202,6 @@ processors:
       target_field: network.community_id
   - remove:
       field: 
-        - message
-        - json
         - zeek.rdp.id
       ignore_missing: true
   - remove:

--- a/packages/zeek/data_stream/rdp/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/rdp/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/rfb/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/rfb/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek rfb.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.rfb
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -29,54 +44,6 @@ processors:
   - set:
       field: network.protocol
       value: rfb
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.rfb
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.rfb
       field: id.orig_p
@@ -210,8 +177,6 @@ processors:
       target_field: network.community_id
   - remove:
       field: 
-        - message
-        - json
         - zeek.rfb.id
       ignore_missing: true
   - remove:

--- a/packages/zeek/data_stream/rfb/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/rfb/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/sip/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/sip/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek sip.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.sip
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -29,54 +44,6 @@ processors:
   - set:
       field: network.protocol
       value: sip
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.sip
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.sip
       field: id.orig_p
@@ -262,8 +229,6 @@ processors:
       target_field: network.community_id
   - remove:
       field: 
-        - message
-        - json
         - zeek.sip.id
       ignore_missing: true
   - remove:

--- a/packages/zeek/data_stream/sip/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/sip/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/smb_cmd/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/smb_cmd/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek smb_cmd.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.smb_cmd
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -29,54 +44,6 @@ processors:
   - set:
       field: network.protocol
       value: smb
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.smb_cmd
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.smb_cmd
       field: referenced_file.ts
@@ -312,8 +279,6 @@ processors:
       target_field: network.community_id
   - remove:
       field: 
-        - message
-        - json
         - zeek.smb_cmd.id
       ignore_missing: true
   - remove:

--- a/packages/zeek/data_stream/smb_cmd/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/smb_cmd/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/smb_files/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/smb_files/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek smb_files.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.smb_files
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -32,54 +47,6 @@ processors:
   - set:
       field: network.protocol
       value: smb
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.smb_files
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.smb_files
       field: id.orig_p
@@ -278,8 +245,6 @@ processors:
       target_field: network.community_id
   - remove:
       field: 
-        - message
-        - json
         - zeek.smb_files.id
       ignore_missing: true
   - remove:

--- a/packages/zeek/data_stream/smb_files/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/smb_files/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/smb_mapping/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/smb_mapping/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek smb_mapping.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.smb_mapping
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -29,54 +44,6 @@ processors:
   - set:
       field: network.protocol
       value: smb
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.smb_mapping
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.smb_mapping
       field: id.orig_p
@@ -186,8 +153,6 @@ processors:
       target_field: network.community_id
   - remove:
       field: 
-        - message
-        - json
         - zeek.smb_mapping.id
       ignore_missing: true
   - remove:

--- a/packages/zeek/data_stream/smb_mapping/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/smb_mapping/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/smtp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/smtp/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek smtp.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.smtp
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -29,54 +44,6 @@ processors:
   - set:
       field: network.protocol
       value: smtp
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.smtp
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.smtp
       field: id.orig_p
@@ -214,8 +181,6 @@ processors:
       if: 'ctx?.zeek?.smtp?.fuids == null || ctx?.zeek?.smtp?.isEmpty()'
   - remove:
       field: 
-        - message
-        - json
         - zeek.smtp.id
       ignore_missing: true
   - remove:

--- a/packages/zeek/data_stream/smtp/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/smtp/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/snmp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/snmp/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek snmp.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.snmp
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -29,54 +44,6 @@ processors:
   - set:
       field: network.protocol
       value: snmp
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.snmp
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.snmp
       field: id.orig_p
@@ -209,8 +176,6 @@ processors:
       target_field: network.community_id
   - remove:
       field: 
-        - message
-        - json
         - zeek.snmp.id
       ignore_missing: true
   - remove:

--- a/packages/zeek/data_stream/snmp/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/snmp/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/socks/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/socks/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek socks.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.socks
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -29,54 +44,6 @@ processors:
   - set:
       field: network.protocol
       value: socks
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.socks
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.socks
       field: id.orig_p
@@ -226,8 +193,6 @@ processors:
       target_field: network.community_id
   - remove:
       field: 
-        - message
-        - json
         - zeek.socks.id
       ignore_missing: true
   - remove:

--- a/packages/zeek/data_stream/socks/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/socks/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/ssh/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/ssh/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek ssh.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.ssh
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -29,54 +44,6 @@ processors:
   - set:
       field: network.protocol
       value: ssh
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.ssh
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.ssh
       field: id.orig_p
@@ -222,8 +189,6 @@ processors:
       target_field: network.community_id
   - remove:
       field: 
-        - message
-        - json
         - zeek.ssh.id
       ignore_missing: true
   - remove:

--- a/packages/zeek/data_stream/ssh/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/ssh/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/ssl/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/ssl/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek ssl.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.ssl
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -26,54 +41,6 @@ processors:
   - set:
       field: network.transport
       value: tcp
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.ssl
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.ssl
       field: id.orig_p
@@ -525,8 +492,6 @@ processors:
       if: 'ctx?.zeek?.ssl?.client == null || ctx?.zeek?.ssl?.client.isEmpty()'
   - remove:
       field: 
-        - message
-        - json
         - zeek.ssl.id
       ignore_missing: true
   - remove:

--- a/packages/zeek/data_stream/ssl/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/ssl/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/stats/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/stats/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek stats.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.stats
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -14,54 +29,6 @@ processors:
   - set:
       field: ecs.version
       value: '1.10.0'
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.stats
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - rename:
       field: zeek.stats.mem
       target_field: zeek.stats.memory
@@ -168,11 +135,6 @@ processors:
   - set:
       field: event.kind
       value: metric
-  - remove:
-      field: 
-        - message
-        - json
-      ignore_missing: true
   - remove:
       field: event.original
       if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"

--- a/packages/zeek/data_stream/stats/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/stats/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/syslog/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/syslog/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek syslog.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.syslog
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -17,54 +32,6 @@ processors:
   - set:
       field: network.protocol
       value: syslog
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.syslog
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.syslog
       field: id.orig_p
@@ -188,11 +155,6 @@ processors:
       allow_duplicates: false
   - community_id:
       target_field: network.community_id
-  - remove:
-      field: 
-        - message
-        - json
-      ignore_missing: true
   - remove:
       field: event.original
       if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"

--- a/packages/zeek/data_stream/syslog/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/syslog/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/traceroute/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/traceroute/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek traceroute.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.traceroute
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -20,54 +35,6 @@ processors:
   - append:
       field: event.type
       value: info
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.traceroute
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - rename:
       field: zeek.traceroute.src
       target_field: source.address
@@ -150,11 +117,6 @@ processors:
         - zeek.traceroute
       ignore_missing: true
       if: 'ctx?.zeek?.traceroute == null || ctx?.zeek?.traceroute.isEmpty()'
-  - remove:
-      field: 
-        - message
-        - json
-      ignore_missing: true
   - remove:
       field: event.original
       if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"

--- a/packages/zeek/data_stream/traceroute/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/traceroute/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/tunnel/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/tunnel/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek tunnel.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.tunnel
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -20,54 +35,6 @@ processors:
   - append:
       field: event.type
       value: connection
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.tunnel
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.tunnel
       field: id.orig_p
@@ -185,8 +152,6 @@ processors:
       target_field: network.community_id
   - remove:
       field: 
-        - message
-        - json
         - zeek.tunnel.id
       ignore_missing: true
   - remove:

--- a/packages/zeek/data_stream/tunnel/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/tunnel/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/weird/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/weird/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek weird.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.weird
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -20,54 +35,6 @@ processors:
   - append:
       field: event.type
       value: info
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.weird
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.weird
       field: id.orig_p
@@ -183,8 +150,6 @@ processors:
       allow_duplicates: false
   - remove:
       field: 
-        - message
-        - json
         - zeek.weird.id
       ignore_missing: true
   - remove:

--- a/packages/zeek/data_stream/weird/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/weird/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/data_stream/x509/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/x509/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,21 @@
 ---
 description: Pipeline for normalizing Zeek x509.log
 processors:
+  - rename:
+      field: message
+      target_field: event.original
+  - json:
+      field: event.original
+      target_field: _temp_
+  - pipeline:
+      if: ctx?._temp_?.result != null
+      name: '{{ IngestPipeline "third-party" }}'
+  - drop:
+      description: Drop if no timestamp (invalid json)
+      if: 'ctx?._temp_?.ts == null'
+  - rename:
+      field: _temp_
+      target_field: zeek.x509
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"
@@ -17,54 +32,6 @@ processors:
   - append:
       field: event.type
       value: info
-  - rename:
-      field: message
-      target_field: event.original
-  - json:
-      field: event.original
-      target_field: _temp_.json
-  - drop:
-      description: Drop if it is a Splunk event but it is empty.
-      if: 'ctx?._temp_?.json?.result == null && ctx?._temp_?.json?.ts == null' 
-# Splunk specific parsing start
-  - fingerprint:
-      fields: 
-        - _temp_.json.result._cd
-        - _temp_.json.result._indextime
-        - _temp_.json.result._raw
-        - _temp_.json.result._time
-        - _temp_.json.result.host
-        - _temp_.json.result.source
-      target_field: '_id'
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - remove:
-      field: event.original
-      ignore_missing: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: event.original
-      copy_from: _temp_.json.result._raw
-      ignore_empty_value: true
-      ignore_failure: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - set:
-      field: host.name
-      copy_from: _temp_.json.result.host
-      ignore_empty_value: true
-      if: 'ctx?._temp_?.json?.result != null && ctx?._temp_?.json?.ts == null'
-  - rename:
-      field: _temp_.json.result.source
-      target_field: log.file.path
-      ignore_missing: true
-  - remove:
-      field: _temp_
-      ignore_missing: true
-# Splunk parsing end
-  - json:
-      field: event.original
-      target_field: zeek.x509
-      ignore_failure: true
-      if: ctx?.event?.original != null
   - dot_expander:
       path: zeek.x509
       field: certificate.version
@@ -445,11 +412,6 @@ processors:
       field: file.x509.subject.state_or_province
       value: "{{zeek.x509.certificate.subject.state}}"
       ignore_empty_value: true
-  - remove:
-      field: 
-        - message
-        - json
-      ignore_missing: true
   - remove:
       field: event.original
       if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"

--- a/packages/zeek/data_stream/x509/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/x509/elasticsearch/ingest_pipeline/third-party.yml
@@ -1,0 +1,39 @@
+---
+description: Pipeline for parsing Zeek logs from third party api
+processors:
+  - fingerprint:
+      fields:
+        - _temp_.result._cd
+        - _temp_.result._indextime
+        - _temp_.result._raw
+        - _temp_.result._time
+        - _temp_.result.host
+        - _temp_.result.source
+      target_field: '_id'
+      ignore_missing: true
+  - set:
+      field: event.original
+      copy_from: _temp_.result._raw
+      ignore_empty_value: true
+  - set:
+      field: host.name
+      copy_from: _temp_.result.host
+      ignore_empty_value: true
+  - set:
+      copy_from: _temp_.result.source
+      field: log.file.path
+      ignore_empty_value: true
+  - remove:
+      field: _temp_
+      ignore_missing: true
+  - json:
+      field: event.original
+      target_field: _temp_
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        error in third party api pipeline:
+        error in [{{_ingest.on_failure_processor_type}}] processor{{#_ingest.on_failure_processor_tag}}
+        with tag [{{_ingest.on_failure_processor_tag }}]{{/_ingest.on_failure_processor_tag}}
+        {{ _ingest.on_failure_message }}

--- a/packages/zeek/manifest.yml
+++ b/packages/zeek/manifest.yml
@@ -1,6 +1,6 @@
 name: zeek
 title: Zeek
-version: 0.8.2
+version: 0.8.3
 release: beta
 description: Zeek Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?

Fixes bug in Third Party REST API ingest pipelines where a rename of
host.name would fail because it was already set.  Also moves third
party api processing to a separate pipeline.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## How to test this PR locally

need to install Splunk & ingest data into that, then configure these
integrations.  Bug isn't visible with pipeline tests.

## Related issues

- Closes #1146