### PR TITLE
Fix: adjust graceful shutdown of Kind cluster while there is an error

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -189,10 +189,14 @@ def withKubernetes(Closure body) {
         sh(label: "Create kind cluster", script: 'kind create cluster --config ../../kind-config.yaml')
       }
 
-      body()
-
-      if (r == 0) {
-        sh(label: "Delete kind cluster", script: 'kind delete cluster')
+      try {
+        body()
+      } catch(error) {
+        throw error // rethrow error up if there is any, but delete k8s cluster first
+      } finally {
+        if (r == 0) {
+          sh(label: "Delete kind cluster", script: 'kind delete cluster')
+        }
       }
     }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -73,7 +73,7 @@ pipeline {
                           withKubernetes() {
                             withCloudTestEnv() {
                               sh(label: "Test integration: ${it}", script: '''
-                                eval "$(../../build/elastic-BUG stack shellinit)"
+                                eval "$(../../build/elastic-package stack shellinit)"
                                 ../../build/elastic-package test -v --report-format xUnit --report-output file
                                 ''')
                             }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -73,7 +73,7 @@ pipeline {
                           withKubernetes() {
                             withCloudTestEnv() {
                               sh(label: "Test integration: ${it}", script: '''
-                                eval "$(../../build/elastic-package stack shellinit)"
+                                eval "$(../../build/elastic-BUG stack shellinit)"
                                 ../../build/elastic-package test -v --report-format xUnit --report-output file
                                 ''')
                             }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR adjusts graceful shutdown of Kind cluster while there is an error.

## Proof that it works

CI job (failing on purpose): https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fintegrations/detail/PR-1202/1/pipeline/378

Kubernetes task boots the kind cluster, then fails, so the try-catch-finally blocks tears down the cluster first, then Elastic stack. Without this fix, the kind cluster wasn't stopped, so the `elastic-package stack down` failed with "active endpoints error".

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes: https://github.com/elastic/elastic-package/issues/383

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
