### PR TITLE
[Redis] set event.module and event.dataset

### DIFF
--- a/packages/redis/changelog.yml
+++ b/packages/redis/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "0.5.0"
   changes:
-    - description: Set "event.module"
+    - description: Set "event.module" and "event.dataset"
       type: enhancement
       link: https://github.com/elastic/integrations/pull/1224
 - version: "0.4.0"

--- a/packages/redis/changelog.yml
+++ b/packages/redis/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.0"
+  changes:
+    - description: Set "event.module"
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1224
 - version: "0.4.0"
   changes:
     - description: Update ECS to 1.10.0, converting pipeline to yml and adding event.original options

--- a/packages/redis/data_stream/info/fields/base-fields.yml
+++ b/packages/redis/data_stream/info/fields/base-fields.yml
@@ -10,3 +10,7 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: redis

--- a/packages/redis/data_stream/info/fields/base-fields.yml
+++ b/packages/redis/data_stream/info/fields/base-fields.yml
@@ -14,3 +14,7 @@
   type: constant_keyword
   description: Event module
   value: redis
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: redis.info

--- a/packages/redis/data_stream/key/fields/base-fields.yml
+++ b/packages/redis/data_stream/key/fields/base-fields.yml
@@ -10,3 +10,7 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: redis

--- a/packages/redis/data_stream/key/fields/base-fields.yml
+++ b/packages/redis/data_stream/key/fields/base-fields.yml
@@ -14,3 +14,7 @@
   type: constant_keyword
   description: Event module
   value: redis
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: redis.key

--- a/packages/redis/data_stream/keyspace/fields/base-fields.yml
+++ b/packages/redis/data_stream/keyspace/fields/base-fields.yml
@@ -10,3 +10,7 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: redis

--- a/packages/redis/data_stream/keyspace/fields/base-fields.yml
+++ b/packages/redis/data_stream/keyspace/fields/base-fields.yml
@@ -14,3 +14,7 @@
   type: constant_keyword
   description: Event module
   value: redis
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: redis.keyspace

--- a/packages/redis/data_stream/log/fields/base-fields.yml
+++ b/packages/redis/data_stream/log/fields/base-fields.yml
@@ -14,3 +14,7 @@
   type: constant_keyword
   description: Event module
   value: redis
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: redis.log

--- a/packages/redis/data_stream/log/fields/base-fields.yml
+++ b/packages/redis/data_stream/log/fields/base-fields.yml
@@ -10,3 +10,7 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: redis

--- a/packages/redis/data_stream/slowlog/fields/base-fields.yml
+++ b/packages/redis/data_stream/slowlog/fields/base-fields.yml
@@ -10,3 +10,7 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: redis

--- a/packages/redis/data_stream/slowlog/fields/base-fields.yml
+++ b/packages/redis/data_stream/slowlog/fields/base-fields.yml
@@ -14,3 +14,7 @@
   type: constant_keyword
   description: Event module
   value: redis
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: redis.slowlog

--- a/packages/redis/docs/README.md
+++ b/packages/redis/docs/README.md
@@ -40,6 +40,7 @@ The `log` dataset collects the Redis standard logs.
 | ecs.version | ECS version | keyword |
 | error.message | Error message. | text |
 | event.created | Date/time when the event was first read by an agent, or by your pipeline. | date |
+| event.module | Event module | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -91,6 +92,7 @@ The `slowlog` dataset collects the Redis slow logs.
 | ecs.version | ECS version | keyword |
 | error.message | Error message. | text |
 | event.created | Date/time when the event was first read by an agent, or by your pipeline. | date |
+| event.module | Event module | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -331,6 +333,7 @@ An example event for `info` looks as following:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
+| event.module | Event module | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -530,6 +533,7 @@ An example event for `key` looks as following:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
+| event.module | Event module | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -614,6 +618,7 @@ An example event for `keyspace` looks as following:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
+| event.module | Event module | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |

--- a/packages/redis/docs/README.md
+++ b/packages/redis/docs/README.md
@@ -40,6 +40,7 @@ The `log` dataset collects the Redis standard logs.
 | ecs.version | ECS version | keyword |
 | error.message | Error message. | text |
 | event.created | Date/time when the event was first read by an agent, or by your pipeline. | date |
+| event.dataset | Event dataset | constant_keyword |
 | event.module | Event module | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
@@ -92,6 +93,7 @@ The `slowlog` dataset collects the Redis slow logs.
 | ecs.version | ECS version | keyword |
 | error.message | Error message. | text |
 | event.created | Date/time when the event was first read by an agent, or by your pipeline. | date |
+| event.dataset | Event dataset | constant_keyword |
 | event.module | Event module | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
@@ -333,6 +335,7 @@ An example event for `info` looks as following:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
+| event.dataset | Event dataset | constant_keyword |
 | event.module | Event module | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
@@ -458,7 +461,7 @@ An example event for `info` looks as following:
 | redis.info.stats.sync.full | The number of full resyncs with slaves | long |
 | redis.info.stats.sync.partial.err | The number of denied partial resync requests | long |
 | redis.info.stats.sync.partial.ok | The number of accepted partial resync requests | long |
-| service.address | Service address | keyword |
+| service.address | Client address | keyword |
 | service.type | Service type | keyword |
 | service.version | Service version | keyword |
 
@@ -533,6 +536,7 @@ An example event for `key` looks as following:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
+| event.dataset | Event dataset | constant_keyword |
 | event.module | Event module | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
@@ -618,6 +622,7 @@ An example event for `keyspace` looks as following:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
+| event.dataset | Event dataset | constant_keyword |
 | event.module | Event module | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |

--- a/packages/redis/manifest.yml
+++ b/packages/redis/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: redis
 title: Redis
-version: 0.4.0
+version: 0.5.0
 license: basic
 description: Redis Integration
 type: integration
@@ -10,7 +10,7 @@ categories:
   - message_queue
 release: experimental
 conditions:
-  kibana.version: '^7.9.0'
+  kibana.version: '^7.14.0'
 screenshots:
   - src: /img/kibana-redis.png
     title: kibana redis


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR adds `event.module` and `event.dataset` to the integration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
