### PR TITLE
[Nginx Ingress Controller] Set event.module and event.dataset

### DIFF
--- a/packages/nginx_ingress_controller/changelog.yml
+++ b/packages/nginx_ingress_controller/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.0"
+  changes:
+    - description: Set "event.module" and "event.dataset"
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/?
 - version: "0.1.1"
   changes:
     - description: Update ECS version to 1.10.0 and add event.original options

--- a/packages/nginx_ingress_controller/changelog.yml
+++ b/packages/nginx_ingress_controller/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set "event.module" and "event.dataset"
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/?
+      link: https://github.com/elastic/integrations/pull/1226
 - version: "0.1.1"
   changes:
     - description: Update ECS version to 1.10.0 and add event.original options

--- a/packages/nginx_ingress_controller/data_stream/access/fields/base-fields.yml
+++ b/packages/nginx_ingress_controller/data_stream/access/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: nginx_ingress_controller
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: nginx_ingress_controller.access

--- a/packages/nginx_ingress_controller/data_stream/error/fields/base-fields.yml
+++ b/packages/nginx_ingress_controller/data_stream/error/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: nginx_ingress_controller
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: nginx_ingress_controller.error

--- a/packages/nginx_ingress_controller/docs/README.md
+++ b/packages/nginx_ingress_controller/docs/README.md
@@ -113,6 +113,8 @@ An example event for `access` looks as following:
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
 | event.created | Date/time when the event was first read by an agent, or by your pipeline. | date |
+| event.dataset | Event dataset | constant_keyword |
+| event.module | Event module | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -281,6 +283,8 @@ An example event for `error` looks as following:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
+| event.dataset | Event dataset | constant_keyword |
+| event.module | Event module | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |

--- a/packages/nginx_ingress_controller/manifest.yml
+++ b/packages/nginx_ingress_controller/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: nginx_ingress_controller
 title: Nginx Ingress Controller
-version: 0.1.1
+version: 0.2.0
 license: basic
 description: Nginx Ingress Controller Integration
 type: integration
@@ -10,7 +10,7 @@ categories:
   - security
 release: experimental
 conditions:
-  kibana.version: '^7.13.0'
+  kibana.version: '^7.14.0'
 screenshots:
   - src: /img/nginx-ingress-controller-overview.png
     title: Overview dashboard


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR adds `event.module` and `event.dataset` to the integration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

