### PR TITLE
Update elastic-package version for constant_keyword value

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/elastic/elastic-package v0.0.0-20210622092619-841b4f0c70cd
+	github.com/elastic/elastic-package v0.0.0-20210628145313-2278b9ec04a6
 	github.com/elastic/package-registry v0.17.0
 	github.com/magefile/mage v1.11.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,8 @@ github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5m
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
-github.com/elastic/elastic-package v0.0.0-20210622092619-841b4f0c70cd h1:LoTtlqS6rCYdBWTE5apTsmUlC/jhrC/RyFXnxSd1XY4=
-github.com/elastic/elastic-package v0.0.0-20210622092619-841b4f0c70cd/go.mod h1:Qpzfj0Sg2dgbWvbaJr3KbK7/+t8j07cbfyDJKNcpAwM=
+github.com/elastic/elastic-package v0.0.0-20210628145313-2278b9ec04a6 h1:DXKZFnbPT8krp9bs4LYJg9mFz6p5vFjhq6U96+wmpgo=
+github.com/elastic/elastic-package v0.0.0-20210628145313-2278b9ec04a6/go.mod h1:9VEZaZJNSFwkc5FLjRbz0EkV78MxLvYGM3OQ0w1AQz0=
 github.com/elastic/go-elasticsearch/v7 v7.9.0 h1:UEau+a1MiiE/F+UrDj60kqIHFWdzU1M2y/YtBU2NC2M=
 github.com/elastic/go-elasticsearch/v7 v7.9.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/go-licenser v0.3.1/go.mod h1:D8eNQk70FOCVBl3smCGQt/lv7meBeQno2eI1S5apiHQ=
@@ -209,8 +209,8 @@ github.com/elastic/go-ucfg v0.8.4-0.20200415140258-1232bd4774a6 h1:Ehbr7du4rSSEy
 github.com/elastic/go-ucfg v0.8.4-0.20200415140258-1232bd4774a6/go.mod h1:iaiY0NBIYeasNgycLyTvhJftQlQEUO2hpF+FX0JKxzo=
 github.com/elastic/package-registry v0.17.0 h1:Gh7u3TlHA3GJh+C/OZ8Pf4EUrFxcCXMAe2kUCjAiYgQ=
 github.com/elastic/package-registry v0.17.0/go.mod h1:fMVt9ozLSPAIgYTDgV23IZrSoDKZma7VKpA4uSkfPts=
-github.com/elastic/package-spec/code/go v0.0.0-20210622082315-342d612eb2a9 h1:Q6hJeu5XL7C65QIW6OTYYF7ViyedrTfu6QnFW9xppjk=
-github.com/elastic/package-spec/code/go v0.0.0-20210622082315-342d612eb2a9/go.mod h1:t0uvhLQGg3D4iQ5lSQEQs4YYS53MIIS05v0zm0fIBPM=
+github.com/elastic/package-spec/code/go v0.0.0-20210623152222-b358e974b7f9 h1:qvoqy6W/mhBY1t4xxP82oy34VTeF+MEqfVLiIGNBsEs=
+github.com/elastic/package-spec/code/go v0.0.0-20210623152222-b358e974b7f9/go.mod h1:t0uvhLQGg3D4iQ5lSQEQs4YYS53MIIS05v0zm0fIBPM=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=


### PR DESCRIPTION
## What does this PR do?

Update to https://github.com/elastic/elastic-package/commit/2278b9ec04a65488757fde3691126f0d551bb4c5. This adds validation that if a document contains a constant_keyword field that its value must match the declared `value` from the fields definition (if declared).

## Related issues


- Relates https://github.com/elastic/package-spec/pull/194
- Relates https://github.com/elastic/elastic-package/pull/386

