### PR TITLE
[Nats] set event.module and event.dataset

### DIFF
--- a/packages/nats/changelog.yml
+++ b/packages/nats/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set "event.module" and "event.dataset"
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/?
+      link: https://github.com/elastic/integrations/pull/1229
 - version: "0.3.0"
   changes:
     - description: update to ECS 1.10.0 and add event.original options

--- a/packages/nats/changelog.yml
+++ b/packages/nats/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.0"
+  changes:
+    - description: Set "event.module" and "event.dataset"
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/?
 - version: "0.3.0"
   changes:
     - description: update to ECS 1.10.0 and add event.original options

--- a/packages/nats/data_stream/connection/fields/base-fields.yml
+++ b/packages/nats/data_stream/connection/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: nats
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: nats.connection

--- a/packages/nats/data_stream/connections/fields/base-fields.yml
+++ b/packages/nats/data_stream/connections/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: nats
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: nats.connections

--- a/packages/nats/data_stream/log/fields/base-fields.yml
+++ b/packages/nats/data_stream/log/fields/base-fields.yml
@@ -21,3 +21,11 @@
 - name: log.offset
   type: long
   description: Offset of the entry in the log file.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: nats
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: nats.log

--- a/packages/nats/data_stream/route/fields/base-fields.yml
+++ b/packages/nats/data_stream/route/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: nats
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: nats.route

--- a/packages/nats/data_stream/routes/fields/base-fields.yml
+++ b/packages/nats/data_stream/routes/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: nats
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: nats.routes

--- a/packages/nats/data_stream/stats/fields/base-fields.yml
+++ b/packages/nats/data_stream/stats/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: nats
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: nats.stats

--- a/packages/nats/data_stream/subscriptions/fields/base-fields.yml
+++ b/packages/nats/data_stream/subscriptions/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: nats
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: nats.subscriptions

--- a/packages/nats/docs/README.md
+++ b/packages/nats/docs/README.md
@@ -121,7 +121,9 @@ An example event for `log` looks as following:
 | ecs.version | ECS version | keyword |
 | error.message | Error message. | text |
 | event.created | Time when the event was first read by an agent or by your pipeline. | date |
+| event.dataset | Event dataset | constant_keyword |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
+| event.module | Event module | constant_keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
@@ -262,6 +264,8 @@ An example event for `stats` looks as following:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
+| event.dataset | Event dataset | constant_keyword |
+| event.module | Event module | constant_keyword |
 | nats.server.id | The server ID | keyword |
 | nats.server.time | Server time of metric creation | date |
 | nats.stats.cores | The number of logical cores the NATS process runs on | integer |
@@ -370,6 +374,8 @@ An example event for `connections` looks as following:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
+| event.dataset | Event dataset | constant_keyword |
+| event.module | Event module | constant_keyword |
 | nats.connections.total | The number of currently active clients | integer |
 | nats.server.id | The server ID | keyword |
 | nats.server.time | Server time of metric creation | date |
@@ -463,6 +469,8 @@ An example event for `routes` looks as following:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
+| event.dataset | Event dataset | constant_keyword |
+| event.module | Event module | constant_keyword |
 | nats.routes.total | The number of registered routes | integer |
 | nats.server.id | The server ID | keyword |
 | nats.server.time | Server time of metric creation | date |
@@ -563,6 +571,8 @@ An example event for `subscriptions` looks as following:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
+| event.dataset | Event dataset | constant_keyword |
+| event.module | Event module | constant_keyword |
 | nats.server.id | The server ID | keyword |
 | nats.server.time | Server time of metric creation | date |
 | nats.subscriptions.cache.fanout.avg | The average fanout served by cache | double |
@@ -674,6 +684,8 @@ An example event for `connection` looks as following:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
+| event.dataset | Event dataset | constant_keyword |
+| event.module | Event module | constant_keyword |
 | nats.connection.idle_time | The period the connection is idle (sec) | long |
 | nats.connection.in.bytes | The amount of incoming bytes | long |
 | nats.connection.in.messages | The amount of incoming messages | long |
@@ -786,6 +798,8 @@ An example event for `route` looks as following:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
+| event.dataset | Event dataset | constant_keyword |
+| event.module | Event module | constant_keyword |
 | nats.route.in.bytes | The amount of incoming bytes | long |
 | nats.route.in.messages | The amount of incoming messages | long |
 | nats.route.ip | The ip of the route | ip |

--- a/packages/nats/manifest.yml
+++ b/packages/nats/manifest.yml
@@ -1,6 +1,6 @@
 name: nats
 title: NATS
-version: 0.3.0
+version: 0.4.0
 release: experimental
 description: NATS Integration
 type: integration
@@ -14,7 +14,7 @@ license: basic
 categories:
   - message_queue
 conditions:
-  kibana.version: "^7.13.0"
+  kibana.version: "^7.14.0"
 screenshots:
   - src: /img/filebeat_nats_dashboard.png
     title: Filebeat NATS Dashboard


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR adds event.module and event.dataset to the integration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).
