### PR TITLE
[Apache] set event.module and event.dataset

### DIFF
--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set event.module and event.dataset
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/?
+      link: https://github.com/elastic/integrations/pull/1230
 - version: "0.7.1"
   changes:
     - description: Fix bug in Third Party REST API ingest pipeline

--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.8.0"
+  changes:
+    - description: Set event.module and event.dataset
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/?
 - version: "0.7.1"
   changes:
     - description: Fix bug in Third Party REST API ingest pipeline

--- a/packages/apache/data_stream/access/fields/base-fields.yml
+++ b/packages/apache/data_stream/access/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: apache
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: apache.access

--- a/packages/apache/data_stream/error/fields/base-fields.yml
+++ b/packages/apache/data_stream/error/fields/base-fields.yml
@@ -15,3 +15,11 @@
   example: '["production", "env2"]'
   ignore_above: 1024
   type: keyword
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: apache
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: apache.error

--- a/packages/apache/data_stream/status/fields/base-fields.yml
+++ b/packages/apache/data_stream/status/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: apache
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: apache.status

--- a/packages/apache/docs/README.md
+++ b/packages/apache/docs/README.md
@@ -42,7 +42,9 @@ Access logs collects the Apache access logs.
 | error.message | Error message. | text |  |  |
 | event.category | Event category. This contains high-level information about the contents of the event. It is more generic than `event.action`, in the sense that typically a category contains multiple actions. Warning: In future versions of ECS, we plan to provide a list of acceptable values for this field, please use with caution. | keyword |  |  |
 | event.created | event.created contains the date/time when the event was first read by an agent, or by your pipeline. This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event. In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source. In case the two timestamps are identical, @timestamp should be used. | date |  |  |
+| event.dataset | Event dataset | constant_keyword |  |  |
 | event.kind | The kind of the event. This gives information about what type of information the event contains, without being specific to the contents of the event.  Examples are `event`, `state`, `alarm`. Warning: In future versions of ECS, we plan to provide a list of acceptable values for this field, please use with caution. | keyword |  |  |
+| event.module | Event module | constant_keyword |  |  |
 | event.outcome | The outcome of the event. If the event describes an action, this fields contains the outcome of that action. Examples outcomes are `success` and `failure`. Warning: In future versions of ECS, we plan to provide a list of acceptable values for this field, please use with caution. | keyword |  |  |
 | file.path | Full path to the file, including the file name. It should include the drive letter, when appropriate. | keyword |  |  |
 | host.architecture | Operating system architecture. | keyword |  |  |
@@ -133,7 +135,9 @@ Error logs collects the Apache error logs.
 | ecs.version | ECS version | keyword |  |  |
 | error.message | Error message. | text |  |  |
 | event.category | Event category. This contains high-level information about the contents of the event. It is more generic than `event.action`, in the sense that typically a category contains multiple actions. Warning: In future versions of ECS, we plan to provide a list of acceptable values for this field, please use with caution. | keyword |  |  |
+| event.dataset | Event dataset | constant_keyword |  |  |
 | event.kind | The kind of the event. This gives information about what type of information the event contains, without being specific to the contents of the event.  Examples are `event`, `state`, `alarm`. Warning: In future versions of ECS, we plan to provide a list of acceptable values for this field, please use with caution. | keyword |  |  |
+| event.module | Event module | constant_keyword |  |  |
 | event.timezone | This field should be populated when the event's timestamp does not include timezone information already (e.g. default Syslog timestamps). It's optional otherwise. Acceptable timezone formats are: a canonical ID (e.g. "Europe/Amsterdam"), abbreviated (e.g. "EST") or an HH:mm differential (e.g. "-05:00"). | keyword |  |  |
 | event.type | Reserved for future usage. Please avoid using this field for user data. | keyword |  |  |
 | file.path | Full path to the file, including the file name. It should include the drive letter, when appropriate. | keyword |  |  |
@@ -359,6 +363,8 @@ An example event for `status` looks as following:
 | data_stream.type | Data stream type. | constant_keyword |  |  |
 | ecs.version | ECS version | keyword |  |  |
 | error.message | Error message. | text |  |  |
+| event.dataset | Event dataset | constant_keyword |  |  |
+| event.module | Event module | constant_keyword |  |  |
 | host.architecture | Operating system architecture. | keyword |  |  |
 | host.containerized | If the host is a container. | boolean |  |  |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: apache
 title: Apache
-version: 0.7.1
+version: 0.8.0
 license: basic
 description: Apache Integration
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR adds event.module and event.dataset to the integration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).
