### PR TITLE
[Docker] set event.module and event.dataset

### DIFF
--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Set "event.module" and "event.dataset"
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/?
 - version: "0.2.1"
   changes:
     - description: Fix data types of some fields in the `cpu` data stream

--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set "event.module" and "event.dataset"
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/?
+      link: https://github.com/elastic/integrations/pull/1231
 - version: "0.2.1"
   changes:
     - description: Fix data types of some fields in the `cpu` data stream

--- a/packages/docker/data_stream/container/fields/base-fields.yml
+++ b/packages/docker/data_stream/container/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: docker
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: docker.container

--- a/packages/docker/data_stream/cpu/fields/base-fields.yml
+++ b/packages/docker/data_stream/cpu/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: docker
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: docker.cpu

--- a/packages/docker/data_stream/diskio/fields/base-fields.yml
+++ b/packages/docker/data_stream/diskio/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: docker
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: docker.diskio

--- a/packages/docker/data_stream/event/fields/base-fields.yml
+++ b/packages/docker/data_stream/event/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: docker
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: docker.event

--- a/packages/docker/data_stream/event/sample_event.json
+++ b/packages/docker/data_stream/event/sample_event.json
@@ -20,7 +20,7 @@
         }
     },
     "event": {
-        "dataset": "event",
+        "dataset": "docker.event",
         "module": "docker"
     },
     "service": {

--- a/packages/docker/data_stream/healthcheck/fields/base-fields.yml
+++ b/packages/docker/data_stream/healthcheck/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: docker
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: docker.healthcheck

--- a/packages/docker/data_stream/image/fields/base-fields.yml
+++ b/packages/docker/data_stream/image/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: docker
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: docker.image

--- a/packages/docker/data_stream/info/fields/base-fields.yml
+++ b/packages/docker/data_stream/info/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: docker
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: docker.info

--- a/packages/docker/data_stream/memory/fields/base-fields.yml
+++ b/packages/docker/data_stream/memory/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: docker
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: docker.memory

--- a/packages/docker/data_stream/network/fields/base-fields.yml
+++ b/packages/docker/data_stream/network/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: docker
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: docker.network

--- a/packages/docker/docs/README.md
+++ b/packages/docker/docs/README.md
@@ -498,7 +498,7 @@ An example event for `event` looks as following:
         }
     },
     "event": {
-        "dataset": "event",
+        "dataset": "docker.event",
         "module": "docker"
     },
     "service": {

--- a/packages/docker/docs/README.md
+++ b/packages/docker/docs/README.md
@@ -58,6 +58,8 @@ running Docker containers.
 | docker.container.status | Container status. | keyword |  |
 | docker.container.tags | Image tags. | keyword |  |
 | ecs.version | ECS version | keyword |  |
+| event.dataset | Event dataset | constant_keyword |  |
+| event.module | Event module | constant_keyword |  |
 | host.architecture | Operating system architecture. | keyword |  |
 | host.ip | Host ip address. | ip |  |
 | host.mac | Host mac address. | keyword |  |
@@ -169,6 +171,8 @@ The Docker `cpu` data stream collects runtime CPU metrics.
 | docker.cpu.user.pct | Percentage of time in user space. | scaled_float | percent | gauge |
 | docker.cpu.user.ticks | CPU ticks in user space. | long |  | counter |
 | ecs.version | ECS version | keyword |  |  |
+| event.dataset | Event dataset | constant_keyword |  |  |
+| event.module | Event module | constant_keyword |  |  |
 | host.architecture | Operating system architecture. | keyword |  |  |
 | host.ip | Host ip address. | ip |  |  |
 | host.mac | Host mac address. | keyword |  |  |
@@ -350,6 +354,8 @@ The Docker `diskio` data stream collects disk I/O metrics.
 | docker.diskio.write.wait_time | Total time requests spent waiting in queues for service, in nanoseconds | long |  | counter |
 | docker.diskio.writes | Number of current writes per second | scaled_float |  | gauge |
 | ecs.version | ECS version | keyword |  |  |
+| event.dataset | Event dataset | constant_keyword |  |  |
+| event.module | Event module | constant_keyword |  |  |
 | host.architecture | Operating system architecture. | keyword |  |  |
 | host.ip | Host ip address. | ip |  |  |
 | host.mac | Host mac address. | keyword |  |  |
@@ -450,6 +456,8 @@ The Docker `event` data stream collects docker events
 | docker.event.status | Event status | keyword |
 | docker.event.type | The type of object emitting the event | keyword |
 | ecs.version | ECS version | keyword |
+| event.dataset | Event dataset | constant_keyword |
+| event.module | Event module | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.ip | Host ip address. | ip |
 | host.mac | Host mac address. | keyword |
@@ -527,6 +535,8 @@ docker `HEALTHCHECK` instruction has been used to build the docker image.
 | docker.healthcheck.failingstreak | concurent failed check | integer | counter |
 | docker.healthcheck.status | Healthcheck status code | keyword |  |
 | ecs.version | ECS version | keyword |  |
+| event.dataset | Event dataset | constant_keyword |  |
+| event.module | Event module | constant_keyword |  |
 | host.architecture | Operating system architecture. | keyword |  |
 | host.ip | Host ip address. | ip |  |
 | host.mac | Host mac address. | keyword |  |
@@ -630,6 +640,8 @@ The Docker `image` data stream collects metrics on docker images
 | docker.image.size.virtual | Size of the image. | long | gauge |
 | docker.image.tags | Image tags. | keyword |  |
 | ecs.version | ECS version | keyword |  |
+| event.dataset | Event dataset | constant_keyword |  |
+| event.module | Event module | constant_keyword |  |
 | host.architecture | Operating system architecture. | keyword |  |
 | host.ip | Host ip address. | ip |  |
 | host.mac | Host mac address. | keyword |  |
@@ -716,6 +728,8 @@ https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/#/display-s
 | docker.info.id | Unique Docker host identifier. | keyword |  |
 | docker.info.images | Total number of existing images. | long | counter |
 | ecs.version | ECS version | keyword |  |
+| event.dataset | Event dataset | constant_keyword |  |
+| event.module | Event module | constant_keyword |  |
 | host.architecture | Operating system architecture. | keyword |  |
 | host.ip | Host ip address. | ip |  |
 | host.mac | Host mac address. | keyword |  |
@@ -793,6 +807,8 @@ The Docker `memory` data stream collects memory metrics from docker.
 | docker.memory.usage.pct | Memory usage percentage. | scaled_float | percent | gauge |
 | docker.memory.usage.total | Total memory usage. | long | byte | gauge |
 | ecs.version | ECS version | keyword |  |  |
+| event.dataset | Event dataset | constant_keyword |  |  |
+| event.module | Event module | constant_keyword |  |  |
 | host.architecture | Operating system architecture. | keyword |  |  |
 | host.ip | Host ip address. | ip |  |  |
 | host.mac | Host mac address. | keyword |  |  |
@@ -923,6 +939,8 @@ The Docker `network` data stream collects network metrics.
 | docker.network.outbound.errors | Total errors on outgoing packets. | long | counter |
 | docker.network.outbound.packets | Total number of outgoing packets. | long | counter |
 | ecs.version | ECS version | keyword |  |
+| event.dataset | Event dataset | constant_keyword |  |
+| event.module | Event module | constant_keyword |  |
 | host.architecture | Operating system architecture. | keyword |  |
 | host.ip | Host ip address. | ip |  |
 | host.mac | Host mac address. | keyword |  |

--- a/packages/docker/manifest.yml
+++ b/packages/docker/manifest.yml
@@ -1,6 +1,6 @@
 name: docker
 title: Docker
-version: 0.2.1
+version: 0.3.0
 release: beta
 description: Docker Integration
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR adds `event.module` and `event.dataset` to the integration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).