### PR TITLE
[HAProxy] set event.module and event.dataset

### DIFF
--- a/packages/haproxy/changelog.yml
+++ b/packages/haproxy/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.0"
+  changes:
+    - description: Set "event.module" and "event.dataset"
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/?
 - version: "0.3.0"
   changes:
     - description: update to ECS 1.10.0 and adding event.original option

--- a/packages/haproxy/changelog.yml
+++ b/packages/haproxy/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set "event.module" and "event.dataset"
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/?
+      link: https://github.com/elastic/integrations/pull/1233
 - version: "0.3.0"
   changes:
     - description: update to ECS 1.10.0 and adding event.original option

--- a/packages/haproxy/data_stream/info/fields/base-fields.yml
+++ b/packages/haproxy/data_stream/info/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: haproxy
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: haproxy.info

--- a/packages/haproxy/data_stream/log/fields/base-fields.yml
+++ b/packages/haproxy/data_stream/log/fields/base-fields.yml
@@ -10,14 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
-- name: input.type
-  description: Type of Filebeat input.
-  type: keyword
-- name: log.file.path
-  description: Full path to the log file this event came from.
-  example: /var/log/example.log
-  ignore_above: 1024
-  type: keyword
-- name: log.offset
-  description: Offset of the entry in the log file.
-  type: long
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: haproxy
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: haproxy.log

--- a/packages/haproxy/data_stream/log/fields/ecs.yml
+++ b/packages/haproxy/data_stream/log/fields/ecs.yml
@@ -248,3 +248,14 @@
       type: keyword
       ignore_above: 1024
       description: Username of the request.
+- name: input.type
+  description: Type of Filebeat input.
+  type: keyword
+- name: log.file.path
+  description: Full path to the log file this event came from.
+  example: /var/log/example.log
+  ignore_above: 1024
+  type: keyword
+- name: log.offset
+  description: Offset of the entry in the log file.
+  type: long

--- a/packages/haproxy/data_stream/stat/fields/base-fields.yml
+++ b/packages/haproxy/data_stream/stat/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: haproxy
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: haproxy.stat

--- a/packages/haproxy/docs/README.md
+++ b/packages/haproxy/docs/README.md
@@ -39,6 +39,8 @@ The `log` dataset collects the HAProxy application logs.
 | destination.ip | IP address of the destination (IPv4 or IPv6). | ip |
 | destination.port | Port of the destination. | long |
 | ecs.version | ECS version | keyword |
+| event.dataset | Event dataset | constant_keyword |
+| event.module | Event module | constant_keyword |
 | haproxy.backend_name | Name of the backend (or listener) which was selected to manage the connection to the server. | keyword |
 | haproxy.backend_queue | Total number of requests which were processed before this one in the backend's global queue. | long |
 | haproxy.bind_name | Name of the listening address which received the connection. | keyword |
@@ -271,6 +273,8 @@ The fields reported are:
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| event.dataset | Event dataset | constant_keyword |
+| event.module | Event module | constant_keyword |
 | haproxy.info.busy_polling | Number of busy polling. | long |
 | haproxy.info.bytes.out.rate | Average bytes output rate. | long |
 | haproxy.info.bytes.out.total | Number of bytes sent out. | long |
@@ -466,6 +470,8 @@ The fields reported are:
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| event.dataset | Event dataset | constant_keyword |
+| event.module | Event module | constant_keyword |
 | haproxy.stat.agent.check.description | Human readable version of check. | keyword |
 | haproxy.stat.agent.check.fall | Fall value of server. | integer |
 | haproxy.stat.agent.check.health | Health parameter of server. Between 0 and `agent.check.rise`+`agent.check.fall`-1. | integer |

--- a/packages/haproxy/manifest.yml
+++ b/packages/haproxy/manifest.yml
@@ -1,6 +1,6 @@
 name: haproxy
 title: HAProxy
-version: 0.3.0
+version: 0.4.0
 description: HAProxy Integration
 type: integration
 icons:
@@ -15,7 +15,7 @@ categories:
   - web
 release: experimental
 conditions:
-  kibana.version: "^7.13.0"
+  kibana.version: "^7.14.0"
 screenshots:
   - src: /img/kibana-haproxy-overview.png
     title: Kibana HAProxy overview


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR adds `event.module` and `event.dataset` to the integration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

