### PR TITLE
[STAN] set event.module and event.dataset

### DIFF
--- a/packages/stan/changelog.yml
+++ b/packages/stan/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set "event.module" and "event.dataset"
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/?
+      link: https://github.com/elastic/integrations/pull/1236
 - version: "0.3.0"
   changes:
     - description: update to ECS 1.10.0 and adding event.original options

--- a/packages/stan/changelog.yml
+++ b/packages/stan/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.0"
+  changes:
+    - description: Set "event.module" and "event.dataset"
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/?
 - version: "0.3.0"
   changes:
     - description: update to ECS 1.10.0 and adding event.original options

--- a/packages/stan/data_stream/channels/fields/base-fields.yml
+++ b/packages/stan/data_stream/channels/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: stan
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: stan.channels

--- a/packages/stan/data_stream/log/fields/base-fields.yml
+++ b/packages/stan/data_stream/log/fields/base-fields.yml
@@ -21,3 +21,11 @@
 - name: log.offset
   type: long
   description: Offset of the entry in the log file.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: stan
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: stan.log

--- a/packages/stan/data_stream/stats/fields/base-fields.yml
+++ b/packages/stan/data_stream/stats/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: stan
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: stan.stats

--- a/packages/stan/data_stream/subscriptions/fields/base-fields.yml
+++ b/packages/stan/data_stream/subscriptions/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: stan
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: stan.subscriptions

--- a/packages/stan/docs/README.md
+++ b/packages/stan/docs/README.md
@@ -124,7 +124,9 @@ An example event for `log` looks as following:
 | ecs.version | ECS version | keyword |
 | error.message | Error message. | text |
 | event.created | Time when the event was first read by an agent or by your pipeline. | date |
+| event.dataset | Event dataset | constant_keyword |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
+| event.module | Event module | constant_keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from. | keyword |
@@ -243,6 +245,8 @@ An example event for `stats` looks as following:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
+| event.dataset | Event dataset | constant_keyword |
+| event.module | Event module | constant_keyword |
 | service.address | Service address | keyword |
 | service.type | Service type | keyword |
 | stan.cluster.id | The cluster ID | keyword |
@@ -349,6 +353,8 @@ An example event for `channels` looks as following:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
+| event.dataset | Event dataset | constant_keyword |
+| event.module | Event module | constant_keyword |
 | service.address | Service address | keyword |
 | service.type | Service type | keyword |
 | stan.channels.bytes | The number of STAN bytes in the channel | long |
@@ -454,6 +460,8 @@ An example event for `subscriptions` looks as following:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
+| event.dataset | Event dataset | constant_keyword |
+| event.module | Event module | constant_keyword |
 | service.address | Service address | keyword |
 | service.type | Service type | keyword |
 | stan.cluster.id | The cluster ID | keyword |

--- a/packages/stan/manifest.yml
+++ b/packages/stan/manifest.yml
@@ -1,6 +1,6 @@
 name: stan
 title: STAN
-version: 0.3.0
+version: 0.4.0
 release: beta
 description: NATS Streaming Integration
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR adds `event.module` and `event.dataset` to the integration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).