### PR TITLE
[Azure] set event.module and event.dataset

### DIFF
--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.0"
+  changes:
+    - description: Set "event.module" and "event.dataset"
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/?
 - version: "0.3.1"
   changes:
     - description: sync package with module changes

--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set "event.module" and "event.dataset"
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/?
+      link: https://github.com/elastic/integrations/pull/1238
 - version: "0.3.1"
   changes:
     - description: sync package with module changes

--- a/packages/azure/data_stream/activitylogs/fields/base-fields.yml
+++ b/packages/azure/data_stream/activitylogs/fields/base-fields.yml
@@ -7,15 +7,14 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
-- name: dataset.type
-  type: constant_keyword
-  description: Dataset type.
-- name: dataset.name
-  type: constant_keyword
-  description: Dataset name.
-- name: dataset.namespace
-  type: constant_keyword
-  description: Dataset namespace.
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: azure
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: azure.activitylogs

--- a/packages/azure/data_stream/auditlogs/fields/base-fields.yml
+++ b/packages/azure/data_stream/auditlogs/fields/base-fields.yml
@@ -7,15 +7,14 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
-- name: dataset.type
-  type: constant_keyword
-  description: Dataset type.
-- name: dataset.name
-  type: constant_keyword
-  description: Dataset name.
-- name: dataset.namespace
-  type: constant_keyword
-  description: Dataset namespace.
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: azure
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: azure.auditlogs

--- a/packages/azure/data_stream/platformlogs/fields/base-fields.yml
+++ b/packages/azure/data_stream/platformlogs/fields/base-fields.yml
@@ -7,15 +7,14 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
-- name: dataset.type
-  type: constant_keyword
-  description: Dataset type.
-- name: dataset.name
-  type: constant_keyword
-  description: Dataset name.
-- name: dataset.namespace
-  type: constant_keyword
-  description: Dataset namespace.
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: azure
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: azure.platformlogs

--- a/packages/azure/data_stream/signinlogs/fields/base-fields.yml
+++ b/packages/azure/data_stream/signinlogs/fields/base-fields.yml
@@ -7,15 +7,14 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
-- name: dataset.type
-  type: constant_keyword
-  description: Dataset type.
-- name: dataset.name
-  type: constant_keyword
-  description: Dataset name.
-- name: dataset.namespace
-  type: constant_keyword
-  description: Dataset namespace.
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: azure
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: azure.signinlogs

--- a/packages/azure/docs/README.md
+++ b/packages/azure/docs/README.md
@@ -201,9 +201,6 @@ An example event for `activitylogs` looks as following:
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
-| dataset.name | Dataset name. | constant_keyword |
-| dataset.namespace | Dataset namespace. | constant_keyword |
-| dataset.type | Dataset type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
 | destination.as.organization.name | Organization name. | keyword |
@@ -222,9 +219,11 @@ An example event for `activitylogs` looks as following:
 | event.action | The action captured by the event. | keyword |
 | event.category | Event category. The second categorization field in the hierarchy. | keyword |
 | event.created | Time when the event was first read by an agent or by your pipeline. | date |
+| event.dataset | Event dataset | constant_keyword |
 | event.id | Unique ID to describe the event. | keyword |
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
+| event.module | Event module | constant_keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
 | file.mime_type | Media type of file, document, or arrangement of bytes. | keyword |
 | file.size | File size in bytes. | long |
@@ -385,9 +384,6 @@ An example event for `platformlogs` looks as following:
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
-| dataset.name | Dataset name. | constant_keyword |
-| dataset.namespace | Dataset namespace. | constant_keyword |
-| dataset.type | Dataset type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
 | destination.as.organization.name | Organization name. | keyword |
@@ -406,9 +402,11 @@ An example event for `platformlogs` looks as following:
 | event.action | The action captured by the event. | keyword |
 | event.category | Event category. The second categorization field in the hierarchy. | keyword |
 | event.created | Time when the event was first read by an agent or by your pipeline. | date |
+| event.dataset | Event dataset | constant_keyword |
 | event.id | Unique ID to describe the event. | keyword |
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
+| event.module | Event module | constant_keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
 | file.mime_type | Media type of file, document, or arrangement of bytes. | keyword |
 | file.size | File size in bytes. | long |
@@ -572,9 +570,6 @@ An example event for `auditlogs` looks as following:
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
-| dataset.name | Dataset name. | constant_keyword |
-| dataset.namespace | Dataset namespace. | constant_keyword |
-| dataset.type | Dataset type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
 | destination.as.organization.name | Organization name. | keyword |
@@ -593,9 +588,11 @@ An example event for `auditlogs` looks as following:
 | event.action | The action captured by the event. | keyword |
 | event.category | Event category. The second categorization field in the hierarchy. | keyword |
 | event.created | Time when the event was first read by an agent or by your pipeline. | date |
+| event.dataset | Event dataset | constant_keyword |
 | event.id | Unique ID to describe the event. | keyword |
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
+| event.module | Event module | constant_keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
 | file.mime_type | Media type of file, document, or arrangement of bytes. | keyword |
 | file.size | File size in bytes. | long |
@@ -775,9 +772,6 @@ An example event for `signinlogs` looks as following:
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
-| dataset.name | Dataset name. | constant_keyword |
-| dataset.namespace | Dataset namespace. | constant_keyword |
-| dataset.type | Dataset type. | constant_keyword |
 | destination.address | Destination network address. | keyword |
 | destination.as.number | Unique number allocated to the autonomous system. | long |
 | destination.as.organization.name | Organization name. | keyword |
@@ -796,9 +790,11 @@ An example event for `signinlogs` looks as following:
 | event.action | The action captured by the event. | keyword |
 | event.category | Event category. The second categorization field in the hierarchy. | keyword |
 | event.created | Time when the event was first read by an agent or by your pipeline. | date |
+| event.dataset | Event dataset | constant_keyword |
 | event.id | Unique ID to describe the event. | keyword |
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
 | event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
+| event.module | Event module | constant_keyword |
 | event.type | Event type. The third categorization field in the hierarchy. | keyword |
 | file.mime_type | Media type of file, document, or arrangement of bytes. | keyword |
 | file.size | File size in bytes. | long |

--- a/packages/azure/manifest.yml
+++ b/packages/azure/manifest.yml
@@ -1,6 +1,6 @@
 name: azure
 title: Azure
-version: 0.3.1
+version: 0.4.0
 release: beta
 description: Azure Integration
 type: integration

--- a/packages/azure/manifest.yml
+++ b/packages/azure/manifest.yml
@@ -17,7 +17,7 @@ categories:
   - network
   - security
 conditions:
-  kibana.version: ^7.9.0
+  kibana.version: ^7.14.0
 screenshots:
   - src: /img/filebeat-azure-overview.png
     title: filebeat azure overview


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR adds `event.module` and `event.dataset` to the integration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

