### PR TITLE
[Linux] set event.module and event.dataset

### DIFF
--- a/packages/linux/changelog.yml
+++ b/packages/linux/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set "event.module" and "event.dataset
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/?
+      link: https://github.com/elastic/integrations/pull/1241
 - version: "0.3.10"
   changes:
     - description: Enable some Linux datastreams by default

--- a/packages/linux/changelog.yml
+++ b/packages/linux/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.0"
+  changes:
+    - description: Set "event.module" and "event.dataset
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/?
 - version: "0.3.10"
   changes:
     - description: Enable some Linux datastreams by default

--- a/packages/linux/data_stream/conntrack/fields/base-fields.yml
+++ b/packages/linux/data_stream/conntrack/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: linux
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: linux.conntrack

--- a/packages/linux/data_stream/entropy/fields/base-fields.yml
+++ b/packages/linux/data_stream/entropy/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: linux
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: linux.entropy

--- a/packages/linux/data_stream/iostat/fields/base-fields.yml
+++ b/packages/linux/data_stream/iostat/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: linux
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: linux.iostat

--- a/packages/linux/data_stream/ksm/fields/base-fields.yml
+++ b/packages/linux/data_stream/ksm/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: linux
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: linux.ksm

--- a/packages/linux/data_stream/memory/fields/base-fields.yml
+++ b/packages/linux/data_stream/memory/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: linux
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: linux.memory

--- a/packages/linux/data_stream/network_summary/fields/base-fields.yml
+++ b/packages/linux/data_stream/network_summary/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: linux
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: linux.network_summary

--- a/packages/linux/data_stream/pageinfo/fields/base-fields.yml
+++ b/packages/linux/data_stream/pageinfo/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: linux
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: linux.pageinfo

--- a/packages/linux/data_stream/raid/fields/base-fields.yml
+++ b/packages/linux/data_stream/raid/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: linux
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: linux.raid

--- a/packages/linux/data_stream/service/fields/base-fields.yml
+++ b/packages/linux/data_stream/service/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: linux
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: linux.service

--- a/packages/linux/data_stream/socket/fields/base-fields.yml
+++ b/packages/linux/data_stream/socket/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: linux
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: linux.socket

--- a/packages/linux/data_stream/users/fields/base-fields.yml
+++ b/packages/linux/data_stream/users/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: linux
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: linux.users

--- a/packages/linux/docs/README.md
+++ b/packages/linux/docs/README.md
@@ -72,6 +72,8 @@ entropy will be out of a total pool size of 4096.
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| event.dataset | Event dataset | constant_keyword |
+| event.module | Event module | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -118,6 +120,8 @@ operating system. These events are global and sorted by protocol.
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| event.dataset | Event dataset | constant_keyword |
+| event.module | Event module | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -170,6 +174,8 @@ This data stream is available on:
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| event.dataset | Event dataset | constant_keyword |
+| event.module | Event module | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -228,6 +234,8 @@ This data stream is available on:
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| event.dataset | Event dataset | constant_keyword |
+| event.module | Event module | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -244,7 +252,7 @@ This data stream is available on:
 | host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| host.type | Type of host. | keyword |
 | process.exit_code | Identifier of the group of processes the process belongs to. | long |
 | process.name | Process name. Sometimes called program name or similar. | keyword |
 | process.pgid | Identifier of the group of processes the process belongs to. | long |
@@ -300,6 +308,8 @@ missing short-lived connections.
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| event.dataset | Event dataset | constant_keyword |
+| event.module | Event module | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -358,6 +368,8 @@ The linux/users data stream reports logged in users and associated sessions via 
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| event.dataset | Event dataset | constant_keyword |
+| event.module | Event module | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |

--- a/packages/linux/manifest.yml
+++ b/packages/linux/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: linux
 title: Linux
-version: 0.3.10
+version: 0.4.0
 license: basic
 description: Linux Integration
 type: integration
@@ -9,7 +9,7 @@ categories:
   - os_system
 release: beta
 conditions:
-  kibana.version: '^7.9.0'
+  kibana.version: '^7.14.0'
 screenshots:
   - src: /img/metricbeat-services-host.png
     title: metricbeat services host


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR adds `event.module` and `event.dataset` to the integration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).
