### PR TITLE
[zookeeper] set event.module and event.dataset

### DIFF
--- a/packages/zookeeper/changelog.yml
+++ b/packages/zookeeper/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set "event.module" and "event.dataset"
       type: enhancement
-      link:
+      link: https://github.com/elastic/integrations/pull/1248
 - version: "0.2.7"
   changes:
     - description: Updating package owner

--- a/packages/zookeeper/changelog.yml
+++ b/packages/zookeeper/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Set "event.module" and "event.dataset"
+      type: enhancement
+      link:
 - version: "0.2.7"
   changes:
     - description: Updating package owner

--- a/packages/zookeeper/data_stream/connection/fields/base-fields.yml
+++ b/packages/zookeeper/data_stream/connection/fields/base-fields.yml
@@ -1,12 +1,11 @@
-- name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
-- name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
-- name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: zookeeper
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: zookeeper.connection

--- a/packages/zookeeper/data_stream/mntr/fields/base-fields.yml
+++ b/packages/zookeeper/data_stream/mntr/fields/base-fields.yml
@@ -1,12 +1,11 @@
-- name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
-- name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
-- name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: zookeeper
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: zookeeper.mntr

--- a/packages/zookeeper/data_stream/server/fields/base-fields.yml
+++ b/packages/zookeeper/data_stream/server/fields/base-fields.yml
@@ -1,12 +1,11 @@
-- name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
-- name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
-- name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: zookeeper
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: zookeeper.server

--- a/packages/zookeeper/docs/README.md
+++ b/packages/zookeeper/docs/README.md
@@ -78,10 +78,9 @@ An example event for `connection` looks as following:
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |
 | container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
+| event.dataset | Event dataset | constant_keyword |
+| event.module | Event module | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -185,10 +184,9 @@ An example event for `mntr` looks as following:
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |
 | container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
+| event.dataset | Event dataset | constant_keyword |
+| event.module | Event module | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -304,10 +302,9 @@ An example event for `server` looks as following:
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |
 | container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
+| event.dataset | Event dataset | constant_keyword |
+| event.module | Event module | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |

--- a/packages/zookeeper/manifest.yml
+++ b/packages/zookeeper/manifest.yml
@@ -1,6 +1,6 @@
 name: zookeeper
 title: ZooKeeper
-version: 0.2.7
+version: 0.3.0
 description: ZooKeeper Integration
 type: integration
 icons:
@@ -15,7 +15,7 @@ categories:
   - config_management
 release: experimental
 conditions:
-  kibana.version: '^7.9.0'
+  kibana.version: '^7.14.0'
 screenshots:
   - src: /img/metricbeat-zookeeper.png
     title: Metricbeat ZooKeeper


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
This PR adds event.module and event.dataset to the integration.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

