### PR TITLE
[prometheus] add event.module and event.dataset

### DIFF
--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.0"
+  changes:
+    - description: Set `module.event` and `module.dataset`
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1249
 - version: "0.3.5"
   changes:
     - description: Updating package owner

--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "0.4.0"
   changes:
-    - description: Set `module.event` and `module.dataset`
+    - description: Set `event.module` and `event.dataset`
       type: enhancement
       link: https://github.com/elastic/integrations/pull/1249
 - version: "0.3.5"

--- a/packages/prometheus/data_stream/collector/fields/base-fields.yml
+++ b/packages/prometheus/data_stream/collector/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module.
+  value: prometheus
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset.
+  value: prometheus.collector

--- a/packages/prometheus/data_stream/query/fields/base-fields.yml
+++ b/packages/prometheus/data_stream/query/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module.
+  value: prometheus
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset.
+  value: prometheus.query

--- a/packages/prometheus/data_stream/remote_write/fields/base-fields.yml
+++ b/packages/prometheus/data_stream/remote_write/fields/base-fields.yml
@@ -10,3 +10,11 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module.
+  value: prometheus
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset.
+  value: prometheus.remote_write

--- a/packages/prometheus/docs/README.md
+++ b/packages/prometheus/docs/README.md
@@ -187,6 +187,8 @@ The fields reported are:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
+| event.dataset | Event dataset. | constant_keyword |
+| event.module | Event module. | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -336,6 +338,8 @@ The fields reported are:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
+| event.dataset | Event dataset. | constant_keyword |
+| event.module | Event module. | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -542,6 +546,8 @@ The fields reported are:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
+| event.dataset | Event dataset. | constant_keyword |
+| event.module | Event module. | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -10,7 +10,7 @@ categories:
   - datastore
 release: experimental
 conditions:
-  kibana.version: "^7.10.0"
+  kibana.version: "^7.14.0"
 screenshots:
   - src: /img/metricbeat-prometheus-overview.png
     title: Metricbeat Prometheus Overview

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: prometheus
 title: Prometheus
-version: 0.3.5
+version: 0.4.0
 license: basic
 description: Prometheus Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?

Add `event.module` and `event.dataset` to all data streams in prometheus package.

From changes discussed in https://github.com/elastic/security-team/issues/780

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

I didn't run `elastic-package test` as I'm still setting up all the required environment.
