### PR TITLE
Fix: add missing data_stream fields

### DIFF
--- a/packages/zookeeper/changelog.yml
+++ b/packages/zookeeper/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Add missing data_stream fields
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1248
 - version: "0.3.0"
   changes:
     - description: Set "event.module" and "event.dataset"

--- a/packages/zookeeper/data_stream/connection/fields/base-fields.yml
+++ b/packages/zookeeper/data_stream/connection/fields/base-fields.yml
@@ -1,3 +1,12 @@
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.
 - name: '@timestamp'
   type: date
   description: Event timestamp.

--- a/packages/zookeeper/data_stream/mntr/fields/base-fields.yml
+++ b/packages/zookeeper/data_stream/mntr/fields/base-fields.yml
@@ -1,3 +1,12 @@
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.
 - name: '@timestamp'
   type: date
   description: Event timestamp.

--- a/packages/zookeeper/data_stream/server/fields/base-fields.yml
+++ b/packages/zookeeper/data_stream/server/fields/base-fields.yml
@@ -1,3 +1,12 @@
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.
 - name: '@timestamp'
   type: date
   description: Event timestamp.

--- a/packages/zookeeper/docs/README.md
+++ b/packages/zookeeper/docs/README.md
@@ -78,6 +78,9 @@ An example event for `connection` looks as following:
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |
 | container.name | Container name. | keyword |
+| data_stream.dataset | Data stream dataset. | constant_keyword |
+| data_stream.namespace | Data stream namespace. | constant_keyword |
+| data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
 | event.dataset | Event dataset | constant_keyword |
 | event.module | Event module | constant_keyword |
@@ -184,6 +187,9 @@ An example event for `mntr` looks as following:
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |
 | container.name | Container name. | keyword |
+| data_stream.dataset | Data stream dataset. | constant_keyword |
+| data_stream.namespace | Data stream namespace. | constant_keyword |
+| data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
 | event.dataset | Event dataset | constant_keyword |
 | event.module | Event module | constant_keyword |
@@ -302,6 +308,9 @@ An example event for `server` looks as following:
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |
 | container.name | Container name. | keyword |
+| data_stream.dataset | Data stream dataset. | constant_keyword |
+| data_stream.namespace | Data stream namespace. | constant_keyword |
+| data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version | keyword |
 | event.dataset | Event dataset | constant_keyword |
 | event.module | Event module | constant_keyword |

--- a/packages/zookeeper/manifest.yml
+++ b/packages/zookeeper/manifest.yml
@@ -1,6 +1,6 @@
 name: zookeeper
 title: ZooKeeper
-version: 0.3.0
+version: 0.3.1
 description: ZooKeeper Integration
 type: integration
 icons:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR brings back `data_stream` fields removed in previous PR: https://github.com/elastic/integrations/pull/1248 .

Spotted in: https://github.com/elastic/package-storage/pull/1517

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

