### PR TITLE
[barracuda] Set event.module and event.dataset

### DIFF
--- a/packages/barracuda/changelog.yml
+++ b/packages/barracuda/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.0"
+  changes:
+    - description: Set "event.module" and "event.dataset"
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1252
 - version: "0.3.0"
   changes:
     - description: update to ECS 1.10.0 and add event.original options

--- a/packages/barracuda/data_stream/spamfirewall/fields/base-fields.yml
+++ b/packages/barracuda/data_stream/spamfirewall/fields/base-fields.yml
@@ -7,6 +7,14 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: barracuda
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: barracuda.spamfirewall
 - name: '@timestamp'
   type: date
   description: Event timestamp.

--- a/packages/barracuda/data_stream/waf/fields/base-fields.yml
+++ b/packages/barracuda/data_stream/waf/fields/base-fields.yml
@@ -7,6 +7,14 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: barracuda
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: barracuda.waf
 - name: '@timestamp'
   type: date
   description: Event timestamp.

--- a/packages/barracuda/manifest.yml
+++ b/packages/barracuda/manifest.yml
@@ -1,14 +1,14 @@
 format_version: 1.0.0
 name: barracuda
 title: Barracuda
-version: 0.3.0
+version: 0.4.0
 description: Barracuda Integration
 categories: ["network", "security"]
 release: experimental
 license: basic
 type: integration
 conditions:
-  kibana.version: "^7.10.0"
+  kibana.version: "^7.14.0"
 policy_templates:
   - name: barracuda
     title: Barracuda logs


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Sets event.module and event.dataset

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).
