### PR TITLE
[osquery] Set event.module and event.dataset

### DIFF
--- a/packages/osquery/changelog.yml
+++ b/packages/osquery/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.0"
+  changes:
+    - description: Set "event.module" and "event.dataset"
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1270
 - version: "0.3.0"
   changes:
     - description: Bump ECS version, add custom processors and make `event.original` optional.

--- a/packages/osquery/data_stream/result/fields/base-fields.yml
+++ b/packages/osquery/data_stream/result/fields/base-fields.yml
@@ -7,6 +7,14 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: osquery
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: osquery.result
 - name: '@timestamp'
   type: date
   description: Event timestamp.

--- a/packages/osquery/data_stream/result/fields/ecs.yml
+++ b/packages/osquery/data_stream/result/fields/ecs.yml
@@ -14,11 +14,6 @@
   group: 2
   type: group
   fields:
-    - name: dataset
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the dataset."
     - name: ingested
       level: core
       type: date

--- a/packages/osquery/docs/README.md
+++ b/packages/osquery/docs/README.md
@@ -154,8 +154,9 @@ An example event for `result` looks as following:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version this event conforms to. | keyword |
-| event.dataset | Name of the dataset. | keyword |
+| event.dataset | Event dataset | constant_keyword |
 | event.ingested | Timestamp when an event arrived in the central data store. | date |
+| event.module | Event module | constant_keyword |
 | file.accessed | Last time the file was accessed. | date |
 | file.created | File creation time. | date |
 | file.directory | Directory where the file is located. It should include the drive letter, when appropriate. | keyword |

--- a/packages/osquery/manifest.yml
+++ b/packages/osquery/manifest.yml
@@ -1,6 +1,6 @@
 name: osquery
 title: Osquery Log Collection
-version: 0.3.0
+version: 0.4.0
 release: experimental
 description: Osquery Log Collection
 type: integration
@@ -15,7 +15,7 @@ categories:
   - security
   - os_system
 conditions:
-  kibana.version: ^7.11.0
+  kibana.version: ^7.14.0
 screenshots:
   - src: /img/kibana-osquery-compatibility.png
     title: kibana osquery compatibility


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->
Sets event.module and event.dataset

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).
