### PR TITLE
ga system module

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0"
+  changes:
+    - description: GA the system module
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1282
 - version: "0.13.6"
   changes:
     - description: Use event.dataset and event.module

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 0.13.6
+version: 1.0.0
 license: basic
 description: System Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?

The system module will be GA for 7.14. This is the version bump.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).


