### PR TITLE
Revert "Update dependency on elastic-package (#1283)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/elastic/elastic-package v0.0.0-20210630141158-7ca3684a1909
+	github.com/elastic/elastic-package v0.0.0-20210630083711-7dc5ebd20527
 	github.com/elastic/package-registry v0.17.0
 	github.com/magefile/mage v1.11.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,8 @@ github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5m
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
-github.com/elastic/elastic-package v0.0.0-20210630141158-7ca3684a1909 h1:lSJgibLYMADL6rGFsnvwFU3xJFa2MjaspxtdTMAyEd4=
-github.com/elastic/elastic-package v0.0.0-20210630141158-7ca3684a1909/go.mod h1:9VEZaZJNSFwkc5FLjRbz0EkV78MxLvYGM3OQ0w1AQz0=
+github.com/elastic/elastic-package v0.0.0-20210630083711-7dc5ebd20527 h1:x+LMXDL3o4A/2Y3J49K8JbYiYGd9NXVBqediByWXprU=
+github.com/elastic/elastic-package v0.0.0-20210630083711-7dc5ebd20527/go.mod h1:9VEZaZJNSFwkc5FLjRbz0EkV78MxLvYGM3OQ0w1AQz0=
 github.com/elastic/go-elasticsearch/v7 v7.9.0 h1:UEau+a1MiiE/F+UrDj60kqIHFWdzU1M2y/YtBU2NC2M=
 github.com/elastic/go-elasticsearch/v7 v7.9.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/go-licenser v0.3.1/go.mod h1:D8eNQk70FOCVBl3smCGQt/lv7meBeQno2eI1S5apiHQ=


### PR DESCRIPTION
This PR reverts latest elastic-package update pushed to the master branch.

Apparently it caused problems for traefik and zeek integrations (system tests).

For reference: https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fintegrations/detail/master/512/pipeline/332