### PR TITLE
Update elastic-package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/elastic/elastic-package v0.0.0-20210630083711-7dc5ebd20527
+	github.com/elastic/elastic-package v0.0.0-20210705153117-e3b9459fa353
 	github.com/elastic/package-registry v0.17.0
 	github.com/magefile/mage v1.11.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,8 @@ github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5m
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
-github.com/elastic/elastic-package v0.0.0-20210630083711-7dc5ebd20527 h1:x+LMXDL3o4A/2Y3J49K8JbYiYGd9NXVBqediByWXprU=
-github.com/elastic/elastic-package v0.0.0-20210630083711-7dc5ebd20527/go.mod h1:9VEZaZJNSFwkc5FLjRbz0EkV78MxLvYGM3OQ0w1AQz0=
+github.com/elastic/elastic-package v0.0.0-20210705153117-e3b9459fa353 h1:SGpZMzM0B6el3cc76fzLk5tH2ihq49pRp9rEyWL4Za4=
+github.com/elastic/elastic-package v0.0.0-20210705153117-e3b9459fa353/go.mod h1:9VEZaZJNSFwkc5FLjRbz0EkV78MxLvYGM3OQ0w1AQz0=
 github.com/elastic/go-elasticsearch/v7 v7.9.0 h1:UEau+a1MiiE/F+UrDj60kqIHFWdzU1M2y/YtBU2NC2M=
 github.com/elastic/go-elasticsearch/v7 v7.9.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/go-licenser v0.3.1/go.mod h1:D8eNQk70FOCVBl3smCGQt/lv7meBeQno2eI1S5apiHQ=


### PR DESCRIPTION
Latest version removes volumes managed by docker compose when scenarios
are stopped (elastic/elastic-package#400).

It also includes a fix for the format of the report displayed when
the system tests of multiple data streams fail (elastic/elastic-package#401).