### PR TITLE
Add _meta information to Kubernetes fields

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.1"
+  changes:
+    - description: Add _meta information to Kubernetes fields
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "0.6.0"
   changes:
     - description: Introduce kubernetes package granularity using input_groups

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.6.1"
+- version: "0.7.0"
   changes:
     - description: Add _meta information to Kubernetes fields
       type: enhancement

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add _meta information to Kubernetes fields
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/1289
 - version: "0.6.0"
   changes:
     - description: Introduce kubernetes package granularity using input_groups

--- a/packages/kubernetes/data_stream/apiserver/fields/fields.yml
+++ b/packages/kubernetes/data_stream/apiserver/fields/fields.yml
@@ -66,20 +66,27 @@
       fields:
         - name: cpu.sec
           type: double
+          metric_type: counter
           description: CPU seconds
         - name: memory.resident.bytes
           type: long
           format: bytes
+          unit: byte
+          metric_type: gauge
           description: Bytes in resident memory
         - name: memory.virtual.bytes
           type: long
           format: bytes
+          unit: byte
+          metric_type: gauge
           description: Bytes in virtual memory
         - name: fds.open.count
           type: long
+          metric_type: gauge
           description: Number of open file descriptors
         - name: started.sec
           type: double
+          metric_type: gauge
           description: Seconds since the process started
     - name: http
       type: group
@@ -89,9 +96,13 @@
           description: Request duration microseconds percentiles
         - name: request.duration.us.sum
           type: double
+          metric_type: counter
+          unit: micros
           description: Request duration microseconds cumulative sum
         - name: request.duration.us.count
           type: long
+          metric_type: counter
+          unit: micros
           description: Request count for duration
         - name: request.size.bytes.percentile.*
           type: object
@@ -99,9 +110,13 @@
         - name: request.size.bytes.sum
           type: long
           format: bytes
+          unit: byte
+          metric_type: counter
           description: Request size cumulative sum
         - name: request.size.bytes.count
           type: long
+          unit: byte
+          metric_type: counter
           description: Request count for size
         - name: response.size.bytes.percentile.*
           type: object
@@ -109,52 +124,67 @@
         - name: response.size.bytes.sum
           type: long
           format: bytes
+          unit: byte
+          metric_type: counter
           description: Response size cumulative sum
         - name: response.size.bytes.count
           type: long
+          metric_type: counter
           description: Response count
         - name: request.count
           type: long
+          metric_type: counter
           description: Request count for response
     - name: client.request.count
       type: long
+      metric_type: counter
       description: Number of requests as client
     - name: request
       type: group
       fields:
         - name: count
           type: long
+          metric_type: counter
           description: Number of requests
         - name: latency.sum
           type: long
+          metric_type: counter
           description: Requests latency, sum of latencies in microseconds
         - name: latency.count
           type: long
+          metric_type: counter
           description: Request latency, number of requests
         - name: latency.bucket.*
           type: object
           description: Request latency histogram buckets
         - name: duration.us.sum
           type: long
+          metric_type: counter
           description: Request duration, sum in microseconds
         - name: duration.us.count
           type: long
+          metric_type: counter
           description: Request duration, number of operations
         - name: duration.us.bucket.*
           type: object
           description: Request duration, histogram buckets
         - name: current.count
           type: long
+          metric_type: counter
           description: Inflight requests
         - name: longrunning.count
           type: long
+          metric_type: counter
           description: Number of requests active long running requests
     - name: etcd.object.count
       type: long
+      metric_type: gauge
       description: Number of kubernetes objects at etcd
     - name: audit.event.count
       type: long
+      metric_type: counter
       description: Number of audit events
     - name: audit.rejected.count
       type: long
+      metric_type: counter
       description: Number of audit rejected events

--- a/packages/kubernetes/data_stream/container/fields/fields.yml
+++ b/packages/kubernetes/data_stream/container/fields/fields.yml
@@ -16,20 +16,26 @@
               fields:
                 - name: ns
                   type: long
+                  metric_type: gauge
                   description: |
                     Container CPU Core usage nanoseconds
             - name: nanocores
               type: long
+              metric_type: gauge
               description: |
                 CPU used nanocores
             - name: node.pct
               type: scaled_float
               format: percent
+              unit: percent
+              metric_type: gauge
               description: |
                 CPU usage as a percentage of the total node allocatable CPU
             - name: limit.pct
               type: scaled_float
               format: percent
+              unit: percent
+              metric_type: gauge
               description: |
                 CPU usage as a percentage of the defined limit for the container (or total node allocatable CPU if unlimited)
     - name: logs
@@ -41,6 +47,8 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: gauge
               description: |
                 Logs available capacity in bytes
         - name: capacity
@@ -49,6 +57,8 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: gauge
               description: |
                 Logs total capacity in bytes
         - name: used
@@ -57,6 +67,8 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: gauge
               description: |
                 Logs used capacity in bytes
         - name: inodes
@@ -64,14 +76,17 @@
           fields:
             - name: count
               type: long
+              metric_type: gauge
               description: |
                 Total available inodes
             - name: free
               type: long
+              metric_type: gauge
               description: |
                 Total free inodes
             - name: used
               type: long
+              metric_type: gauge
               description: |
                 Total used inodes
     - name: memory
@@ -83,6 +98,8 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: gauge
               description: |
                 Total available memory
         - name: usage
@@ -91,16 +108,22 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: gauge
               description: |
                 Total memory usage
             - name: node.pct
               type: scaled_float
               format: percent
+              unit: percent
+              metric_type: gauge
               description: |
                 Memory usage as a percentage of the total node allocatable memory
             - name: limit.pct
               type: scaled_float
               format: percent
+              unit: percetn
+              metric_type: gauge
               description: |
                 Memory usage as a percentage of the defined limit for the container (or total node allocatable memory if unlimited)
         - name: rss
@@ -109,6 +132,8 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: gauge
               description: |
                 RSS memory usage
         - name: workingset
@@ -117,14 +142,18 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: gauge
               description: |
                 Working set memory usage
         - name: pagefaults
           type: long
+          metric_type: counter
           description: |
             Number of page faults
         - name: majorpagefaults
           type: long
+          metric_type: counter
           description: |
             Number of major page faults
     - name: rootfs
@@ -136,6 +165,8 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: gauge
               description: |
                 Root filesystem total capacity in bytes
         - name: available
@@ -144,6 +175,8 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: gauge
               description: |
                 Root filesystem total available in bytes
         - name: used
@@ -152,6 +185,8 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: gauge
               description: |
                 Root filesystem total used in bytes
         - name: inodes
@@ -159,5 +194,6 @@
           fields:
             - name: used
               type: long
+              metric_type: gauge
               description: |
                 Used inodes

--- a/packages/kubernetes/data_stream/container/fields/fields.yml
+++ b/packages/kubernetes/data_stream/container/fields/fields.yml
@@ -122,7 +122,7 @@
             - name: limit.pct
               type: scaled_float
               format: percent
-              unit: percetn
+              unit: percent
               metric_type: gauge
               description: |
                 Memory usage as a percentage of the defined limit for the container (or total node allocatable memory if unlimited)

--- a/packages/kubernetes/data_stream/controllermanager/fields/fields.yml
+++ b/packages/kubernetes/data_stream/controllermanager/fields/fields.yml
@@ -30,20 +30,27 @@
       fields:
         - name: cpu.sec
           type: double
+          metric_type: counter
           description: CPU seconds
         - name: memory.resident.bytes
           type: long
           format: bytes
+          unit: byte
+          metric_type: gauge
           description: Bytes in resident memory
         - name: memory.virtual.bytes
           type: long
           format: bytes
+          unit: byte
+          metric_type: gauge
           description: Bytes in virtual memory
         - name: fds.open.count
           type: long
+          metric_type: gauge
           description: Number of open file descriptors
         - name: started.sec
           type: double
+          metric_type: gauge
           description: Seconds since the process started
     - name: http
       type: group
@@ -53,9 +60,11 @@
           description: Request duration microseconds percentiles
         - name: request.duration.us.sum
           type: double
+          metric_type: counter
           description: Request duration microseconds cumulative sum
         - name: request.duration.us.count
           type: long
+          metric_type: counter
           description: Request count for duration
         - name: request.size.bytes.percentile.*
           type: object
@@ -63,9 +72,13 @@
         - name: request.size.bytes.sum
           type: long
           format: bytes
+          unit: byte
+          metric_type: counter
           description: Request size cumulative sum
         - name: request.size.bytes.count
           type: long
+          unit: byte
+          metric_type: counter
           description: Request count for size
         - name: response.size.bytes.percentile.*
           type: object
@@ -73,15 +86,21 @@
         - name: response.size.bytes.sum
           type: long
           format: bytes
+          unit: byte
+          metric_type: counter
           description: Response size cumulative sum
         - name: response.size.bytes.count
           type: long
+          unit: byte
+          metric_type: counter
           description: Response count
         - name: request.count
           type: long
+          metric_type: counter
           description: Request count for response
     - name: client.request.count
       type: long
+      metric_type: counter
       description: |
         Number of requests as client
     - name: workqueue
@@ -89,33 +108,42 @@
       fields:
         - name: longestrunning.sec
           type: double
+          metric_type: gauge
           description: Longest running processors
         - name: unfinished.sec
           type: double
+          metric_type: gauge
           description: Unfinished processors
         - name: adds.count
           type: long
+          metric_type: counter
           description: Workqueue add count
         - name: depth.count
           type: long
+          metric_type: gauge
           description: Workqueue depth count
         - name: retries.count
           type: long
+          metric_type: counter
           description: Workqueue number of retries
     - name: node.collector
       type: group
       fields:
         - name: eviction.count
           type: long
+          metric_type: counter
           description: Number of node evictions
         - name: unhealthy.count
           type: long
+          metric_type: gauge
           description: Number of unhealthy nodes
         - name: count
           type: long
+          metric_type: gauge
           description: Number of nodes
         - name: health.pct
           type: long
+          metric_type: gauge
           description: Percentage of healthy nodes
     - name: leader.is_master
       type: boolean

--- a/packages/kubernetes/data_stream/controllermanager/fields/fields.yml
+++ b/packages/kubernetes/data_stream/controllermanager/fields/fields.yml
@@ -60,10 +60,12 @@
           description: Request duration microseconds percentiles
         - name: request.duration.us.sum
           type: double
+          unit: micros
           metric_type: counter
           description: Request duration microseconds cumulative sum
         - name: request.duration.us.count
           type: long
+          unit: micros
           metric_type: counter
           description: Request count for duration
         - name: request.size.bytes.percentile.*

--- a/packages/kubernetes/data_stream/event/fields/fields.yml
+++ b/packages/kubernetes/data_stream/event/fields/fields.yml
@@ -3,6 +3,7 @@
   fields:
     - name: count
       type: long
+      metric_type: counter
       description: |
         Count field records the number of times the particular event has occurred
     - name: timestamp

--- a/packages/kubernetes/data_stream/node/fields/fields.yml
+++ b/packages/kubernetes/data_stream/node/fields/fields.yml
@@ -16,10 +16,12 @@
               fields:
                 - name: ns
                   type: long
+                  metric_type: gauge
                   description: |
                     Node CPU Core usage nanoseconds
             - name: nanocores
               type: long
+              metric_type: gauge
               description: |
                 CPU used nanocores
     - name: memory
@@ -31,6 +33,8 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: gauge
               description: |
                 Total available memory
         - name: usage
@@ -39,6 +43,8 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: gauge
               description: |
                 Total memory usage
         - name: rss
@@ -47,6 +53,8 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: gauge
               description: |
                 RSS memory usage
         - name: workingset
@@ -55,14 +63,18 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: gauge
               description: |
                 Working set memory usage
         - name: pagefaults
           type: long
+          metric_type: counter
           description: |
             Number of page faults
         - name: majorpagefaults
           type: long
+          metric_type: counter
           description: |
             Number of major page faults
     - name: network
@@ -74,6 +86,8 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: counter
               description: |
                 Received bytes
             - name: errors
@@ -86,10 +100,13 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: counter
               description: |
                 Transmitted bytes
             - name: errors
               type: long
+              metric_type: counter
               description: |
                 Tx errors
     - name: fs
@@ -101,6 +118,8 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: gauge
               description: |
                 Filesystem total capacity in bytes
         - name: available
@@ -109,6 +128,8 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: gauge
               description: |
                 Filesystem total available in bytes
         - name: used
@@ -117,6 +138,8 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: gauge
               description: |
                 Filesystem total used in bytes
         - name: inodes
@@ -124,14 +147,17 @@
           fields:
             - name: used
               type: long
+              metric_type: gauge
               description: |
                 Number of used inodes
             - name: count
               type: long
+              metric_type: gauge
               description: |
                 Number of inodes
             - name: free
               type: long
+              metric_type: gauge
               description: |
                 Number of free inodes
     - name: runtime
@@ -146,6 +172,8 @@
                 - name: bytes
                   type: long
                   format: bytes
+                  unit: byte
+                  metric_type: gauge
                   description: |
                     Image filesystem total capacity in bytes
             - name: available
@@ -154,6 +182,8 @@
                 - name: bytes
                   type: long
                   format: bytes
+                  unit: byte
+                  metric_type: gauge
                   description: |
                     Image filesystem total available in bytes
             - name: used
@@ -162,5 +192,7 @@
                 - name: bytes
                   type: long
                   format: bytes
+                  unit: byte
+                  metric_type: gauge
                   description: |
                     Image filesystem total used in bytes

--- a/packages/kubernetes/data_stream/pod/fields/fields.yml
+++ b/packages/kubernetes/data_stream/pod/fields/fields.yml
@@ -14,10 +14,13 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: counter
               description: |
                 Received bytes
             - name: errors
               type: long
+              metric_type: counter
               description: |
                 Rx errors
         - name: tx
@@ -26,10 +29,13 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: counter
               description: |
                 Transmitted bytes
             - name: errors
               type: long
+              metric_type: counter
               description: |
                 Tx errors
     - name: cpu
@@ -40,16 +46,22 @@
           fields:
             - name: nanocores
               type: long
+              unit: byte
+              metric_type: gauge
               description: |
                 CPU used nanocores
             - name: node.pct
               type: scaled_float
               format: percent
+              unit: percent
+              metric_type: gauge
               description: |
                 CPU usage as a percentage of the total node CPU
             - name: limit.pct
               type: scaled_float
               format: percent
+              unit: percent
+              metric_type: gauge
               description: |
                 CPU usage as a percentage of the defined limit for the pod containers (or total node CPU if one or more containers of the pod are unlimited)
     - name: memory
@@ -61,16 +73,22 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: gauge
               description: |
                 Total memory usage
             - name: node.pct
               type: scaled_float
               format: percent
+              unit: percent
+              metric_type: gauge
               description: |
                 Memory usage as a percentage of the total node allocatable memory
             - name: limit.pct
               type: scaled_float
               format: percent
+              unit: percent
+              metric_type: gauge
               description: |
                 Memory usage as a percentage of the defined limit for the pod containers (or total node allocatable memory if unlimited)
         - name: available
@@ -79,6 +97,8 @@
             - name: bytes
               type: long
               format: bytes
+              unit: percent
+              metric_type: gauge
               description: |
                 Total memory available
         - name: working_set
@@ -87,6 +107,8 @@
             - name: bytes
               type: long
               format: bytes
+              unit: percent
+              metric_type: gauge
               description: |
                 Total working set memory
         - name: rss
@@ -95,14 +117,18 @@
             - name: bytes
               type: long
               format: bytes
+              unit: percent
+              metric_type: gauge
               description: |
                 Total resident set size memory
         - name: page_faults
           type: long
+          metric_type: counter
           description: |
             Total page faults
         - name: major_page_faults
           type: long
+          metric_type: counter
           description: |
             Total major page faults
     - name: ip

--- a/packages/kubernetes/data_stream/proxy/fields/fields.yml
+++ b/packages/kubernetes/data_stream/proxy/fields/fields.yml
@@ -22,20 +22,27 @@
       fields:
         - name: cpu.sec
           type: double
+          metric_type: counter
           description: CPU seconds
         - name: memory.resident.bytes
           type: long
           format: bytes
+          unit: byte
+          metric_type: gauge
           description: Bytes in resident memory
         - name: memory.virtual.bytes
           type: long
           format: bytes
+          unit: byte
+          metric_type: gauge
           description: Bytes in virtual memory
         - name: fds.open.count
           type: long
+          metric_type: gauge
           description: Number of open file descriptors
         - name: started.sec
           type: double
+          metric_type: gauge
           description: Seconds since the process started
     - name: http
       type: group
@@ -45,9 +52,13 @@
           description: Request duration microseconds percentiles
         - name: request.duration.us.sum
           type: double
+          metric_type: counter
+          unit: micros
           description: Request duration microseconds cumulative sum
         - name: request.duration.us.count
           type: long
+          metric_type: counter
+          unit: micros
           description: Request count for duration
         - name: request.size.bytes.percentile.*
           type: object
@@ -55,9 +66,13 @@
         - name: request.size.bytes.sum
           type: long
           format: bytes
+          unit: byte
+          metric_type: counter
           description: Request size cumulative sum
         - name: request.size.bytes.count
           type: long
+          unit: byte
+          metric_type: counter
           description: Request count for size
         - name: response.size.bytes.percentile.*
           type: object
@@ -65,15 +80,20 @@
         - name: response.size.bytes.sum
           type: long
           format: bytes
+          unit: byte
+          metric_type: counter
           description: Response size cumulative sum
         - name: response.size.bytes.count
           type: long
+          metric_type: counter
           description: Response count
         - name: request.count
           type: long
+          metric_type: counter
           description: Request count
     - name: client.request.count
       type: long
+      metric_type: counter
       description: |
         Number of requests as client
     - name: sync
@@ -81,18 +101,22 @@
       fields:
         - name: rules.duration.us.sum
           type: long
+          metric_type: counter
           description: SyncProxyRules duration, sum of durations in microseconds
         - name: rules.duration.us.count
           type: long
+          metric_type: counter
           description: SyncProxyRules duration, number of operations
         - name: rules.duration.us.bucket.*
           type: object
           description: SyncProxyRules duration, histogram buckets
         - name: networkprogramming.duration.us.sum
           type: long
+          metric_type: counter
           description: Network programming duration, sum in microseconds
         - name: networkprogramming.duration.us.count
           type: long
+          metric_type: counter
           description: Network programming duration, number of operations
         - name: networkprogramming.duration.us.bucket.*
           type: object

--- a/packages/kubernetes/data_stream/scheduler/fields/fields.yml
+++ b/packages/kubernetes/data_stream/scheduler/fields/fields.yml
@@ -34,20 +34,27 @@
       fields:
         - name: cpu.sec
           type: double
+          metric_type: counter
           description: CPU seconds
         - name: memory.resident.bytes
           type: long
           format: bytes
+          unit: byte
+          metric_type: gauge
           description: Bytes in resident memory
         - name: memory.virtual.bytes
           type: long
           format: bytes
+          unit: byte
+          metric_type: gauge
           description: Bytes in virtual memory
         - name: fds.open.count
           type: long
+          metric_type: gauge
           description: Number of open file descriptors
         - name: started.sec
           type: double
+          metric_type: gauge
           description: Seconds since the process started
     - name: http
       type: group
@@ -57,9 +64,13 @@
           description: Request duration microseconds percentiles
         - name: request.duration.us.sum
           type: double
+          metric_type: counter
+          unit: micros
           description: Request duration microseconds cumulative sum
         - name: request.duration.us.count
           type: long
+          metric_type: counter
+          unit: micros
           description: Request count for duration
         - name: request.size.bytes.percentile.*
           type: object
@@ -67,9 +78,13 @@
         - name: request.size.bytes.sum
           type: long
           format: bytes
+          unit: byte
+          metric_type: counter
           description: Request size cumulative sum
         - name: request.size.bytes.count
           type: long
+          unit: byte
+          metric_type: counter
           description: Request count for size
         - name: response.size.bytes.percentile.*
           type: object
@@ -77,15 +92,20 @@
         - name: response.size.bytes.sum
           type: long
           format: bytes
+          unit: byte
+          metric_type: counter
           description: Response size cumulative sum
         - name: response.size.bytes.count
           type: long
+          metric_type: counter
           description: Response count
         - name: request.count
           type: long
+          metric_type: counter
           description: Request count
     - name: client.request.count
       type: long
+      metric_type: counter
       description: |
         Number of requests as client
     - name: leader.is_master
@@ -100,28 +120,37 @@
           description: End to end scheduling duration microseconds
         - name: e2e.duration.us.sum
           type: long
+          unit: micros
+          metric_type: counter
           description: End to end scheduling duration microseconds sum
         - name: e2e.duration.us.count
           type: long
+          unit: micros
+          metric_type: counter
           description: End to end scheduling count
         - name: pod.preemption.victims.bucket.*
           type: long
           description: Pod preemption victims
         - name: pod.preemption.victims.sum
           type: long
+          metric_type: counter
           description: Pod preemption victims sum
         - name: pod.preemption.victims.count
           type: long
+          metric_type: counter
           description: Pod preemption victims count
         - name: pod.attempts.count
           type: long
+          metric_type: counter
           description: Pod attempts count
         - name: duration.seconds.percentile.*
           type: object
           description: Scheduling duration percentiles
         - name: duration.seconds.sum
           type: double
+          metric_type: counter
           description: Scheduling duration cumulative sum
         - name: duration.seconds.count
           type: long
+          metric_type: counter
           description: Scheduling count

--- a/packages/kubernetes/data_stream/state_container/fields/fields.yml
+++ b/packages/kubernetes/data_stream/state_container/fields/fields.yml
@@ -17,6 +17,7 @@
             Container ready status
         - name: restarts
           type: integer
+          metric_type: counter
           description: |
             Container restarts count
         - name: reason
@@ -28,18 +29,22 @@
       fields:
         - name: limit.cores
           type: float
+          metric_type: gauge
           description: |
             Container CPU cores limit
         - name: request.cores
           type: float
+          metric_type: gauge
           description: |
             Container CPU requested cores
         - name: limit.nanocores
           type: long
+          metric_type: gauge
           description: |
             Container CPU nanocores limit
         - name: request.nanocores
           type: long
+          metric_type: gauge
           description: |
             Container CPU requested nanocores
     - name: memory
@@ -48,10 +53,14 @@
         - name: limit.bytes
           type: long
           format: bytes
+          unit: byte
+          metric_type: gauge
           description: |
             Container memory limit in bytes
         - name: request.bytes
           type: long
           format: bytes
+          unit: byte
+          metric_type: gauge
           description: |
             Container requested memory in bytes

--- a/packages/kubernetes/data_stream/state_cronjob/fields/fields.yml
+++ b/packages/kubernetes/data_stream/state_cronjob/fields/fields.yml
@@ -12,19 +12,28 @@
       description: Concurrency policy
     - name: active.count
       type: long
+      metric_type: gauge
       description: Number of active pods for the cronjob
     - name: is_suspended
       type: boolean
       description: Whether the cronjob is suspended
     - name: created.sec
       type: double
+      unit: s
+      metric_type: gauge
       description: Epoch seconds since the cronjob was created
     - name: last_schedule.sec
       type: double
+      unit: s
+      metric_type: gauge
       description: Epoch seconds for last cronjob run
     - name: next_schedule.sec
       type: double
+      unit: s
+      metric_type: gauge
       description: Epoch seconds for next cronjob run
     - name: deadline.sec
       type: long
+      unit: s
+      metric_type: gauge
       description: Deadline seconds after schedule for considering failed

--- a/packages/kubernetes/data_stream/state_daemonset/fields/fields.yml
+++ b/packages/kubernetes/data_stream/state_daemonset/fields/fields.yml
@@ -10,17 +10,21 @@
       fields:
         - name: available
           type: long
+          metric_type: gauge
           description: |
             The number of available replicas per DaemonSet
         - name: desired
           type: long
+          metric_type: gauge
           description: |
             The desired number of replicas per DaemonSet
         - name: ready
           type: long
+          metric_type: gauge
           description: |
             The number of ready replicas per DaemonSet
         - name: unavailable
           type: long
+          metric_type: gauge
           description: |
             The number of unavailable replicas per DaemonSet

--- a/packages/kubernetes/data_stream/state_deployment/fields/fields.yml
+++ b/packages/kubernetes/data_stream/state_deployment/fields/fields.yml
@@ -10,17 +10,21 @@
       fields:
         - name: desired
           type: integer
+          metric_type: gauge
           description: |
             Deployment number of desired replicas (spec)
         - name: available
           type: integer
+          metric_type: gauge
           description: |
             Deployment available replicas
         - name: unavailable
           type: integer
+          metric_type: gauge
           description: |
             Deployment unavailable replicas
         - name: updated
           type: integer
+          metric_type: gauge
           description: |
             Deployment updated replicas

--- a/packages/kubernetes/data_stream/state_node/fields/fields.yml
+++ b/packages/kubernetes/data_stream/state_node/fields/fields.yml
@@ -29,10 +29,12 @@
       fields:
         - name: allocatable.cores
           type: float
+          metric_type: gauge
           description: |
             Node CPU allocatable cores
         - name: capacity.cores
           type: long
+          metric_type: gauge
           description: |
             Node CPU capacity cores
     - name: memory
@@ -41,11 +43,15 @@
         - name: allocatable.bytes
           type: long
           format: bytes
+          unit: byte
+          metric_type: gauge
           description: |
             Node allocatable memory in bytes
         - name: capacity.bytes
           type: long
           format: bytes
+          unit: byte
+          metric_type: gauge
           description: |
             Node memory capacity in bytes
     - name: pod
@@ -53,9 +59,11 @@
       fields:
         - name: allocatable.total
           type: long
+          metric_type: gauge
           description: |
             Node allocatable pods
         - name: capacity.total
           type: long
+          metric_type: gauge
           description: |
             Node pod capacity

--- a/packages/kubernetes/data_stream/state_persistentvolume/fields/fields.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolume/fields/fields.yml
@@ -6,6 +6,8 @@
       description: Volume name.
     - name: capacity.bytes
       type: long
+      unit: byte
+      metric_type: gauge
       description: Volume capacity
     - name: phase
       type: keyword

--- a/packages/kubernetes/data_stream/state_persistentvolumeclaim/fields/fields.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolumeclaim/fields/fields.yml
@@ -9,6 +9,8 @@
       description: Binded volume name.
     - name: request_storage.bytes
       type: long
+      unit: byte
+      metric_type: gauge
       description: Requested capacity.
     - name: phase
       type: keyword

--- a/packages/kubernetes/data_stream/state_replicaset/fields/fields.yml
+++ b/packages/kubernetes/data_stream/state_replicaset/fields/fields.yml
@@ -6,21 +6,26 @@
       fields:
         - name: available
           type: long
+          metric_type: gauge
           description: |
             The number of replicas per ReplicaSet
         - name: desired
           type: long
+          metric_type: gauge
           description: |
             The number of replicas per ReplicaSet
         - name: ready
           type: long
+          metric_type: gauge
           description: |
             The number of ready replicas per ReplicaSet
         - name: observed
           type: long
+          metric_type: gauge
           description: |
             The generation observed by the ReplicaSet controller
         - name: labeled
           type: long
+          metric_type: gauge
           description: |
             The number of fully labeled replicas per ReplicaSet

--- a/packages/kubernetes/data_stream/state_resourcequota/fields/fields.yml
+++ b/packages/kubernetes/data_stream/state_resourcequota/fields/fields.yml
@@ -3,9 +3,12 @@
   fields:
     - name: created.sec
       type: double
+      unit: s
+      metric_type: gauge
       description: Epoch seconds since the ResourceQuota was created
     - name: quota
       type: double
+      metric_type: gauge
       description: Quota informed (hard or used) for the resource
     - name: name
       type: keyword

--- a/packages/kubernetes/data_stream/state_statefulset/fields/fields.yml
+++ b/packages/kubernetes/data_stream/state_statefulset/fields/fields.yml
@@ -3,6 +3,7 @@
   fields:
     - name: created
       type: long
+      metric_type: gauge
       description: |
         The creation timestamp (epoch) for StatefulSet
     - name: replicas
@@ -10,14 +11,17 @@
       fields:
         - name: observed
           type: long
+          metric_type: gauge
           description: |
             The number of observed replicas per StatefulSet
         - name: desired
           type: long
+          metric_type: gauge
           description: |
             The number of desired replicas per StatefulSet
         - name: ready
           type: long
+          metric_type: gauge
           description: >
             The number of ready replicas per StatefulSet
 
@@ -26,9 +30,11 @@
       fields:
         - name: observed
           type: long
+          metric_type: gauge
           description: |
             The observed generation per StatefulSet
         - name: desired
           type: long
+          metric_type: gauge
           description: |
             The desired generation per StatefulSet

--- a/packages/kubernetes/data_stream/system/fields/fields.yml
+++ b/packages/kubernetes/data_stream/system/fields/fields.yml
@@ -20,10 +20,12 @@
               fields:
                 - name: ns
                   type: long
+                  metric_type: gauge
                   description: |
                     CPU Core usage nanoseconds
             - name: nanocores
               type: long
+              metric_type: gauge
               description: |
                 CPU used nanocores
     - name: memory
@@ -35,6 +37,8 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: gauge
               description: |
                 Total memory usage
         - name: rss
@@ -43,6 +47,8 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: gauge
               description: |
                 RSS memory usage
         - name: workingset
@@ -51,13 +57,17 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: gauge
               description: |
                 Working set memory usage
         - name: pagefaults
           type: long
+          metric_type: counter
           description: |
             Number of page faults
         - name: majorpagefaults
           type: long
+          metric_type: counter
           description: |
             Number of major page faults

--- a/packages/kubernetes/data_stream/volume/fields/fields.yml
+++ b/packages/kubernetes/data_stream/volume/fields/fields.yml
@@ -14,6 +14,8 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: gauge
               description: |
                 Filesystem total capacity in bytes
         - name: available
@@ -22,6 +24,8 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: gauge
               description: |
                 Filesystem total available in bytes
         - name: used
@@ -30,10 +34,14 @@
             - name: bytes
               type: long
               format: bytes
+              unit: byte
+              metric_type: gauge
               description: |
                 Filesystem total used in bytes
             - name: pct
               type: long
+              unit: percent
+              metric_type: gauge
               description: |
                 Percentage of filesystem total used
         - name: inodes
@@ -41,13 +49,16 @@
           fields:
             - name: used
               type: long
+              metric_type: gauge
               description: |
                 Used inodes
             - name: free
               type: long
+              metric_type: gauge
               description: |
                 Free inodes
             - name: count
               type: long
+              metric_type: gauge
               description: |
                 Total inodes

--- a/packages/kubernetes/docs/events.md
+++ b/packages/kubernetes/docs/events.md
@@ -92,74 +92,74 @@ An example event for `event` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| kubernetes.annotations.* | Kubernetes annotations map | object |
-| kubernetes.container.image | Kubernetes container image | keyword |
-| kubernetes.container.name | Kubernetes container name | keyword |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |
-| kubernetes.event.count | Count field records the number of times the particular event has occurred | long |
-| kubernetes.event.involved_object.api_version | API version of the object | keyword |
-| kubernetes.event.involved_object.kind | API kind of the object | keyword |
-| kubernetes.event.involved_object.name | name of the object | keyword |
-| kubernetes.event.involved_object.resource_version | resource version of the object | keyword |
-| kubernetes.event.involved_object.uid | UUID version of the object | keyword |
-| kubernetes.event.message | Message recorded for the given event | text |
-| kubernetes.event.metadata.generate_name | Generate name of the event | keyword |
-| kubernetes.event.metadata.name | Name of the event | keyword |
-| kubernetes.event.metadata.namespace | Namespace in which event was generated | keyword |
-| kubernetes.event.metadata.resource_version | Version of the event resource | keyword |
-| kubernetes.event.metadata.self_link | URL representing the event | keyword |
-| kubernetes.event.metadata.timestamp.created | Timestamp of creation of the given event | date |
-| kubernetes.event.metadata.uid | Unique identifier to the event object | keyword |
-| kubernetes.event.reason | Reason recorded for the given event | keyword |
-| kubernetes.event.source.component | Component from which the event is generated | keyword |
-| kubernetes.event.source.host | Node name on which the event is generated | keyword |
-| kubernetes.event.timestamp.first_occurrence | Timestamp of first occurrence of event | date |
-| kubernetes.event.timestamp.last_occurrence | Timestamp of last occurrence of event | date |
-| kubernetes.event.type | Type of the given event | keyword |
-| kubernetes.labels.* | Kubernetes labels map | object |
-| kubernetes.namespace | Kubernetes namespace | keyword |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
-| kubernetes.node.name | Kubernetes node name | keyword |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |
-| kubernetes.pod.name | Kubernetes pod name | keyword |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Metric Type |
+|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |
+| cloud.region | Region in which this host is running. | keyword |  |
+| container.id | Unique container id. | keyword |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |
+| container.labels | Image labels. | object |  |
+| container.name | Container name. | keyword |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |
+| data_stream.type | Data stream type. | constant_keyword |  |
+| ecs.version | ECS version | keyword |  |
+| host.architecture | Operating system architecture. | keyword |  |
+| host.containerized | If the host is a container. | boolean |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |
+| host.ip | Host ip addresses. | ip |  |
+| host.mac | Host mac addresses. | keyword |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |
+| host.os.build | OS build information. | keyword |  |
+| host.os.codename | OS codename, if any. | keyword |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |
+| host.os.name | Operating system name, without the version. | keyword |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
+| kubernetes.annotations.* | Kubernetes annotations map | object |  |
+| kubernetes.container.image | Kubernetes container image | keyword |  |
+| kubernetes.container.name | Kubernetes container name | keyword |  |
+| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |
+| kubernetes.event.count | Count field records the number of times the particular event has occurred | long | counter |
+| kubernetes.event.involved_object.api_version | API version of the object | keyword |  |
+| kubernetes.event.involved_object.kind | API kind of the object | keyword |  |
+| kubernetes.event.involved_object.name | name of the object | keyword |  |
+| kubernetes.event.involved_object.resource_version | resource version of the object | keyword |  |
+| kubernetes.event.involved_object.uid | UUID version of the object | keyword |  |
+| kubernetes.event.message | Message recorded for the given event | text |  |
+| kubernetes.event.metadata.generate_name | Generate name of the event | keyword |  |
+| kubernetes.event.metadata.name | Name of the event | keyword |  |
+| kubernetes.event.metadata.namespace | Namespace in which event was generated | keyword |  |
+| kubernetes.event.metadata.resource_version | Version of the event resource | keyword |  |
+| kubernetes.event.metadata.self_link | URL representing the event | keyword |  |
+| kubernetes.event.metadata.timestamp.created | Timestamp of creation of the given event | date |  |
+| kubernetes.event.metadata.uid | Unique identifier to the event object | keyword |  |
+| kubernetes.event.reason | Reason recorded for the given event | keyword |  |
+| kubernetes.event.source.component | Component from which the event is generated | keyword |  |
+| kubernetes.event.source.host | Node name on which the event is generated | keyword |  |
+| kubernetes.event.timestamp.first_occurrence | Timestamp of first occurrence of event | date |  |
+| kubernetes.event.timestamp.last_occurrence | Timestamp of last occurrence of event | date |  |
+| kubernetes.event.type | Type of the given event | keyword |  |
+| kubernetes.labels.* | Kubernetes labels map | object |  |
+| kubernetes.namespace | Kubernetes namespace | keyword |  |
+| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |
+| kubernetes.node.name | Kubernetes node name | keyword |  |
+| kubernetes.pod.ip | Kubernetes pod IP | ip |  |
+| kubernetes.pod.name | Kubernetes pod name | keyword |  |
+| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |
+| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |
+| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |
+| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |
+| service.type | Service type | keyword |  |

--- a/packages/kubernetes/docs/kube-apiserver.md
+++ b/packages/kubernetes/docs/kube-apiserver.md
@@ -97,84 +97,84 @@ An example event for `apiserver` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| kubernetes.apiserver.audit.event.count | Number of audit events | long |
-| kubernetes.apiserver.audit.rejected.count | Number of audit rejected events | long |
-| kubernetes.apiserver.client.request.count | Number of requests as client | long |
-| kubernetes.apiserver.etcd.object.count | Number of kubernetes objects at etcd | long |
-| kubernetes.apiserver.http.request.count | Request count for response | long |
-| kubernetes.apiserver.http.request.duration.us.count | Request count for duration | long |
-| kubernetes.apiserver.http.request.duration.us.percentile.* | Request duration microseconds percentiles | object |
-| kubernetes.apiserver.http.request.duration.us.sum | Request duration microseconds cumulative sum | double |
-| kubernetes.apiserver.http.request.size.bytes.count | Request count for size | long |
-| kubernetes.apiserver.http.request.size.bytes.percentile.* | Request size percentiles | object |
-| kubernetes.apiserver.http.request.size.bytes.sum | Request size cumulative sum | long |
-| kubernetes.apiserver.http.response.size.bytes.count | Response count | long |
-| kubernetes.apiserver.http.response.size.bytes.percentile.* | Response size percentiles | object |
-| kubernetes.apiserver.http.response.size.bytes.sum | Response size cumulative sum | long |
-| kubernetes.apiserver.process.cpu.sec | CPU seconds | double |
-| kubernetes.apiserver.process.fds.open.count | Number of open file descriptors | long |
-| kubernetes.apiserver.process.memory.resident.bytes | Bytes in resident memory | long |
-| kubernetes.apiserver.process.memory.virtual.bytes | Bytes in virtual memory | long |
-| kubernetes.apiserver.process.started.sec | Seconds since the process started | double |
-| kubernetes.apiserver.request.client | Client executing requests | keyword |
-| kubernetes.apiserver.request.code | HTTP code | keyword |
-| kubernetes.apiserver.request.component | Component handling the request | keyword |
-| kubernetes.apiserver.request.content_type | Request HTTP content type | keyword |
-| kubernetes.apiserver.request.count | Number of requests | long |
-| kubernetes.apiserver.request.current.count | Inflight requests | long |
-| kubernetes.apiserver.request.dry_run | Wether the request uses dry run | keyword |
-| kubernetes.apiserver.request.duration.us.bucket.* | Request duration, histogram buckets | object |
-| kubernetes.apiserver.request.duration.us.count | Request duration, number of operations | long |
-| kubernetes.apiserver.request.duration.us.sum | Request duration, sum in microseconds | long |
-| kubernetes.apiserver.request.group | API group for the resource | keyword |
-| kubernetes.apiserver.request.handler | Request handler | keyword |
-| kubernetes.apiserver.request.host | Request host | keyword |
-| kubernetes.apiserver.request.kind | Kind of request | keyword |
-| kubernetes.apiserver.request.latency.bucket.* | Request latency histogram buckets | object |
-| kubernetes.apiserver.request.latency.count | Request latency, number of requests | long |
-| kubernetes.apiserver.request.latency.sum | Requests latency, sum of latencies in microseconds | long |
-| kubernetes.apiserver.request.longrunning.count | Number of requests active long running requests | long |
-| kubernetes.apiserver.request.method | HTTP method | keyword |
-| kubernetes.apiserver.request.resource | Requested resource | keyword |
-| kubernetes.apiserver.request.scope | Request scope (cluster, namespace, resource) | keyword |
-| kubernetes.apiserver.request.subresource | Requested subresource | keyword |
-| kubernetes.apiserver.request.verb | HTTP verb | keyword |
-| kubernetes.apiserver.request.version | version for the group | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| ecs.version | ECS version | keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| kubernetes.apiserver.audit.event.count | Number of audit events | long |  | counter |
+| kubernetes.apiserver.audit.rejected.count | Number of audit rejected events | long |  | counter |
+| kubernetes.apiserver.client.request.count | Number of requests as client | long |  | counter |
+| kubernetes.apiserver.etcd.object.count | Number of kubernetes objects at etcd | long |  | gauge |
+| kubernetes.apiserver.http.request.count | Request count for response | long |  | counter |
+| kubernetes.apiserver.http.request.duration.us.count | Request count for duration | long | micros | counter |
+| kubernetes.apiserver.http.request.duration.us.percentile.* | Request duration microseconds percentiles | object |  |  |
+| kubernetes.apiserver.http.request.duration.us.sum | Request duration microseconds cumulative sum | double | micros | counter |
+| kubernetes.apiserver.http.request.size.bytes.count | Request count for size | long | byte | counter |
+| kubernetes.apiserver.http.request.size.bytes.percentile.* | Request size percentiles | object |  |  |
+| kubernetes.apiserver.http.request.size.bytes.sum | Request size cumulative sum | long | byte | counter |
+| kubernetes.apiserver.http.response.size.bytes.count | Response count | long |  | counter |
+| kubernetes.apiserver.http.response.size.bytes.percentile.* | Response size percentiles | object |  |  |
+| kubernetes.apiserver.http.response.size.bytes.sum | Response size cumulative sum | long | byte | counter |
+| kubernetes.apiserver.process.cpu.sec | CPU seconds | double |  | counter |
+| kubernetes.apiserver.process.fds.open.count | Number of open file descriptors | long |  | gauge |
+| kubernetes.apiserver.process.memory.resident.bytes | Bytes in resident memory | long | byte | gauge |
+| kubernetes.apiserver.process.memory.virtual.bytes | Bytes in virtual memory | long | byte | gauge |
+| kubernetes.apiserver.process.started.sec | Seconds since the process started | double |  | gauge |
+| kubernetes.apiserver.request.client | Client executing requests | keyword |  |  |
+| kubernetes.apiserver.request.code | HTTP code | keyword |  |  |
+| kubernetes.apiserver.request.component | Component handling the request | keyword |  |  |
+| kubernetes.apiserver.request.content_type | Request HTTP content type | keyword |  |  |
+| kubernetes.apiserver.request.count | Number of requests | long |  | counter |
+| kubernetes.apiserver.request.current.count | Inflight requests | long |  | counter |
+| kubernetes.apiserver.request.dry_run | Wether the request uses dry run | keyword |  |  |
+| kubernetes.apiserver.request.duration.us.bucket.* | Request duration, histogram buckets | object |  |  |
+| kubernetes.apiserver.request.duration.us.count | Request duration, number of operations | long |  | counter |
+| kubernetes.apiserver.request.duration.us.sum | Request duration, sum in microseconds | long |  | counter |
+| kubernetes.apiserver.request.group | API group for the resource | keyword |  |  |
+| kubernetes.apiserver.request.handler | Request handler | keyword |  |  |
+| kubernetes.apiserver.request.host | Request host | keyword |  |  |
+| kubernetes.apiserver.request.kind | Kind of request | keyword |  |  |
+| kubernetes.apiserver.request.latency.bucket.* | Request latency histogram buckets | object |  |  |
+| kubernetes.apiserver.request.latency.count | Request latency, number of requests | long |  | counter |
+| kubernetes.apiserver.request.latency.sum | Requests latency, sum of latencies in microseconds | long |  | counter |
+| kubernetes.apiserver.request.longrunning.count | Number of requests active long running requests | long |  | counter |
+| kubernetes.apiserver.request.method | HTTP method | keyword |  |  |
+| kubernetes.apiserver.request.resource | Requested resource | keyword |  |  |
+| kubernetes.apiserver.request.scope | Request scope (cluster, namespace, resource) | keyword |  |  |
+| kubernetes.apiserver.request.subresource | Requested subresource | keyword |  |  |
+| kubernetes.apiserver.request.verb | HTTP verb | keyword |  |  |
+| kubernetes.apiserver.request.version | version for the group | keyword |  |  |
+| service.address | Service address | keyword |  |  |
+| service.type | Service type | keyword |  |  |

--- a/packages/kubernetes/docs/kube-controller-manager.md
+++ b/packages/kubernetes/docs/kube-controller-manager.md
@@ -107,87 +107,87 @@ An example event for `controllermanager` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| kubernetes.annotations.* | Kubernetes annotations map | object |
-| kubernetes.container.image | Kubernetes container image | keyword |
-| kubernetes.container.name | Kubernetes container name | keyword |
-| kubernetes.controllermanager.client.request.count | Number of requests as client | long |
-| kubernetes.controllermanager.code | HTTP code | keyword |
-| kubernetes.controllermanager.handler | Request handler | keyword |
-| kubernetes.controllermanager.host | Request host | keyword |
-| kubernetes.controllermanager.http.request.count | Request count for response | long |
-| kubernetes.controllermanager.http.request.duration.us.count | Request count for duration | long |
-| kubernetes.controllermanager.http.request.duration.us.percentile.* | Request duration microseconds percentiles | object |
-| kubernetes.controllermanager.http.request.duration.us.sum | Request duration microseconds cumulative sum | double |
-| kubernetes.controllermanager.http.request.size.bytes.count | Request count for size | long |
-| kubernetes.controllermanager.http.request.size.bytes.percentile.* | Request size percentiles | object |
-| kubernetes.controllermanager.http.request.size.bytes.sum | Request size cumulative sum | long |
-| kubernetes.controllermanager.http.response.size.bytes.count | Response count | long |
-| kubernetes.controllermanager.http.response.size.bytes.percentile.* | Response size percentiles | object |
-| kubernetes.controllermanager.http.response.size.bytes.sum | Response size cumulative sum | long |
-| kubernetes.controllermanager.leader.is_master | Whether the node is master | boolean |
-| kubernetes.controllermanager.method | HTTP method | keyword |
-| kubernetes.controllermanager.name | Name for the resource | keyword |
-| kubernetes.controllermanager.node.collector.count | Number of nodes | long |
-| kubernetes.controllermanager.node.collector.eviction.count | Number of node evictions | long |
-| kubernetes.controllermanager.node.collector.health.pct | Percentage of healthy nodes | long |
-| kubernetes.controllermanager.node.collector.unhealthy.count | Number of unhealthy nodes | long |
-| kubernetes.controllermanager.process.cpu.sec | CPU seconds | double |
-| kubernetes.controllermanager.process.fds.open.count | Number of open file descriptors | long |
-| kubernetes.controllermanager.process.memory.resident.bytes | Bytes in resident memory | long |
-| kubernetes.controllermanager.process.memory.virtual.bytes | Bytes in virtual memory | long |
-| kubernetes.controllermanager.process.started.sec | Seconds since the process started | double |
-| kubernetes.controllermanager.workqueue.adds.count | Workqueue add count | long |
-| kubernetes.controllermanager.workqueue.depth.count | Workqueue depth count | long |
-| kubernetes.controllermanager.workqueue.longestrunning.sec | Longest running processors | double |
-| kubernetes.controllermanager.workqueue.retries.count | Workqueue number of retries | long |
-| kubernetes.controllermanager.workqueue.unfinished.sec | Unfinished processors | double |
-| kubernetes.controllermanager.zone | Infrastructure zone | keyword |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |
-| kubernetes.labels.* | Kubernetes labels map | object |
-| kubernetes.namespace | Kubernetes namespace | keyword |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
-| kubernetes.node.name | Kubernetes node name | keyword |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |
-| kubernetes.pod.name | Kubernetes pod name | keyword |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| ecs.version | ECS version | keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.container.image | Kubernetes container image | keyword |  |  |
+| kubernetes.container.name | Kubernetes container name | keyword |  |  |
+| kubernetes.controllermanager.client.request.count | Number of requests as client | long |  | counter |
+| kubernetes.controllermanager.code | HTTP code | keyword |  |  |
+| kubernetes.controllermanager.handler | Request handler | keyword |  |  |
+| kubernetes.controllermanager.host | Request host | keyword |  |  |
+| kubernetes.controllermanager.http.request.count | Request count for response | long |  | counter |
+| kubernetes.controllermanager.http.request.duration.us.count | Request count for duration | long | micros | counter |
+| kubernetes.controllermanager.http.request.duration.us.percentile.* | Request duration microseconds percentiles | object |  |  |
+| kubernetes.controllermanager.http.request.duration.us.sum | Request duration microseconds cumulative sum | double | micros | counter |
+| kubernetes.controllermanager.http.request.size.bytes.count | Request count for size | long | byte | counter |
+| kubernetes.controllermanager.http.request.size.bytes.percentile.* | Request size percentiles | object |  |  |
+| kubernetes.controllermanager.http.request.size.bytes.sum | Request size cumulative sum | long | byte | counter |
+| kubernetes.controllermanager.http.response.size.bytes.count | Response count | long | byte | counter |
+| kubernetes.controllermanager.http.response.size.bytes.percentile.* | Response size percentiles | object |  |  |
+| kubernetes.controllermanager.http.response.size.bytes.sum | Response size cumulative sum | long | byte | counter |
+| kubernetes.controllermanager.leader.is_master | Whether the node is master | boolean |  |  |
+| kubernetes.controllermanager.method | HTTP method | keyword |  |  |
+| kubernetes.controllermanager.name | Name for the resource | keyword |  |  |
+| kubernetes.controllermanager.node.collector.count | Number of nodes | long |  | gauge |
+| kubernetes.controllermanager.node.collector.eviction.count | Number of node evictions | long |  | counter |
+| kubernetes.controllermanager.node.collector.health.pct | Percentage of healthy nodes | long |  | gauge |
+| kubernetes.controllermanager.node.collector.unhealthy.count | Number of unhealthy nodes | long |  | gauge |
+| kubernetes.controllermanager.process.cpu.sec | CPU seconds | double |  | counter |
+| kubernetes.controllermanager.process.fds.open.count | Number of open file descriptors | long |  | gauge |
+| kubernetes.controllermanager.process.memory.resident.bytes | Bytes in resident memory | long | byte | gauge |
+| kubernetes.controllermanager.process.memory.virtual.bytes | Bytes in virtual memory | long | byte | gauge |
+| kubernetes.controllermanager.process.started.sec | Seconds since the process started | double |  | gauge |
+| kubernetes.controllermanager.workqueue.adds.count | Workqueue add count | long |  | counter |
+| kubernetes.controllermanager.workqueue.depth.count | Workqueue depth count | long |  | gauge |
+| kubernetes.controllermanager.workqueue.longestrunning.sec | Longest running processors | double |  | gauge |
+| kubernetes.controllermanager.workqueue.retries.count | Workqueue number of retries | long |  | counter |
+| kubernetes.controllermanager.workqueue.unfinished.sec | Unfinished processors | double |  | gauge |
+| kubernetes.controllermanager.zone | Infrastructure zone | keyword |  |  |
+| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
+| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
+| kubernetes.node.name | Kubernetes node name | keyword |  |  |
+| kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
+| kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
+| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
+| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
+| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
+| service.address | Service address | keyword |  |  |
+| service.type | Service type | keyword |  |  |

--- a/packages/kubernetes/docs/kube-proxy.md
+++ b/packages/kubernetes/docs/kube-proxy.md
@@ -230,67 +230,67 @@ An example event for `proxy` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| kubernetes.proxy.client.request.count | Number of requests as client | long |
-| kubernetes.proxy.code | HTTP code | keyword |
-| kubernetes.proxy.handler | Request handler | keyword |
-| kubernetes.proxy.host | Request host | keyword |
-| kubernetes.proxy.http.request.count | Request count | long |
-| kubernetes.proxy.http.request.duration.us.count | Request count for duration | long |
-| kubernetes.proxy.http.request.duration.us.percentile.* | Request duration microseconds percentiles | object |
-| kubernetes.proxy.http.request.duration.us.sum | Request duration microseconds cumulative sum | double |
-| kubernetes.proxy.http.request.size.bytes.count | Request count for size | long |
-| kubernetes.proxy.http.request.size.bytes.percentile.* | Request size percentiles | object |
-| kubernetes.proxy.http.request.size.bytes.sum | Request size cumulative sum | long |
-| kubernetes.proxy.http.response.size.bytes.count | Response count | long |
-| kubernetes.proxy.http.response.size.bytes.percentile.* | Response size percentiles | object |
-| kubernetes.proxy.http.response.size.bytes.sum | Response size cumulative sum | long |
-| kubernetes.proxy.method | HTTP method | keyword |
-| kubernetes.proxy.process.cpu.sec | CPU seconds | double |
-| kubernetes.proxy.process.fds.open.count | Number of open file descriptors | long |
-| kubernetes.proxy.process.memory.resident.bytes | Bytes in resident memory | long |
-| kubernetes.proxy.process.memory.virtual.bytes | Bytes in virtual memory | long |
-| kubernetes.proxy.process.started.sec | Seconds since the process started | double |
-| kubernetes.proxy.sync.networkprogramming.duration.us.bucket.* | Network programming duration, histogram buckets | object |
-| kubernetes.proxy.sync.networkprogramming.duration.us.count | Network programming duration, number of operations | long |
-| kubernetes.proxy.sync.networkprogramming.duration.us.sum | Network programming duration, sum in microseconds | long |
-| kubernetes.proxy.sync.rules.duration.us.bucket.* | SyncProxyRules duration, histogram buckets | object |
-| kubernetes.proxy.sync.rules.duration.us.count | SyncProxyRules duration, number of operations | long |
-| kubernetes.proxy.sync.rules.duration.us.sum | SyncProxyRules duration, sum of durations in microseconds | long |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| ecs.version | ECS version | keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| kubernetes.proxy.client.request.count | Number of requests as client | long |  | counter |
+| kubernetes.proxy.code | HTTP code | keyword |  |  |
+| kubernetes.proxy.handler | Request handler | keyword |  |  |
+| kubernetes.proxy.host | Request host | keyword |  |  |
+| kubernetes.proxy.http.request.count | Request count | long |  | counter |
+| kubernetes.proxy.http.request.duration.us.count | Request count for duration | long | micros | counter |
+| kubernetes.proxy.http.request.duration.us.percentile.* | Request duration microseconds percentiles | object |  |  |
+| kubernetes.proxy.http.request.duration.us.sum | Request duration microseconds cumulative sum | double | micros | counter |
+| kubernetes.proxy.http.request.size.bytes.count | Request count for size | long | byte | counter |
+| kubernetes.proxy.http.request.size.bytes.percentile.* | Request size percentiles | object |  |  |
+| kubernetes.proxy.http.request.size.bytes.sum | Request size cumulative sum | long | byte | counter |
+| kubernetes.proxy.http.response.size.bytes.count | Response count | long |  | counter |
+| kubernetes.proxy.http.response.size.bytes.percentile.* | Response size percentiles | object |  |  |
+| kubernetes.proxy.http.response.size.bytes.sum | Response size cumulative sum | long | byte | counter |
+| kubernetes.proxy.method | HTTP method | keyword |  |  |
+| kubernetes.proxy.process.cpu.sec | CPU seconds | double |  | counter |
+| kubernetes.proxy.process.fds.open.count | Number of open file descriptors | long |  | gauge |
+| kubernetes.proxy.process.memory.resident.bytes | Bytes in resident memory | long | byte | gauge |
+| kubernetes.proxy.process.memory.virtual.bytes | Bytes in virtual memory | long | byte | gauge |
+| kubernetes.proxy.process.started.sec | Seconds since the process started | double |  | gauge |
+| kubernetes.proxy.sync.networkprogramming.duration.us.bucket.* | Network programming duration, histogram buckets | object |  |  |
+| kubernetes.proxy.sync.networkprogramming.duration.us.count | Network programming duration, number of operations | long |  | counter |
+| kubernetes.proxy.sync.networkprogramming.duration.us.sum | Network programming duration, sum in microseconds | long |  | counter |
+| kubernetes.proxy.sync.rules.duration.us.bucket.* | SyncProxyRules duration, histogram buckets | object |  |  |
+| kubernetes.proxy.sync.rules.duration.us.count | SyncProxyRules duration, number of operations | long |  | counter |
+| kubernetes.proxy.sync.rules.duration.us.sum | SyncProxyRules duration, sum of durations in microseconds | long |  | counter |
+| service.address | Service address | keyword |  |  |
+| service.type | Service type | keyword |  |  |

--- a/packages/kubernetes/docs/kube-scheduler.md
+++ b/packages/kubernetes/docs/kube-scheduler.md
@@ -93,89 +93,89 @@ An example event for `scheduler` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| kubernetes.annotations.* | Kubernetes annotations map | object |
-| kubernetes.container.image | Kubernetes container image | keyword |
-| kubernetes.container.name | Kubernetes container name | keyword |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |
-| kubernetes.labels.* | Kubernetes labels map | object |
-| kubernetes.namespace | Kubernetes namespace | keyword |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
-| kubernetes.node.name | Kubernetes node name | keyword |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |
-| kubernetes.pod.name | Kubernetes pod name | keyword |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
-| kubernetes.scheduler.client.request.count | Number of requests as client | long |
-| kubernetes.scheduler.code | HTTP code | keyword |
-| kubernetes.scheduler.handler | Request handler | keyword |
-| kubernetes.scheduler.host | Request host | keyword |
-| kubernetes.scheduler.http.request.count | Request count | long |
-| kubernetes.scheduler.http.request.duration.us.count | Request count for duration | long |
-| kubernetes.scheduler.http.request.duration.us.percentile.* | Request duration microseconds percentiles | object |
-| kubernetes.scheduler.http.request.duration.us.sum | Request duration microseconds cumulative sum | double |
-| kubernetes.scheduler.http.request.size.bytes.count | Request count for size | long |
-| kubernetes.scheduler.http.request.size.bytes.percentile.* | Request size percentiles | object |
-| kubernetes.scheduler.http.request.size.bytes.sum | Request size cumulative sum | long |
-| kubernetes.scheduler.http.response.size.bytes.count | Response count | long |
-| kubernetes.scheduler.http.response.size.bytes.percentile.* | Response size percentiles | object |
-| kubernetes.scheduler.http.response.size.bytes.sum | Response size cumulative sum | long |
-| kubernetes.scheduler.leader.is_master | Whether the node is master | boolean |
-| kubernetes.scheduler.method | HTTP method | keyword |
-| kubernetes.scheduler.name | Name for the resource | keyword |
-| kubernetes.scheduler.operation | Scheduling operation | keyword |
-| kubernetes.scheduler.process.cpu.sec | CPU seconds | double |
-| kubernetes.scheduler.process.fds.open.count | Number of open file descriptors | long |
-| kubernetes.scheduler.process.memory.resident.bytes | Bytes in resident memory | long |
-| kubernetes.scheduler.process.memory.virtual.bytes | Bytes in virtual memory | long |
-| kubernetes.scheduler.process.started.sec | Seconds since the process started | double |
-| kubernetes.scheduler.result | Schedule attempt result | keyword |
-| kubernetes.scheduler.scheduling.duration.seconds.count | Scheduling count | long |
-| kubernetes.scheduler.scheduling.duration.seconds.percentile.* | Scheduling duration percentiles | object |
-| kubernetes.scheduler.scheduling.duration.seconds.sum | Scheduling duration cumulative sum | double |
-| kubernetes.scheduler.scheduling.e2e.duration.us.bucket.* | End to end scheduling duration microseconds | object |
-| kubernetes.scheduler.scheduling.e2e.duration.us.count | End to end scheduling count | long |
-| kubernetes.scheduler.scheduling.e2e.duration.us.sum | End to end scheduling duration microseconds sum | long |
-| kubernetes.scheduler.scheduling.pod.attempts.count | Pod attempts count | long |
-| kubernetes.scheduler.scheduling.pod.preemption.victims.bucket.* | Pod preemption victims | long |
-| kubernetes.scheduler.scheduling.pod.preemption.victims.count | Pod preemption victims count | long |
-| kubernetes.scheduler.scheduling.pod.preemption.victims.sum | Pod preemption victims sum | long |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| ecs.version | ECS version | keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.container.image | Kubernetes container image | keyword |  |  |
+| kubernetes.container.name | Kubernetes container name | keyword |  |  |
+| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
+| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
+| kubernetes.node.name | Kubernetes node name | keyword |  |  |
+| kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
+| kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
+| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
+| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
+| kubernetes.scheduler.client.request.count | Number of requests as client | long |  | counter |
+| kubernetes.scheduler.code | HTTP code | keyword |  |  |
+| kubernetes.scheduler.handler | Request handler | keyword |  |  |
+| kubernetes.scheduler.host | Request host | keyword |  |  |
+| kubernetes.scheduler.http.request.count | Request count | long |  | counter |
+| kubernetes.scheduler.http.request.duration.us.count | Request count for duration | long | micros | counter |
+| kubernetes.scheduler.http.request.duration.us.percentile.* | Request duration microseconds percentiles | object |  |  |
+| kubernetes.scheduler.http.request.duration.us.sum | Request duration microseconds cumulative sum | double | micros | counter |
+| kubernetes.scheduler.http.request.size.bytes.count | Request count for size | long | byte | counter |
+| kubernetes.scheduler.http.request.size.bytes.percentile.* | Request size percentiles | object |  |  |
+| kubernetes.scheduler.http.request.size.bytes.sum | Request size cumulative sum | long | byte | counter |
+| kubernetes.scheduler.http.response.size.bytes.count | Response count | long |  | counter |
+| kubernetes.scheduler.http.response.size.bytes.percentile.* | Response size percentiles | object |  |  |
+| kubernetes.scheduler.http.response.size.bytes.sum | Response size cumulative sum | long | byte | counter |
+| kubernetes.scheduler.leader.is_master | Whether the node is master | boolean |  |  |
+| kubernetes.scheduler.method | HTTP method | keyword |  |  |
+| kubernetes.scheduler.name | Name for the resource | keyword |  |  |
+| kubernetes.scheduler.operation | Scheduling operation | keyword |  |  |
+| kubernetes.scheduler.process.cpu.sec | CPU seconds | double |  | counter |
+| kubernetes.scheduler.process.fds.open.count | Number of open file descriptors | long |  | gauge |
+| kubernetes.scheduler.process.memory.resident.bytes | Bytes in resident memory | long | byte | gauge |
+| kubernetes.scheduler.process.memory.virtual.bytes | Bytes in virtual memory | long | byte | gauge |
+| kubernetes.scheduler.process.started.sec | Seconds since the process started | double |  | gauge |
+| kubernetes.scheduler.result | Schedule attempt result | keyword |  |  |
+| kubernetes.scheduler.scheduling.duration.seconds.count | Scheduling count | long |  | counter |
+| kubernetes.scheduler.scheduling.duration.seconds.percentile.* | Scheduling duration percentiles | object |  |  |
+| kubernetes.scheduler.scheduling.duration.seconds.sum | Scheduling duration cumulative sum | double |  | counter |
+| kubernetes.scheduler.scheduling.e2e.duration.us.bucket.* | End to end scheduling duration microseconds | object |  |  |
+| kubernetes.scheduler.scheduling.e2e.duration.us.count | End to end scheduling count | long | micros | counter |
+| kubernetes.scheduler.scheduling.e2e.duration.us.sum | End to end scheduling duration microseconds sum | long | micros | counter |
+| kubernetes.scheduler.scheduling.pod.attempts.count | Pod attempts count | long |  | counter |
+| kubernetes.scheduler.scheduling.pod.preemption.victims.bucket.* | Pod preemption victims | long |  |  |
+| kubernetes.scheduler.scheduling.pod.preemption.victims.count | Pod preemption victims count | long |  | counter |
+| kubernetes.scheduler.scheduling.pod.preemption.victims.sum | Pod preemption victims sum | long |  | counter |
+| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
+| service.address | Service address | keyword |  |  |
+| service.type | Service type | keyword |  |  |

--- a/packages/kubernetes/docs/kube-state-metrics.md
+++ b/packages/kubernetes/docs/kube-state-metrics.md
@@ -94,70 +94,70 @@ An example event for `state_container` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| container.runtime | Runtime managing this container | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| kubernetes.annotations.* | Kubernetes annotations map | object |
-| kubernetes.container.cpu.limit.cores | Container CPU cores limit | float |
-| kubernetes.container.cpu.limit.nanocores | Container CPU nanocores limit | long |
-| kubernetes.container.cpu.request.cores | Container CPU requested cores | float |
-| kubernetes.container.cpu.request.nanocores | Container CPU requested nanocores | long |
-| kubernetes.container.id | Container id | keyword |
-| kubernetes.container.image | Kubernetes container image | keyword |
-| kubernetes.container.memory.limit.bytes | Container memory limit in bytes | long |
-| kubernetes.container.memory.request.bytes | Container requested memory in bytes | long |
-| kubernetes.container.name | Kubernetes container name | keyword |
-| kubernetes.container.status.phase | Container phase (running, waiting, terminated) | keyword |
-| kubernetes.container.status.ready | Container ready status | boolean |
-| kubernetes.container.status.reason | Waiting (ContainerCreating, CrashLoopBackoff, ErrImagePull, ImagePullBackoff) or termination (Completed, ContainerCannotRun, Error, OOMKilled) reason. | keyword |
-| kubernetes.container.status.restarts | Container restarts count | integer |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |
-| kubernetes.labels.* | Kubernetes labels map | object |
-| kubernetes.namespace | Kubernetes namespace | keyword |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
-| kubernetes.node.name | Kubernetes node name | keyword |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |
-| kubernetes.pod.name | Kubernetes pod name | keyword |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| container.runtime | Runtime managing this container | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| ecs.version | ECS version | keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.container.cpu.limit.cores | Container CPU cores limit | float |  | gauge |
+| kubernetes.container.cpu.limit.nanocores | Container CPU nanocores limit | long |  | gauge |
+| kubernetes.container.cpu.request.cores | Container CPU requested cores | float |  | gauge |
+| kubernetes.container.cpu.request.nanocores | Container CPU requested nanocores | long |  | gauge |
+| kubernetes.container.id | Container id | keyword |  |  |
+| kubernetes.container.image | Kubernetes container image | keyword |  |  |
+| kubernetes.container.memory.limit.bytes | Container memory limit in bytes | long | byte | gauge |
+| kubernetes.container.memory.request.bytes | Container requested memory in bytes | long | byte | gauge |
+| kubernetes.container.name | Kubernetes container name | keyword |  |  |
+| kubernetes.container.status.phase | Container phase (running, waiting, terminated) | keyword |  |  |
+| kubernetes.container.status.ready | Container ready status | boolean |  |  |
+| kubernetes.container.status.reason | Waiting (ContainerCreating, CrashLoopBackoff, ErrImagePull, ImagePullBackoff) or termination (Completed, ContainerCannotRun, Error, OOMKilled) reason. | keyword |  |  |
+| kubernetes.container.status.restarts | Container restarts count | integer |  | counter |
+| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
+| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
+| kubernetes.node.name | Kubernetes node name | keyword |  |  |
+| kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
+| kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
+| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
+| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
+| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
+| service.address | Service address | keyword |  |  |
+| service.type | Service type | keyword |  |  |
 
 
 ### state_cronjob
@@ -238,67 +238,67 @@ An example event for `state_cronjob` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| kubernetes.annotations.* | Kubernetes annotations map | object |
-| kubernetes.container.image | Kubernetes container image | keyword |
-| kubernetes.container.name | Kubernetes container name | keyword |
-| kubernetes.cronjob.active.count | Number of active pods for the cronjob | long |
-| kubernetes.cronjob.concurrency | Concurrency policy | keyword |
-| kubernetes.cronjob.created.sec | Epoch seconds since the cronjob was created | double |
-| kubernetes.cronjob.deadline.sec | Deadline seconds after schedule for considering failed | long |
-| kubernetes.cronjob.is_suspended | Whether the cronjob is suspended | boolean |
-| kubernetes.cronjob.last_schedule.sec | Epoch seconds for last cronjob run | double |
-| kubernetes.cronjob.name | Cronjob name | keyword |
-| kubernetes.cronjob.next_schedule.sec | Epoch seconds for next cronjob run | double |
-| kubernetes.cronjob.schedule | Cronjob schedule | keyword |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |
-| kubernetes.labels.* | Kubernetes labels map | object |
-| kubernetes.namespace | Kubernetes namespace | keyword |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
-| kubernetes.node.name | Kubernetes node name | keyword |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |
-| kubernetes.pod.name | Kubernetes pod name | keyword |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| ecs.version | ECS version | keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.container.image | Kubernetes container image | keyword |  |  |
+| kubernetes.container.name | Kubernetes container name | keyword |  |  |
+| kubernetes.cronjob.active.count | Number of active pods for the cronjob | long |  | gauge |
+| kubernetes.cronjob.concurrency | Concurrency policy | keyword |  |  |
+| kubernetes.cronjob.created.sec | Epoch seconds since the cronjob was created | double | s | gauge |
+| kubernetes.cronjob.deadline.sec | Deadline seconds after schedule for considering failed | long | s | gauge |
+| kubernetes.cronjob.is_suspended | Whether the cronjob is suspended | boolean |  |  |
+| kubernetes.cronjob.last_schedule.sec | Epoch seconds for last cronjob run | double | s | gauge |
+| kubernetes.cronjob.name | Cronjob name | keyword |  |  |
+| kubernetes.cronjob.next_schedule.sec | Epoch seconds for next cronjob run | double | s | gauge |
+| kubernetes.cronjob.schedule | Cronjob schedule | keyword |  |  |
+| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
+| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
+| kubernetes.node.name | Kubernetes node name | keyword |  |  |
+| kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
+| kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
+| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
+| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
+| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
+| service.address | Service address | keyword |  |  |
+| service.type | Service type | keyword |  |  |
 
 
 ### state_daemonset
@@ -375,63 +375,63 @@ An example event for `state_daemonset` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| kubernetes.annotations.* | Kubernetes annotations map | object |
-| kubernetes.container.image | Kubernetes container image | keyword |
-| kubernetes.container.name | Kubernetes container name | keyword |
-| kubernetes.daemonset.name |  | keyword |
-| kubernetes.daemonset.replicas.available | The number of available replicas per DaemonSet | long |
-| kubernetes.daemonset.replicas.desired | The desired number of replicas per DaemonSet | long |
-| kubernetes.daemonset.replicas.ready | The number of ready replicas per DaemonSet | long |
-| kubernetes.daemonset.replicas.unavailable | The number of unavailable replicas per DaemonSet | long |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |
-| kubernetes.labels.* | Kubernetes labels map | object |
-| kubernetes.namespace | Kubernetes namespace | keyword |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
-| kubernetes.node.name | Kubernetes node name | keyword |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |
-| kubernetes.pod.name | Kubernetes pod name | keyword |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Metric Type |
+|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |
+| cloud.region | Region in which this host is running. | keyword |  |
+| container.id | Unique container id. | keyword |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |
+| container.labels | Image labels. | object |  |
+| container.name | Container name. | keyword |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |
+| data_stream.type | Data stream type. | constant_keyword |  |
+| ecs.version | ECS version | keyword |  |
+| host.architecture | Operating system architecture. | keyword |  |
+| host.containerized | If the host is a container. | boolean |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |
+| host.ip | Host ip addresses. | ip |  |
+| host.mac | Host mac addresses. | keyword |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |
+| host.os.build | OS build information. | keyword |  |
+| host.os.codename | OS codename, if any. | keyword |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |
+| host.os.name | Operating system name, without the version. | keyword |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
+| kubernetes.annotations.* | Kubernetes annotations map | object |  |
+| kubernetes.container.image | Kubernetes container image | keyword |  |
+| kubernetes.container.name | Kubernetes container name | keyword |  |
+| kubernetes.daemonset.name |  | keyword |  |
+| kubernetes.daemonset.replicas.available | The number of available replicas per DaemonSet | long | gauge |
+| kubernetes.daemonset.replicas.desired | The desired number of replicas per DaemonSet | long | gauge |
+| kubernetes.daemonset.replicas.ready | The number of ready replicas per DaemonSet | long | gauge |
+| kubernetes.daemonset.replicas.unavailable | The number of unavailable replicas per DaemonSet | long | gauge |
+| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |
+| kubernetes.labels.* | Kubernetes labels map | object |  |
+| kubernetes.namespace | Kubernetes namespace | keyword |  |
+| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |
+| kubernetes.node.name | Kubernetes node name | keyword |  |
+| kubernetes.pod.ip | Kubernetes pod IP | ip |  |
+| kubernetes.pod.name | Kubernetes pod name | keyword |  |
+| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |
+| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |
+| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |
+| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |
+| service.address | Service address | keyword |  |
+| service.type | Service type | keyword |  |
 
 
 ### state_deployment
@@ -509,63 +509,63 @@ An example event for `state_deployment` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| kubernetes.annotations.* | Kubernetes annotations map | object |
-| kubernetes.container.image | Kubernetes container image | keyword |
-| kubernetes.container.name | Kubernetes container name | keyword |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |
-| kubernetes.deployment.paused | Kubernetes deployment paused status | boolean |
-| kubernetes.deployment.replicas.available | Deployment available replicas | integer |
-| kubernetes.deployment.replicas.desired | Deployment number of desired replicas (spec) | integer |
-| kubernetes.deployment.replicas.unavailable | Deployment unavailable replicas | integer |
-| kubernetes.deployment.replicas.updated | Deployment updated replicas | integer |
-| kubernetes.labels.* | Kubernetes labels map | object |
-| kubernetes.namespace | Kubernetes namespace | keyword |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
-| kubernetes.node.name | Kubernetes node name | keyword |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |
-| kubernetes.pod.name | Kubernetes pod name | keyword |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Metric Type |
+|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |
+| cloud.region | Region in which this host is running. | keyword |  |
+| container.id | Unique container id. | keyword |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |
+| container.labels | Image labels. | object |  |
+| container.name | Container name. | keyword |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |
+| data_stream.type | Data stream type. | constant_keyword |  |
+| ecs.version | ECS version | keyword |  |
+| host.architecture | Operating system architecture. | keyword |  |
+| host.containerized | If the host is a container. | boolean |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |
+| host.ip | Host ip addresses. | ip |  |
+| host.mac | Host mac addresses. | keyword |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |
+| host.os.build | OS build information. | keyword |  |
+| host.os.codename | OS codename, if any. | keyword |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |
+| host.os.name | Operating system name, without the version. | keyword |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
+| kubernetes.annotations.* | Kubernetes annotations map | object |  |
+| kubernetes.container.image | Kubernetes container image | keyword |  |
+| kubernetes.container.name | Kubernetes container name | keyword |  |
+| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |
+| kubernetes.deployment.paused | Kubernetes deployment paused status | boolean |  |
+| kubernetes.deployment.replicas.available | Deployment available replicas | integer | gauge |
+| kubernetes.deployment.replicas.desired | Deployment number of desired replicas (spec) | integer | gauge |
+| kubernetes.deployment.replicas.unavailable | Deployment unavailable replicas | integer | gauge |
+| kubernetes.deployment.replicas.updated | Deployment updated replicas | integer | gauge |
+| kubernetes.labels.* | Kubernetes labels map | object |  |
+| kubernetes.namespace | Kubernetes namespace | keyword |  |
+| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |
+| kubernetes.node.name | Kubernetes node name | keyword |  |
+| kubernetes.pod.ip | Kubernetes pod IP | ip |  |
+| kubernetes.pod.name | Kubernetes pod name | keyword |  |
+| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |
+| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |
+| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |
+| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |
+| service.address | Service address | keyword |  |
+| service.type | Service type | keyword |  |
 
 
 ### state_node
@@ -668,70 +668,70 @@ An example event for `state_node` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| kubernetes.annotations.* | Kubernetes annotations map | object |
-| kubernetes.container.image | Kubernetes container image | keyword |
-| kubernetes.container.name | Kubernetes container name | keyword |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |
-| kubernetes.labels.* | Kubernetes labels map | object |
-| kubernetes.namespace | Kubernetes namespace | keyword |
-| kubernetes.node.cpu.allocatable.cores | Node CPU allocatable cores | float |
-| kubernetes.node.cpu.capacity.cores | Node CPU capacity cores | long |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
-| kubernetes.node.memory.allocatable.bytes | Node allocatable memory in bytes | long |
-| kubernetes.node.memory.capacity.bytes | Node memory capacity in bytes | long |
-| kubernetes.node.name | Kubernetes node name | keyword |
-| kubernetes.node.pod.allocatable.total | Node allocatable pods | long |
-| kubernetes.node.pod.capacity.total | Node pod capacity | long |
-| kubernetes.node.status.disk_pressure | Node DiskPressure status (true, false or unknown) | keyword |
-| kubernetes.node.status.memory_pressure | Node MemoryPressure status (true, false or unknown) | keyword |
-| kubernetes.node.status.out_of_disk | Node OutOfDisk status (true, false or unknown) | keyword |
-| kubernetes.node.status.pid_pressure | Node PIDPressure status (true, false or unknown) | keyword |
-| kubernetes.node.status.ready | Node ready status (true, false or unknown) | keyword |
-| kubernetes.node.status.unschedulable | Node unschedulable status | boolean |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |
-| kubernetes.pod.name | Kubernetes pod name | keyword |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| ecs.version | ECS version | keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.container.image | Kubernetes container image | keyword |  |  |
+| kubernetes.container.name | Kubernetes container name | keyword |  |  |
+| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
+| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.node.cpu.allocatable.cores | Node CPU allocatable cores | float |  | gauge |
+| kubernetes.node.cpu.capacity.cores | Node CPU capacity cores | long |  | gauge |
+| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
+| kubernetes.node.memory.allocatable.bytes | Node allocatable memory in bytes | long | byte | gauge |
+| kubernetes.node.memory.capacity.bytes | Node memory capacity in bytes | long | byte | gauge |
+| kubernetes.node.name | Kubernetes node name | keyword |  |  |
+| kubernetes.node.pod.allocatable.total | Node allocatable pods | long |  | gauge |
+| kubernetes.node.pod.capacity.total | Node pod capacity | long |  | gauge |
+| kubernetes.node.status.disk_pressure | Node DiskPressure status (true, false or unknown) | keyword |  |  |
+| kubernetes.node.status.memory_pressure | Node MemoryPressure status (true, false or unknown) | keyword |  |  |
+| kubernetes.node.status.out_of_disk | Node OutOfDisk status (true, false or unknown) | keyword |  |  |
+| kubernetes.node.status.pid_pressure | Node PIDPressure status (true, false or unknown) | keyword |  |  |
+| kubernetes.node.status.ready | Node ready status (true, false or unknown) | keyword |  |  |
+| kubernetes.node.status.unschedulable | Node unschedulable status | boolean |  |  |
+| kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
+| kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
+| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
+| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
+| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
+| service.address | Service address | keyword |  |  |
+| service.type | Service type | keyword |  |  |
 
 
 ### state_persistentvolume
@@ -806,62 +806,62 @@ An example event for `state_persistentvolume` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| kubernetes.annotations.* | Kubernetes annotations map | object |
-| kubernetes.container.image | Kubernetes container image | keyword |
-| kubernetes.container.name | Kubernetes container name | keyword |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |
-| kubernetes.labels.* | Kubernetes labels map | object |
-| kubernetes.namespace | Kubernetes namespace | keyword |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
-| kubernetes.node.name | Kubernetes node name | keyword |
-| kubernetes.persistentvolume.capacity.bytes | Volume capacity | long |
-| kubernetes.persistentvolume.name | Volume name. | keyword |
-| kubernetes.persistentvolume.phase | Volume phase according to kubernetes | keyword |
-| kubernetes.persistentvolume.storage_class | Storage class for the volume | keyword |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |
-| kubernetes.pod.name | Kubernetes pod name | keyword |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| ecs.version | ECS version | keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.container.image | Kubernetes container image | keyword |  |  |
+| kubernetes.container.name | Kubernetes container name | keyword |  |  |
+| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
+| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
+| kubernetes.node.name | Kubernetes node name | keyword |  |  |
+| kubernetes.persistentvolume.capacity.bytes | Volume capacity | long | byte | gauge |
+| kubernetes.persistentvolume.name | Volume name. | keyword |  |  |
+| kubernetes.persistentvolume.phase | Volume phase according to kubernetes | keyword |  |  |
+| kubernetes.persistentvolume.storage_class | Storage class for the volume | keyword |  |  |
+| kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
+| kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
+| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
+| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
+| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
+| service.address | Service address | keyword |  |  |
+| service.type | Service type | keyword |  |  |
 
 
 ### state_persistentvolumeclaim
@@ -936,64 +936,64 @@ An example event for `state_persistentvolumeclaim` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| kubernetes.annotations.* | Kubernetes annotations map | object |
-| kubernetes.container.image | Kubernetes container image | keyword |
-| kubernetes.container.name | Kubernetes container name | keyword |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |
-| kubernetes.labels.* | Kubernetes labels map | object |
-| kubernetes.namespace | Kubernetes namespace | keyword |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
-| kubernetes.node.name | Kubernetes node name | keyword |
-| kubernetes.persistentvolumeclaim.access_mode | Access mode. | keyword |
-| kubernetes.persistentvolumeclaim.name | PVC name. | keyword |
-| kubernetes.persistentvolumeclaim.phase | PVC phase. | keyword |
-| kubernetes.persistentvolumeclaim.request_storage.bytes | Requested capacity. | long |
-| kubernetes.persistentvolumeclaim.storage_class | Storage class for the PVC. | keyword |
-| kubernetes.persistentvolumeclaim.volume_name | Binded volume name. | keyword |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |
-| kubernetes.pod.name | Kubernetes pod name | keyword |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| ecs.version | ECS version | keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.container.image | Kubernetes container image | keyword |  |  |
+| kubernetes.container.name | Kubernetes container name | keyword |  |  |
+| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
+| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
+| kubernetes.node.name | Kubernetes node name | keyword |  |  |
+| kubernetes.persistentvolumeclaim.access_mode | Access mode. | keyword |  |  |
+| kubernetes.persistentvolumeclaim.name | PVC name. | keyword |  |  |
+| kubernetes.persistentvolumeclaim.phase | PVC phase. | keyword |  |  |
+| kubernetes.persistentvolumeclaim.request_storage.bytes | Requested capacity. | long | byte | gauge |
+| kubernetes.persistentvolumeclaim.storage_class | Storage class for the PVC. | keyword |  |  |
+| kubernetes.persistentvolumeclaim.volume_name | Binded volume name. | keyword |  |  |
+| kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
+| kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
+| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
+| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
+| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
+| service.address | Service address | keyword |  |  |
+| service.type | Service type | keyword |  |  |
 
 
 ### state_pod
@@ -1217,63 +1217,63 @@ An example event for `state_replicaset` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| kubernetes.annotations.* | Kubernetes annotations map | object |
-| kubernetes.container.image | Kubernetes container image | keyword |
-| kubernetes.container.name | Kubernetes container name | keyword |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |
-| kubernetes.labels.* | Kubernetes labels map | object |
-| kubernetes.namespace | Kubernetes namespace | keyword |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
-| kubernetes.node.name | Kubernetes node name | keyword |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |
-| kubernetes.pod.name | Kubernetes pod name | keyword |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
-| kubernetes.replicaset.replicas.available | The number of replicas per ReplicaSet | long |
-| kubernetes.replicaset.replicas.desired | The number of replicas per ReplicaSet | long |
-| kubernetes.replicaset.replicas.labeled | The number of fully labeled replicas per ReplicaSet | long |
-| kubernetes.replicaset.replicas.observed | The generation observed by the ReplicaSet controller | long |
-| kubernetes.replicaset.replicas.ready | The number of ready replicas per ReplicaSet | long |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Metric Type |
+|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |
+| cloud.region | Region in which this host is running. | keyword |  |
+| container.id | Unique container id. | keyword |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |
+| container.labels | Image labels. | object |  |
+| container.name | Container name. | keyword |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |
+| data_stream.type | Data stream type. | constant_keyword |  |
+| ecs.version | ECS version | keyword |  |
+| host.architecture | Operating system architecture. | keyword |  |
+| host.containerized | If the host is a container. | boolean |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |
+| host.ip | Host ip addresses. | ip |  |
+| host.mac | Host mac addresses. | keyword |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |
+| host.os.build | OS build information. | keyword |  |
+| host.os.codename | OS codename, if any. | keyword |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |
+| host.os.name | Operating system name, without the version. | keyword |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
+| kubernetes.annotations.* | Kubernetes annotations map | object |  |
+| kubernetes.container.image | Kubernetes container image | keyword |  |
+| kubernetes.container.name | Kubernetes container name | keyword |  |
+| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |
+| kubernetes.labels.* | Kubernetes labels map | object |  |
+| kubernetes.namespace | Kubernetes namespace | keyword |  |
+| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |
+| kubernetes.node.name | Kubernetes node name | keyword |  |
+| kubernetes.pod.ip | Kubernetes pod IP | ip |  |
+| kubernetes.pod.name | Kubernetes pod name | keyword |  |
+| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |
+| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |
+| kubernetes.replicaset.replicas.available | The number of replicas per ReplicaSet | long | gauge |
+| kubernetes.replicaset.replicas.desired | The number of replicas per ReplicaSet | long | gauge |
+| kubernetes.replicaset.replicas.labeled | The number of fully labeled replicas per ReplicaSet | long | gauge |
+| kubernetes.replicaset.replicas.observed | The generation observed by the ReplicaSet controller | long | gauge |
+| kubernetes.replicaset.replicas.ready | The number of ready replicas per ReplicaSet | long | gauge |
+| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |
+| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |
+| service.address | Service address | keyword |  |
+| service.type | Service type | keyword |  |
 
 
 ### state_resourcequota
@@ -1344,63 +1344,63 @@ An example event for `state_resourcequota` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| kubernetes.annotations.* | Kubernetes annotations map | object |
-| kubernetes.container.image | Kubernetes container image | keyword |
-| kubernetes.container.name | Kubernetes container name | keyword |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |
-| kubernetes.labels.* | Kubernetes labels map | object |
-| kubernetes.namespace | Kubernetes namespace | keyword |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
-| kubernetes.node.name | Kubernetes node name | keyword |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |
-| kubernetes.pod.name | Kubernetes pod name | keyword |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
-| kubernetes.resourcequota.created.sec | Epoch seconds since the ResourceQuota was created | double |
-| kubernetes.resourcequota.name | ResourceQuota name | keyword |
-| kubernetes.resourcequota.quota | Quota informed (hard or used) for the resource | double |
-| kubernetes.resourcequota.resource | Resource name the quota applies to | keyword |
-| kubernetes.resourcequota.type | Quota information type, `hard` or `used` | keyword |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| ecs.version | ECS version | keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.container.image | Kubernetes container image | keyword |  |  |
+| kubernetes.container.name | Kubernetes container name | keyword |  |  |
+| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
+| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
+| kubernetes.node.name | Kubernetes node name | keyword |  |  |
+| kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
+| kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
+| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
+| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
+| kubernetes.resourcequota.created.sec | Epoch seconds since the ResourceQuota was created | double | s | gauge |
+| kubernetes.resourcequota.name | ResourceQuota name | keyword |  |  |
+| kubernetes.resourcequota.quota | Quota informed (hard or used) for the resource | double |  | gauge |
+| kubernetes.resourcequota.resource | Resource name the quota applies to | keyword |  |  |
+| kubernetes.resourcequota.type | Quota information type, `hard` or `used` | keyword |  |  |
+| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
+| service.address | Service address | keyword |  |  |
+| service.type | Service type | keyword |  |  |
 
 
 ### state_service
@@ -1613,64 +1613,64 @@ An example event for `state_statefulset` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| kubernetes.annotations.* | Kubernetes annotations map | object |
-| kubernetes.container.image | Kubernetes container image | keyword |
-| kubernetes.container.name | Kubernetes container name | keyword |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |
-| kubernetes.labels.* | Kubernetes labels map | object |
-| kubernetes.namespace | Kubernetes namespace | keyword |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
-| kubernetes.node.name | Kubernetes node name | keyword |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |
-| kubernetes.pod.name | Kubernetes pod name | keyword |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |
-| kubernetes.statefulset.created | The creation timestamp (epoch) for StatefulSet | long |
-| kubernetes.statefulset.generation.desired | The desired generation per StatefulSet | long |
-| kubernetes.statefulset.generation.observed | The observed generation per StatefulSet | long |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |
-| kubernetes.statefulset.replicas.desired | The number of desired replicas per StatefulSet | long |
-| kubernetes.statefulset.replicas.observed | The number of observed replicas per StatefulSet | long |
-| kubernetes.statefulset.replicas.ready | The number of ready replicas per StatefulSet | long |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Metric Type |
+|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |
+| cloud.region | Region in which this host is running. | keyword |  |
+| container.id | Unique container id. | keyword |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |
+| container.labels | Image labels. | object |  |
+| container.name | Container name. | keyword |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |
+| data_stream.type | Data stream type. | constant_keyword |  |
+| ecs.version | ECS version | keyword |  |
+| host.architecture | Operating system architecture. | keyword |  |
+| host.containerized | If the host is a container. | boolean |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |
+| host.ip | Host ip addresses. | ip |  |
+| host.mac | Host mac addresses. | keyword |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |
+| host.os.build | OS build information. | keyword |  |
+| host.os.codename | OS codename, if any. | keyword |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |
+| host.os.name | Operating system name, without the version. | keyword |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
+| kubernetes.annotations.* | Kubernetes annotations map | object |  |
+| kubernetes.container.image | Kubernetes container image | keyword |  |
+| kubernetes.container.name | Kubernetes container name | keyword |  |
+| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |
+| kubernetes.labels.* | Kubernetes labels map | object |  |
+| kubernetes.namespace | Kubernetes namespace | keyword |  |
+| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |
+| kubernetes.node.name | Kubernetes node name | keyword |  |
+| kubernetes.pod.ip | Kubernetes pod IP | ip |  |
+| kubernetes.pod.name | Kubernetes pod name | keyword |  |
+| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |
+| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |
+| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |
+| kubernetes.statefulset.created | The creation timestamp (epoch) for StatefulSet | long | gauge |
+| kubernetes.statefulset.generation.desired | The desired generation per StatefulSet | long | gauge |
+| kubernetes.statefulset.generation.observed | The observed generation per StatefulSet | long | gauge |
+| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |
+| kubernetes.statefulset.replicas.desired | The number of desired replicas per StatefulSet | long | gauge |
+| kubernetes.statefulset.replicas.observed | The number of observed replicas per StatefulSet | long | gauge |
+| kubernetes.statefulset.replicas.ready | The number of ready replicas per StatefulSet | long | gauge |
+| service.address | Service address | keyword |  |
+| service.type | Service type | keyword |  |
 
 
 ### state_storageclass

--- a/packages/kubernetes/docs/kubelet.md
+++ b/packages/kubernetes/docs/kubelet.md
@@ -217,7 +217,7 @@ An example event for `container` looks as following:
 | kubernetes.container.memory.pagefaults | Number of page faults | long |  | counter |
 | kubernetes.container.memory.rss.bytes | RSS memory usage | long | byte | gauge |
 | kubernetes.container.memory.usage.bytes | Total memory usage | long | byte | gauge |
-| kubernetes.container.memory.usage.limit.pct | Memory usage as a percentage of the defined limit for the container (or total node allocatable memory if unlimited) | scaled_float | percetn | gauge |
+| kubernetes.container.memory.usage.limit.pct | Memory usage as a percentage of the defined limit for the container (or total node allocatable memory if unlimited) | scaled_float | percent | gauge |
 | kubernetes.container.memory.usage.node.pct | Memory usage as a percentage of the total node allocatable memory | scaled_float | percent | gauge |
 | kubernetes.container.memory.workingset.bytes | Working set memory usage | long | byte | gauge |
 | kubernetes.container.name | Kubernetes container name | keyword |  |  |

--- a/packages/kubernetes/docs/kubelet.md
+++ b/packages/kubernetes/docs/kubelet.md
@@ -164,81 +164,81 @@ An example event for `container` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| kubernetes.annotations.* | Kubernetes annotations map | object |
-| kubernetes.container.cpu.usage.core.ns | Container CPU Core usage nanoseconds | long |
-| kubernetes.container.cpu.usage.limit.pct | CPU usage as a percentage of the defined limit for the container (or total node allocatable CPU if unlimited) | scaled_float |
-| kubernetes.container.cpu.usage.nanocores | CPU used nanocores | long |
-| kubernetes.container.cpu.usage.node.pct | CPU usage as a percentage of the total node allocatable CPU | scaled_float |
-| kubernetes.container.image | Kubernetes container image | keyword |
-| kubernetes.container.logs.available.bytes | Logs available capacity in bytes | long |
-| kubernetes.container.logs.capacity.bytes | Logs total capacity in bytes | long |
-| kubernetes.container.logs.inodes.count | Total available inodes | long |
-| kubernetes.container.logs.inodes.free | Total free inodes | long |
-| kubernetes.container.logs.inodes.used | Total used inodes | long |
-| kubernetes.container.logs.used.bytes | Logs used capacity in bytes | long |
-| kubernetes.container.memory.available.bytes | Total available memory | long |
-| kubernetes.container.memory.majorpagefaults | Number of major page faults | long |
-| kubernetes.container.memory.pagefaults | Number of page faults | long |
-| kubernetes.container.memory.rss.bytes | RSS memory usage | long |
-| kubernetes.container.memory.usage.bytes | Total memory usage | long |
-| kubernetes.container.memory.usage.limit.pct | Memory usage as a percentage of the defined limit for the container (or total node allocatable memory if unlimited) | scaled_float |
-| kubernetes.container.memory.usage.node.pct | Memory usage as a percentage of the total node allocatable memory | scaled_float |
-| kubernetes.container.memory.workingset.bytes | Working set memory usage | long |
-| kubernetes.container.name | Kubernetes container name | keyword |
-| kubernetes.container.rootfs.available.bytes | Root filesystem total available in bytes | long |
-| kubernetes.container.rootfs.capacity.bytes | Root filesystem total capacity in bytes | long |
-| kubernetes.container.rootfs.inodes.used | Used inodes | long |
-| kubernetes.container.rootfs.used.bytes | Root filesystem total used in bytes | long |
-| kubernetes.container.start_time | Start time | date |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |
-| kubernetes.labels.* | Kubernetes labels map | object |
-| kubernetes.namespace | Kubernetes namespace | keyword |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
-| kubernetes.node.name | Kubernetes node name | keyword |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |
-| kubernetes.pod.name | Kubernetes pod name | keyword |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| ecs.version | ECS version | keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.container.cpu.usage.core.ns | Container CPU Core usage nanoseconds | long |  | gauge |
+| kubernetes.container.cpu.usage.limit.pct | CPU usage as a percentage of the defined limit for the container (or total node allocatable CPU if unlimited) | scaled_float | percent | gauge |
+| kubernetes.container.cpu.usage.nanocores | CPU used nanocores | long |  | gauge |
+| kubernetes.container.cpu.usage.node.pct | CPU usage as a percentage of the total node allocatable CPU | scaled_float | percent | gauge |
+| kubernetes.container.image | Kubernetes container image | keyword |  |  |
+| kubernetes.container.logs.available.bytes | Logs available capacity in bytes | long | byte | gauge |
+| kubernetes.container.logs.capacity.bytes | Logs total capacity in bytes | long | byte | gauge |
+| kubernetes.container.logs.inodes.count | Total available inodes | long |  | gauge |
+| kubernetes.container.logs.inodes.free | Total free inodes | long |  | gauge |
+| kubernetes.container.logs.inodes.used | Total used inodes | long |  | gauge |
+| kubernetes.container.logs.used.bytes | Logs used capacity in bytes | long | byte | gauge |
+| kubernetes.container.memory.available.bytes | Total available memory | long | byte | gauge |
+| kubernetes.container.memory.majorpagefaults | Number of major page faults | long |  | counter |
+| kubernetes.container.memory.pagefaults | Number of page faults | long |  | counter |
+| kubernetes.container.memory.rss.bytes | RSS memory usage | long | byte | gauge |
+| kubernetes.container.memory.usage.bytes | Total memory usage | long | byte | gauge |
+| kubernetes.container.memory.usage.limit.pct | Memory usage as a percentage of the defined limit for the container (or total node allocatable memory if unlimited) | scaled_float | percetn | gauge |
+| kubernetes.container.memory.usage.node.pct | Memory usage as a percentage of the total node allocatable memory | scaled_float | percent | gauge |
+| kubernetes.container.memory.workingset.bytes | Working set memory usage | long | byte | gauge |
+| kubernetes.container.name | Kubernetes container name | keyword |  |  |
+| kubernetes.container.rootfs.available.bytes | Root filesystem total available in bytes | long | byte | gauge |
+| kubernetes.container.rootfs.capacity.bytes | Root filesystem total capacity in bytes | long | byte | gauge |
+| kubernetes.container.rootfs.inodes.used | Used inodes | long |  | gauge |
+| kubernetes.container.rootfs.used.bytes | Root filesystem total used in bytes | long | byte | gauge |
+| kubernetes.container.start_time | Start time | date |  |  |
+| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
+| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
+| kubernetes.node.name | Kubernetes node name | keyword |  |  |
+| kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
+| kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
+| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
+| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
+| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
+| service.address | Service address | keyword |  |  |
+| service.type | Service type | keyword |  |  |
 
 
 ### node
@@ -401,80 +401,80 @@ An example event for `node` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| kubernetes.annotations.* | Kubernetes annotations map | object |
-| kubernetes.container.image | Kubernetes container image | keyword |
-| kubernetes.container.name | Kubernetes container name | keyword |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |
-| kubernetes.labels.* | Kubernetes labels map | object |
-| kubernetes.namespace | Kubernetes namespace | keyword |
-| kubernetes.node.cpu.usage.core.ns | Node CPU Core usage nanoseconds | long |
-| kubernetes.node.cpu.usage.nanocores | CPU used nanocores | long |
-| kubernetes.node.fs.available.bytes | Filesystem total available in bytes | long |
-| kubernetes.node.fs.capacity.bytes | Filesystem total capacity in bytes | long |
-| kubernetes.node.fs.inodes.count | Number of inodes | long |
-| kubernetes.node.fs.inodes.free | Number of free inodes | long |
-| kubernetes.node.fs.inodes.used | Number of used inodes | long |
-| kubernetes.node.fs.used.bytes | Filesystem total used in bytes | long |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
-| kubernetes.node.memory.available.bytes | Total available memory | long |
-| kubernetes.node.memory.majorpagefaults | Number of major page faults | long |
-| kubernetes.node.memory.pagefaults | Number of page faults | long |
-| kubernetes.node.memory.rss.bytes | RSS memory usage | long |
-| kubernetes.node.memory.usage.bytes | Total memory usage | long |
-| kubernetes.node.memory.workingset.bytes | Working set memory usage | long |
-| kubernetes.node.name | Kubernetes node name | keyword |
-| kubernetes.node.network.rx.bytes | Received bytes | long |
-| kubernetes.node.network.rx.errors | Rx errors | long |
-| kubernetes.node.network.tx.bytes | Transmitted bytes | long |
-| kubernetes.node.network.tx.errors | Tx errors | long |
-| kubernetes.node.runtime.imagefs.available.bytes | Image filesystem total available in bytes | long |
-| kubernetes.node.runtime.imagefs.capacity.bytes | Image filesystem total capacity in bytes | long |
-| kubernetes.node.runtime.imagefs.used.bytes | Image filesystem total used in bytes | long |
-| kubernetes.node.start_time | Start time | date |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |
-| kubernetes.pod.name | Kubernetes pod name | keyword |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| ecs.version | ECS version | keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.container.image | Kubernetes container image | keyword |  |  |
+| kubernetes.container.name | Kubernetes container name | keyword |  |  |
+| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
+| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.node.cpu.usage.core.ns | Node CPU Core usage nanoseconds | long |  | gauge |
+| kubernetes.node.cpu.usage.nanocores | CPU used nanocores | long |  | gauge |
+| kubernetes.node.fs.available.bytes | Filesystem total available in bytes | long | byte | gauge |
+| kubernetes.node.fs.capacity.bytes | Filesystem total capacity in bytes | long | byte | gauge |
+| kubernetes.node.fs.inodes.count | Number of inodes | long |  | gauge |
+| kubernetes.node.fs.inodes.free | Number of free inodes | long |  | gauge |
+| kubernetes.node.fs.inodes.used | Number of used inodes | long |  | gauge |
+| kubernetes.node.fs.used.bytes | Filesystem total used in bytes | long | byte | gauge |
+| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
+| kubernetes.node.memory.available.bytes | Total available memory | long | byte | gauge |
+| kubernetes.node.memory.majorpagefaults | Number of major page faults | long |  | counter |
+| kubernetes.node.memory.pagefaults | Number of page faults | long |  | counter |
+| kubernetes.node.memory.rss.bytes | RSS memory usage | long | byte | gauge |
+| kubernetes.node.memory.usage.bytes | Total memory usage | long | byte | gauge |
+| kubernetes.node.memory.workingset.bytes | Working set memory usage | long | byte | gauge |
+| kubernetes.node.name | Kubernetes node name | keyword |  |  |
+| kubernetes.node.network.rx.bytes | Received bytes | long | byte | counter |
+| kubernetes.node.network.rx.errors | Rx errors | long |  |  |
+| kubernetes.node.network.tx.bytes | Transmitted bytes | long | byte | counter |
+| kubernetes.node.network.tx.errors | Tx errors | long |  | counter |
+| kubernetes.node.runtime.imagefs.available.bytes | Image filesystem total available in bytes | long | byte | gauge |
+| kubernetes.node.runtime.imagefs.capacity.bytes | Image filesystem total capacity in bytes | long | byte | gauge |
+| kubernetes.node.runtime.imagefs.used.bytes | Image filesystem total used in bytes | long | byte | gauge |
+| kubernetes.node.start_time | Start time | date |  |  |
+| kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
+| kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
+| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
+| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
+| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
+| service.address | Service address | keyword |  |  |
+| service.type | Service type | keyword |  |  |
 
 
 ### pod
@@ -614,74 +614,74 @@ An example event for `pod` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| kubernetes.annotations.* | Kubernetes annotations map | object |
-| kubernetes.container.image | Kubernetes container image | keyword |
-| kubernetes.container.name | Kubernetes container name | keyword |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |
-| kubernetes.labels.* | Kubernetes labels map | object |
-| kubernetes.namespace | Kubernetes namespace | keyword |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
-| kubernetes.node.name | Kubernetes node name | keyword |
-| kubernetes.pod.cpu.usage.limit.pct | CPU usage as a percentage of the defined limit for the pod containers (or total node CPU if one or more containers of the pod are unlimited) | scaled_float |
-| kubernetes.pod.cpu.usage.nanocores | CPU used nanocores | long |
-| kubernetes.pod.cpu.usage.node.pct | CPU usage as a percentage of the total node CPU | scaled_float |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |
-| kubernetes.pod.memory.available.bytes | Total memory available | long |
-| kubernetes.pod.memory.major_page_faults | Total major page faults | long |
-| kubernetes.pod.memory.page_faults | Total page faults | long |
-| kubernetes.pod.memory.rss.bytes | Total resident set size memory | long |
-| kubernetes.pod.memory.usage.bytes | Total memory usage | long |
-| kubernetes.pod.memory.usage.limit.pct | Memory usage as a percentage of the defined limit for the pod containers (or total node allocatable memory if unlimited) | scaled_float |
-| kubernetes.pod.memory.usage.node.pct | Memory usage as a percentage of the total node allocatable memory | scaled_float |
-| kubernetes.pod.memory.working_set.bytes | Total working set memory | long |
-| kubernetes.pod.name | Kubernetes pod name | keyword |
-| kubernetes.pod.network.rx.bytes | Received bytes | long |
-| kubernetes.pod.network.rx.errors | Rx errors | long |
-| kubernetes.pod.network.tx.bytes | Transmitted bytes | long |
-| kubernetes.pod.network.tx.errors | Tx errors | long |
-| kubernetes.pod.start_time | Start time | date |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| ecs.version | ECS version | keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.container.image | Kubernetes container image | keyword |  |  |
+| kubernetes.container.name | Kubernetes container name | keyword |  |  |
+| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
+| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
+| kubernetes.node.name | Kubernetes node name | keyword |  |  |
+| kubernetes.pod.cpu.usage.limit.pct | CPU usage as a percentage of the defined limit for the pod containers (or total node CPU if one or more containers of the pod are unlimited) | scaled_float | percent | gauge |
+| kubernetes.pod.cpu.usage.nanocores | CPU used nanocores | long | byte | gauge |
+| kubernetes.pod.cpu.usage.node.pct | CPU usage as a percentage of the total node CPU | scaled_float | percent | gauge |
+| kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
+| kubernetes.pod.memory.available.bytes | Total memory available | long | percent | gauge |
+| kubernetes.pod.memory.major_page_faults | Total major page faults | long |  | counter |
+| kubernetes.pod.memory.page_faults | Total page faults | long |  | counter |
+| kubernetes.pod.memory.rss.bytes | Total resident set size memory | long | percent | gauge |
+| kubernetes.pod.memory.usage.bytes | Total memory usage | long | byte | gauge |
+| kubernetes.pod.memory.usage.limit.pct | Memory usage as a percentage of the defined limit for the pod containers (or total node allocatable memory if unlimited) | scaled_float | percent | gauge |
+| kubernetes.pod.memory.usage.node.pct | Memory usage as a percentage of the total node allocatable memory | scaled_float | percent | gauge |
+| kubernetes.pod.memory.working_set.bytes | Total working set memory | long | percent | gauge |
+| kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
+| kubernetes.pod.network.rx.bytes | Received bytes | long | byte | counter |
+| kubernetes.pod.network.rx.errors | Rx errors | long |  | counter |
+| kubernetes.pod.network.tx.bytes | Transmitted bytes | long | byte | counter |
+| kubernetes.pod.network.tx.errors | Tx errors | long |  | counter |
+| kubernetes.pod.start_time | Start time | date |  |  |
+| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
+| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
+| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
+| service.address | Service address | keyword |  |  |
+| service.type | Service type | keyword |  |  |
 
 
 ### system
@@ -797,67 +797,67 @@ An example event for `system` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| kubernetes.annotations.* | Kubernetes annotations map | object |
-| kubernetes.container.image | Kubernetes container image | keyword |
-| kubernetes.container.name | Kubernetes container name | keyword |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |
-| kubernetes.labels.* | Kubernetes labels map | object |
-| kubernetes.namespace | Kubernetes namespace | keyword |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
-| kubernetes.node.name | Kubernetes node name | keyword |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |
-| kubernetes.pod.name | Kubernetes pod name | keyword |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |
-| kubernetes.system.container | Container name | keyword |
-| kubernetes.system.cpu.usage.core.ns | CPU Core usage nanoseconds | long |
-| kubernetes.system.cpu.usage.nanocores | CPU used nanocores | long |
-| kubernetes.system.memory.majorpagefaults | Number of major page faults | long |
-| kubernetes.system.memory.pagefaults | Number of page faults | long |
-| kubernetes.system.memory.rss.bytes | RSS memory usage | long |
-| kubernetes.system.memory.usage.bytes | Total memory usage | long |
-| kubernetes.system.memory.workingset.bytes | Working set memory usage | long |
-| kubernetes.system.start_time | Start time | date |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| ecs.version | ECS version | keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.container.image | Kubernetes container image | keyword |  |  |
+| kubernetes.container.name | Kubernetes container name | keyword |  |  |
+| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
+| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
+| kubernetes.node.name | Kubernetes node name | keyword |  |  |
+| kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
+| kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
+| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
+| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
+| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
+| kubernetes.system.container | Container name | keyword |  |  |
+| kubernetes.system.cpu.usage.core.ns | CPU Core usage nanoseconds | long |  | gauge |
+| kubernetes.system.cpu.usage.nanocores | CPU used nanocores | long |  | gauge |
+| kubernetes.system.memory.majorpagefaults | Number of major page faults | long |  | counter |
+| kubernetes.system.memory.pagefaults | Number of page faults | long |  | counter |
+| kubernetes.system.memory.rss.bytes | RSS memory usage | long | byte | gauge |
+| kubernetes.system.memory.usage.bytes | Total memory usage | long | byte | gauge |
+| kubernetes.system.memory.workingset.bytes | Working set memory usage | long | byte | gauge |
+| kubernetes.system.start_time | Start time | date |  |  |
+| service.address | Service address | keyword |  |  |
+| service.type | Service type | keyword |  |  |
 
 
 ### volume
@@ -971,63 +971,63 @@ An example event for `volume` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version | keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| kubernetes.annotations.* | Kubernetes annotations map | object |
-| kubernetes.container.image | Kubernetes container image | keyword |
-| kubernetes.container.name | Kubernetes container name | keyword |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |
-| kubernetes.labels.* | Kubernetes labels map | object |
-| kubernetes.namespace | Kubernetes namespace | keyword |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
-| kubernetes.node.name | Kubernetes node name | keyword |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |
-| kubernetes.pod.name | Kubernetes pod name | keyword |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |
-| kubernetes.volume.fs.available.bytes | Filesystem total available in bytes | long |
-| kubernetes.volume.fs.capacity.bytes | Filesystem total capacity in bytes | long |
-| kubernetes.volume.fs.inodes.count | Total inodes | long |
-| kubernetes.volume.fs.inodes.free | Free inodes | long |
-| kubernetes.volume.fs.inodes.used | Used inodes | long |
-| kubernetes.volume.fs.used.bytes | Filesystem total used in bytes | long |
-| kubernetes.volume.fs.used.pct | Percentage of filesystem total used | long |
-| kubernetes.volume.name | Volume name | keyword |
-| service.address | Service address | keyword |
-| service.type | Service type | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host is running. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| ecs.version | ECS version | keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host mac addresses. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.container.image | Kubernetes container image | keyword |  |  |
+| kubernetes.container.name | Kubernetes container name | keyword |  |  |
+| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
+| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
+| kubernetes.node.name | Kubernetes node name | keyword |  |  |
+| kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
+| kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
+| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
+| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
+| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
+| kubernetes.volume.fs.available.bytes | Filesystem total available in bytes | long | byte | gauge |
+| kubernetes.volume.fs.capacity.bytes | Filesystem total capacity in bytes | long | byte | gauge |
+| kubernetes.volume.fs.inodes.count | Total inodes | long |  | gauge |
+| kubernetes.volume.fs.inodes.free | Free inodes | long |  | gauge |
+| kubernetes.volume.fs.inodes.used | Used inodes | long |  | gauge |
+| kubernetes.volume.fs.used.bytes | Filesystem total used in bytes | long | byte | gauge |
+| kubernetes.volume.fs.used.pct | Percentage of filesystem total used | long | percent | gauge |
+| kubernetes.volume.name | Volume name | keyword |  |  |
+| service.address | Service address | keyword |  |  |
+| service.type | Service type | keyword |  |  |

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 0.6.0
+version: 0.6.1
 license: basic
 description: Kubernetes Integration
 type: integration

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 0.6.1
+version: 0.7.0
 license: basic
 description: Kubernetes Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?
This change updates `fields.yml` defintions to include units and metric type information so as to enhance meta information for each collected Kubernetes fields in accordance with https://github.com/elastic/elasticsearch/pull/61941/. More example [here](https://github.com/elastic/kibana/issues/82273).

## Related issues

- Closes https://github.com/elastic/integrations/issues/934
