### PR TITLE
[okta] Add missing initial_interval option to the manifest

### DIFF
--- a/packages/okta/changelog.yml
+++ b/packages/okta/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: add missing `initial_interval` option to the manifest
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1299
 - version: "1.0.0"
   changes:
     - description: make GA

--- a/packages/okta/manifest.yml
+++ b/packages/okta/manifest.yml
@@ -1,6 +1,6 @@
 name: okta
 title: Okta
-version: 1.0.0
+version: 1.0.1
 release: ga
 description: Okta Integration
 type: integration
@@ -45,6 +45,13 @@ policy_templates:
             required: true
             show_user: true
             default: 60s
+          - name: initial_interval
+            type: text
+            title: Initial Interval
+            multi: false
+            required: true
+            show_user: true
+            default: 24h
           - name: ssl
             type: yaml
             title: SSL


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~
