### PR TITLE
Add Processors to linux package

### DIFF
--- a/packages/linux/changelog.yml
+++ b/packages/linux/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.1"
+  changes:
+    - description: Fix event.module in network_summary
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1317
 - version: "0.4.0"
   changes:
     - description: Set "event.module" and "event.dataset

--- a/packages/linux/data_stream/entropy/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/entropy/agent/stream/stream.yml.hbs
@@ -4,3 +4,6 @@ period: {{period}}
 {{#if system.hostfs}}
 system.hostfs: {{system.hostfs}}
 {{/if}}
+processors:
+  - drop_fields:
+      fields: event.module

--- a/packages/linux/data_stream/network_summary/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/network_summary/agent/stream/stream.yml.hbs
@@ -1,3 +1,6 @@
 metricsets: ["network_summary"]
 condition: ${host.platform} == 'linux'
 period: {{period}}
+processors:
+  - drop_fields:
+      fields: event.module

--- a/packages/linux/data_stream/raid/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/raid/agent/stream/stream.yml.hbs
@@ -7,3 +7,6 @@ period: {{period}}
 {{#if system.hostfs}}
 system.hostfs: {{system.hostfs}}
 {{/if}}
+processors:
+  - drop_fields:
+      fields: event.module

--- a/packages/linux/data_stream/service/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/service/agent/stream/stream.yml.hbs
@@ -7,3 +7,6 @@ service.state_filter: {{service.state_filter}}
 service.pattern_filter: {{service.pattern_filter}}
 {{/if}}
 period: {{period}}
+processors:
+  - drop_fields:
+      fields: event.module

--- a/packages/linux/data_stream/socket/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/socket/agent/stream/stream.yml.hbs
@@ -13,3 +13,6 @@ period: {{period}}
 {{#if system.hostfs}}
 system.hostfs: {{system.hostfs}}
 {{/if}}
+processors:
+  - drop_fields:
+      fields: event.module

--- a/packages/linux/data_stream/users/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/users/agent/stream/stream.yml.hbs
@@ -1,3 +1,6 @@
 metricsets: ["users"]
 condition: ${host.platform} == 'linux'
 period: {{period}}
+processors:
+  - drop_fields:
+      fields: event.module

--- a/packages/linux/manifest.yml
+++ b/packages/linux/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: linux
 title: Linux
-version: 0.4.0
+version: 0.4.1
 license: basic
 description: Linux Integration
 type: integration


### PR DESCRIPTION

## What does this PR do?

This is a fix for https://github.com/elastic/integrations/issues/1296

So, because a handful of `linux` data streams are actually backed by the `system` module within metricbeat, they'll break the mapping, since they'll report `event.module` as `system` and not `linux`. This adds a processor to said data streams, so we can drop the event in ingest, and then the proper value is inserted in the mapping.

This is a (somewhat) temporary workaround, as eventually the metricsets will be migrated to `linux`.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.


## How to test this PR locally

- Pull down and build
- On a linux host, run the elastic stack, add the linux integration and enable the `entropy`, `network_summary`, `service`, `socket` and  `users` data streams. Note: `users` and `service` won't work if you're running the agent from inside a docker container
- Make sure the agent is healthy and all the data streams are collecting data.

