### PR TITLE
Osquery manager: ECS mapping support

### DIFF
--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.0"
+  changes:
+    - description: ECS mapping configuration support for queries/streams
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/
 - version: "0.3.2"
   changes:
     - description: Updates Osquery Manager readme for 7.14 Release

--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: ECS mapping configuration support for queries/streams
       type: enhancement # can be one of: enhancement, bugfix, breaking-change
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/1318
 - version: "0.3.2"
   changes:
     - description: Updates Osquery Manager readme for 7.14 Release

--- a/packages/osquery_manager/data_stream/result/agent/stream/stream.yml.hbs
+++ b/packages/osquery_manager/data_stream/result/agent/stream/stream.yml.hbs
@@ -9,3 +9,9 @@ platform: {{platform}}
 {{#if version}}
 version: {{version}}
 {{/if}}
+{{#if ecs_mapping}}
+ecs_mapping:
+{{#each ecs_mapping}}
+   {{@key}}: {{this}}
+{{/each}}
+{{/if}}

--- a/packages/osquery_manager/manifest.yml
+++ b/packages/osquery_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: osquery_manager
 title: Osquery Manager
-version: 0.3.2
+version: 0.4.0
 license: basic
 description: Centrally manage osquery deployments, run live queries, and schedule recurring queries
 type: integration
@@ -11,7 +11,7 @@ categories:
   - os_system
   - config_management
 conditions:
-  kibana.version: '^7.14.0'
+  kibana.version: '^7.15.0'
 icons:
   - src: /img/logo_osquery.svg
     title: logo osquery


### PR DESCRIPTION
## What does this PR do?

Adds ECS mapping settings support for each query/stream.
Bumps up version to 0.4.0 and minimum kibana version to 7.15.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.15.0`).

The integration settings update payload with ```ecs_mapping``` (using ```/api/fleet/package_policies``` kibana API) example:

```
{
    "version": "WzE3MjUsM10=",
    "name": "osquery_manager-1",
    "description": "",
    "namespace": "default",
    "policy_id": "548a3940-df4e-11eb-8fdd-b98cebb63257",
    "enabled": true,
    "output_id": "",
    "package": {
        "name": "osquery_manager",
        "title": "Osquery Manager",
        "version": "0.4.0"
    },
    "inputs": [
        {
            "policy_template": "osquery_manager",
            "type": "osquery",
            "enabled": true,
            "streams": [
                {
                    "data_stream": {
                        "type": "logs",
                        "dataset": "osquery_manager.result"
                    },
                    "id": "osquery-osquery_manager.result-1b63ffff-c050-4bef-98d9-fc8507fd1406",
                    "vars": {
                        "query": {
                            "type": "text",
                            "value": "select * from users limit 6"
                        },
                        "interval": {
                            "type": "integer",
                            "value": 60
                        },
                        "id": {
                            "type": "text",
                            "value": "users"
                        },
                        "ecs_mapping": {
                            "value": {
                                "uid" : "user.id",
                                "gid" : "user.group.id",
                                "username" : "user.name"
                            }
                        }
                    },
                    "enabled": true
                }
            ]
        }
    ]
}
```

## Screenshots

Verified, it's stored correctly within the policy:
<img width="502" alt="Screen Shot 2021-07-09 at 7 10 23 PM" src="https://user-images.githubusercontent.com/872351/125147552-227d1280-e0fa-11eb-8bc1-b2480cb49b7a.png">

Tested with Agent and Osquerybeat with sample mapping:
<img width="502" alt="Screen Shot 2021-07-09 at 4 52 25 PM" src="https://user-images.githubusercontent.com/872351/125147515-dcc04a00-e0f9-11eb-8f3d-eb551c310e67.png">

that results in the document with ECS mapped fields according to the given mapping:
<img width="489" alt="Screen Shot 2021-07-09 at 4 52 10 PM" src="https://user-images.githubusercontent.com/872351/125147497-b39fb980-e0f9-11eb-8409-d9ef641cd88c.png">
