### PR TITLE
Change AWS default credential option to access keys

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.8.1"
+- version: "0.9.0"
   changes:
     - description: Change default credential options to access keys
       type: enhancement

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,6 +3,7 @@
   changes:
     - description: Change default credential options to access keys
       type: enhancement
+      link: https://github.com/elastic/integrations/pull/1320
 - version: "0.8.0"
   changes:
     - description: Set "event.module" and "event.dataset"

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,8 @@
 # newer versions go on top
+- version: "0.8.1"
+  changes:
+    - description: Change default credential options to access keys
+      type: enhancement
 - version: "0.8.0"
   changes:
     - description: Set "event.module" and "event.dataset"

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 0.8.1
+version: 0.9.0
 license: basic
 description: AWS Integration
 type: integration

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 0.8.0
+version: 0.8.1
 license: basic
 description: AWS Integration
 type: integration
@@ -36,25 +36,25 @@ vars:
     title: Credential Profile Name
     multi: false
     required: false
-    show_user: true
+    show_user: false
   - name: access_key_id
     type: text
     title: Access Key ID
     multi: false
     required: false
-    show_user: false
+    show_user: true
   - name: secret_access_key
     type: text
     title: Secret Access Key
     multi: false
     required: false
-    show_user: false
+    show_user: true
   - name: session_token
     type: text
     title: Session Token
     multi: false
     required: false
-    show_user: false
+    show_user: true
   - name: role_arn
     type: text
     title: Role ARN


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR changes AWS default credential option to access keys. When running on Docker, AWS credential file needs to be provided via volume mount and this is not shipped with elastic agent by default. Therefore, we should recommend users to use access key, secret access key and/or session token as default credential option.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Screenshots

<img width="705" alt="Screen Shot 2021-07-12 at 8 12 37 AM" src="https://user-images.githubusercontent.com/14081635/125302178-4b054680-e35e-11eb-902c-2a6d53f02278.png">

