### PR TITLE
Fix reversed ingress and egress interfaces in cisco asa and ftd

### DIFF
--- a/packages/cisco/changelog.yml
+++ b/packages/cisco/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.10.1"
+  changes:
+    - description: Fix reversed ingress / egress interfaces
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1326
 - version: "0.10.0"
   changes:
     - description: Set "event.module" and "event.dataset"

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -31,7 +31,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "fw111"
+                        "name": "net"
                     }
                 },
                 "hostname": "dev01",
@@ -40,7 +40,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "net"
+                        "name": "fw111"
                     }
                 }
             },
@@ -64,7 +64,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.715911Z",
+                "ingested": "2021-07-19T09:05:57.086480145Z",
                 "original": "May  5 17:51:17 dev01: %FTD-6-302013: Built inbound TCP connection 111111111 for net:10.10.10.10/53500 (8.8.8.8/53500) to fw111:192.168.2.2/53500 (8.8.5.4/53500)",
                 "code": "302013",
                 "kind": "event",
@@ -119,7 +119,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "fw111"
+                        "name": "net"
                     }
                 },
                 "hostname": "dev01",
@@ -128,7 +128,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "net"
+                        "name": "fw111"
                     }
                 }
             },
@@ -152,7 +152,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.715939500Z",
+                "ingested": "2021-07-19T09:05:57.086488034Z",
                 "original": "May  5 17:51:17 dev01: %FTD-6-302015: Built inbound UDP connection 111111111 for net:10.10.10.10/53500 (8.8.8.8/53500) to fw111:192.168.2.2/53500 (8.8.5.4/53500)",
                 "code": "302015",
                 "kind": "event",
@@ -223,7 +223,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.715948Z",
+                "ingested": "2021-07-19T09:05:57.086490223Z",
                 "original": "May  5 17:51:17 dev01: %FTD-6-302020: Built inbound ICMP connection for faddr 10.10.10.10/0 gaddr 8.8.8.8/0 laddr 192.168.2.2/0 type 3 code 3",
                 "code": "302020",
                 "kind": "event",
@@ -256,15 +256,15 @@
                 "preserve_original_event"
             ],
             "observer": {
-                "hostname": "dev01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "net"
                     }
-                }
+                },
+                "hostname": "dev01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2021-05-05T17:51:17.000Z",
             "ecs": {
@@ -284,7 +284,7 @@
             "event": {
                 "severity": 7,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:10.715980300Z",
+                "ingested": "2021-07-19T09:05:57.086492152Z",
                 "original": "May  5 17:51:17 dev01: %FTD-7-609002: Teardown local-host net:192.168.2.2 duration 0:00:00",
                 "code": "609002",
                 "kind": "event",
@@ -317,15 +317,15 @@
                 "preserve_original_event"
             ],
             "observer": {
-                "hostname": "dev01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "net"
                     }
-                }
+                },
+                "hostname": "dev01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2021-05-05T17:51:17.000Z",
             "ecs": {
@@ -344,7 +344,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:10.715988300Z",
+                "ingested": "2021-07-19T09:05:57.086493854Z",
                 "original": "May  5 17:51:17 dev01: %FTD-7-609001: Built local-host net:192.168.2.2",
                 "code": "609001",
                 "kind": "event",
@@ -410,7 +410,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.715994700Z",
+                "ingested": "2021-07-19T09:05:57.086495542Z",
                 "original": "May  5 17:51:17 dev01: %FTD-6-302020: Built inbound ICMP connection for faddr 10.10.10.10/0 gaddr 8.8.8.8/0 laddr 192.168.2.2/0 type 3 code 1",
                 "code": "302020",
                 "kind": "event",
@@ -493,7 +493,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716002Z",
+                "ingested": "2021-07-19T09:05:57.086497218Z",
                 "original": "May  5 17:51:17 dev01: %FTD-6-805001: Offloaded TCP Flow for connection 111111111 from fw111:10.10.10.10/111 (8.8.8.8/111) to fw111:192.168.2.2/111 (8.8.5.4/111)",
                 "code": "805001",
                 "kind": "event",
@@ -541,7 +541,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "fw109"
+                        "name": "net"
                     }
                 },
                 "hostname": "dev01",
@@ -550,7 +550,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "net"
+                        "name": "fw109"
                     }
                 }
             },
@@ -572,7 +572,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716008200Z",
+                "ingested": "2021-07-19T09:05:57.086498881Z",
                 "original": "May  5 17:51:17 dev01: %FTD-6-805002: TCP Flow is no longer offloaded for connection 941243214 from net:10.192.18.4/51261 (10.192.18.4/51261) to fw109:10.192.70.66/443 (10.192.70.66/443)",
                 "code": "805002",
                 "kind": "event",
@@ -618,15 +618,15 @@
                 "transport": "udp"
             },
             "observer": {
-                "ingress": {
-                    "interface": {
-                        "name": "fw111"
-                    }
-                },
                 "hostname": "dev01",
                 "product": "asa",
                 "type": "firewall",
-                "vendor": "Cisco"
+                "vendor": "Cisco",
+                "egress": {
+                    "interface": {
+                        "name": "fw111"
+                    }
+                }
             },
             "@timestamp": "2021-05-05T17:51:17.000Z",
             "ecs": {
@@ -646,7 +646,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:10.716014400Z",
+                "ingested": "2021-07-19T09:05:57.086500586Z",
                 "original": "May  5 17:51:17 dev01: %FTD-7-710005: UDP request discarded from 192.168.2.2/68 to fw111:10.10.10.10/67",
                 "code": "710005",
                 "kind": "event",
@@ -689,7 +689,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "fw111"
+                        "name": "net"
                     }
                 },
                 "hostname": "dev01",
@@ -698,7 +698,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "net"
+                        "name": "fw111"
                     }
                 }
             },
@@ -728,7 +728,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716020100Z",
+                "ingested": "2021-07-19T09:05:57.086502259Z",
                 "original": "May  5 17:51:17 dev01: %FTD-6-303002: FTP connection from net:192.168.2.2/63656 to fw111:10.192.18.4/21, user testuser Stored file /export/home/sysm/ftproot/sdsdsds/tmp.log",
                 "code": "303002",
                 "kind": "event",
@@ -771,7 +771,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:10.716027200Z",
+                "ingested": "2021-07-19T09:05:57.086503922Z",
                 "original": "May  5 17:51:17 dev01: %FTD-7-710006: VRRP request discarded from 192.168.2.2 to fw111:192.18.4",
                 "code": "710006",
                 "kind": "event",
@@ -802,15 +802,15 @@
                 "transport": "icmp"
             },
             "observer": {
-                "hostname": "dev01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "fw111"
                     }
-                }
+                },
+                "hostname": "dev01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2021-05-05T17:51:17.000Z",
             "ecs": {
@@ -826,7 +826,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:10.716033200Z",
+                "ingested": "2021-07-19T09:05:57.086505920Z",
                 "original": "May  5 17:51:17 dev01: %FTD-4-313005: No matching connection for ICMP error message: icmp src fw111:10.192.33.100 dst fw111:192.18.4 (type 3, code 3) on fw111 interface. Original IP payload: udp src 192.18.4/53 dst 8.8.8.8/10872.",
                 "code": "313005",
                 "kind": "event",
@@ -891,7 +891,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716039200Z",
+                "ingested": "2021-07-19T09:05:57.086507628Z",
                 "original": "May  5 18:16:21 dev01: %ASA-6-302021: Teardown ICMP connection for faddr 192.168.2.2/0 gaddr 8.8.8.8/2 laddr 10.10.10.10/2 type 8 code 0",
                 "code": "302021",
                 "kind": "event",
@@ -924,15 +924,15 @@
                 "preserve_original_event"
             ],
             "observer": {
-                "hostname": "dev01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "net"
                     }
-                }
+                },
+                "hostname": "dev01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2021-05-05T18:22:35.000Z",
             "ecs": {
@@ -951,7 +951,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:10.716044900Z",
+                "ingested": "2021-07-19T09:05:57.086509334Z",
                 "original": "May  5 18:22:35 dev01: %ASA-7-609001: Built local-host net:10.10.10.10",
                 "code": "609001",
                 "kind": "event",
@@ -982,15 +982,15 @@
                 "preserve_original_event"
             ],
             "observer": {
-                "hostname": "dev01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "identity"
                     }
-                }
+                },
+                "hostname": "dev01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2021-05-05T18:24:31.000Z",
             "ecs": {
@@ -1010,7 +1010,7 @@
             "event": {
                 "severity": 7,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:10.716050700Z",
+                "ingested": "2021-07-19T09:05:57.086511048Z",
                 "original": "May  5 18:24:31 dev01: %ASA-7-609002: Teardown local-host identity:10.10.10.10 duration 0:00:00",
                 "code": "609002",
                 "kind": "event",
@@ -1078,7 +1078,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716056400Z",
+                "ingested": "2021-07-19T09:05:57.086512745Z",
                 "original": "May  5 18:29:32 dev01: %ASA-6-302020: Built inbound ICMP connection for faddr 10.10.10.10/0 gaddr 8.8.8.8/0 laddr 10.192.46.90/0",
                 "code": "302020",
                 "kind": "event",
@@ -1144,7 +1144,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716063400Z",
+                "ingested": "2021-07-19T09:05:57.086514613Z",
                 "original": "May  5 18:29:32 dev01: %ASA-6-302020: Built outbound ICMP connection for faddr 10.10.10.10/0 gaddr 8.8.8.8/0 laddr 192.168.2.2/0 type 3 code 3",
                 "code": "302020",
                 "kind": "event",
@@ -1190,7 +1190,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "fw111"
+                        "name": "out111"
                     }
                 },
                 "hostname": "dev01",
@@ -1199,7 +1199,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "out111"
+                        "name": "fw111"
                     }
                 }
             },
@@ -1223,7 +1223,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:10.716074900Z",
+                "ingested": "2021-07-19T09:05:57.086516327Z",
                 "original": "May  5 18:29:32 dev01: %ASA-6-302014: Teardown TCP connection 2960892904 for out111:10.10.10.10/443 to fw111:192.168.2.2/55225 duration 0:00:00 bytes 0 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -1277,7 +1277,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "net"
+                        "name": "intfacename"
                     }
                 },
                 "hostname": "dev01",
@@ -1286,7 +1286,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "intfacename"
+                        "name": "net"
                     }
                 }
             },
@@ -1309,7 +1309,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716080600Z",
+                "ingested": "2021-07-19T09:05:57.086517980Z",
                 "original": "May  5 18:29:32 dev01: %ASA-6-302013: Built outbound TCP connection 1588662 for intfacename:192.168.2.2/80 (8.8.8.8/80) to net:10.10.10.10/54839 (8.8.8.8/54839)",
                 "code": "302013",
                 "kind": "event",
@@ -1357,7 +1357,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "out111"
+                        "name": "fw111"
                     }
                 },
                 "hostname": "dev01",
@@ -1366,7 +1366,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "fw111"
+                        "name": "out111"
                     }
                 }
             },
@@ -1389,7 +1389,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:10.716086400Z",
+                "ingested": "2021-07-19T09:05:57.086519682Z",
                 "original": "May  5 18:29:32 dev01: %ASA-6-302012: Teardown dynamic UDP translation from fw111:10.10.10.10/54230 to out111:192.168.2.2/54230 duration 0:00:00",
                 "code": "302012",
                 "kind": "event",
@@ -1431,15 +1431,15 @@
                 "transport": "icmp"
             },
             "observer": {
-                "hostname": "dev01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "fw502"
                     }
-                }
+                },
+                "hostname": "dev01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2021-05-05T18:40:50.000Z",
             "ecs": {
@@ -1459,7 +1459,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:10.716092Z",
+                "ingested": "2021-07-19T09:05:57.086521342Z",
                 "original": "May  5 18:40:50 dev01: %ASA-4-313004: Denied ICMP type=0, from laddr 10.10.10.10 on interface fw502 to 192.168.2.2: no matching session",
                 "code": "313004",
                 "kind": "event",
@@ -1504,7 +1504,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "out111"
+                        "name": "fw111"
                     }
                 },
                 "hostname": "dev01",
@@ -1513,7 +1513,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "fw111"
+                        "name": "out111"
                     }
                 }
             },
@@ -1535,7 +1535,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716097600Z",
+                "ingested": "2021-07-19T09:05:57.086523016Z",
                 "original": "May  5 18:40:50 dev01: %ASA-6-305011: Built dynamic TCP translation from fw111:10.10.10.10/57006 to out111:192.168.2.2/57006",
                 "code": "305011",
                 "kind": "event",
@@ -1577,15 +1577,15 @@
                 "direction": "inbound"
             },
             "observer": {
-                "hostname": "dev01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "out111"
                     }
-                }
+                },
+                "hostname": "dev01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2021-05-05T18:40:50.000Z",
             "ecs": {
@@ -1605,7 +1605,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:10.716107400Z",
+                "ingested": "2021-07-19T09:05:57.086524660Z",
                 "original": "May  5 18:40:50 dev01: %ASA-2-106001: Inbound TCP connection denied from 192.168.2.2/43803 to 10.10.10.10/14322 flags SYN  on interface out111",
                 "code": "106001",
                 "kind": "event",
@@ -1668,7 +1668,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "net"
+                        "name": "intfacename"
                     }
                 },
                 "hostname": "dev01",
@@ -1677,7 +1677,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "intfacename"
+                        "name": "net"
                     }
                 }
             },
@@ -1700,7 +1700,7 @@
             "event": {
                 "severity": 2,
                 "duration": 124000000000,
-                "ingested": "2021-06-09T10:11:10.716113Z",
+                "ingested": "2021-07-19T09:05:57.086526496Z",
                 "original": "May  5 18:40:50 dev01: %ASA-2-302016: Teardown UDP connection 1671727 for intfacename:10.10.10.10/161 to net:192.186.2.2/53356 duration 0:02:04 bytes 64585",
                 "code": "302016",
                 "kind": "event",
@@ -1754,7 +1754,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "net"
+                        "name": "intfacename"
                     }
                 },
                 "hostname": "dev01",
@@ -1763,7 +1763,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "intfacename"
+                        "name": "net"
                     }
                 }
             },
@@ -1787,7 +1787,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:10.716118900Z",
+                "ingested": "2021-07-19T09:05:57.086528138Z",
                 "original": "May  5 18:40:50 dev01: %ASA-2-302015: Built outbound UDP connection 1743372 for intfacename:10.10.10.10/161 (8.8.8.4/161) to net:192.168.2.2/22638 (8.8.8.8/22638)",
                 "code": "302015",
                 "kind": "event",
@@ -1842,7 +1842,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "net"
+                        "name": "intfacename"
                     }
                 },
                 "hostname": "dev01",
@@ -1851,7 +1851,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "intfacename"
+                        "name": "net"
                     }
                 }
             },
@@ -1875,7 +1875,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:10.716124700Z",
+                "ingested": "2021-07-19T09:05:57.086529828Z",
                 "original": "May  5 18:40:50 dev01: %ASA-2-302015: Built outbound UDP connection 1743372 for intfacename:10.10.10.10/161 (8.8.8.4/161) to net:192.168.2.2/22638 (8.8.8.8/22638)",
                 "code": "302015",
                 "kind": "event",
@@ -1923,7 +1923,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "out111"
+                        "name": "fw111"
                     }
                 },
                 "hostname": "dev01",
@@ -1932,7 +1932,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "fw111"
+                        "name": "out111"
                     }
                 }
             },
@@ -1954,7 +1954,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:10.716130200Z",
+                "ingested": "2021-07-19T09:05:57.086531503Z",
                 "original": "May  5 18:40:50 dev01: %ASA-4-106023: Deny tcp src fw111:10.10.10.10/64388 dst out111:192.168.2.2/443 by access-group \"out1111_access_out\" [0x47e21ef4, 0x47e21ef4]",
                 "code": "106023",
                 "kind": "event",
@@ -1996,15 +1996,15 @@
                 "transport": "tcp"
             },
             "observer": {
-                "hostname": "dev01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "fw111"
                     }
-                }
+                },
+                "hostname": "dev01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2021-05-05T18:40:50.000Z",
             "ecs": {
@@ -2024,7 +2024,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:10.716136Z",
+                "ingested": "2021-07-19T09:05:57.086533203Z",
                 "original": "May  5 18:40:50 dev01: %ASA-4-106021: Deny TCP reverse path check from 192.168.2.2 to 10.10.10.10 on interface fw111",
                 "code": "106021",
                 "kind": "event",
@@ -2067,15 +2067,15 @@
                 "direction": "inbound"
             },
             "observer": {
-                "hostname": "dev01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "fw111"
                     }
-                }
+                },
+                "hostname": "dev01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2021-05-05T19:02:58.000Z",
             "ecs": {
@@ -2095,7 +2095,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:10.716140900Z",
+                "ingested": "2021-07-19T09:05:57.086534863Z",
                 "original": "May  5 19:02:58 dev01: %ASA-2-106006: Deny inbound UDP from 192.168.2.2/65020 to 10.10.10.10/65020 on interface fw111",
                 "code": "106006",
                 "kind": "event",
@@ -2137,15 +2137,15 @@
                 "transport": "tcp"
             },
             "observer": {
-                "hostname": "dev01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "out111"
                     }
-                }
+                },
+                "hostname": "dev01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2021-05-05T19:02:58.000Z",
             "ecs": {
@@ -2165,7 +2165,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716145600Z",
+                "ingested": "2021-07-19T09:05:57.086536607Z",
                 "original": "May  5 19:02:58 dev01: %ASA-6-106015: Deny TCP (no connection) from 192.168.2.2/53089 to 10.10.10.10/443 flags FIN PSH ACK  on interface out111",
                 "code": "106015",
                 "kind": "event",
@@ -2207,15 +2207,15 @@
                 "transport": "tcp"
             },
             "observer": {
-                "hostname": "dev01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "out111"
                     }
-                }
+                },
+                "hostname": "dev01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2021-05-05T19:02:58.000Z",
             "ecs": {
@@ -2235,7 +2235,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716150400Z",
+                "ingested": "2021-07-19T09:05:57.086538302Z",
                 "original": "May  5 19:02:58 dev01: %ASA-6-106015: Deny TCP (no connection) from 192.168.2.2/17127 to 10.10.10.10/443 flags PSH ACK  on interface out111",
                 "code": "106015",
                 "kind": "event",
@@ -2277,15 +2277,15 @@
                 "transport": "tcp"
             },
             "observer": {
-                "hostname": "dev01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "fw111"
                     }
-                }
+                },
+                "hostname": "dev01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2021-05-05T19:02:58.000Z",
             "ecs": {
@@ -2305,7 +2305,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716155200Z",
+                "ingested": "2021-07-19T09:05:57.086539979Z",
                 "original": "May  5 19:02:58 dev01: %ASA-6-106015: Deny TCP (no connection) from 192.168.2.2/24223 to 10.10.10.10/443 flags RST  on interface fw111",
                 "code": "106015",
                 "kind": "event",
@@ -2349,7 +2349,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "net"
+                        "name": "fw1111"
                     }
                 },
                 "hostname": "dev01",
@@ -2358,7 +2358,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "fw1111"
+                        "name": "net"
                     }
                 }
             },
@@ -2380,7 +2380,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716159800Z",
+                "ingested": "2021-07-19T09:05:57.086541778Z",
                 "original": "May  5 19:02:58 dev01: %ASA-6-302022: Built director stub TCP connection for fw1111:10.10.10.10/38540 (8.8.8.5/38540) to net:192.168.2.2/10051 (8.8.8.8/10051)",
                 "code": "302022",
                 "kind": "event",
@@ -2423,7 +2423,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "net"
+                        "name": "fw111"
                     }
                 },
                 "hostname": "dev01",
@@ -2432,7 +2432,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "fw111"
+                        "name": "net"
                     }
                 }
             },
@@ -2454,7 +2454,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716170800Z",
+                "ingested": "2021-07-19T09:05:57.086543487Z",
                 "original": "May  5 19:02:58 dev01: %ASA-6-302022: Built forwarder  stub TCP connection for fw111:10.10.10.10/38540 (8.8.8.5/38540) to net:192.168.2.2/10051 (8.8.8.8/10051)",
                 "code": "302022",
                 "kind": "event",
@@ -2497,7 +2497,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "net"
+                        "name": "fw111"
                     }
                 },
                 "hostname": "dev01",
@@ -2506,7 +2506,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "fw111"
+                        "name": "net"
                     }
                 }
             },
@@ -2528,7 +2528,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716176400Z",
+                "ingested": "2021-07-19T09:05:57.086545260Z",
                 "original": "May  5 19:02:58 dev01: %ASA-6-302022: Built backup  stub TCP connection for fw111:10.10.10.10/38540 (8.8.8.5/38540) to net:192.1682.2.2/10051 (8.8.8.8/10051)",
                 "code": "302022",
                 "kind": "event",
@@ -2572,7 +2572,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "net"
+                        "name": "fw111"
                     }
                 },
                 "hostname": "dev01",
@@ -2581,7 +2581,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "fw111"
+                        "name": "net"
                     }
                 }
             },
@@ -2605,7 +2605,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "Cluster flow with CLU closed on owner",
-                "ingested": "2021-06-09T10:11:10.716182200Z",
+                "ingested": "2021-07-19T09:05:57.086546926Z",
                 "original": "May  5 19:02:58 dev01: %ASA-6-302023: Teardown stub TCP connection for fw111:10.10.10.10/39210 to net:192.168.2.2/10051 duration 0:00:00 forwarded bytes 0 Cluster flow with CLU closed on owner",
                 "code": "302023",
                 "kind": "event",
@@ -2651,7 +2651,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "unknown"
+                        "name": "net"
                     }
                 },
                 "hostname": "dev01",
@@ -2660,7 +2660,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "net"
+                        "name": "unknown"
                     }
                 }
             },
@@ -2684,7 +2684,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "Forwarding or redirect flow removed to create director or backup flow",
-                "ingested": "2021-06-09T10:11:10.716187400Z",
+                "ingested": "2021-07-19T09:05:57.086548589Z",
                 "original": "May  5 19:02:58 dev01: %ASA-6-302023: Teardown stub TCP connection for net:10.10.10.10/10051 to unknown:192.168.2.2/39222 duration 0:00:00 forwarded bytes 0 Forwarding or redirect flow removed to create director or backup flow",
                 "code": "302023",
                 "kind": "event",
@@ -2735,7 +2735,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:10.716192400Z",
+                "ingested": "2021-07-19T09:05:57.086550311Z",
                 "original": "May  5 19:03:27 dev01: %ASA-7-111009: User 'aaaa' executed cmd: show access-list fw211111_access_out brief",
                 "code": "111009",
                 "kind": "event",
@@ -2786,7 +2786,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:10.716197300Z",
+                "ingested": "2021-07-19T09:05:57.086552061Z",
                 "original": "May  5 19:02:26 dev01: %ASA-7-111009: User 'aaaa' executed cmd: show access-list aaa_out brief",
                 "code": "111009",
                 "kind": "event",
@@ -2831,7 +2831,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "fw111"
+                        "name": "ptaaac"
                     }
                 },
                 "hostname": "dev01",
@@ -2840,7 +2840,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "ptaaac"
+                        "name": "fw111"
                     }
                 }
             },
@@ -2862,7 +2862,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716202200Z",
+                "ingested": "2021-07-19T09:05:57.086555023Z",
                 "original": "May  5 19:02:26 dev01: %ASA-6-106100: access-list fw111_out permitted tcp ptaaac/192.168.2.2(62157) -\u003e fw111/10.10.10.10(3452) hit-cnt 1 first hit [0x38ff326b, 0x00000000]",
                 "code": "106100",
                 "kind": "event",
@@ -2908,7 +2908,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "fw111"
+                        "name": "net"
                     }
                 },
                 "hostname": "dev01",
@@ -2917,7 +2917,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "net"
+                        "name": "fw111"
                     }
                 }
             },
@@ -2939,7 +2939,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716207300Z",
+                "ingested": "2021-07-19T09:05:57.086556858Z",
                 "original": "May  5 19:02:26 dev01: %ASA-6-106100: access-list fw111_out permitted tcp net/192.168.2.2(49033) -\u003e fw111/10.10.10.10(6007) hit-cnt 2 300-second interval [0x38ff326b, 0x00000000]",
                 "code": "106100",
                 "kind": "event",
@@ -2985,7 +2985,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716212500Z",
+                "ingested": "2021-07-19T09:05:57.086559272Z",
                 "original": "May  5 19:02:26 dev01: %ASA-6-302027: Teardown stub ICMP connection for fw1111:10.10.10.10/6426 to net:192.168.2.2/0 duration 1:00:04 forwarded bytes 56 Cluster flow with CLU closed on owner",
                 "code": "302027",
                 "kind": "event",
@@ -3028,7 +3028,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716217700Z",
+                "ingested": "2021-07-19T09:05:57.086564615Z",
                 "original": "May  5 19:02:26 dev01: %ASA-6-302026: Built director stub ICMP connection for fw111:10.10.10.10/32004 (8.8.8.5) to net:192.168.2.2/0 (8.8.8.8)",
                 "code": "302026",
                 "kind": "event",
@@ -3069,15 +3069,15 @@
                 "transport": "udp"
             },
             "observer": {
-                "ingress": {
-                    "interface": {
-                        "name": "net"
-                    }
-                },
                 "hostname": "dev01",
                 "product": "asa",
                 "type": "firewall",
-                "vendor": "Cisco"
+                "vendor": "Cisco",
+                "egress": {
+                    "interface": {
+                        "name": "net"
+                    }
+                }
             },
             "@timestamp": "2021-05-05T19:02:26.000Z",
             "ecs": {
@@ -3097,7 +3097,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:10.716222900Z",
+                "ingested": "2021-07-19T09:05:57.086566426Z",
                 "original": "May  5 19:02:26 dev01: %ASA-7-710005: UDP request discarded from 10.10.10.10/1985 to net:192.168.2.2/1985",
                 "code": "710005",
                 "kind": "event",
@@ -3141,7 +3141,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716227800Z",
+                "ingested": "2021-07-19T09:05:57.086568118Z",
                 "original": "May  5 19:02:26 dev01: %ASA-6-302025: Teardown stub UDP connection for net:192.168.2.2/123 to unknown:10.10.10.10/123 duration 0:01:00 forwarded bytes 48 Cluster flow with CLU removed from due to idle timeout",
                 "code": "302025",
                 "kind": "event",
@@ -3184,7 +3184,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716232500Z",
+                "ingested": "2021-07-19T09:05:57.086569821Z",
                 "original": "May  5 19:02:26 dev01: %ASA-6-302024: Built backup stub UDP connection for net:192.168.2.2/9051 (8.8.8.5(19051) to fw111:10.10.10.10/123 (8.8.8.8/123)",
                 "code": "302024",
                 "kind": "event",
@@ -3256,7 +3256,7 @@
             },
             "event": {
                 "severity": 3,
-                "ingested": "2021-06-09T10:11:10.716236900Z",
+                "ingested": "2021-07-19T09:05:57.086571516Z",
                 "original": "May  5 19:02:26 dev01: %ASA-3-106014: Deny inbound icmp src fw111:10.10.10.10 dst fw111:10.10.10.10(type 8, code 0)",
                 "code": "106014",
                 "kind": "event",
@@ -3301,7 +3301,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:10.716241200Z",
+                "ingested": "2021-07-19T09:05:57.086573238Z",
                 "original": "May  5 19:02:25 dev01: %ASA-4-733100: [192.168.2.2] drop rate-1 exceeded. Current burst rate is 0 per second, max configured rate is -4; Current average rate is 7 per second, max configured rate is -4; Cumulative total count is 9063",
                 "code": "733100",
                 "kind": "event",
@@ -3384,7 +3384,7 @@
             },
             "event": {
                 "severity": 3,
-                "ingested": "2021-06-09T10:11:10.716245400Z",
+                "ingested": "2021-07-19T09:05:57.086574972Z",
                 "original": "May  5 19:02:25 dev01: %ASA-3-106010: Deny inbound sctp src fw111:10.10.10.10/5114 dst fw111:10.10.10.10/2",
                 "code": "106010",
                 "kind": "event",
@@ -3429,7 +3429,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "out111"
+                        "name": "fw111"
                     }
                 },
                 "hostname": "dev01",
@@ -3438,7 +3438,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "fw111"
+                        "name": "out111"
                     }
                 }
             },
@@ -3460,7 +3460,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:10.716249500Z",
+                "ingested": "2021-07-19T09:05:57.086576688Z",
                 "original": "May  5 19:02:25 dev01: %ASA-4-507003: tcp flow from fw111:10.10.10.10/49574 to out111:192.168.2.2/80 terminated by inspection engine, reason - disconnected, dropped packet.",
                 "code": "507003",
                 "kind": "event",
@@ -3523,7 +3523,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:10.716253800Z",
+                "ingested": "2021-07-19T09:05:57.086578574Z",
                 "original": "Apr 27 04:18:49 dev01: %ASA-5-304001: 10.20.30.40 Accessed URL 10.20.30.40:http://10.20.30.40/",
                 "code": "304001",
                 "kind": "event",
@@ -3585,7 +3585,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:10.716258Z",
+                "ingested": "2021-07-19T09:05:57.086580245Z",
                 "original": "Apr 27 04:18:49 dev01: %ASA-5-304001: 10.20.30.40 Accessed URL someuser@10.20.30.40:http://10.20.30.40/IOFUHSIU98[0]",
                 "code": "304001",
                 "kind": "event",
@@ -3647,7 +3647,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:10.716262Z",
+                "ingested": "2021-07-19T09:05:57.086581960Z",
                 "original": "Apr 27 17:54:52 dev01: %ASA-5-304001: 10.20.30.40 Accessed JAVA URL 10.20.30.40:http://10.20.30.40/some/longer/url-asd-er9789870[0]_=23",
                 "code": "304001",
                 "kind": "event",
@@ -3709,7 +3709,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:10.716266400Z",
+                "ingested": "2021-07-19T09:05:57.086583658Z",
                 "original": "Apr 27 04:18:49 dev01: %ASA-5-304001: 10.20.30.40 Accessed JAVA URL someuser@10.20.30.40:http://10.20.30.40/",
                 "code": "304001",
                 "kind": "event",
@@ -3815,7 +3815,7 @@
                 "severity": 6,
                 "duration": 3602000000000,
                 "reason": "Connection timeout",
-                "ingested": "2021-06-09T10:11:10.716270600Z",
+                "ingested": "2021-07-19T09:05:57.086585355Z",
                 "original": "Apr 27 04:12:23 dev01: %ASA-6-302304: Teardown TCP state-bypass connection 2751765169 from server.deflan:1.2.3.4/54242 to server.deflan:2.3.4.5/9101 duration 1:00:02 bytes 245 Connection timeout",
                 "code": "302304",
                 "kind": "event",
@@ -3862,7 +3862,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "srv"
+                        "name": "outside"
                     }
                 },
                 "hostname": "dev01",
@@ -3871,7 +3871,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "srv"
                     }
                 }
             },
@@ -3893,7 +3893,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:10.716274700Z",
+                "ingested": "2021-07-19T09:05:57.086587091Z",
                 "original": "Apr 27 02:02:02 dev01: %ASA-4-106023: Deny tcp src outside:10.10.10.2/56444 dst srv:192.168.2.2/51635(testhostname.domain) by access-group \"global_access_1\"",
                 "code": "106023",
                 "kind": "event",
@@ -3957,7 +3957,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "OUTSIDE"
+                        "name": "insideintf"
                     }
                 },
                 "hostname": "dev01",
@@ -3966,7 +3966,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "insideintf"
+                        "name": "OUTSIDE"
                     }
                 }
             },
@@ -3988,7 +3988,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:10.716278700Z",
+                "ingested": "2021-07-19T09:05:57.086595499Z",
                 "original": "Oct 20 2019 15:15:15 dev01: %ASA-5-106100: access-list testrulename denied tcp insideintf/somedomainname.local(27218) -\u003e OUTSIDE/195.122.12.242(53) hit-cnt 1 first hit [0x16847359, 0x00000000]",
                 "code": "106100",
                 "kind": "event",
@@ -4042,7 +4042,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:10.716282700Z",
+                "ingested": "2021-07-19T09:05:57.086600770Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-5-111004: console end configuration: OK",
                 "code": "111004",
                 "kind": "event",
@@ -4100,7 +4100,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:10.716286800Z",
+                "ingested": "2021-07-19T09:05:57.086603139Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-5-111010: User 'enable_15', running 'CLI' from IP 10.10.0.87, executed 'clear'",
                 "code": "111010",
                 "kind": "event",
@@ -4148,7 +4148,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:10.716290900Z",
+                "ingested": "2021-07-19T09:05:57.086604910Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-5-502103: User priv level changed: Uname: enable_15 From: 1 To: 15",
                 "code": "502103",
                 "kind": "event",
@@ -4195,15 +4195,15 @@
                 "protocol": "https"
             },
             "observer": {
-                "ingress": {
-                    "interface": {
-                        "name": "FCD-FS-LAN"
-                    }
-                },
                 "hostname": "dev01",
                 "product": "asa",
                 "type": "firewall",
-                "vendor": "Cisco"
+                "vendor": "Cisco",
+                "egress": {
+                    "interface": {
+                        "name": "FCD-FS-LAN"
+                    }
+                }
             },
             "@timestamp": "2021-04-27T02:03:03.000Z",
             "ecs": {
@@ -4226,7 +4226,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716295Z",
+                "ingested": "2021-07-19T09:05:57.086606694Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-6-605004: Login denied from 10.10.1.212/51923 to FCD-FS-LAN:10.10.1.254/https for user \"*****\"",
                 "code": "605004",
                 "kind": "event",
@@ -4286,7 +4286,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716299Z",
+                "ingested": "2021-07-19T09:05:57.086608448Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-6-611102: User authentication failed: IP address: 10.10.0.87, Uname: admin",
                 "code": "611102",
                 "kind": "event",
@@ -4326,15 +4326,15 @@
                 "protocol": "ssh"
             },
             "observer": {
-                "ingress": {
-                    "interface": {
-                        "name": "FCD-FS-LAN"
-                    }
-                },
                 "hostname": "dev01",
                 "product": "asa",
                 "type": "firewall",
-                "vendor": "Cisco"
+                "vendor": "Cisco",
+                "egress": {
+                    "interface": {
+                        "name": "FCD-FS-LAN"
+                    }
+                }
             },
             "@timestamp": "2021-04-27T02:03:03.000Z",
             "ecs": {
@@ -4357,7 +4357,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716303Z",
+                "ingested": "2021-07-19T09:05:57.086610181Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-6-605005: Login permitted from 10.10.0.87/6651 to FCD-FS-LAN:10.10.1.254/ssh for user \"admin\"",
                 "code": "605005",
                 "kind": "event",
@@ -4417,7 +4417,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716307Z",
+                "ingested": "2021-07-19T09:05:57.086611905Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-6-611101: User authentication succeeded: IP address: 10.10.0.87, Uname: admin",
                 "code": "611101",
                 "kind": "event",
@@ -4486,7 +4486,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:10.716311100Z",
+                "ingested": "2021-07-19T09:05:57.086613585Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-5-713049: Group = 91.240.17.178, IP = 91.240.17.178, Security negotiation complete for LAN-to-LAN Group (91.240.17.178) Responder, Inbound SPI = 0x276b1da2, Outbound SPI = 0x0e1a581d",
                 "code": "713049",
                 "kind": "event",
@@ -4565,7 +4565,7 @@
             "event": {
                 "severity": 4,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:10.716315100Z",
+                "ingested": "2021-07-19T09:05:57.086615270Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-4-113019: Group = 91.240.17.178, Username = 91.240.17.178, IP = 91.240.17.178, Session disconnected. Session Type: LAN-to-LAN, Duration: 0h:32m:16s, Bytes xmt: 297103, Bytes rcv: 1216163, Reason: User Requested",
                 "code": "113019",
                 "kind": "event",
@@ -4623,7 +4623,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:10.716319Z",
+                "ingested": "2021-07-19T09:05:57.086616962Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-4-722051: Group \u003cVPN5Policy\u003e User \u003cjohn\u003e IP \u003c192.168.50.3\u003e IPv4 Address \u003c192.168.50.5\u003e IPv6 address \u003c::\u003e assigned to session",
                 "code": "722051",
                 "kind": "event",
@@ -4700,7 +4700,7 @@
             "event": {
                 "severity": 6,
                 "reason": "User Requested",
-                "ingested": "2021-06-09T10:11:10.716323Z",
+                "ingested": "2021-07-19T09:05:57.086618639Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-6-716002: Group another-policy User testuser IP 8.8.8.8 WebVPN session terminated: User Requested.",
                 "code": "716002",
                 "kind": "event",
@@ -4761,7 +4761,7 @@
             "event": {
                 "severity": 6,
                 "reason": "Idle timeout",
-                "ingested": "2021-06-09T10:11:10.716328400Z",
+                "ingested": "2021-07-19T09:05:57.086620348Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-6-716002: Group another-policy User alice IP 192.168.50.1 WebVPN session terminated: Idle timeout.",
                 "code": "716002",
                 "kind": "event",
@@ -4839,15 +4839,15 @@
                 "transport": "tcp"
             },
             "observer": {
-                "ingress": {
-                    "interface": {
-                        "name": "outside"
-                    }
-                },
                 "hostname": "dev01",
                 "product": "asa",
                 "type": "firewall",
-                "vendor": "Cisco"
+                "vendor": "Cisco",
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                }
             },
             "@timestamp": "2021-04-27T02:03:03.000Z",
             "ecs": {
@@ -4867,7 +4867,7 @@
             },
             "event": {
                 "severity": 3,
-                "ingested": "2021-06-09T10:11:10.716332600Z",
+                "ingested": "2021-07-19T09:05:57.086622029Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-3-710003: TCP access denied by ACL from 104.46.88.19/6370 to outside:195.74.114.34/23",
                 "code": "710003",
                 "kind": "event",
@@ -4928,7 +4928,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "destinationInterfaceName"
+                        "name": "sourceInterfaceName"
                     }
                 },
                 "hostname": "dev01",
@@ -4937,7 +4937,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "sourceInterfaceName"
+                        "name": "destinationInterfaceName"
                     }
                 }
             },
@@ -4959,7 +4959,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:10.716336800Z",
+                "ingested": "2021-07-19T09:05:57.086623748Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-5-434004: SFR requested ASA to bypass further packet redirection and process TCP flow from sourceInterfaceName:91.240.17.178/8888 to destinationInterfaceName:192.168.2.2/123123 locally",
                 "code": "434004",
                 "kind": "event",
@@ -5021,7 +5021,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "destinationInterfaceName"
+                        "name": "sourceInterfaceName"
                     }
                 },
                 "hostname": "dev01",
@@ -5030,7 +5030,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "sourceInterfaceName"
+                        "name": "destinationInterfaceName"
                     }
                 }
             },
@@ -5053,7 +5053,7 @@
             "event": {
                 "severity": 4,
                 "action": "drop",
-                "ingested": "2021-06-09T10:11:10.716341100Z",
+                "ingested": "2021-07-19T09:05:57.086625415Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-4-434002: SFR requested to drop TCP packet from sourceInterfaceName:91.240.17.138/8888 to destinationInterfaceName:192.168.2.2/514514",
                 "code": "434002",
                 "outcome": "unknown"
@@ -5104,15 +5104,15 @@
                 "protocol": "tcp"
             },
             "observer": {
-                "hostname": "dev01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "sourceInterfaceName"
                     }
-                }
+                },
+                "hostname": "dev01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2020-04-27T02:03:03.000Z",
             "ecs": {
@@ -5133,7 +5133,7 @@
             "event": {
                 "severity": 6,
                 "reason": "Failed to locate egress interface",
-                "ingested": "2021-06-09T10:11:10.716346600Z",
+                "ingested": "2021-07-19T09:05:57.086627143Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-6-110002: Failed to locate egress interface for TCP from sourceInterfaceName:91.240.17.178/7777 to 192.168.2.2/123412",
                 "code": "110002",
                 "kind": "event",
@@ -5194,7 +5194,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "destinationInterfaceName"
+                        "name": "sourceInterfaceName"
                     }
                 },
                 "hostname": "dev01",
@@ -5203,7 +5203,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "sourceInterfaceName"
+                        "name": "destinationInterfaceName"
                     }
                 }
             },
@@ -5226,7 +5226,7 @@
             "event": {
                 "severity": 4,
                 "reason": "Duplicate TCP SYN with different initial sequence number",
-                "ingested": "2021-06-09T10:11:10.716351100Z",
+                "ingested": "2021-07-19T09:05:57.086628859Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-4-419002: Duplicate TCP SYN from sourceInterfaceName:91.240.17.178/7777 to destinationInterfaceName:192.168.2.2/514514 with different initial sequence number",
                 "code": "419002",
                 "kind": "event",
@@ -5311,7 +5311,7 @@
             "event": {
                 "severity": 6,
                 "action": "created",
-                "ingested": "2021-06-09T10:11:10.716356Z",
+                "ingested": "2021-07-19T09:05:57.086630778Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-6-602303: IPSEC: An outbound LAN-to-LAN SA (SPI= 0xF81283) between 91.240.17.178 and 192.168.2.2 (user= admin) has been created.",
                 "code": "602303",
                 "outcome": "success"
@@ -5388,7 +5388,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716360100Z",
+                "ingested": "2021-07-19T09:05:57.086632521Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-6-602304: IPSEC: An outbound LAN-to-LAN SA (SPI= 0xF81283) between 91.240.17.178 and 192.168.2.2 (user= admin) has been deleted.",
                 "code": "602304",
                 "kind": "event",
@@ -5474,7 +5474,7 @@
             "event": {
                 "severity": 5,
                 "reason": "Received a IKE_INIT_SA request",
-                "ingested": "2021-06-09T10:11:10.716364300Z",
+                "ingested": "2021-07-19T09:05:57.086634297Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-5-750002: Local:91.240.17.178:7777 Remote:192.168.2.2:7777 Username:admin Received a IKE_INIT_SA request",
                 "code": "750002",
                 "kind": "event",
@@ -5557,7 +5557,7 @@
             "event": {
                 "severity": 4,
                 "reason": "Negotiation aborted due to Failed to locate an item in the database",
-                "ingested": "2021-06-09T10:11:10.716368200Z",
+                "ingested": "2021-07-19T09:05:57.086635947Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-4-750003: Local:91.240.17.178:7777 Remote:192.168.2.2:7777 Username:admin Negotiation aborted due to ERROR: Failed to locate an item in the database",
                 "code": "750003",
                 "kind": "event",
@@ -5620,7 +5620,7 @@
             "event": {
                 "severity": 5,
                 "reason": "PHASE 2 COMPLETED",
-                "ingested": "2021-06-09T10:11:10.716372300Z",
+                "ingested": "2021-07-19T09:05:57.086637615Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-5-713120: Group = 100.60.140.10, IP = 192.128.1.1, PHASE 2 COMPLETED (msgid=bbe383e88)",
                 "code": "713120",
                 "kind": "event",
@@ -5683,7 +5683,7 @@
             "event": {
                 "severity": 5,
                 "reason": "Duplicate first packet detected",
-                "ingested": "2021-06-09T10:11:10.716376200Z",
+                "ingested": "2021-07-19T09:05:57.086639319Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-5-713202: IP = 192.64.157.61, Duplicate first packet detected. Ignoring packet.",
                 "code": "713202",
                 "kind": "event",
@@ -5743,7 +5743,7 @@
             "event": {
                 "severity": 6,
                 "reason": "All IPSec SA proposals found unacceptable!",
-                "ingested": "2021-06-09T10:11:10.716380100Z",
+                "ingested": "2021-07-19T09:05:57.086641034Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-6-713905: Group = 100.60.140.10, IP = 192.128.1.1, All IPSec SA proposals found unacceptable!",
                 "code": "713905",
                 "kind": "event",
@@ -5786,7 +5786,7 @@
             "event": {
                 "severity": 6,
                 "reason": "All IPSec SA proposals found unacceptable!",
-                "ingested": "2021-06-09T10:11:10.716383800Z",
+                "ingested": "2021-07-19T09:05:57.086642711Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-6-713904: All IPSec SA proposals found unacceptable!",
                 "code": "713904",
                 "kind": "event",
@@ -5831,7 +5831,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:10.716387600Z",
+                "ingested": "2021-07-19T09:05:57.086644442Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-6-713903: IP = 192.128.1.1, All IPSec SA proposals found unacceptable!",
                 "code": "713903",
                 "kind": "event",
@@ -5875,7 +5875,7 @@
             "event": {
                 "severity": 6,
                 "reason": "All IPSec SA proposals found unacceptable!",
-                "ingested": "2021-06-09T10:11:10.716391400Z",
+                "ingested": "2021-07-19T09:05:57.086646109Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-6-713902: Group = 100.60.140.10, All IPSec SA proposals found unacceptable!",
                 "code": "713902",
                 "kind": "event",
@@ -5940,7 +5940,7 @@
             "event": {
                 "severity": 6,
                 "reason": "All IPSec SA proposals found unacceptable!",
-                "ingested": "2021-06-09T10:11:10.716395200Z",
+                "ingested": "2021-07-19T09:05:57.086647796Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-6-713901: Group = 100.60.140.10, IP = 192.128.1.1, All IPSec SA proposals found unacceptable!",
                 "code": "713901",
                 "kind": "event",

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-asa-fix.log-expected.json
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-asa-fix.log-expected.json
@@ -25,7 +25,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "Inside"
+                        "name": "Outside"
                     }
                 },
                 "hostname": "SNL-ASA-VPN-A01",
@@ -34,7 +34,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "Outside"
+                        "name": "Inside"
                     }
                 }
             },
@@ -57,7 +57,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.122896Z",
+                "ingested": "2021-07-19T09:06:01.498773141Z",
                 "original": "Apr 17 2020 14:08:08 SNL-ASA-VPN-A01 : %ASA-6-302016: Teardown UDP connection 110577675 for Outside:10.123.123.123/53723(LOCAL\\Elastic) to Inside:10.233.123.123/53 duration 0:00:00 bytes 148 (zzzzzz)",
                 "code": "302016",
                 "kind": "event",
@@ -104,7 +104,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "Outside"
+                        "name": "Inside"
                     }
                 },
                 "hostname": "SNL-ASA-VPN-A01",
@@ -113,7 +113,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "Inside"
+                        "name": "Outside"
                     }
                 }
             },
@@ -134,7 +134,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.122912100Z",
+                "ingested": "2021-07-19T09:06:01.498779612Z",
                 "original": "Apr 17 2020 14:00:31 SNL-ASA-VPN-A01 : %ASA-4-106023: Deny icmp src Inside:10.123.123.123 dst Outside:10.123.123.123 (type 11, code 0) by access-group \"Inside_access_in\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -180,7 +180,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 },
                 "product": "asa",
@@ -188,7 +188,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 }
             },
@@ -203,7 +203,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.122916200Z",
+                "ingested": "2021-07-19T09:06:01.498781958Z",
                 "original": "Apr 15 2013 09:36:50: %ASA-4-106023: Deny tcp src dmz:10.123.123.123/6316 dst outside:10.123.123.123/53 type 3, code 0, by access-group \"acl_dmz\" [0xe3afb522, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -249,7 +249,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "Outside"
+                        "name": "Inside"
                     }
                 },
                 "hostname": "SNL-ASA-VPN-A01",
@@ -258,7 +258,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "Inside"
+                        "name": "Outside"
                     }
                 }
             },
@@ -279,7 +279,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.122919700Z",
+                "ingested": "2021-07-19T09:06:01.498783785Z",
                 "original": "Apr 17 2020 14:16:20 SNL-ASA-VPN-A01 : %ASA-4-106023: Deny udp src Inside:10.123.123.123/57621(LOCAL\\Elastic) dst Outside:10.123.123.123/57621 by access-group \"Inside_access_in\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -340,7 +340,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:13.122922600Z",
+                "ingested": "2021-07-19T09:06:01.498789415Z",
                 "original": "Apr 17 2020 14:15:07 SNL-ASA-VPN-A01 : %ASA-2-106017: Deny IP due to Land Attack from 10.123.123.123 to 10.123.123.123",
                 "code": "106017",
                 "kind": "event",
@@ -374,15 +374,15 @@
                 "transport": "ipv6-icmp"
             },
             "observer": {
-                "hostname": "SNL-ASA-VPN-A01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "ISP1"
                     }
-                }
+                },
+                "hostname": "SNL-ASA-VPN-A01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2020-04-17T14:15:07.000Z",
             "ecs": {
@@ -401,7 +401,7 @@
             },
             "event": {
                 "severity": 3,
-                "ingested": "2021-06-09T10:11:13.122925400Z",
+                "ingested": "2021-07-19T09:06:01.498792593Z",
                 "original": "Apr 17 2020 14:15:07 SNL-ASA-VPN-A01 : %ASA-3-313008: Denied IPv6-ICMP type=134, code=0 from fe80::1ff:fe23:4567:890a on interface ISP1",
                 "code": "313008",
                 "kind": "event",
@@ -447,7 +447,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "identity"
+                        "name": "Inside"
                     }
                 },
                 "product": "asa",
@@ -455,7 +455,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "Inside"
+                        "name": "identity"
                     }
                 }
             },
@@ -471,7 +471,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.122928300Z",
+                "ingested": "2021-07-19T09:06:01.498794471Z",
                 "original": "Jun 08 2020 12:59:57: %ASA-4-313009: Denied invalid ICMP code 9, for Inside:10.255.0.206/8795 (10.255.0.206/8795) to identity:10.12.31.51/0 (10.12.31.51/0), ICMP id 295, ICMP type 8",
                 "code": "313009",
                 "kind": "event",
@@ -521,7 +521,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "dmz2"
                     }
                 },
                 "product": "asa",
@@ -529,7 +529,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "dmz2"
+                        "name": "inside"
                     }
                 }
             },
@@ -545,7 +545,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.122931100Z",
+                "ingested": "2021-07-19T09:06:01.498796270Z",
                 "original": "Oct 20 2019 15:42:53: %ASA-6-106100: access-list incoming permitted udp dmz2/127.2.3.4(56575) -\u003e inside/127.3.4.5(53) hit-cnt 1 first hit [0x93d0e533, 0x578ef52f]",
                 "code": "106100",
                 "kind": "event",
@@ -591,7 +591,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "dmz2"
                     }
                 },
                 "product": "asa",
@@ -599,7 +599,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "dmz2"
+                        "name": "inside"
                     }
                 }
             },
@@ -615,7 +615,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.122934700Z",
+                "ingested": "2021-07-19T09:06:01.498798076Z",
                 "original": "Oct 20 2019 15:42:54: %ASA-6-106100: access-list incoming permitted udp dmz2/127.2.3.4(56575)(LOCAL\\\\username) -\u003e inside/127.3.4.5(53) hit-cnt 1 first hit [0x93d0e533, 0x578ef52f]",
                 "code": "106100",
                 "kind": "event",
@@ -661,7 +661,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "product": "asa",
@@ -669,7 +669,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -688,7 +688,7 @@
             },
             "event": {
                 "severity": 3,
-                "ingested": "2021-06-09T10:11:13.122938500Z",
+                "ingested": "2021-07-19T09:06:01.498799824Z",
                 "original": "Aug  6 2020 11:01:37: %ASA-session-3-106102: access-list dev_inward_client permitted udp for user redacted outside/10.123.123.20(49721) -\u003e inside/10.223.223.40(53) hit-cnt 1 first hit [0x3c8b88c1, 0xbee595c3]",
                 "code": "106102",
                 "kind": "event",
@@ -749,7 +749,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -757,7 +757,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -776,7 +776,7 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-06-09T10:11:13.122941400Z",
+                "ingested": "2021-07-19T09:06:01.498801541Z",
                 "original": "Aug  6 2020 11:01:38: %ASA-1-106103: access-list filter denied icmp for user joe inside/10.1.2.3(64321) -\u003e outside/1.2.33.40(8080) hit-cnt 1 first hit [0x3c8b88c1, 0xbee595c3]",
                 "code": "106103",
                 "kind": "event",

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-asa.log-expected.json
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-asa.log-expected.json
@@ -28,7 +28,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -37,7 +37,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -59,7 +59,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439115800Z",
+                "ingested": "2021-07-19T09:06:02.111550576Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1772 to outside:100.66.98.44/8256",
                 "code": "305011",
                 "kind": "event",
@@ -107,7 +107,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -116,7 +116,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -138,7 +138,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439131600Z",
+                "ingested": "2021-07-19T09:06:02.111556081Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11757 for outside:100.66.205.104/80 (100.66.205.104/80) to inside:172.31.98.44/1772 (172.31.98.44/1772)",
                 "code": "302013",
                 "kind": "event",
@@ -191,7 +191,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -200,7 +200,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -224,7 +224,7 @@
                 "severity": 6,
                 "duration": 67000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:13.439135500Z",
+                "ingested": "2021-07-19T09:06:02.111559421Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11749 for outside:100.66.211.242/80 to inside:172.31.98.44/1758 duration 0:01:07 bytes 38110 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -276,7 +276,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -285,7 +285,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -309,7 +309,7 @@
                 "severity": 6,
                 "duration": 67000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:13.439138600Z",
+                "ingested": "2021-07-19T09:06:02.111561357Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11748 for outside:100.66.211.242/80 to inside:172.31.98.44/1757 duration 0:01:07 bytes 44010 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -361,7 +361,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -370,7 +370,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -394,7 +394,7 @@
                 "severity": 6,
                 "duration": 67000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:13.439141300Z",
+                "ingested": "2021-07-19T09:06:02.111563080Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11745 for outside:100.66.185.90/80 to inside:172.31.98.44/1755 duration 0:01:07 bytes 7652 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -446,7 +446,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -455,7 +455,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -479,7 +479,7 @@
                 "severity": 6,
                 "duration": 67000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:13.439144100Z",
+                "ingested": "2021-07-19T09:06:02.111564689Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11744 for outside:100.66.185.90/80 to inside:172.31.98.44/1754 duration 0:01:07 bytes 7062 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -531,7 +531,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -540,7 +540,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -564,7 +564,7 @@
                 "severity": 6,
                 "duration": 68000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:13.439146700Z",
+                "ingested": "2021-07-19T09:06:02.111566358Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11742 for outside:100.66.160.197/80 to inside:172.31.98.44/1752 duration 0:01:08 bytes 5738 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -616,7 +616,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -625,7 +625,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -649,7 +649,7 @@
                 "severity": 6,
                 "duration": 68000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:13.439149300Z",
+                "ingested": "2021-07-19T09:06:02.111567977Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11738 for outside:100.66.205.14/80 to inside:172.31.98.44/1749 duration 0:01:08 bytes 4176 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -701,7 +701,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -710,7 +710,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -734,7 +734,7 @@
                 "severity": 6,
                 "duration": 68000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:13.439151800Z",
+                "ingested": "2021-07-19T09:06:02.111569614Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11739 for outside:100.66.124.33/80 to inside:172.31.98.44/1750 duration 0:01:08 bytes 1715 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -786,7 +786,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -795,7 +795,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -819,7 +819,7 @@
                 "severity": 6,
                 "duration": 69000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:13.439154200Z",
+                "ingested": "2021-07-19T09:06:02.111571296Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11731 for outside:100.66.35.9/80 to inside:172.31.98.44/1747 duration 0:01:09 bytes 45595 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -871,7 +871,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -880,7 +880,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -904,7 +904,7 @@
                 "severity": 6,
                 "duration": 69000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:13.439156800Z",
+                "ingested": "2021-07-19T09:06:02.111572966Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11723 for outside:100.66.211.242/80 to inside:172.31.98.44/1742 duration 0:01:09 bytes 27359 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -956,7 +956,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -965,7 +965,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -989,7 +989,7 @@
                 "severity": 6,
                 "duration": 69000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:13.439159600Z",
+                "ingested": "2021-07-19T09:06:02.111574850Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11715 for outside:100.66.218.21/80 to inside:172.31.98.44/1741 duration 0:01:09 bytes 4457 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -1041,7 +1041,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -1050,7 +1050,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -1074,7 +1074,7 @@
                 "severity": 6,
                 "duration": 69000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:13.439162100Z",
+                "ingested": "2021-07-19T09:06:02.111576497Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11711 for outside:100.66.198.27/80 to inside:172.31.98.44/1739 duration 0:01:09 bytes 26709 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -1126,7 +1126,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -1135,7 +1135,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -1159,7 +1159,7 @@
                 "severity": 6,
                 "duration": 69000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:13.439164600Z",
+                "ingested": "2021-07-19T09:06:02.111578094Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11712 for outside:100.66.198.27/80 to inside:172.31.98.44/1740 duration 0:01:09 bytes 22097 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -1211,7 +1211,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -1220,7 +1220,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -1244,7 +1244,7 @@
                 "severity": 6,
                 "duration": 70000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:13.439167100Z",
+                "ingested": "2021-07-19T09:06:02.111579805Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11708 for outside:100.66.202.211/80 to inside:172.31.98.44/1738 duration 0:01:10 bytes 2209 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -1296,7 +1296,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -1305,7 +1305,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -1329,7 +1329,7 @@
                 "severity": 6,
                 "duration": 67000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:13.439169800Z",
+                "ingested": "2021-07-19T09:06:02.111581438Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11746 for outside:100.66.124.15/80 to inside:172.31.98.44/1756 duration 0:01:07 bytes 10404 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -1381,7 +1381,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -1390,7 +1390,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -1414,7 +1414,7 @@
                 "severity": 6,
                 "duration": 70000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:13.439172300Z",
+                "ingested": "2021-07-19T09:06:02.111583241Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11706 for outside:100.66.124.15/80 to inside:172.31.98.44/1737 duration 0:01:10 bytes 123694 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -1466,7 +1466,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -1475,7 +1475,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -1499,7 +1499,7 @@
                 "severity": 6,
                 "duration": 71000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:13.439175Z",
+                "ingested": "2021-07-19T09:06:02.111584913Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11702 for outside:100.66.209.247/80 to inside:172.31.98.44/1736 duration 0:01:11 bytes 35835 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -1551,7 +1551,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -1560,7 +1560,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -1584,7 +1584,7 @@
                 "severity": 6,
                 "duration": 30000000000,
                 "reason": "SYN Timeout",
-                "ingested": "2021-06-09T10:11:13.439177500Z",
+                "ingested": "2021-07-19T09:06:02.111586589Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11753 for outside:100.66.35.162/80 to inside:172.31.98.44/1765 duration 0:00:30 bytes 0 SYN Timeout",
                 "code": "302014",
                 "kind": "event",
@@ -1635,7 +1635,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -1644,7 +1644,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1666,7 +1666,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439180Z",
+                "ingested": "2021-07-19T09:06:02.111588192Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic UDP translation from inside:172.31.98.44/56132 to outside:100.66.98.44/1188",
                 "code": "305011",
                 "kind": "event",
@@ -1714,7 +1714,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -1723,7 +1723,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -1745,7 +1745,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439182400Z",
+                "ingested": "2021-07-19T09:06:02.111589869Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11758 for outside:100.66.80.32/53 (100.66.80.32/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -1798,7 +1798,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -1807,7 +1807,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -1830,7 +1830,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439185Z",
+                "ingested": "2021-07-19T09:06:02.111591537Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11758 for outside:100.66.80.32/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 148",
                 "code": "302016",
                 "kind": "event",
@@ -1882,7 +1882,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -1891,7 +1891,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -1913,7 +1913,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439187600Z",
+                "ingested": "2021-07-19T09:06:02.111593139Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11759 for outside:100.66.252.6/53 (100.66.252.6/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -1966,7 +1966,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -1975,7 +1975,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -1998,7 +1998,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439191Z",
+                "ingested": "2021-07-19T09:06:02.111594912Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11759 for outside:100.66.252.6/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 164",
                 "code": "302016",
                 "kind": "event",
@@ -2049,7 +2049,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -2058,7 +2058,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2080,7 +2080,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439193800Z",
+                "ingested": "2021-07-19T09:06:02.111596585Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1773 to outside:100.66.98.44/8257",
                 "code": "305011",
                 "kind": "event",
@@ -2128,7 +2128,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -2137,7 +2137,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -2159,7 +2159,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439196700Z",
+                "ingested": "2021-07-19T09:06:02.111598241Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11760 for outside:100.66.252.226/80 (100.66.252.226/80) to inside:172.31.98.44/1773 (172.31.98.44/1773)",
                 "code": "302013",
                 "kind": "event",
@@ -2211,7 +2211,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -2220,7 +2220,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2242,7 +2242,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439199100Z",
+                "ingested": "2021-07-19T09:06:02.111599873Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1774 to outside:100.66.98.44/8258",
                 "code": "305011",
                 "kind": "event",
@@ -2290,7 +2290,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -2299,7 +2299,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -2321,7 +2321,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439202400Z",
+                "ingested": "2021-07-19T09:06:02.111601536Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11761 for outside:100.66.252.226/80 (100.66.252.226/80) to inside:172.31.98.44/1774 (172.31.98.44/1774)",
                 "code": "302013",
                 "kind": "event",
@@ -2374,7 +2374,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -2383,7 +2383,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -2405,7 +2405,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439205100Z",
+                "ingested": "2021-07-19T09:06:02.111603181Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11762 for outside:100.66.238.126/53 (100.66.238.126/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -2458,7 +2458,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -2467,7 +2467,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -2489,7 +2489,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439208100Z",
+                "ingested": "2021-07-19T09:06:02.111604859Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11763 for outside:100.66.93.51/53 (100.66.93.51/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -2542,7 +2542,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -2551,7 +2551,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -2574,7 +2574,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439210900Z",
+                "ingested": "2021-07-19T09:06:02.111606551Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11762 for outside:100.66.238.126/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 111",
                 "code": "302016",
                 "kind": "event",
@@ -2626,7 +2626,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -2635,7 +2635,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -2658,7 +2658,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439214300Z",
+                "ingested": "2021-07-19T09:06:02.111613702Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11763 for outside:100.66.93.51/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 237",
                 "code": "302016",
                 "kind": "event",
@@ -2709,7 +2709,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -2718,7 +2718,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2740,7 +2740,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439217100Z",
+                "ingested": "2021-07-19T09:06:02.111615442Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1775 to outside:100.66.98.44/8259",
                 "code": "305011",
                 "kind": "event",
@@ -2788,7 +2788,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -2797,7 +2797,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -2819,7 +2819,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439219900Z",
+                "ingested": "2021-07-19T09:06:02.111617090Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11764 for outside:100.66.225.103/443 (100.66.225.103/443) to inside:172.31.98.44/1775 (172.31.98.44/1775)",
                 "code": "302013",
                 "kind": "event",
@@ -2871,7 +2871,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -2880,7 +2880,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2902,7 +2902,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439222500Z",
+                "ingested": "2021-07-19T09:06:02.111618941Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic UDP translation from inside:172.31.98.44/56132 to outside:100.66.98.44/1189",
                 "code": "305011",
                 "kind": "event",
@@ -2950,7 +2950,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -2959,7 +2959,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -2981,7 +2981,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439225Z",
+                "ingested": "2021-07-19T09:06:02.111620598Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11772 for outside:100.66.240.126/53 (100.66.240.126/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -3034,7 +3034,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -3043,7 +3043,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -3065,7 +3065,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439227500Z",
+                "ingested": "2021-07-19T09:06:02.111622286Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11773 for outside:100.66.44.45/53 (100.66.44.45/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -3118,7 +3118,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -3127,7 +3127,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -3150,7 +3150,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439230200Z",
+                "ingested": "2021-07-19T09:06:02.111623941Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11772 for outside:100.66.240.126/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 87",
                 "code": "302016",
                 "kind": "event",
@@ -3202,7 +3202,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -3211,7 +3211,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -3234,7 +3234,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439232700Z",
+                "ingested": "2021-07-19T09:06:02.111625568Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11773 for outside:100.66.44.45/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 221",
                 "code": "302016",
                 "kind": "event",
@@ -3285,7 +3285,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -3294,7 +3294,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -3316,7 +3316,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439237400Z",
+                "ingested": "2021-07-19T09:06:02.111627193Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1452 to outside:100.66.98.44/8265",
                 "code": "305011",
                 "kind": "event",
@@ -3364,7 +3364,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -3373,7 +3373,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -3395,7 +3395,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439240100Z",
+                "ingested": "2021-07-19T09:06:02.111628893Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11774 for outside:100.66.179.219/80 (100.66.179.219/80) to inside:172.31.98.44/1452 (172.31.98.44/1452)",
                 "code": "302013",
                 "kind": "event",
@@ -3448,7 +3448,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -3457,7 +3457,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -3479,7 +3479,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439242600Z",
+                "ingested": "2021-07-19T09:06:02.111630499Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11775 for outside:100.66.157.232/53 (100.66.157.232/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -3532,7 +3532,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -3541,7 +3541,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -3563,7 +3563,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439245200Z",
+                "ingested": "2021-07-19T09:06:02.111632137Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11776 for outside:100.66.178.133/53 (100.66.178.133/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -3616,7 +3616,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -3625,7 +3625,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -3648,7 +3648,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439247700Z",
+                "ingested": "2021-07-19T09:06:02.111633784Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11775 for outside:100.66.157.232/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 101",
                 "code": "302016",
                 "kind": "event",
@@ -3700,7 +3700,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -3709,7 +3709,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -3732,7 +3732,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439250300Z",
+                "ingested": "2021-07-19T09:06:02.111635426Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11776 for outside:100.66.178.133/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 126",
                 "code": "302016",
                 "kind": "event",
@@ -3783,7 +3783,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -3792,7 +3792,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -3814,7 +3814,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439252900Z",
+                "ingested": "2021-07-19T09:06:02.111637048Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1453 to outside:100.66.98.44/8266",
                 "code": "305011",
                 "kind": "event",
@@ -3862,7 +3862,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -3871,7 +3871,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -3893,7 +3893,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439255400Z",
+                "ingested": "2021-07-19T09:06:02.111638855Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11777 for outside:100.66.133.112/80 (100.66.133.112/80) to inside:172.31.98.44/1453 (172.31.98.44/1453)",
                 "code": "302013",
                 "kind": "event",
@@ -3946,7 +3946,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -3955,7 +3955,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -3979,7 +3979,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:13.439258Z",
+                "ingested": "2021-07-19T09:06:02.111640482Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11777 for outside:100.66.133.112/80 to inside:172.31.98.44/1453 duration 0:00:00 bytes 862 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -4031,7 +4031,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -4040,7 +4040,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -4062,7 +4062,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439260600Z",
+                "ingested": "2021-07-19T09:06:02.111642139Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11779 for outside:100.66.204.197/53 (100.66.204.197/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -4115,7 +4115,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -4124,7 +4124,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -4147,7 +4147,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439263200Z",
+                "ingested": "2021-07-19T09:06:02.111643791Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11778 for outside:100.66.157.232/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 104",
                 "code": "302016",
                 "kind": "event",
@@ -4199,7 +4199,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -4208,7 +4208,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -4231,7 +4231,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439265900Z",
+                "ingested": "2021-07-19T09:06:02.111645590Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11779 for outside:100.66.204.197/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 176",
                 "code": "302016",
                 "kind": "event",
@@ -4282,7 +4282,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -4291,7 +4291,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -4313,7 +4313,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439268300Z",
+                "ingested": "2021-07-19T09:06:02.111647250Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1454 to outside:100.66.98.44/8267",
                 "code": "305011",
                 "kind": "event",
@@ -4361,7 +4361,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -4370,7 +4370,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -4392,7 +4392,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439270900Z",
+                "ingested": "2021-07-19T09:06:02.111648940Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11780 for outside:100.66.128.3/80 (100.66.128.3/80) to inside:172.31.98.44/1454 (172.31.98.44/1454)",
                 "code": "302013",
                 "kind": "event",
@@ -4444,7 +4444,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -4453,7 +4453,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -4475,7 +4475,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439273400Z",
+                "ingested": "2021-07-19T09:06:02.111650692Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1455 to outside:100.66.98.44/8268",
                 "code": "305011",
                 "kind": "event",
@@ -4523,7 +4523,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -4532,7 +4532,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -4554,7 +4554,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439276400Z",
+                "ingested": "2021-07-19T09:06:02.111652434Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11781 for outside:100.66.128.3/80 (100.66.128.3/80) to inside:172.31.98.44/1455 (172.31.98.44/1455)",
                 "code": "302013",
                 "kind": "event",
@@ -4606,7 +4606,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -4615,7 +4615,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -4637,7 +4637,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439279Z",
+                "ingested": "2021-07-19T09:06:02.111654088Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1456 to outside:100.66.98.44/8269",
                 "code": "305011",
                 "kind": "event",
@@ -4685,7 +4685,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -4694,7 +4694,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -4716,7 +4716,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439282200Z",
+                "ingested": "2021-07-19T09:06:02.111655742Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11782 for outside:100.66.128.3/80 (100.66.128.3/80) to inside:172.31.98.44/1456 (172.31.98.44/1456)",
                 "code": "302013",
                 "kind": "event",
@@ -4769,7 +4769,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -4778,7 +4778,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -4800,7 +4800,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439284900Z",
+                "ingested": "2021-07-19T09:06:02.111657481Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11783 for outside:100.66.100.4/53 (100.66.100.4/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -4853,7 +4853,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -4862,7 +4862,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -4885,7 +4885,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439287400Z",
+                "ingested": "2021-07-19T09:06:02.111659156Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11783 for outside:100.66.100.4/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 104",
                 "code": "302016",
                 "kind": "event",
@@ -4936,7 +4936,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -4945,7 +4945,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -4967,7 +4967,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439290Z",
+                "ingested": "2021-07-19T09:06:02.111660818Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1457 to outside:100.66.98.44/8270",
                 "code": "305011",
                 "kind": "event",
@@ -5015,7 +5015,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -5024,7 +5024,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -5046,7 +5046,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439292600Z",
+                "ingested": "2021-07-19T09:06:02.111662474Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11784 for outside:100.66.198.40/80 (100.66.198.40/80) to inside:172.31.98.44/1457 (172.31.98.44/1457)",
                 "code": "302013",
                 "kind": "event",
@@ -5098,7 +5098,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -5107,7 +5107,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -5129,7 +5129,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439295200Z",
+                "ingested": "2021-07-19T09:06:02.111664116Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1458 to outside:100.66.98.44/8271",
                 "code": "305011",
                 "kind": "event",
@@ -5177,7 +5177,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -5186,7 +5186,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -5208,7 +5208,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439297900Z",
+                "ingested": "2021-07-19T09:06:02.111665819Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11785 for outside:100.66.198.40/80 (100.66.198.40/80) to inside:172.31.98.44/1458 (172.31.98.44/1458)",
                 "code": "302013",
                 "kind": "event",
@@ -5261,7 +5261,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -5270,7 +5270,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -5292,7 +5292,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439300400Z",
+                "ingested": "2021-07-19T09:06:02.111667537Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11786 for outside:100.66.1.107/53 (100.66.1.107/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -5345,7 +5345,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -5354,7 +5354,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -5378,7 +5378,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:13.439302900Z",
+                "ingested": "2021-07-19T09:06:02.111669206Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11784 for outside:100.66.198.40/80 to inside:172.31.98.44/1457 duration 0:00:00 bytes 593 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -5429,7 +5429,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -5438,7 +5438,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -5460,7 +5460,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439305400Z",
+                "ingested": "2021-07-19T09:06:02.111670851Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1459 to outside:100.66.98.44/8272",
                 "code": "305011",
                 "kind": "event",
@@ -5508,7 +5508,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -5517,7 +5517,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -5539,7 +5539,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439307900Z",
+                "ingested": "2021-07-19T09:06:02.111672537Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11787 for outside:100.66.198.40/80 (100.66.198.40/80) to inside:172.31.98.44/1459 (172.31.98.44/1459)",
                 "code": "302013",
                 "kind": "event",
@@ -5592,7 +5592,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -5601,7 +5601,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -5624,7 +5624,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439310400Z",
+                "ingested": "2021-07-19T09:06:02.111674159Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11786 for outside:100.66.1.107/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 375",
                 "code": "302016",
                 "kind": "event",
@@ -5675,7 +5675,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -5684,7 +5684,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -5706,7 +5706,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439313Z",
+                "ingested": "2021-07-19T09:06:02.111675872Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1460 to outside:100.66.98.44/8273",
                 "code": "305011",
                 "kind": "event",
@@ -5754,7 +5754,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -5763,7 +5763,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -5785,7 +5785,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439315600Z",
+                "ingested": "2021-07-19T09:06:02.111677512Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11788 for outside:100.66.192.44/80 (100.66.192.44/80) to inside:172.31.98.44/1460 (172.31.98.44/1460)",
                 "code": "302013",
                 "kind": "event",
@@ -5840,7 +5840,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439335900Z",
+                "ingested": "2021-07-19T09:06:02.111679154Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1454 to outside:100.66.98.44/8267 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -5884,7 +5884,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -5893,7 +5893,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -5915,7 +5915,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439341300Z",
+                "ingested": "2021-07-19T09:06:02.111680802Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.156.80/1385 to outside:100.66.98.44/8277",
                 "code": "305011",
                 "kind": "event",
@@ -5963,7 +5963,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -5972,7 +5972,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -5994,7 +5994,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439344700Z",
+                "ingested": "2021-07-19T09:06:02.111682475Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11797 for outside:100.66.19.254/80 (100.66.19.254/80) to inside:172.31.156.80/1385 (172.31.156.80/1385)",
                 "code": "302013",
                 "kind": "event",
@@ -6049,7 +6049,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439347500Z",
+                "ingested": "2021-07-19T09:06:02.111684125Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1455 to outside:100.66.98.44/8268 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -6096,7 +6096,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439350200Z",
+                "ingested": "2021-07-19T09:06:02.111686039Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1456 to outside:100.66.98.44/8269 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -6143,7 +6143,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439352800Z",
+                "ingested": "2021-07-19T09:06:02.111687686Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1457 to outside:100.66.98.44/8270 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -6190,7 +6190,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439355400Z",
+                "ingested": "2021-07-19T09:06:02.111689325Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1458 to outside:100.66.98.44/8271 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -6237,7 +6237,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439357800Z",
+                "ingested": "2021-07-19T09:06:02.111692195Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1459 to outside:100.66.98.44/8272 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -6284,7 +6284,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439360600Z",
+                "ingested": "2021-07-19T09:06:02.111693913Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1460 to outside:100.66.98.44/8273 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -6329,7 +6329,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -6338,7 +6338,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -6362,7 +6362,7 @@
                 "severity": 6,
                 "duration": 325000000000,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:13.439364100Z",
+                "ingested": "2021-07-19T09:06:02.111695713Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11564 for outside:100.66.115.46/80 to inside:172.31.156.80/1382 duration 0:05:25 bytes 575 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -6414,7 +6414,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -6423,7 +6423,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -6447,7 +6447,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:13.439366800Z",
+                "ingested": "2021-07-19T09:06:02.111697358Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11797 for outside:100.66.19.254/80 to inside:172.31.156.80/1385 duration 0:00:00 bytes 5391 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -6498,7 +6498,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -6507,7 +6507,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -6529,7 +6529,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439369300Z",
+                "ingested": "2021-07-19T09:06:02.111699045Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.156.80/1386 to outside:100.66.98.44/8278",
                 "code": "305011",
                 "kind": "event",
@@ -6577,7 +6577,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -6586,7 +6586,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -6608,7 +6608,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439371900Z",
+                "ingested": "2021-07-19T09:06:02.111700712Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11798 for outside:100.66.115.46/80 (100.66.115.46/80) to inside:172.31.156.80/1386 (172.31.156.80/1386)",
                 "code": "302013",
                 "kind": "event",
@@ -6660,7 +6660,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -6669,7 +6669,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -6691,7 +6691,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439374300Z",
+                "ingested": "2021-07-19T09:06:02.111702310Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -6741,7 +6741,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -6750,7 +6750,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -6772,7 +6772,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439376800Z",
+                "ingested": "2021-07-19T09:06:02.111703927Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -6822,7 +6822,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -6831,7 +6831,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -6853,7 +6853,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439379400Z",
+                "ingested": "2021-07-19T09:06:02.111705650Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -6903,7 +6903,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -6912,7 +6912,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -6934,7 +6934,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439381800Z",
+                "ingested": "2021-07-19T09:06:02.111707305Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -6984,7 +6984,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -6993,7 +6993,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -7015,7 +7015,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439384300Z",
+                "ingested": "2021-07-19T09:06:02.111709033Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -7065,7 +7065,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -7074,7 +7074,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -7096,7 +7096,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439386800Z",
+                "ingested": "2021-07-19T09:06:02.111710675Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -7146,7 +7146,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -7155,7 +7155,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -7177,7 +7177,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439389500Z",
+                "ingested": "2021-07-19T09:06:02.111712385Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -7227,7 +7227,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -7236,7 +7236,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -7258,7 +7258,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439392Z",
+                "ingested": "2021-07-19T09:06:02.111714077Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -7308,7 +7308,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -7317,7 +7317,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -7339,7 +7339,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439394400Z",
+                "ingested": "2021-07-19T09:06:02.111715703Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -7389,7 +7389,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -7398,7 +7398,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -7420,7 +7420,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439397Z",
+                "ingested": "2021-07-19T09:06:02.111717377Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -7470,7 +7470,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -7479,7 +7479,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -7501,7 +7501,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439399500Z",
+                "ingested": "2021-07-19T09:06:02.111719061Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -7551,7 +7551,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -7560,7 +7560,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -7582,7 +7582,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439402Z",
+                "ingested": "2021-07-19T09:06:02.111720693Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -7632,7 +7632,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -7641,7 +7641,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -7663,7 +7663,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439404500Z",
+                "ingested": "2021-07-19T09:06:02.111722323Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -7713,7 +7713,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -7722,7 +7722,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -7744,7 +7744,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439407Z",
+                "ingested": "2021-07-19T09:06:02.111724118Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1275 to outside:100.66.98.44/8279",
                 "code": "305011",
                 "kind": "event",
@@ -7792,7 +7792,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -7801,7 +7801,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -7823,7 +7823,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439409500Z",
+                "ingested": "2021-07-19T09:06:02.111725754Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11799 for outside:100.66.205.99/80 (100.66.205.99/80) to inside:172.31.98.44/1275 (172.31.98.44/1275)",
                 "code": "302013",
                 "kind": "event",
@@ -7875,7 +7875,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -7884,7 +7884,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -7906,7 +7906,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439412Z",
+                "ingested": "2021-07-19T09:06:02.111727405Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic UDP translation from inside:172.31.98.44/56132 to outside:100.66.98.44/1190",
                 "code": "305011",
                 "kind": "event",
@@ -7954,7 +7954,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -7963,7 +7963,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -7985,7 +7985,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439414500Z",
+                "ingested": "2021-07-19T09:06:02.111729107Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11800 for outside:100.66.14.30/53 (100.66.14.30/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -8038,7 +8038,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -8047,7 +8047,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -8070,7 +8070,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439417100Z",
+                "ingested": "2021-07-19T09:06:02.111730826Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11800 for outside:100.66.14.30/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 373",
                 "code": "302016",
                 "kind": "event",
@@ -8122,7 +8122,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -8131,7 +8131,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -8153,7 +8153,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439419500Z",
+                "ingested": "2021-07-19T09:06:02.111732496Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11801 for outside:100.66.252.210/53 (100.66.252.210/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -8206,7 +8206,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -8215,7 +8215,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -8238,7 +8238,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439422Z",
+                "ingested": "2021-07-19T09:06:02.111734134Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11801 for outside:100.66.252.210/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 207",
                 "code": "302016",
                 "kind": "event",
@@ -8289,7 +8289,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -8298,7 +8298,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -8320,7 +8320,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439424500Z",
+                "ingested": "2021-07-19T09:06:02.111735796Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1276 to outside:100.66.98.44/8280",
                 "code": "305011",
                 "kind": "event",
@@ -8368,7 +8368,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -8377,7 +8377,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -8399,7 +8399,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439427100Z",
+                "ingested": "2021-07-19T09:06:02.111737422Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11802 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1276 (172.31.98.44/1276)",
                 "code": "302013",
                 "kind": "event",
@@ -8451,7 +8451,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -8460,7 +8460,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -8482,7 +8482,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439430800Z",
+                "ingested": "2021-07-19T09:06:02.111739111Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1277 to outside:100.66.98.44/8281",
                 "code": "305011",
                 "kind": "event",
@@ -8530,7 +8530,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -8539,7 +8539,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -8561,7 +8561,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439433500Z",
+                "ingested": "2021-07-19T09:06:02.111740789Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11803 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1277 (172.31.98.44/1277)",
                 "code": "302013",
                 "kind": "event",
@@ -8614,7 +8614,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -8623,7 +8623,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -8647,7 +8647,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:13.439436800Z",
+                "ingested": "2021-07-19T09:06:02.111742487Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11802 for outside:100.66.98.165/80 to inside:172.31.98.44/1276 duration 0:00:00 bytes 12853 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -8698,7 +8698,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -8707,7 +8707,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -8729,7 +8729,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439439900Z",
+                "ingested": "2021-07-19T09:06:02.111744117Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1278 to outside:100.66.98.44/8282",
                 "code": "305011",
                 "kind": "event",
@@ -8777,7 +8777,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -8786,7 +8786,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -8808,7 +8808,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439442500Z",
+                "ingested": "2021-07-19T09:06:02.111745758Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11804 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1278 (172.31.98.44/1278)",
                 "code": "302013",
                 "kind": "event",
@@ -8861,7 +8861,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -8870,7 +8870,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -8894,7 +8894,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:13.439445200Z",
+                "ingested": "2021-07-19T09:06:02.111747624Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11803 for outside:100.66.98.165/80 to inside:172.31.98.44/1277 duration 0:00:00 bytes 5291 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -8945,7 +8945,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -8954,7 +8954,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -8976,7 +8976,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439447800Z",
+                "ingested": "2021-07-19T09:06:02.111749322Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1279 to outside:100.66.98.44/8283",
                 "code": "305011",
                 "kind": "event",
@@ -9024,7 +9024,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -9033,7 +9033,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -9055,7 +9055,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439450300Z",
+                "ingested": "2021-07-19T09:06:02.111751044Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11805 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1279 (172.31.98.44/1279)",
                 "code": "302013",
                 "kind": "event",
@@ -9108,7 +9108,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -9117,7 +9117,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -9141,7 +9141,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:13.439452800Z",
+                "ingested": "2021-07-19T09:06:02.111752702Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11804 for outside:100.66.98.165/80 to inside:172.31.98.44/1278 duration 0:00:00 bytes 965 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -9193,7 +9193,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -9202,7 +9202,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -9226,7 +9226,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:13.439455300Z",
+                "ingested": "2021-07-19T09:06:02.111754358Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11805 for outside:100.66.98.165/80 to inside:172.31.98.44/1279 duration 0:00:00 bytes 8605 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -9277,7 +9277,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -9286,7 +9286,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -9308,7 +9308,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439457700Z",
+                "ingested": "2021-07-19T09:06:02.111756037Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1280 to outside:100.66.98.44/8284",
                 "code": "305011",
                 "kind": "event",
@@ -9356,7 +9356,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -9365,7 +9365,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -9387,7 +9387,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439460300Z",
+                "ingested": "2021-07-19T09:06:02.111757714Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11806 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1280 (172.31.98.44/1280)",
                 "code": "302013",
                 "kind": "event",
@@ -9440,7 +9440,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -9449,7 +9449,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -9473,7 +9473,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:13.439462800Z",
+                "ingested": "2021-07-19T09:06:02.111759363Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11806 for outside:100.66.98.165/80 to inside:172.31.98.44/1280 duration 0:00:00 bytes 3428 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -9524,7 +9524,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -9533,7 +9533,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -9555,7 +9555,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439465200Z",
+                "ingested": "2021-07-19T09:06:02.111761031Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1281 to outside:100.66.98.44/8285",
                 "code": "305011",
                 "kind": "event",
@@ -9603,7 +9603,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -9612,7 +9612,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -9634,7 +9634,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439467700Z",
+                "ingested": "2021-07-19T09:06:02.111762647Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11807 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1281 (172.31.98.44/1281)",
                 "code": "302013",
                 "kind": "event",
@@ -9686,7 +9686,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -9695,7 +9695,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -9717,7 +9717,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439470200Z",
+                "ingested": "2021-07-19T09:06:02.111764277Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1282 to outside:100.66.98.44/8286",
                 "code": "305011",
                 "kind": "event",
@@ -9765,7 +9765,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -9774,7 +9774,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -9796,7 +9796,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439472600Z",
+                "ingested": "2021-07-19T09:06:02.111765940Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11808 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1282 (172.31.98.44/1282)",
                 "code": "302013",
                 "kind": "event",
@@ -9848,7 +9848,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -9857,7 +9857,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -9879,7 +9879,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439475100Z",
+                "ingested": "2021-07-19T09:06:02.111820442Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1283 to outside:100.66.98.44/8287",
                 "code": "305011",
                 "kind": "event",
@@ -9927,7 +9927,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -9936,7 +9936,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -9958,7 +9958,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439477500Z",
+                "ingested": "2021-07-19T09:06:02.111823975Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11809 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1283 (172.31.98.44/1283)",
                 "code": "302013",
                 "kind": "event",
@@ -10010,7 +10010,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -10019,7 +10019,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -10041,7 +10041,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439480Z",
+                "ingested": "2021-07-19T09:06:02.111826181Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1284 to outside:100.66.98.44/8288",
                 "code": "305011",
                 "kind": "event",
@@ -10089,7 +10089,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -10098,7 +10098,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -10120,7 +10120,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439482500Z",
+                "ingested": "2021-07-19T09:06:02.111828200Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11810 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1284 (172.31.98.44/1284)",
                 "code": "302013",
                 "kind": "event",
@@ -10173,7 +10173,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -10182,7 +10182,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -10206,7 +10206,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:13.439485Z",
+                "ingested": "2021-07-19T09:06:02.111830107Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11807 for outside:100.66.98.165/80 to inside:172.31.98.44/1281 duration 0:00:00 bytes 2028 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -10258,7 +10258,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -10267,7 +10267,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -10291,7 +10291,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:13.439487500Z",
+                "ingested": "2021-07-19T09:06:02.111831796Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11808 for outside:100.66.98.165/80 to inside:172.31.98.44/1282 duration 0:00:00 bytes 1085 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -10343,7 +10343,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -10352,7 +10352,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -10376,7 +10376,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:13.439490Z",
+                "ingested": "2021-07-19T09:06:02.111833539Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11809 for outside:100.66.98.165/80 to inside:172.31.98.44/1283 duration 0:00:00 bytes 868 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -10427,7 +10427,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -10436,7 +10436,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -10458,7 +10458,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439492600Z",
+                "ingested": "2021-07-19T09:06:02.111835195Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1285 to outside:100.66.98.44/8289",
                 "code": "305011",
                 "kind": "event",
@@ -10506,7 +10506,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -10515,7 +10515,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -10537,7 +10537,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439495Z",
+                "ingested": "2021-07-19T09:06:02.111836924Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11811 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1285 (172.31.98.44/1285)",
                 "code": "302013",
                 "kind": "event",
@@ -10589,7 +10589,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -10598,7 +10598,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -10620,7 +10620,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439497500Z",
+                "ingested": "2021-07-19T09:06:02.111838570Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1286 to outside:100.66.98.44/8290",
                 "code": "305011",
                 "kind": "event",
@@ -10668,7 +10668,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -10677,7 +10677,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -10699,7 +10699,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439500100Z",
+                "ingested": "2021-07-19T09:06:02.111840310Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11812 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1286 (172.31.98.44/1286)",
                 "code": "302013",
                 "kind": "event",
@@ -10752,7 +10752,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -10761,7 +10761,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -10785,7 +10785,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:13.439502600Z",
+                "ingested": "2021-07-19T09:06:02.111841971Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11810 for outside:100.66.98.165/80 to inside:172.31.98.44/1284 duration 0:00:00 bytes 4439 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -10836,7 +10836,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -10845,7 +10845,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -10867,7 +10867,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439505Z",
+                "ingested": "2021-07-19T09:06:02.111843694Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1287 to outside:100.66.98.44/8291",
                 "code": "305011",
                 "kind": "event",
@@ -10915,7 +10915,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -10924,7 +10924,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -10946,7 +10946,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439507500Z",
+                "ingested": "2021-07-19T09:06:02.111845342Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11813 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1287 (172.31.98.44/1287)",
                 "code": "302013",
                 "kind": "event",
@@ -10999,7 +10999,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -11008,7 +11008,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -11032,7 +11032,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:13.439510Z",
+                "ingested": "2021-07-19T09:06:02.111847012Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11811 for outside:100.66.98.165/80 to inside:172.31.98.44/1285 duration 0:00:00 bytes 914 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -11084,7 +11084,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -11093,7 +11093,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -11117,7 +11117,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:13.439512600Z",
+                "ingested": "2021-07-19T09:06:02.111848640Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11812 for outside:100.66.98.165/80 to inside:172.31.98.44/1286 duration 0:00:00 bytes 871 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -11169,7 +11169,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -11178,7 +11178,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -11200,7 +11200,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439515200Z",
+                "ingested": "2021-07-19T09:06:02.111850268Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11814 for outside:100.66.100.107/53 (100.66.100.107/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -11252,7 +11252,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -11261,7 +11261,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -11283,7 +11283,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439517600Z",
+                "ingested": "2021-07-19T09:06:02.111851948Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1288 to outside:100.66.98.44/8292",
                 "code": "305011",
                 "kind": "event",
@@ -11331,7 +11331,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -11340,7 +11340,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -11362,7 +11362,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439520100Z",
+                "ingested": "2021-07-19T09:06:02.111853547Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11815 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1288 (172.31.98.44/1288)",
                 "code": "302013",
                 "kind": "event",
@@ -11415,7 +11415,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -11424,7 +11424,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -11447,7 +11447,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439522600Z",
+                "ingested": "2021-07-19T09:06:02.111855207Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11814 for outside:100.66.100.107/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 384",
                 "code": "302016",
                 "kind": "event",
@@ -11499,7 +11499,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -11508,7 +11508,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -11530,7 +11530,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439525200Z",
+                "ingested": "2021-07-19T09:06:02.111856794Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11816 for outside:100.66.104.8/53 (100.66.104.8/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -11583,7 +11583,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -11592,7 +11592,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -11615,7 +11615,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439527700Z",
+                "ingested": "2021-07-19T09:06:02.111858454Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11816 for outside:100.66.104.8/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 94",
                 "code": "302016",
                 "kind": "event",
@@ -11666,7 +11666,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -11675,7 +11675,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -11697,7 +11697,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439530100Z",
+                "ingested": "2021-07-19T09:06:02.111860078Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1289 to outside:100.66.98.44/8293",
                 "code": "305011",
                 "kind": "event",
@@ -11745,7 +11745,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -11754,7 +11754,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -11776,7 +11776,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439532600Z",
+                "ingested": "2021-07-19T09:06:02.111861690Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11817 for outside:100.66.123.191/80 (100.66.123.191/80) to inside:172.31.98.44/1289 (172.31.98.44/1289)",
                 "code": "302013",
                 "kind": "event",
@@ -11829,7 +11829,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -11838,7 +11838,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -11862,7 +11862,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:13.439535200Z",
+                "ingested": "2021-07-19T09:06:02.111863300Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11815 for outside:100.66.98.165/80 to inside:172.31.98.44/1288 duration 0:00:00 bytes 945 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -11914,7 +11914,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -11923,7 +11923,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -11947,7 +11947,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:13.439537700Z",
+                "ingested": "2021-07-19T09:06:02.111865046Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11813 for outside:100.66.98.165/80 to inside:172.31.98.44/1287 duration 0:00:00 bytes 13284 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -11999,7 +11999,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -12008,7 +12008,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -12030,7 +12030,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439540200Z",
+                "ingested": "2021-07-19T09:06:02.111866653Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11818 for outside:100.66.100.4/53 (100.66.100.4/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -12083,7 +12083,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -12092,7 +12092,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -12115,7 +12115,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439542700Z",
+                "ingested": "2021-07-19T09:06:02.111868253Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11818 for outside:100.66.100.4/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 104",
                 "code": "302016",
                 "kind": "event",
@@ -12166,7 +12166,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -12175,7 +12175,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -12197,7 +12197,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439545200Z",
+                "ingested": "2021-07-19T09:06:02.111869836Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1290 to outside:100.66.98.44/8294",
                 "code": "305011",
                 "kind": "event",
@@ -12245,7 +12245,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -12254,7 +12254,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -12276,7 +12276,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439548200Z",
+                "ingested": "2021-07-19T09:06:02.111871482Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11819 for outside:100.66.198.25/80 (100.66.198.25/80) to inside:172.31.98.44/1290 (172.31.98.44/1290)",
                 "code": "302013",
                 "kind": "event",
@@ -12329,7 +12329,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "NP Identity Ifc"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -12338,7 +12338,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "NP Identity Ifc"
                     }
                 }
             },
@@ -12361,7 +12361,7 @@
             "event": {
                 "severity": 6,
                 "duration": 3526000000000,
-                "ingested": "2021-06-09T10:11:13.439551Z",
+                "ingested": "2021-07-19T09:06:02.111875722Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 9828 for outside:100.66.48.1/67 to NP Identity Ifc:255.255.255.255/68 duration 0:58:46 bytes 58512",
                 "code": "302016",
                 "kind": "event",
@@ -12415,7 +12415,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439553700Z",
+                "ingested": "2021-07-19T09:06:02.111877388Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1272 to outside:100.66.98.44/8276 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -12460,7 +12460,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -12469,7 +12469,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -12491,7 +12491,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439556500Z",
+                "ingested": "2021-07-19T09:06:02.111878979Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11820 for outside:100.66.3.39/53 (100.66.3.39/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -12544,7 +12544,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -12553,7 +12553,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -12575,7 +12575,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439559100Z",
+                "ingested": "2021-07-19T09:06:02.111880620Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11821 for outside:100.66.162.30/53 (100.66.162.30/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -12628,7 +12628,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -12637,7 +12637,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -12660,7 +12660,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439561600Z",
+                "ingested": "2021-07-19T09:06:02.111882278Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11820 for outside:100.66.3.39/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 168",
                 "code": "302016",
                 "kind": "event",
@@ -12712,7 +12712,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -12721,7 +12721,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -12743,7 +12743,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439564400Z",
+                "ingested": "2021-07-19T09:06:02.111883925Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11822 for outside:100.66.3.39/53 (100.66.3.39/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -12796,7 +12796,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -12805,7 +12805,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -12828,7 +12828,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439567Z",
+                "ingested": "2021-07-19T09:06:02.111885689Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11821 for outside:100.66.162.30/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 198",
                 "code": "302016",
                 "kind": "event",
@@ -12880,7 +12880,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -12889,7 +12889,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -12912,7 +12912,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439570300Z",
+                "ingested": "2021-07-19T09:06:02.111919526Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11822 for outside:100.66.3.39/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 150",
                 "code": "302016",
                 "kind": "event",
@@ -12964,7 +12964,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -12973,7 +12973,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -12995,7 +12995,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439573100Z",
+                "ingested": "2021-07-19T09:06:02.111923483Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11823 for outside:100.66.48.186/53 (100.66.48.186/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -13048,7 +13048,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -13057,7 +13057,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -13080,7 +13080,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439575700Z",
+                "ingested": "2021-07-19T09:06:02.111925944Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11823 for outside:100.66.48.186/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 84",
                 "code": "302016",
                 "kind": "event",
@@ -13131,7 +13131,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -13140,7 +13140,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -13162,7 +13162,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439578400Z",
+                "ingested": "2021-07-19T09:06:02.111928115Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1291 to outside:100.66.98.44/8295",
                 "code": "305011",
                 "kind": "event",
@@ -13210,7 +13210,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -13219,7 +13219,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -13241,7 +13241,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439581300Z",
+                "ingested": "2021-07-19T09:06:02.111929889Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11824 for outside:100.66.54.190/80 (100.66.54.190/80) to inside:172.31.98.44/1291 (172.31.98.44/1291)",
                 "code": "302013",
                 "kind": "event",
@@ -13294,7 +13294,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -13303,7 +13303,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -13325,7 +13325,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439584100Z",
+                "ingested": "2021-07-19T09:06:02.111932020Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11825 for outside:100.66.254.94/53 (100.66.254.94/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -13378,7 +13378,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -13387,7 +13387,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -13410,7 +13410,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439587Z",
+                "ingested": "2021-07-19T09:06:02.111933732Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11825 for outside:100.66.254.94/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 188",
                 "code": "302016",
                 "kind": "event",
@@ -13461,7 +13461,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -13470,7 +13470,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -13492,7 +13492,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439589600Z",
+                "ingested": "2021-07-19T09:06:02.111935462Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1292 to outside:100.66.98.44/8296",
                 "code": "305011",
                 "kind": "event",
@@ -13540,7 +13540,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -13549,7 +13549,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -13571,7 +13571,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439598300Z",
+                "ingested": "2021-07-19T09:06:02.111937160Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11826 for outside:100.66.54.190/80 (100.66.54.190/80) to inside:172.31.98.44/1292 (172.31.98.44/1292)",
                 "code": "302013",
                 "kind": "event",
@@ -13623,7 +13623,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -13632,7 +13632,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -13654,7 +13654,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439601100Z",
+                "ingested": "2021-07-19T09:06:02.111939072Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1293 to outside:100.66.98.44/8297",
                 "code": "305011",
                 "kind": "event",
@@ -13702,7 +13702,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -13711,7 +13711,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -13733,7 +13733,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439603800Z",
+                "ingested": "2021-07-19T09:06:02.111940756Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11827 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1293 (172.31.98.44/1293)",
                 "code": "302013",
                 "kind": "event",
@@ -13785,7 +13785,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -13794,7 +13794,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -13816,7 +13816,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439606400Z",
+                "ingested": "2021-07-19T09:06:02.111942464Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1294 to outside:100.66.98.44/8298",
                 "code": "305011",
                 "kind": "event",
@@ -13864,7 +13864,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -13873,7 +13873,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -13895,7 +13895,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439608900Z",
+                "ingested": "2021-07-19T09:06:02.111944143Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11828 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1294 (172.31.98.44/1294)",
                 "code": "302013",
                 "kind": "event",
@@ -13948,7 +13948,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -13957,7 +13957,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -13981,7 +13981,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:13.439611400Z",
+                "ingested": "2021-07-19T09:06:02.111945860Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11827 for outside:100.66.98.165/80 to inside:172.31.98.44/1293 duration 0:00:00 bytes 5964 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -14032,7 +14032,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -14041,7 +14041,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -14063,7 +14063,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439614Z",
+                "ingested": "2021-07-19T09:06:02.111947526Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1295 to outside:100.66.98.44/8299",
                 "code": "305011",
                 "kind": "event",
@@ -14111,7 +14111,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -14120,7 +14120,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -14142,7 +14142,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439616500Z",
+                "ingested": "2021-07-19T09:06:02.111949218Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11829 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1295 (172.31.98.44/1295)",
                 "code": "302013",
                 "kind": "event",
@@ -14194,7 +14194,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -14203,7 +14203,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -14225,7 +14225,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439619Z",
+                "ingested": "2021-07-19T09:06:02.111950929Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1296 to outside:100.66.98.44/8300",
                 "code": "305011",
                 "kind": "event",
@@ -14273,7 +14273,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -14282,7 +14282,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -14304,7 +14304,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439621500Z",
+                "ingested": "2021-07-19T09:06:02.111952653Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11830 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1296 (172.31.98.44/1296)",
                 "code": "302013",
                 "kind": "event",
@@ -14357,7 +14357,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -14366,7 +14366,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -14390,7 +14390,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:13.439624100Z",
+                "ingested": "2021-07-19T09:06:02.111954329Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11828 for outside:100.66.98.165/80 to inside:172.31.98.44/1294 duration 0:00:00 bytes 6694 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -14442,7 +14442,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -14451,7 +14451,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -14475,7 +14475,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:13.439626800Z",
+                "ingested": "2021-07-19T09:06:02.111956050Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11829 for outside:100.66.98.165/80 to inside:172.31.98.44/1295 duration 0:00:00 bytes 1493 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -14527,7 +14527,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -14536,7 +14536,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -14560,7 +14560,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:13.439629300Z",
+                "ingested": "2021-07-19T09:06:02.111957829Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11830 for outside:100.66.98.165/80 to inside:172.31.98.44/1296 duration 0:00:00 bytes 893 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -14611,7 +14611,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -14620,7 +14620,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -14642,7 +14642,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439631900Z",
+                "ingested": "2021-07-19T09:06:02.111959527Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1297 to outside:100.66.98.44/8301",
                 "code": "305011",
                 "kind": "event",
@@ -14690,7 +14690,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -14699,7 +14699,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -14721,7 +14721,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439634500Z",
+                "ingested": "2021-07-19T09:06:02.111961201Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11831 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1297 (172.31.98.44/1297)",
                 "code": "302013",
                 "kind": "event",
@@ -14773,7 +14773,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -14782,7 +14782,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -14804,7 +14804,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439637Z",
+                "ingested": "2021-07-19T09:06:02.111962914Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1298 to outside:100.66.98.44/8302",
                 "code": "305011",
                 "kind": "event",
@@ -14852,7 +14852,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -14861,7 +14861,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -14883,7 +14883,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439639400Z",
+                "ingested": "2021-07-19T09:06:02.111964597Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11832 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1298 (172.31.98.44/1298)",
                 "code": "302013",
                 "kind": "event",
@@ -14936,7 +14936,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -14945,7 +14945,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -14967,7 +14967,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439642Z",
+                "ingested": "2021-07-19T09:06:02.111966432Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11833 for outside:100.66.179.9/53 (100.66.179.9/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -15020,7 +15020,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -15029,7 +15029,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -15052,7 +15052,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439644500Z",
+                "ingested": "2021-07-19T09:06:02.111968117Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11833 for outside:100.66.179.9/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 150",
                 "code": "302016",
                 "kind": "event",
@@ -15104,7 +15104,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -15113,7 +15113,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -15137,7 +15137,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:13.439647Z",
+                "ingested": "2021-07-19T09:06:02.111969856Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11831 for outside:100.66.98.165/80 to inside:172.31.98.44/1297 duration 0:00:00 bytes 2750 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -15188,7 +15188,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -15197,7 +15197,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -15219,7 +15219,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439649500Z",
+                "ingested": "2021-07-19T09:06:02.111971542Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1299 to outside:100.66.98.44/8303",
                 "code": "305011",
                 "kind": "event",
@@ -15267,7 +15267,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -15276,7 +15276,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -15298,7 +15298,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439652Z",
+                "ingested": "2021-07-19T09:06:02.111973237Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11834 for outside:100.66.247.99/80 (100.66.247.99/80) to inside:172.31.98.44/1299 (172.31.98.44/1299)",
                 "code": "302013",
                 "kind": "event",
@@ -15350,7 +15350,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -15359,7 +15359,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -15381,7 +15381,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439654500Z",
+                "ingested": "2021-07-19T09:06:02.111974896Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1300 to outside:100.66.98.44/8304",
                 "code": "305011",
                 "kind": "event",
@@ -15429,7 +15429,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -15438,7 +15438,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -15460,7 +15460,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439657Z",
+                "ingested": "2021-07-19T09:06:02.111976804Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11835 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1300 (172.31.98.44/1300)",
                 "code": "302013",
                 "kind": "event",
@@ -15513,7 +15513,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -15522,7 +15522,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -15546,7 +15546,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:13.439660300Z",
+                "ingested": "2021-07-19T09:06:02.111978478Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11832 for outside:100.66.98.165/80 to inside:172.31.98.44/1298 duration 0:00:00 bytes 881 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -15598,7 +15598,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -15607,7 +15607,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -15631,7 +15631,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:13.439662900Z",
+                "ingested": "2021-07-19T09:06:02.111980180Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11835 for outside:100.66.98.165/80 to inside:172.31.98.44/1300 duration 0:00:00 bytes 2202 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -15682,7 +15682,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -15691,7 +15691,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -15713,7 +15713,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439665900Z",
+                "ingested": "2021-07-19T09:06:02.111981860Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1301 to outside:100.66.98.44/8305",
                 "code": "305011",
                 "kind": "event",
@@ -15761,7 +15761,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -15770,7 +15770,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -15792,7 +15792,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439668400Z",
+                "ingested": "2021-07-19T09:06:02.111983582Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11836 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1301 (172.31.98.44/1301)",
                 "code": "302013",
                 "kind": "event",
@@ -15844,7 +15844,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -15853,7 +15853,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -15875,7 +15875,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439670900Z",
+                "ingested": "2021-07-19T09:06:02.111985205Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1302 to outside:100.66.98.44/8306",
                 "code": "305011",
                 "kind": "event",
@@ -15923,7 +15923,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -15932,7 +15932,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -15954,7 +15954,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439673600Z",
+                "ingested": "2021-07-19T09:06:02.111987070Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11837 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1302 (172.31.98.44/1302)",
                 "code": "302013",
                 "kind": "event",
@@ -16009,7 +16009,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439676100Z",
+                "ingested": "2021-07-19T09:06:02.111988723Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1276 to outside:100.66.98.44/8280 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16056,7 +16056,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439679300Z",
+                "ingested": "2021-07-19T09:06:02.111990375Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1277 to outside:100.66.98.44/8281 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16103,7 +16103,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439681900Z",
+                "ingested": "2021-07-19T09:06:02.111992065Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1278 to outside:100.66.98.44/8282 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16150,7 +16150,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439684500Z",
+                "ingested": "2021-07-19T09:06:02.111993775Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1279 to outside:100.66.98.44/8283 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16197,7 +16197,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439687Z",
+                "ingested": "2021-07-19T09:06:02.111995514Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1280 to outside:100.66.98.44/8284 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16244,7 +16244,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439689500Z",
+                "ingested": "2021-07-19T09:06:02.111997193Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1281 to outside:100.66.98.44/8285 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16291,7 +16291,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439692Z",
+                "ingested": "2021-07-19T09:06:02.111998878Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1282 to outside:100.66.98.44/8286 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16338,7 +16338,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439694500Z",
+                "ingested": "2021-07-19T09:06:02.112000603Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1283 to outside:100.66.98.44/8287 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16385,7 +16385,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439697100Z",
+                "ingested": "2021-07-19T09:06:02.112002247Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1284 to outside:100.66.98.44/8288 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16432,7 +16432,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439701900Z",
+                "ingested": "2021-07-19T09:06:02.112004024Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1285 to outside:100.66.98.44/8289 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16479,7 +16479,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439705600Z",
+                "ingested": "2021-07-19T09:06:02.112005769Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1286 to outside:100.66.98.44/8290 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16526,7 +16526,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439708500Z",
+                "ingested": "2021-07-19T09:06:02.112007456Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1287 to outside:100.66.98.44/8291 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16573,7 +16573,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439711Z",
+                "ingested": "2021-07-19T09:06:02.112009133Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1288 to outside:100.66.98.44/8292 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16620,7 +16620,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439713500Z",
+                "ingested": "2021-07-19T09:06:02.112010826Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1293 to outside:100.66.98.44/8297 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16667,7 +16667,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439716Z",
+                "ingested": "2021-07-19T09:06:02.112012468Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1294 to outside:100.66.98.44/8298 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16711,7 +16711,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -16720,7 +16720,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -16742,7 +16742,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439718600Z",
+                "ingested": "2021-07-19T09:06:02.112014142Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1304 to outside:100.66.98.44/8308",
                 "code": "305011",
                 "kind": "event",
@@ -16790,7 +16790,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -16799,7 +16799,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -16821,7 +16821,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439721100Z",
+                "ingested": "2021-07-19T09:06:02.112015960Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11840 for outside:100.66.205.99/80 (100.66.205.99/80) to inside:172.31.98.44/1304 (172.31.98.44/1304)",
                 "code": "302013",
                 "kind": "event",
@@ -16876,7 +16876,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439723700Z",
+                "ingested": "2021-07-19T09:06:02.112017591Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1295 to outside:100.66.98.44/8299 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16923,7 +16923,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439726400Z",
+                "ingested": "2021-07-19T09:06:02.112019269Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1296 to outside:100.66.98.44/8300 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16968,7 +16968,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -16977,7 +16977,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -16999,7 +16999,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439728900Z",
+                "ingested": "2021-07-19T09:06:02.112020935Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11841 for outside:100.66.0.124/53 (100.66.0.124/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -17052,7 +17052,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -17061,7 +17061,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -17083,7 +17083,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439731600Z",
+                "ingested": "2021-07-19T09:06:02.112022684Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11842 for outside:100.66.160.2/53 (100.66.160.2/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -17136,7 +17136,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -17145,7 +17145,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -17168,7 +17168,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439734100Z",
+                "ingested": "2021-07-19T09:06:02.112024333Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11841 for outside:100.66.0.124/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 318",
                 "code": "302016",
                 "kind": "event",
@@ -17220,7 +17220,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -17229,7 +17229,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -17252,7 +17252,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:13.439736700Z",
+                "ingested": "2021-07-19T09:06:02.112026121Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11842 for outside:100.66.160.2/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 104",
                 "code": "302016",
                 "kind": "event",
@@ -17303,7 +17303,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -17312,7 +17312,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -17334,7 +17334,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439739300Z",
+                "ingested": "2021-07-19T09:06:02.112027811Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1305 to outside:100.66.98.44/8309",
                 "code": "305011",
                 "kind": "event",
@@ -17382,7 +17382,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -17391,7 +17391,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -17413,7 +17413,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439741900Z",
+                "ingested": "2021-07-19T09:06:02.112029475Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11843 for outside:100.66.124.24/80 (100.66.124.24/80) to inside:172.31.98.44/1305 (172.31.98.44/1305)",
                 "code": "302013",
                 "kind": "event",
@@ -17468,7 +17468,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439745200Z",
+                "ingested": "2021-07-19T09:06:02.112031140Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1297 to outside:100.66.98.44/8301 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -17515,7 +17515,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439747700Z",
+                "ingested": "2021-07-19T09:06:02.112032811Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1298 to outside:100.66.98.44/8302 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -17562,7 +17562,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439750400Z",
+                "ingested": "2021-07-19T09:06:02.112034532Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1299 to outside:100.66.98.44/8303 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -17609,7 +17609,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439753100Z",
+                "ingested": "2021-07-19T09:06:02.112036270Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1300 to outside:100.66.98.44/8304 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -17656,7 +17656,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439755700Z",
+                "ingested": "2021-07-19T09:06:02.112037910Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1301 to outside:100.66.98.44/8305 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -17703,7 +17703,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439758200Z",
+                "ingested": "2021-07-19T09:06:02.112041652Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1302 to outside:100.66.98.44/8306 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -17750,7 +17750,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439760800Z",
+                "ingested": "2021-07-19T09:06:02.112043342Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1303 to outside:100.66.98.44/8307 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -17795,7 +17795,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -17804,7 +17804,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -17828,7 +17828,7 @@
                 "severity": 6,
                 "duration": 4000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:13.439763400Z",
+                "ingested": "2021-07-19T09:06:02.112045086Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11843 for outside:100.66.124.24/80 to inside:172.31.98.44/1305 duration 0:00:04 bytes 410333 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -17879,7 +17879,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -17888,7 +17888,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -17910,7 +17910,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439766100Z",
+                "ingested": "2021-07-19T09:06:02.112046841Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -17960,7 +17960,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -17969,7 +17969,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -17991,7 +17991,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439768700Z",
+                "ingested": "2021-07-19T09:06:02.112048556Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -18041,7 +18041,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -18050,7 +18050,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -18072,7 +18072,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439771100Z",
+                "ingested": "2021-07-19T09:06:02.112050201Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -18122,7 +18122,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -18131,7 +18131,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -18153,7 +18153,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439774100Z",
+                "ingested": "2021-07-19T09:06:02.112051881Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1306 to outside:100.66.98.44/8310",
                 "code": "305011",
                 "kind": "event",
@@ -18201,7 +18201,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -18210,7 +18210,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -18232,7 +18232,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:13.439776700Z",
+                "ingested": "2021-07-19T09:06:02.112053561Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11844 for outside:100.66.124.24/80 (100.66.124.24/80) to inside:172.31.98.44/1306 (172.31.98.44/1306)",
                 "code": "302013",
                 "kind": "event",
@@ -18284,7 +18284,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -18293,7 +18293,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -18315,7 +18315,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439779200Z",
+                "ingested": "2021-07-19T09:06:02.112055226Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -18365,7 +18365,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -18374,7 +18374,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -18396,7 +18396,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439782900Z",
+                "ingested": "2021-07-19T09:06:02.112056870Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -18446,7 +18446,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -18455,7 +18455,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -18477,7 +18477,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439785500Z",
+                "ingested": "2021-07-19T09:06:02.112058568Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -18527,7 +18527,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -18536,7 +18536,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -18558,7 +18558,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439788100Z",
+                "ingested": "2021-07-19T09:06:02.112060213Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -18608,7 +18608,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -18617,7 +18617,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -18639,7 +18639,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439790600Z",
+                "ingested": "2021-07-19T09:06:02.112061881Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -18689,7 +18689,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -18698,7 +18698,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -18720,7 +18720,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439793100Z",
+                "ingested": "2021-07-19T09:06:02.112063520Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -18770,7 +18770,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -18779,7 +18779,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -18801,7 +18801,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439795700Z",
+                "ingested": "2021-07-19T09:06:02.112065209Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -18851,7 +18851,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -18860,7 +18860,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -18882,7 +18882,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439798200Z",
+                "ingested": "2021-07-19T09:06:02.112067085Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -18932,7 +18932,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -18941,7 +18941,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -18963,7 +18963,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439800700Z",
+                "ingested": "2021-07-19T09:06:02.112068731Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19013,7 +19013,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19022,7 +19022,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -19044,7 +19044,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439803300Z",
+                "ingested": "2021-07-19T09:06:02.112070434Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19094,7 +19094,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19103,7 +19103,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -19125,7 +19125,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439806Z",
+                "ingested": "2021-07-19T09:06:02.112072281Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19175,7 +19175,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19184,7 +19184,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -19206,7 +19206,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439808600Z",
+                "ingested": "2021-07-19T09:06:02.112073890Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19256,7 +19256,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19265,7 +19265,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -19287,7 +19287,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439811100Z",
+                "ingested": "2021-07-19T09:06:02.112075545Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19337,7 +19337,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19346,7 +19346,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -19368,7 +19368,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439814100Z",
+                "ingested": "2021-07-19T09:06:02.112077210Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19418,7 +19418,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19427,7 +19427,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -19449,7 +19449,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439816700Z",
+                "ingested": "2021-07-19T09:06:02.112078941Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19499,7 +19499,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19508,7 +19508,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -19530,7 +19530,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439819200Z",
+                "ingested": "2021-07-19T09:06:02.112080595Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19580,7 +19580,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19589,7 +19589,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -19611,7 +19611,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439821700Z",
+                "ingested": "2021-07-19T09:06:02.112082328Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19661,7 +19661,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19670,7 +19670,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -19692,7 +19692,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439824200Z",
+                "ingested": "2021-07-19T09:06:02.112083980Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19742,7 +19742,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19751,7 +19751,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -19773,7 +19773,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439826700Z",
+                "ingested": "2021-07-19T09:06:02.112085665Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19823,7 +19823,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19832,7 +19832,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -19854,7 +19854,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439829200Z",
+                "ingested": "2021-07-19T09:06:02.112087314Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19904,7 +19904,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19913,7 +19913,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -19935,7 +19935,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439831700Z",
+                "ingested": "2021-07-19T09:06:02.112089014Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19985,7 +19985,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19994,7 +19994,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -20016,7 +20016,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439834300Z",
+                "ingested": "2021-07-19T09:06:02.112090667Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -20066,7 +20066,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -20075,7 +20075,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -20097,7 +20097,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439836800Z",
+                "ingested": "2021-07-19T09:06:02.112092366Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -20147,7 +20147,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -20156,7 +20156,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -20178,7 +20178,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439839200Z",
+                "ingested": "2021-07-19T09:06:02.112093994Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -20228,7 +20228,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -20237,7 +20237,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -20259,7 +20259,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439841800Z",
+                "ingested": "2021-07-19T09:06:02.112095648Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -20309,7 +20309,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -20318,7 +20318,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -20340,7 +20340,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439844400Z",
+                "ingested": "2021-07-19T09:06:02.112097305Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -20390,7 +20390,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -20399,7 +20399,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -20421,7 +20421,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439846800Z",
+                "ingested": "2021-07-19T09:06:02.112098975Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -20471,7 +20471,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -20480,7 +20480,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -20502,7 +20502,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439849300Z",
+                "ingested": "2021-07-19T09:06:02.112100697Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -20552,7 +20552,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -20561,7 +20561,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -20583,7 +20583,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439851800Z",
+                "ingested": "2021-07-19T09:06:02.112102392Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -20633,7 +20633,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -20642,7 +20642,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -20664,7 +20664,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439854400Z",
+                "ingested": "2021-07-19T09:06:02.112104035Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -20714,7 +20714,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -20723,7 +20723,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -20745,7 +20745,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439856900Z",
+                "ingested": "2021-07-19T09:06:02.112105681Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -20795,7 +20795,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -20804,7 +20804,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -20826,7 +20826,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439859300Z",
+                "ingested": "2021-07-19T09:06:02.112107320Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -20876,7 +20876,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -20885,7 +20885,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -20907,7 +20907,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:13.439861800Z",
+                "ingested": "2021-07-19T09:06:02.112108998Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-dap-records.log-expected.json
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-dap-records.log-expected.json
@@ -39,7 +39,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:21.033561300Z",
+                "ingested": "2021-07-19T09:06:19.139615469Z",
                 "original": "Feb 20 2020 16:11:11: %ASA-6-734001: DAP: User firsname.lastname@domain.net, Addr 1.2.3.4, Connection AnyConnect: The following DAP records were selected for this connection: dap_1, dap_2",
                 "code": "734001",
                 "kind": "event",

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-filtered.log-expected.json
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-filtered.log-expected.json
@@ -31,7 +31,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:21.061971Z",
+                "ingested": "2021-07-19T09:06:19.206386917Z",
                 "original": "Jan  1 01:00:27 beats asa[1234]: %ASA-7-999999: This message is not filtered.",
                 "code": "999999",
                 "kind": "event",
@@ -72,7 +72,7 @@
             },
             "event": {
                 "severity": 8,
-                "ingested": "2021-06-09T10:11:21.061976900Z",
+                "ingested": "2021-07-19T09:06:19.206392337Z",
                 "original": "Jan  1 01:00:30 beats asa[1234]: %ASA-8-999999: This phony message is dropped due to log level.",
                 "code": "999999",
                 "kind": "event",
@@ -118,15 +118,15 @@
                 "direction": "inbound"
             },
             "observer": {
-                "hostname": "beats",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "eth0"
                     }
-                }
+                },
+                "hostname": "beats",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2021-01-01T01:02:12.000Z",
             "ecs": {
@@ -146,7 +146,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:21.061978800Z",
+                "ingested": "2021-07-19T09:06:19.206394377Z",
                 "original": "Jan  1 01:02:12 beats asa[1234]: %ASA-2-106001: Inbound TCP connection denied from 10.13.12.11/45321 to 192.168.33.12/443 flags URG+SYN+RST on interface eth0",
                 "code": "106001",
                 "kind": "event",

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-hostnames.log-expected.json
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-hostnames.log-expected.json
@@ -45,7 +45,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:21.129156900Z",
+                "ingested": "2021-07-19T09:06:19.346120522Z",
                 "original": "Oct 10 2019 10:21:36 localhost: %ASA-6-302021: Teardown ICMP connection for faddr target.destination.hostname.local/10005 gaddr 10.0.55.66/0 laddr Prod-host.name.addr/0",
                 "code": "302021",
                 "kind": "event",
@@ -107,7 +107,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:21.129164700Z",
+                "ingested": "2021-07-19T09:06:19.346126402Z",
                 "original": "Jun 04 2011 21:59:52 MYHOSTNAME : %ASA-6-302021: Teardown ICMP connection for faddr 192.0.2.15/0 gaddr 192.0.2.134/57808 laddr 192.0.2.134/57808 type 8 code 0",
                 "code": "302021",
                 "kind": "event",

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-not-ip.log-expected.json
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-not-ip.log-expected.json
@@ -29,7 +29,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "OUTSIDE"
+                        "name": "LB-DMZ"
                     }
                 },
                 "product": "asa",
@@ -37,7 +37,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "LB-DMZ"
+                        "name": "OUTSIDE"
                     }
                 }
             },
@@ -55,7 +55,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:21.190319800Z",
+                "ingested": "2021-07-19T09:06:19.451996709Z",
                 "original": "\u003c165\u003eOct 04 2019 15:27:55: %ASA-5-106100: access-list AL-DMZ-LB-IN denied tcp LB-DMZ/WHAT-IS-THIS-A-HOSTNAME-192.0.2.244(27218) -\u003e OUTSIDE/203.0.113.42(53) hit-cnt 1 first hit [0x16847359, 0x00000000]",
                 "code": "106100",
                 "kind": "event",
@@ -120,7 +120,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:21.190328900Z",
+                "ingested": "2021-07-19T09:06:19.452002310Z",
                 "original": "Jan  1 2020 10:42:53 localhost : %ASA-6-302021: Teardown ICMP connection for faddr 172.24.177.29/0 gaddr mydomain.example.net/17233 laddr 192.168.132.46/17233",
                 "code": "302021",
                 "kind": "event",
@@ -170,7 +170,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "wan"
+                        "name": "eth0"
                     }
                 },
                 "hostname": "localhost",
@@ -179,7 +179,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "eth0"
+                        "name": "wan"
                     }
                 }
             },
@@ -202,7 +202,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:21.190331Z",
+                "ingested": "2021-07-19T09:06:19.452004366Z",
                 "original": "Jan  2 2020 11:33:20 localhost : %ASA-4-338204: Dynamic filter dropped greylisted TCP traffic from eth0:10.10.10.1/1234 (source.example.net/11234) to wan:172.24.177.3/80 (www.example.org/80), destination malicious address resolved from dynamic list: example.org, threat-level: high, category: malware",
                 "code": "338204",
                 "kind": "event",

--- a/packages/cisco/data_stream/asa/_dev/test/pipeline/test-sample.log-expected.json
+++ b/packages/cisco/data_stream/asa/_dev/test/pipeline/test-sample.log-expected.json
@@ -24,7 +24,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 },
                 "product": "asa",
@@ -32,7 +32,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 }
             },
@@ -48,7 +48,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:21.284623600Z",
+                "ingested": "2021-07-19T09:06:19.672304618Z",
                 "original": "Apr 15 2013 09:36:50: %ASA-4-106023: Deny tcp src dmz:10.1.2.30/63016 dst outside:192.0.0.8/53 by access-group \"acl_dmz\" [0xe3aab522, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -94,7 +94,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 },
                 "product": "asa",
@@ -102,7 +102,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 }
             },
@@ -118,7 +118,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:21.284630Z",
+                "ingested": "2021-07-19T09:06:19.672398079Z",
                 "original": "Apr 15 2013 09:36:50: %ASA-4-106023: Deny tcp src dmz:10.1.2.30/63016 dst outside:192.0.0.8/53 type 3, code 0, by access-group \"acl_dmz\" [0xe3aab522, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -164,7 +164,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -172,7 +172,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -188,7 +188,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:21.284658100Z",
+                "ingested": "2021-07-19T09:06:19.672402326Z",
                 "original": "Apr 15 2014 09:34:34 EDT: %ASA-session-5-106100: access-list acl_in permitted tcp inside/10.1.2.16(2241) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -235,7 +235,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "INT-FW01",
@@ -244,7 +244,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -266,7 +266,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:21.284660800Z",
+                "ingested": "2021-07-19T09:06:19.672404806Z",
                 "original": "Apr 24 2013 16:00:28 INT-FW01 : %ASA-6-106100: access-list inside denied udp inside/172.29.2.101(1039) -\u003e outside/192.0.2.10(53) hit-cnt 1 first hit [0xd820e56a, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -312,7 +312,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "INT-FW01",
@@ -321,7 +321,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -343,7 +343,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:21.284662800Z",
+                "ingested": "2021-07-19T09:06:19.672406643Z",
                 "original": "Apr 24 2013 16:00:27 INT-FW01 : %ASA-6-106100: access-list inside permitted udp inside/172.29.2.3(1065) -\u003e outside/192.0.2.57(53) hit-cnt 144 300-second interval [0xe982c7a4, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -413,7 +413,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:21.284664600Z",
+                "ingested": "2021-07-19T09:06:19.672408379Z",
                 "original": "Apr 29 2013 12:59:50: %ASA-6-305011: Built dynamic TCP translation from outside:10.123.3.42/4952 to outside:192.0.2.130/12834",
                 "code": "305011",
                 "kind": "event",
@@ -484,7 +484,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:21.284666200Z",
+                "ingested": "2021-07-19T09:06:19.672410128Z",
                 "original": "Apr 29 2013 12:59:50: %ASA-6-302013: Built outbound TCP connection 89743274 for outside:192.0.2.43/443 (192.0.2.43/443) to outside:10.123.3.42/4952 (10.123.3.42/12834)",
                 "code": "302013",
                 "kind": "event",
@@ -556,7 +556,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:21.284667800Z",
+                "ingested": "2021-07-19T09:06:19.672411932Z",
                 "original": "Apr 29 2013 12:59:50: %ASA-6-305011: Built dynamic UDP translation from outside:10.123.1.35/52925 to outside:192.0.2.130/25882",
                 "code": "305011",
                 "kind": "event",
@@ -631,7 +631,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:21.284678100Z",
+                "ingested": "2021-07-19T09:06:19.672413702Z",
                 "original": "Apr 29 2013 12:59:50: %ASA-6-302015: Built outbound UDP connection 89743275 for outside:192.0.2.222/53 (192.0.2.43/53) to outside:10.123.1.35/52925 (10.123.1.35/25882)",
                 "code": "302015",
                 "kind": "event",
@@ -703,7 +703,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:21.284681500Z",
+                "ingested": "2021-07-19T09:06:19.672415481Z",
                 "original": "Apr 29 2013 12:59:50: %ASA-6-305011: Built dynamic TCP translation from outside:10.123.3.42/4953 to outside:192.0.2.130/45392",
                 "code": "305011",
                 "kind": "event",
@@ -776,7 +776,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:21.284696500Z",
+                "ingested": "2021-07-19T09:06:19.672417225Z",
                 "original": "Apr 29 2013 12:59:50: %ASA-6-302013: Built outbound TCP connection 89743276 for outside:192.0.2.1/80 (192.0.2.1/80) to outside:10.123.3.42/4953 (10.123.3.130/45392)",
                 "code": "302013",
                 "kind": "event",
@@ -825,7 +825,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "product": "asa",
@@ -833,7 +833,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -850,7 +850,7 @@
             "event": {
                 "severity": 6,
                 "duration": 5025000000000,
-                "ingested": "2021-06-09T10:11:21.284698600Z",
+                "ingested": "2021-07-19T09:06:19.672419500Z",
                 "original": "Apr 29 2013 12:59:50: %ASA-6-302016: Teardown UDP connection 89743275 for outside:192.0.2.222/53 to inside:10.123.1.35/52925 duration 1:23:45 bytes 140",
                 "code": "302016",
                 "kind": "event",
@@ -898,7 +898,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "product": "asa",
@@ -906,7 +906,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -923,7 +923,7 @@
             "event": {
                 "severity": 6,
                 "duration": 36000000000000,
-                "ingested": "2021-06-09T10:11:21.284700200Z",
+                "ingested": "2021-07-19T09:06:19.672421418Z",
                 "original": "Apr 29 2013 12:59:50: %ASA-6-302016: Teardown UDP connection 666 for outside:192.0.2.222/53 user1 to inside:10.123.1.35/52925 user2 duration 10:00:00 bytes 9999999",
                 "code": "302016",
                 "kind": "event",
@@ -991,7 +991,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:21.284701800Z",
+                "ingested": "2021-07-19T09:06:19.672423189Z",
                 "original": "Jun 04 2011 21:59:52 FJSG2NRFW01 : %ASA-6-302021: Teardown ICMP connection for faddr 172.24.177.29/0 gaddr 192.168.132.46/17233 laddr 192.168.132.46/17233",
                 "code": "302021",
                 "kind": "event",
@@ -1034,7 +1034,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -1042,7 +1042,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1058,7 +1058,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:21.284703300Z",
+                "ingested": "2021-07-19T09:06:19.672424900Z",
                 "original": "Apr 29 2013 12:59:50: %ASA-6-305011: Built dynamic TCP translation from inside:192.168.3.42/4954 to outside:192.0.0.130/10879",
                 "code": "305011",
                 "kind": "event",
@@ -1106,7 +1106,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "product": "asa",
@@ -1114,7 +1114,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -1131,7 +1131,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:21.284704800Z",
+                "ingested": "2021-07-19T09:06:19.672426609Z",
                 "original": "Apr 29 2013 12:59:50: %ASA-6-302013: Built outbound TCP connection 89743277 for outside:192.0.0.17/80 (192.0.0.17/80) to inside:192.168.3.42/4954 (10.0.0.130/10879)",
                 "code": "302013",
                 "kind": "event",
@@ -1195,7 +1195,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:21.284706500Z",
+                "ingested": "2021-07-19T09:06:19.672428567Z",
                 "original": "Apr 30 2013 09:22:33: %ASA-2-106007: Deny inbound UDP from 192.0.0.66/12981 to 10.1.2.60/53 due to DNS Query",
                 "code": "106007",
                 "kind": "event",
@@ -1237,7 +1237,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -1245,7 +1245,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1261,7 +1261,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:21.284708Z",
+                "ingested": "2021-07-19T09:06:19.672430273Z",
                 "original": "Apr 30 2013 09:22:38: %ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2006) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -1307,7 +1307,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -1315,7 +1315,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1331,7 +1331,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:21.284709500Z",
+                "ingested": "2021-07-19T09:06:19.672432095Z",
                 "original": "Apr 30 2013 09:22:38: %ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49734) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -1377,7 +1377,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -1385,7 +1385,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1401,7 +1401,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:21.284710900Z",
+                "ingested": "2021-07-19T09:06:19.672433901Z",
                 "original": "Apr 30 2013 09:22:39: %ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49735) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -1447,7 +1447,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -1455,7 +1455,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1471,7 +1471,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:21.284712500Z",
+                "ingested": "2021-07-19T09:06:19.672435687Z",
                 "original": "Apr 30 2013 09:22:39: %ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49736) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -1517,7 +1517,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -1525,7 +1525,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1541,7 +1541,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:21.284714100Z",
+                "ingested": "2021-07-19T09:06:19.672437410Z",
                 "original": "Apr 30 2013 09:22:39: %ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49737) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -1587,7 +1587,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -1595,7 +1595,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1611,7 +1611,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:21.284715600Z",
+                "ingested": "2021-07-19T09:06:19.672439163Z",
                 "original": "Apr 30 2013 09:22:40: %ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49738) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -1657,7 +1657,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -1665,7 +1665,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1681,7 +1681,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:21.284717200Z",
+                "ingested": "2021-07-19T09:06:19.672441057Z",
                 "original": "Apr 30 2013 09:22:41: %ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49746) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -1727,7 +1727,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -1735,7 +1735,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1751,7 +1751,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:21.284718700Z",
+                "ingested": "2021-07-19T09:06:19.672442981Z",
                 "original": "Apr 30 2013 09:22:47: %ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2007) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -1797,7 +1797,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -1805,7 +1805,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "dmz"
                     }
                 }
             },
@@ -1821,7 +1821,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:21.284720200Z",
+                "ingested": "2021-07-19T09:06:19.672444700Z",
                 "original": "Apr 30 2013 09:22:48: %ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.13(43013) -\u003e dmz/192.168.33.31(25) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -1867,7 +1867,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -1875,7 +1875,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1891,7 +1891,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:21.284721700Z",
+                "ingested": "2021-07-19T09:06:19.672686227Z",
                 "original": "Apr 30 2013 09:22:56: %ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2008) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -1936,14 +1936,14 @@
                 "direction": "inbound"
             },
             "observer": {
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "inside"
                     }
-                }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2013-04-30T09:23:02.000Z",
             "ecs": {
@@ -1957,7 +1957,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:21.284723300Z",
+                "ingested": "2021-07-19T09:06:19.672694181Z",
                 "original": "Apr 30 2013 09:23:02: %ASA-2-106006: Deny inbound UDP from 192.0.2.66/137 to 10.1.2.42/137 on interface inside",
                 "code": "106006",
                 "kind": "event",
@@ -2017,7 +2017,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:21.284724700Z",
+                "ingested": "2021-07-19T09:06:19.672696392Z",
                 "original": "Apr 30 2013 09:23:03: %ASA-2-106007: Deny inbound UDP from 192.0.2.66/12981 to 10.1.5.60/53 due to DNS Query",
                 "code": "106007",
                 "kind": "event",
@@ -2059,7 +2059,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -2067,7 +2067,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2083,7 +2083,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:21.284726200Z",
+                "ingested": "2021-07-19T09:06:19.672698183Z",
                 "original": "Apr 30 2013 09:23:06: %ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2009) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -2129,7 +2129,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -2137,7 +2137,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2153,7 +2153,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:21.284727800Z",
+                "ingested": "2021-07-19T09:06:19.672699982Z",
                 "original": "Apr 30 2013 09:23:08: %ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49776) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -2199,7 +2199,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -2207,7 +2207,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2223,7 +2223,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:21.284729400Z",
+                "ingested": "2021-07-19T09:06:19.672701734Z",
                 "original": "Apr 30 2013 09:23:15: %ASA-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2010) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -2269,7 +2269,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -2277,7 +2277,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2293,7 +2293,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:21.284730900Z",
+                "ingested": "2021-07-19T09:06:19.672703527Z",
                 "original": "Apr 30 2013 09:23:24: %ASA-5-106100: access-list acl_in denied tcp inside/10.0.0.16(2011) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -2339,7 +2339,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -2347,7 +2347,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2363,7 +2363,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:21.284732400Z",
+                "ingested": "2021-07-19T09:06:19.672705277Z",
                 "original": "Apr 30 2013 09:23:34: %ASA-5-106100: access-list acl_in denied tcp inside/10.0.0.16(2012) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -2409,7 +2409,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "product": "asa",
@@ -2417,7 +2417,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -2433,7 +2433,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:21.284734Z",
+                "ingested": "2021-07-19T09:06:19.672707494Z",
                 "original": "Apr 30 2013 09:23:40: %ASA-4-106023: Deny tcp src outside:192.0.2.126/53638 dst inside:10.0.0.132/8111 by access-group \"acl_out\" [0x71761f18, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -2479,7 +2479,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "product": "asa",
@@ -2487,7 +2487,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -2503,7 +2503,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:21.284735500Z",
+                "ingested": "2021-07-19T09:06:19.672709522Z",
                 "original": "Apr 30 2013 09:23:41: %ASA-4-106023: Deny tcp src outside:192.0.2.126/53638 dst inside:10.0.0.132/8111 by access-group \"acl_out\" [0x71761f18, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -2549,7 +2549,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -2557,7 +2557,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2573,7 +2573,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:21.284737Z",
+                "ingested": "2021-07-19T09:06:19.672711305Z",
                 "original": "Apr 30 2013 09:23:43: %ASA-5-106100: access-list acl_in est-allowed tcp inside/10.0.0.46(49840) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -2619,7 +2619,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -2627,7 +2627,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2643,7 +2643,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:21.284738500Z",
+                "ingested": "2021-07-19T09:06:19.672717900Z",
                 "original": "Apr 30 2013 09:23:43: %ASA-5-106100: access-list acl_in est-allowed tcp inside/10.0.0.16(2013) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -2689,7 +2689,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -2697,7 +2697,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2713,7 +2713,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:21.284740Z",
+                "ingested": "2021-07-19T09:06:19.673302991Z",
                 "original": "Apr 15 2018 09:34:34 EDT: %ASA-session-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2241) -\u003e outside/192.0.0.99(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -2764,7 +2764,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "identity"
+                        "name": "outside"
                     }
                 },
                 "product": "asa",
@@ -2772,7 +2772,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "identity"
                     }
                 }
             },
@@ -2788,7 +2788,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:21.284741500Z",
+                "ingested": "2021-07-19T09:06:19.673308988Z",
                 "original": "Dec 11 2018 08:01:24 \u003cIP\u003e: %ASA-6-302015: Built outbound UDP connection 447235 for outside:192.168.77.12/11180 (192.168.77.12/11180) to identity:10.0.13.13/80 (10.0.13.13/80)",
                 "code": "302015",
                 "kind": "event",
@@ -2839,7 +2839,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 },
                 "product": "asa",
@@ -2847,7 +2847,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 }
             },
@@ -2863,7 +2863,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:21.284743100Z",
+                "ingested": "2021-07-19T09:06:19.673311212Z",
                 "original": "Dec 11 2018 08:01:24 \u003cIP\u003e: %ASA-4-106023: Deny udp src dmz:192.168.1.33/5555 dst outside:192.0.0.12/53 by access-group \"dmz\" [0x123a465e, 0x4c7bf613]",
                 "code": "106023",
                 "kind": "event",
@@ -2912,7 +2912,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 },
                 "product": "asa",
@@ -2920,7 +2920,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 }
             },
@@ -2936,7 +2936,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:21.284744600Z",
+                "ingested": "2021-07-19T09:06:19.673313288Z",
                 "original": "Dec 11 2018 08:01:24 \u003cIP\u003e: %ASA-4-106023: Deny udp src dmz:192.168.1.33/5555 dst outside:192.0.0.12/53 by access-group \"dmz\" [0x123a465e, 0x4c7bf613]",
                 "code": "106023",
                 "kind": "event",
@@ -2986,7 +2986,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 },
                 "product": "asa",
@@ -2994,7 +2994,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 }
             },
@@ -3012,7 +3012,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:21.284746200Z",
+                "ingested": "2021-07-19T09:06:19.673315096Z",
                 "original": "Dec 11 2018 08:01:31 \u003cIP\u003e: %ASA-6-302013: Built outbound TCP connection 447236 for outside:192.0.2.222/1234 (192.0.2.222/1234) to dmz:OCSP_Server/5678 (OCSP_Server/5678)",
                 "code": "302013",
                 "kind": "event",
@@ -3064,7 +3064,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 },
                 "product": "asa",
@@ -3072,7 +3072,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 }
             },
@@ -3090,7 +3090,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:21.284747700Z",
+                "ingested": "2021-07-19T09:06:19.673316830Z",
                 "original": "Dec 11 2018 08:01:31 \u003cIP\u003e: %ASA-6-302013: Built outbound TCP connection 447236 for outside:192.0.2.222/1234 (192.0.2.222/1234) to dmz:OCSP_Server/5678 (OCSP_Server/5678)",
                 "code": "302013",
                 "kind": "event",
@@ -3142,7 +3142,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 },
                 "product": "asa",
@@ -3150,7 +3150,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 }
             },
@@ -3168,7 +3168,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:21.284749200Z",
+                "ingested": "2021-07-19T09:06:19.673318546Z",
                 "original": "Dec 11 2018 08:01:31 \u003cIP\u003e: %ASA-6-302014: Teardown TCP connection 447236 for outside:192.0.2.222/1234 to dmz:192.168.1.34/5678 duration 0:00:00 bytes 14804 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -3219,7 +3219,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 },
                 "product": "asa",
@@ -3227,7 +3227,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 }
             },
@@ -3245,7 +3245,7 @@
                 "severity": 6,
                 "duration": 68000000000,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:21.284750700Z",
+                "ingested": "2021-07-19T09:06:19.673320261Z",
                 "original": "Dec 11 2018 08:01:38 \u003cIP\u003e: %ASA-6-302014: Teardown TCP connection 447234 for outside:192.0.2.222/1234 to dmz:192.168.1.35/5678 duration 0:01:08 bytes 134781 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -3296,7 +3296,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 },
                 "product": "asa",
@@ -3304,7 +3304,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 }
             },
@@ -3322,7 +3322,7 @@
                 "severity": 6,
                 "duration": 68000000000,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:21.284752200Z",
+                "ingested": "2021-07-19T09:06:19.673321982Z",
                 "original": "Dec 11 2018 08:01:38 \u003cIP\u003e: %ASA-6-302014: Teardown TCP connection 447234 for outside:192.0.2.222/1234 to dmz:192.168.1.35/5678 duration 0:01:08 bytes 134781 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -3370,14 +3370,14 @@
                 "transport": "tcp"
             },
             "observer": {
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "outside"
                     }
-                }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2018-12-11T08:01:38.000Z",
             "ecs": {
@@ -3391,7 +3391,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:21.284753800Z",
+                "ingested": "2021-07-19T09:06:19.673324042Z",
                 "original": "Dec 11 2018 08:01:38 \u003cIP\u003e: %ASA-6-106015: Deny TCP (no connection) from 192.0.2.222/1234 to 192.168.1.34/5679 flags RST  on interface outside",
                 "code": "106015",
                 "kind": "event",
@@ -3436,14 +3436,14 @@
                 "transport": "tcp"
             },
             "observer": {
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "outside"
                     }
-                }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2018-12-11T08:01:38.000Z",
             "ecs": {
@@ -3457,7 +3457,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:21.284755300Z",
+                "ingested": "2021-07-19T09:06:19.673325801Z",
                 "original": "Dec 11 2018 08:01:38 \u003cIP\u003e: %ASA-6-106015: Deny TCP (no connection) from 192.0.2.222/1234 to 192.168.1.34/5679 flags RST  on interface outside",
                 "code": "106015",
                 "kind": "event",
@@ -3504,7 +3504,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 },
                 "product": "asa",
@@ -3512,7 +3512,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 }
             },
@@ -3528,7 +3528,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:21.284757800Z",
+                "ingested": "2021-07-19T09:06:19.673327545Z",
                 "original": "Dec 11 2018 08:01:39 \u003cIP\u003e: %ASA-4-106023: Deny udp src dmz:192.168.1.34/5679 dst outside:192.0.0.12/5000 by access-group \"dmz\" [0x123a465e, 0x8c20f21]",
                 "code": "106023",
                 "kind": "event",
@@ -3578,7 +3578,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 },
                 "product": "asa",
@@ -3586,7 +3586,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 }
             },
@@ -3602,7 +3602,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:21.284759400Z",
+                "ingested": "2021-07-19T09:06:19.673329741Z",
                 "original": "Dec 11 2018 08:01:53 \u003cIP\u003e: %ASA-6-302013: Built outbound TCP connection 447237 for outside:192.0.2.222/1234 (192.0.2.222/1234) to dmz:192.168.1.34/65000 (192.168.1.34/65000)",
                 "code": "302013",
                 "kind": "event",
@@ -3654,7 +3654,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 },
                 "product": "asa",
@@ -3662,7 +3662,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 }
             },
@@ -3678,7 +3678,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:21.284761Z",
+                "ingested": "2021-07-19T09:06:19.673331489Z",
                 "original": "Dec 11 2018 08:01:53 \u003cIP\u003e: %ASA-6-302013: Built outbound TCP connection 447237 for outside:192.0.2.222/1234 (192.0.2.222/1234) to dmz:192.168.1.34/65000 (192.168.1.34/65000)",
                 "code": "302013",
                 "kind": "event",
@@ -3730,7 +3730,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 },
                 "product": "asa",
@@ -3738,7 +3738,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 }
             },
@@ -3756,7 +3756,7 @@
                 "severity": 6,
                 "duration": 86399000000000,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:21.284762500Z",
+                "ingested": "2021-07-19T09:06:19.673333295Z",
                 "original": "Dec 11 2018 08:01:53 \u003cIP\u003e: %ASA-6-302014: Teardown TCP connection 447237 for outside:192.0.2.222/1234 to dmz:10.10.10.10/1235 duration 23:59:59 bytes 11420 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -3804,7 +3804,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "product": "asa",
@@ -3812,7 +3812,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -3829,7 +3829,7 @@
             "event": {
                 "severity": 6,
                 "duration": 122000000000,
-                "ingested": "2021-06-09T10:11:21.284764100Z",
+                "ingested": "2021-07-19T09:06:19.673335095Z",
                 "original": "Aug 15 2012 23:30:09 : %ASA-6-302016 Teardown UDP connection 40 for outside:10.44.4.4/500 to inside:10.44.2.2/500 duration 0:02:02 bytes 1416",
                 "code": "302016",
                 "kind": "event",
@@ -3868,15 +3868,15 @@
                 "preserve_original_event"
             ],
             "observer": {
-                "hostname": "GIFRCHN01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "Mobile_Traffic"
                     }
-                }
+                },
+                "hostname": "GIFRCHN01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2014-09-12T06:50:53.000Z",
             "ecs": {
@@ -3896,7 +3896,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:21.284765600Z",
+                "ingested": "2021-07-19T09:06:19.673336875Z",
                 "original": "Sep 12 2014 06:50:53 GIFRCHN01 : %ASA-2-106016: Deny IP spoof from (0.0.0.0) to 192.88.99.47 on interface Mobile_Traffic",
                 "code": "106016",
                 "kind": "event",
@@ -3932,15 +3932,15 @@
                 "preserve_original_event"
             ],
             "observer": {
-                "hostname": "GIFRCHN01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "Mobile_Traffic"
                     }
-                }
+                },
+                "hostname": "GIFRCHN01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2014-09-12T06:51:01.000Z",
             "ecs": {
@@ -3960,7 +3960,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:21.284777Z",
+                "ingested": "2021-07-19T09:06:19.673338607Z",
                 "original": "Sep 12 2014 06:51:01 GIFRCHN01 : %ASA-2-106016: Deny IP spoof from (0.0.0.0) to 192.88.99.57 on interface Mobile_Traffic",
                 "code": "106016",
                 "kind": "event",
@@ -3996,15 +3996,15 @@
                 "preserve_original_event"
             ],
             "observer": {
-                "hostname": "GIFRCHN01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "Mobile_Traffic"
                     }
-                }
+                },
+                "hostname": "GIFRCHN01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2014-09-12T06:51:05.000Z",
             "ecs": {
@@ -4024,7 +4024,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:21.284781Z",
+                "ingested": "2021-07-19T09:06:19.673340382Z",
                 "original": "Sep 12 2014 06:51:05 GIFRCHN01 : %ASA-2-106016: Deny IP spoof from (0.0.0.0) to 192.88.99.47 on interface Mobile_Traffic",
                 "code": "106016",
                 "kind": "event",
@@ -4060,15 +4060,15 @@
                 "preserve_original_event"
             ],
             "observer": {
-                "hostname": "GIFRCHN01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "Mobile_Traffic"
                     }
-                }
+                },
+                "hostname": "GIFRCHN01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2014-09-12T06:51:05.000Z",
             "ecs": {
@@ -4088,7 +4088,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:21.284783200Z",
+                "ingested": "2021-07-19T09:06:19.673342142Z",
                 "original": "Sep 12 2014 06:51:05 GIFRCHN01 : %ASA-2-106016: Deny IP spoof from (0.0.0.0) to 192.88.99.47 on interface Mobile_Traffic",
                 "code": "106016",
                 "kind": "event",
@@ -4124,15 +4124,15 @@
                 "preserve_original_event"
             ],
             "observer": {
-                "hostname": "GIFRCHN01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "Mobile_Traffic"
                     }
-                }
+                },
+                "hostname": "GIFRCHN01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2014-09-12T06:51:06.000Z",
             "ecs": {
@@ -4152,7 +4152,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:21.284784900Z",
+                "ingested": "2021-07-19T09:06:19.673343970Z",
                 "original": "Sep 12 2014 06:51:06 GIFRCHN01 : %ASA-2-106016: Deny IP spoof from (0.0.0.0) to 192.88.99.57 on interface Mobile_Traffic",
                 "code": "106016",
                 "kind": "event",
@@ -4188,15 +4188,15 @@
                 "preserve_original_event"
             ],
             "observer": {
-                "hostname": "GIFRCHN01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "Mobile_Traffic"
                     }
-                }
+                },
+                "hostname": "GIFRCHN01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2014-09-12T06:51:17.000Z",
             "ecs": {
@@ -4216,7 +4216,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:21.284786500Z",
+                "ingested": "2021-07-19T09:06:19.673345870Z",
                 "original": "Sep 12 2014 06:51:17 GIFRCHN01 : %ASA-2-106016: Deny IP spoof from (0.0.0.0) to 192.88.99.57 on interface Mobile_Traffic",
                 "code": "106016",
                 "kind": "event",
@@ -4252,15 +4252,15 @@
                 "preserve_original_event"
             ],
             "observer": {
-                "hostname": "GIFRCHN01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "Mobile_Traffic"
                     }
-                }
+                },
+                "hostname": "GIFRCHN01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2014-09-12T06:52:48.000Z",
             "ecs": {
@@ -4280,7 +4280,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:21.284788Z",
+                "ingested": "2021-07-19T09:06:19.673347696Z",
                 "original": "Sep 12 2014 06:52:48 GIFRCHN01 : %ASA-2-106016: Deny IP spoof from (0.0.0.0) to 192.168.1.255 on interface Mobile_Traffic",
                 "code": "106016",
                 "kind": "event",
@@ -4316,15 +4316,15 @@
                 "preserve_original_event"
             ],
             "observer": {
-                "hostname": "GIFRCHN01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "Mobile_Traffic"
                     }
-                }
+                },
+                "hostname": "GIFRCHN01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2014-09-12T06:53:00.000Z",
             "ecs": {
@@ -4344,7 +4344,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:21.284789500Z",
+                "ingested": "2021-07-19T09:06:19.673349429Z",
                 "original": "Sep 12 2014 06:53:00 GIFRCHN01 : %ASA-2-106016: Deny IP spoof from (0.0.0.0) to 192.168.1.255 on interface Mobile_Traffic",
                 "code": "106016",
                 "kind": "event",
@@ -4388,7 +4388,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "GIFRCHN01",
@@ -4397,7 +4397,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -4419,7 +4419,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:21.284791100Z",
+                "ingested": "2021-07-19T09:06:19.673351166Z",
                 "original": "Sep 12 2014 06:53:01 GIFRCHN01 : %ASA-4-106023: Deny tcp src outside:192.0.2.95/24069 dst inside:10.32.112.125/25 by access-group \"PERMIT_IN\" [0x0, 0x0]\"",
                 "code": "106023",
                 "kind": "event",
@@ -4457,15 +4457,15 @@
                 "transport": "icmp"
             },
             "observer": {
-                "hostname": "GIFRCHN01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "Outside"
                     }
-                }
+                },
+                "hostname": "GIFRCHN01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2014-09-12T06:53:02.000Z",
             "ecs": {
@@ -4484,7 +4484,7 @@
             },
             "event": {
                 "severity": 3,
-                "ingested": "2021-06-09T10:11:21.284792700Z",
+                "ingested": "2021-07-19T09:06:19.673353847Z",
                 "original": "Sep 12 2014 06:53:02 GIFRCHN01 : %ASA-3-313001: Denied ICMP type=3, code=3 from 10.2.3.5 on interface Outside",
                 "code": "313001",
                 "kind": "event",
@@ -4526,14 +4526,14 @@
                 "transport": "icmp"
             },
             "observer": {
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "inside"
                     }
-                }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2015-01-14T13:16:13.000Z",
             "ecs": {
@@ -4547,7 +4547,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:21.284794200Z",
+                "ingested": "2021-07-19T09:06:19.673448562Z",
                 "original": "Jan 14 2015 13:16:13: %ASA-4-313004: Denied ICMP type=0, from laddr 172.16.30.2 on interface inside to 172.16.1.10: no matching session",
                 "code": "313004",
                 "kind": "event",
@@ -4600,7 +4600,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -4608,7 +4608,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -4628,7 +4628,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:21.284795800Z",
+                "ingested": "2021-07-19T09:06:19.673454555Z",
                 "original": "Jan 14 2015 13:16:14: %ASA-4-338002: Dynamic Filter permitted black listed TCP traffic from inside:10.1.1.45/6798 (192.88.99.1/7890) to outside:192.88.99.129/80 (192.88.99.129/80), destination 192.88.99.129 resolved from dynamic list: bad.example.com",
                 "code": "338002",
                 "kind": "event",
@@ -4681,7 +4681,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outsidet"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -4689,7 +4689,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outsidet"
                     }
                 }
             },
@@ -4706,7 +4706,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:21.284797400Z",
+                "ingested": "2021-07-19T09:06:19.673457311Z",
                 "original": "Jan 14 2015 13:16:14: %ASA-4-338004: Dynamic Filter monitored blacklisted TCP traffic from inside:10.1.1.1/33340 (10.2.1.1/33340) to outsidet:192.0.2.223/80 (192.0.2.223/80), destination 192.0.2.223 resolved from dynamic list: 192.0.2.223/255.255.255.255, threat-level: very-high, category: Malware",
                 "code": "338004",
                 "kind": "event",
@@ -4760,7 +4760,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outsidet"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -4768,7 +4768,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outsidet"
                     }
                 }
             },
@@ -4785,7 +4785,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:21.284798800Z",
+                "ingested": "2021-07-19T09:06:19.673459727Z",
                 "original": "Jan 14 2015 13:16:14: %ASA-4-338008: Dynamic Filter dropped blacklisted TCP traffic from inside:10.1.1.1/33340 (10.2.1.1/33340) to outsidet:192.0.2.223/80 (192.0.2.223/80), destination 192.0.2.223 resolved from dynamic list: 192.0.2.223/255.255.255.255, threat-level: very-high, category: Malware",
                 "code": "338008",
                 "kind": "event",
@@ -4849,7 +4849,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:21.284800500Z",
+                "ingested": "2021-07-19T09:06:19.673489272Z",
                 "original": "Nov 16 2009 14:12:35: %ASA-5-304001: 10.30.30.30 Accessed URL 192.0.2.1:/app",
                 "code": "304001",
                 "kind": "event",
@@ -4905,7 +4905,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:21.284802Z",
+                "ingested": "2021-07-19T09:06:19.673495577Z",
                 "original": "Nov 16 2009 14:12:36: %ASA-5-304001: 10.5.111.32 Accessed URL 192.0.2.32:http://example.com",
                 "code": "304001",
                 "kind": "event",
@@ -4946,14 +4946,14 @@
                 "preserve_original_event"
             ],
             "observer": {
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "inside"
                     }
-                }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2009-11-16T14:12:37.000Z",
             "ecs": {
@@ -4967,7 +4967,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:21.284803500Z",
+                "ingested": "2021-07-19T09:06:19.673498923Z",
                 "original": "Nov 16 2009 14:12:37: %ASA-5-304002: Access denied URL http://www.example.net/images/favicon.ico SRC 10.69.6.39 DEST 192.0.0.19 on interface inside",
                 "code": "304002",
                 "kind": "event",
@@ -5030,7 +5030,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "vlan-42"
+                        "name": "internet"
                     }
                 },
                 "product": "asa",
@@ -5038,7 +5038,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "internet"
+                        "name": "vlan-42"
                     }
                 }
             },
@@ -5057,7 +5057,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:21.284805100Z",
+                "ingested": "2021-07-19T09:06:19.673501322Z",
                 "original": "Jan 13 2021 19:12:37: %ASA-6-302013: Built inbound TCP connection 27215708 for internet:10.2.3.4/49926 (1.2.3.4/49926)(LOCAL\\username) to vlan-42:1.2.3.4/80 (1.2.3.4/80) (username)",
                 "code": "302013",
                 "kind": "event",

--- a/packages/cisco/data_stream/asa/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco/data_stream/asa/elasticsearch/ingest_pipeline/default.yml
@@ -1849,11 +1849,11 @@ processors:
       ignore_empty_value: true
   - set:
       field: observer.egress.interface.name
-      value: "{{ cisco.asa.source_interface }}"
+      value: "{{ cisco.asa.destination_interface }}"
       ignore_empty_value: true
   - set:
       field: observer.ingress.interface.name
-      value: "{{ cisco.asa.destination_interface }}"
+      value: "{{ cisco.asa.source_interface }}"
       ignore_empty_value: true
   - append:
       field: related.ip

--- a/packages/cisco/data_stream/asa/sample_event.json
+++ b/packages/cisco/data_stream/asa/sample_event.json
@@ -1,9 +1,9 @@
 {
     "@timestamp": "2018-10-10T12:34:56.000Z",
     "agent": {
-        "ephemeral_id": "f5535a1f-52da-44d4-a626-f85bbdc25e74",
+        "ephemeral_id": "a548620b-0623-4130-b586-fe233f00e6e5",
         "hostname": "docker-fleet-agent",
-        "id": "37c96a8c-c323-4db5-b898-9ba84c49e2ea",
+        "id": "3c803d12-46a2-48a4-a206-8fd3630cc2a9",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "7.14.0"
@@ -11,7 +11,6 @@
     "cisco": {
         "asa": {
             "destination_interface": "outside",
-            "message_id": "305011",
             "source_interface": "inside"
         }
     },
@@ -26,23 +25,24 @@
         "port": 8256
     },
     "ecs": {
-        "version": "1.9.0"
+        "version": "1.10.0"
     },
     "elastic_agent": {
-        "id": "732b7efe-6d7b-40fc-bbfe-799296be9d11",
+        "id": "3c803d12-46a2-48a4-a206-8fd3630cc2a9",
         "snapshot": true,
         "version": "7.14.0"
     },
     "event": {
         "action": "firewall-rule",
+        "agent_id_status": "verified",
         "category": [
             "network"
         ],
         "code": "305011",
         "dataset": "cisco.asa",
-        "ingested": "2021-06-03T09:22:20.519428820Z",
+        "ingested": "2021-07-19T08:54:36.436846422Z",
         "kind": "event",
-        "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1772 to outside:100.66.98.44/8256",
+        "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1772 to outside:100.66.98.44/8256\n",
         "severity": 6,
         "timezone": "+00:00",
         "type": [
@@ -50,26 +50,8 @@
         ]
     },
     "host": {
-        "architecture": "x86_64",
-        "containerized": true,
         "hostname": "localhost",
-        "id": "f46ddd9d65ff20633d9c337909855778",
-        "ip": [
-            "172.19.0.7"
-        ],
-        "mac": [
-            "02:42:ac:13:00:07"
-        ],
-        "name": "docker-fleet-agent",
-        "os": {
-            "codename": "Core",
-            "family": "redhat",
-            "kernel": "5.10.25-linuxkit",
-            "name": "CentOS Linux",
-            "platform": "centos",
-            "type": "linux",
-            "version": "7 (Core)"
-        }
+        "name": "docker-fleet-agent"
     },
     "input": {
         "type": "udp"
@@ -77,7 +59,7 @@
     "log": {
         "level": "informational",
         "source": {
-            "address": "172.19.0.4:47315"
+            "address": "172.23.0.4:59451"
         }
     },
     "network": {
@@ -87,13 +69,13 @@
     "observer": {
         "egress": {
             "interface": {
-                "name": "inside"
+                "name": "outside"
             }
         },
         "hostname": "localhost",
         "ingress": {
             "interface": {
-                "name": "outside"
+                "name": "inside"
             }
         },
         "product": "asa",
@@ -119,7 +101,8 @@
         "port": 1772
     },
     "tags": [
+        "preserve_original_event",
         "cisco-asa",
-        "preserve_original_event"
+        "forwarded"
     ]
 }

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-asa-fix.log-expected.json
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-asa-fix.log-expected.json
@@ -25,7 +25,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "Inside"
+                        "name": "Outside"
                     }
                 },
                 "hostname": "SNL-ASA-VPN-A01",
@@ -34,7 +34,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "Outside"
+                        "name": "Inside"
                     }
                 }
             },
@@ -57,7 +57,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.472044100Z",
+                "ingested": "2021-07-19T09:06:24.775064690Z",
                 "original": "Apr 17 2020 14:08:08 SNL-ASA-VPN-A01 : %ASA-6-302016: Teardown UDP connection 110577675 for Outside:10.123.123.123/53723(LOCAL\\Elastic) to Inside:10.233.123.123/53 duration 0:00:00 bytes 148 (zzzzzz)",
                 "code": "302016",
                 "kind": "event",
@@ -104,7 +104,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "Outside"
+                        "name": "Inside"
                     }
                 },
                 "hostname": "SNL-ASA-VPN-A01",
@@ -113,7 +113,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "Inside"
+                        "name": "Outside"
                     }
                 }
             },
@@ -134,7 +134,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.472055500Z",
+                "ingested": "2021-07-19T09:06:24.775070482Z",
                 "original": "Apr 17 2020 14:00:31 SNL-ASA-VPN-A01 : %ASA-4-106023: Deny icmp src Inside:10.123.123.123 dst Outside:10.123.123.123 (type 11, code 0) by access-group \"Inside_access_in\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -180,7 +180,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 },
                 "product": "asa",
@@ -188,7 +188,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 }
             },
@@ -203,7 +203,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.472056900Z",
+                "ingested": "2021-07-19T09:06:24.775072629Z",
                 "original": "Apr 15 2013 09:36:50: %ASA-4-106023: Deny tcp src dmz:10.123.123.123/6316 dst outside:10.123.123.123/53 type 3, code 0, by access-group \"acl_dmz\" [0xe3afb522, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -249,7 +249,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "Outside"
+                        "name": "Inside"
                     }
                 },
                 "hostname": "SNL-ASA-VPN-A01",
@@ -258,7 +258,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "Inside"
+                        "name": "Outside"
                     }
                 }
             },
@@ -279,7 +279,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.472058Z",
+                "ingested": "2021-07-19T09:06:24.775074513Z",
                 "original": "Apr 17 2020 14:16:20 SNL-ASA-VPN-A01 : %ASA-4-106023: Deny udp src Inside:10.123.123.123/57621(LOCAL\\Elastic) dst Outside:10.123.123.123/57621 by access-group \"Inside_access_in\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -340,7 +340,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:23.472059100Z",
+                "ingested": "2021-07-19T09:06:24.775076252Z",
                 "original": "Apr 17 2020 14:15:07 SNL-ASA-VPN-A01 : %ASA-2-106017: Deny IP due to Land Attack from 10.123.123.123 to 10.123.123.123",
                 "code": "106017",
                 "kind": "event",

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-asa.log-expected.json
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-asa.log-expected.json
@@ -28,7 +28,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -37,7 +37,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -59,7 +59,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658548300Z",
+                "ingested": "2021-07-19T09:06:25.094745429Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1772 to outside:100.66.98.44/8256",
                 "code": "305011",
                 "kind": "event",
@@ -107,7 +107,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -116,7 +116,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -138,7 +138,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658553600Z",
+                "ingested": "2021-07-19T09:06:25.094751156Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11757 for outside:100.66.205.104/80 (100.66.205.104/80) to inside:172.31.98.44/1772 (172.31.98.44/1772)",
                 "code": "302013",
                 "kind": "event",
@@ -191,7 +191,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -200,7 +200,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -224,7 +224,7 @@
                 "severity": 6,
                 "duration": 67000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:23.658556Z",
+                "ingested": "2021-07-19T09:06:25.094753243Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11749 for outside:100.66.211.242/80 to inside:172.31.98.44/1758 duration 0:01:07 bytes 38110 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -276,7 +276,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -285,7 +285,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -309,7 +309,7 @@
                 "severity": 6,
                 "duration": 67000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:23.658557100Z",
+                "ingested": "2021-07-19T09:06:25.094755060Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11748 for outside:100.66.211.242/80 to inside:172.31.98.44/1757 duration 0:01:07 bytes 44010 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -361,7 +361,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -370,7 +370,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -394,7 +394,7 @@
                 "severity": 6,
                 "duration": 67000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:23.658558200Z",
+                "ingested": "2021-07-19T09:06:25.094756847Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11745 for outside:100.66.185.90/80 to inside:172.31.98.44/1755 duration 0:01:07 bytes 7652 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -446,7 +446,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -455,7 +455,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -479,7 +479,7 @@
                 "severity": 6,
                 "duration": 67000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:23.658559200Z",
+                "ingested": "2021-07-19T09:06:25.094759636Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11744 for outside:100.66.185.90/80 to inside:172.31.98.44/1754 duration 0:01:07 bytes 7062 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -531,7 +531,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -540,7 +540,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -564,7 +564,7 @@
                 "severity": 6,
                 "duration": 68000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:23.658560200Z",
+                "ingested": "2021-07-19T09:06:25.094761597Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11742 for outside:100.66.160.197/80 to inside:172.31.98.44/1752 duration 0:01:08 bytes 5738 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -616,7 +616,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -625,7 +625,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -649,7 +649,7 @@
                 "severity": 6,
                 "duration": 68000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:23.658561200Z",
+                "ingested": "2021-07-19T09:06:25.094763317Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11738 for outside:100.66.205.14/80 to inside:172.31.98.44/1749 duration 0:01:08 bytes 4176 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -701,7 +701,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -710,7 +710,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -734,7 +734,7 @@
                 "severity": 6,
                 "duration": 68000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:23.658562200Z",
+                "ingested": "2021-07-19T09:06:25.094765076Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11739 for outside:100.66.124.33/80 to inside:172.31.98.44/1750 duration 0:01:08 bytes 1715 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -786,7 +786,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -795,7 +795,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -819,7 +819,7 @@
                 "severity": 6,
                 "duration": 69000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:23.658563300Z",
+                "ingested": "2021-07-19T09:06:25.094766798Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11731 for outside:100.66.35.9/80 to inside:172.31.98.44/1747 duration 0:01:09 bytes 45595 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -871,7 +871,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -880,7 +880,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -904,7 +904,7 @@
                 "severity": 6,
                 "duration": 69000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:23.658564300Z",
+                "ingested": "2021-07-19T09:06:25.094768669Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11723 for outside:100.66.211.242/80 to inside:172.31.98.44/1742 duration 0:01:09 bytes 27359 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -956,7 +956,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -965,7 +965,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -989,7 +989,7 @@
                 "severity": 6,
                 "duration": 69000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:23.658565500Z",
+                "ingested": "2021-07-19T09:06:25.094770817Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11715 for outside:100.66.218.21/80 to inside:172.31.98.44/1741 duration 0:01:09 bytes 4457 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -1041,7 +1041,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -1050,7 +1050,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -1074,7 +1074,7 @@
                 "severity": 6,
                 "duration": 69000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:23.658566600Z",
+                "ingested": "2021-07-19T09:06:25.094772560Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11711 for outside:100.66.198.27/80 to inside:172.31.98.44/1739 duration 0:01:09 bytes 26709 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -1126,7 +1126,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -1135,7 +1135,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -1159,7 +1159,7 @@
                 "severity": 6,
                 "duration": 69000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:23.658567600Z",
+                "ingested": "2021-07-19T09:06:25.094774295Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11712 for outside:100.66.198.27/80 to inside:172.31.98.44/1740 duration 0:01:09 bytes 22097 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -1211,7 +1211,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -1220,7 +1220,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -1244,7 +1244,7 @@
                 "severity": 6,
                 "duration": 70000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:23.658568600Z",
+                "ingested": "2021-07-19T09:06:25.094776017Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11708 for outside:100.66.202.211/80 to inside:172.31.98.44/1738 duration 0:01:10 bytes 2209 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -1296,7 +1296,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -1305,7 +1305,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -1329,7 +1329,7 @@
                 "severity": 6,
                 "duration": 67000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:23.658569600Z",
+                "ingested": "2021-07-19T09:06:25.094777782Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11746 for outside:100.66.124.15/80 to inside:172.31.98.44/1756 duration 0:01:07 bytes 10404 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -1381,7 +1381,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -1390,7 +1390,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -1414,7 +1414,7 @@
                 "severity": 6,
                 "duration": 70000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:23.658570900Z",
+                "ingested": "2021-07-19T09:06:25.094779735Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11706 for outside:100.66.124.15/80 to inside:172.31.98.44/1737 duration 0:01:10 bytes 123694 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -1466,7 +1466,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -1475,7 +1475,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -1499,7 +1499,7 @@
                 "severity": 6,
                 "duration": 71000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:23.658571900Z",
+                "ingested": "2021-07-19T09:06:25.094781472Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11702 for outside:100.66.209.247/80 to inside:172.31.98.44/1736 duration 0:01:11 bytes 35835 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -1551,7 +1551,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -1560,7 +1560,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -1584,7 +1584,7 @@
                 "severity": 6,
                 "duration": 30000000000,
                 "reason": "SYN Timeout",
-                "ingested": "2021-06-09T10:11:23.658573Z",
+                "ingested": "2021-07-19T09:06:25.094783210Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11753 for outside:100.66.35.162/80 to inside:172.31.98.44/1765 duration 0:00:30 bytes 0 SYN Timeout",
                 "code": "302014",
                 "kind": "event",
@@ -1635,7 +1635,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -1644,7 +1644,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1666,7 +1666,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658573900Z",
+                "ingested": "2021-07-19T09:06:25.094784960Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic UDP translation from inside:172.31.98.44/56132 to outside:100.66.98.44/1188",
                 "code": "305011",
                 "kind": "event",
@@ -1714,7 +1714,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -1723,7 +1723,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -1745,7 +1745,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658575Z",
+                "ingested": "2021-07-19T09:06:25.094786730Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11758 for outside:100.66.80.32/53 (100.66.80.32/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -1798,7 +1798,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -1807,7 +1807,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -1830,7 +1830,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658576Z",
+                "ingested": "2021-07-19T09:06:25.094788478Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11758 for outside:100.66.80.32/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 148",
                 "code": "302016",
                 "kind": "event",
@@ -1882,7 +1882,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -1891,7 +1891,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -1913,7 +1913,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658577Z",
+                "ingested": "2021-07-19T09:06:25.094790183Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11759 for outside:100.66.252.6/53 (100.66.252.6/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -1966,7 +1966,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -1975,7 +1975,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -1998,7 +1998,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658578100Z",
+                "ingested": "2021-07-19T09:06:25.094792093Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11759 for outside:100.66.252.6/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 164",
                 "code": "302016",
                 "kind": "event",
@@ -2049,7 +2049,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -2058,7 +2058,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2080,7 +2080,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658579100Z",
+                "ingested": "2021-07-19T09:06:25.094793878Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1773 to outside:100.66.98.44/8257",
                 "code": "305011",
                 "kind": "event",
@@ -2128,7 +2128,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -2137,7 +2137,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -2159,7 +2159,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658580100Z",
+                "ingested": "2021-07-19T09:06:25.094795609Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11760 for outside:100.66.252.226/80 (100.66.252.226/80) to inside:172.31.98.44/1773 (172.31.98.44/1773)",
                 "code": "302013",
                 "kind": "event",
@@ -2211,7 +2211,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -2220,7 +2220,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2242,7 +2242,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658581100Z",
+                "ingested": "2021-07-19T09:06:25.094797364Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1774 to outside:100.66.98.44/8258",
                 "code": "305011",
                 "kind": "event",
@@ -2290,7 +2290,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -2299,7 +2299,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -2321,7 +2321,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658582100Z",
+                "ingested": "2021-07-19T09:06:25.094799118Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11761 for outside:100.66.252.226/80 (100.66.252.226/80) to inside:172.31.98.44/1774 (172.31.98.44/1774)",
                 "code": "302013",
                 "kind": "event",
@@ -2374,7 +2374,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -2383,7 +2383,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -2405,7 +2405,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658583100Z",
+                "ingested": "2021-07-19T09:06:25.094800868Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11762 for outside:100.66.238.126/53 (100.66.238.126/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -2458,7 +2458,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -2467,7 +2467,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -2489,7 +2489,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658584200Z",
+                "ingested": "2021-07-19T09:06:25.094802588Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11763 for outside:100.66.93.51/53 (100.66.93.51/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -2542,7 +2542,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -2551,7 +2551,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -2574,7 +2574,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658585200Z",
+                "ingested": "2021-07-19T09:06:25.094804338Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11762 for outside:100.66.238.126/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 111",
                 "code": "302016",
                 "kind": "event",
@@ -2626,7 +2626,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -2635,7 +2635,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -2658,7 +2658,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658586600Z",
+                "ingested": "2021-07-19T09:06:25.094806119Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11763 for outside:100.66.93.51/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 237",
                 "code": "302016",
                 "kind": "event",
@@ -2709,7 +2709,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -2718,7 +2718,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2740,7 +2740,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658587700Z",
+                "ingested": "2021-07-19T09:06:25.094807851Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1775 to outside:100.66.98.44/8259",
                 "code": "305011",
                 "kind": "event",
@@ -2788,7 +2788,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -2797,7 +2797,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -2819,7 +2819,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658588700Z",
+                "ingested": "2021-07-19T09:06:25.094809645Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11764 for outside:100.66.225.103/443 (100.66.225.103/443) to inside:172.31.98.44/1775 (172.31.98.44/1775)",
                 "code": "302013",
                 "kind": "event",
@@ -2871,7 +2871,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -2880,7 +2880,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2902,7 +2902,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658589800Z",
+                "ingested": "2021-07-19T09:06:25.094811539Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic UDP translation from inside:172.31.98.44/56132 to outside:100.66.98.44/1189",
                 "code": "305011",
                 "kind": "event",
@@ -2950,7 +2950,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -2959,7 +2959,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -2981,7 +2981,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658590800Z",
+                "ingested": "2021-07-19T09:06:25.094815755Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11772 for outside:100.66.240.126/53 (100.66.240.126/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -3034,7 +3034,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -3043,7 +3043,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -3065,7 +3065,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658591800Z",
+                "ingested": "2021-07-19T09:06:25.094817625Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11773 for outside:100.66.44.45/53 (100.66.44.45/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -3118,7 +3118,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -3127,7 +3127,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -3150,7 +3150,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658592800Z",
+                "ingested": "2021-07-19T09:06:25.094819363Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11772 for outside:100.66.240.126/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 87",
                 "code": "302016",
                 "kind": "event",
@@ -3202,7 +3202,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -3211,7 +3211,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -3234,7 +3234,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658594400Z",
+                "ingested": "2021-07-19T09:06:25.094821104Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11773 for outside:100.66.44.45/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 221",
                 "code": "302016",
                 "kind": "event",
@@ -3285,7 +3285,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -3294,7 +3294,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -3316,7 +3316,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658595400Z",
+                "ingested": "2021-07-19T09:06:25.094822926Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1452 to outside:100.66.98.44/8265",
                 "code": "305011",
                 "kind": "event",
@@ -3364,7 +3364,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -3373,7 +3373,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -3395,7 +3395,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658596400Z",
+                "ingested": "2021-07-19T09:06:25.094824626Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11774 for outside:100.66.179.219/80 (100.66.179.219/80) to inside:172.31.98.44/1452 (172.31.98.44/1452)",
                 "code": "302013",
                 "kind": "event",
@@ -3448,7 +3448,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -3457,7 +3457,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -3479,7 +3479,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658597400Z",
+                "ingested": "2021-07-19T09:06:25.094826343Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11775 for outside:100.66.157.232/53 (100.66.157.232/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -3532,7 +3532,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -3541,7 +3541,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -3563,7 +3563,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658598500Z",
+                "ingested": "2021-07-19T09:06:25.094828177Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11776 for outside:100.66.178.133/53 (100.66.178.133/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -3616,7 +3616,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -3625,7 +3625,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -3648,7 +3648,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658599500Z",
+                "ingested": "2021-07-19T09:06:25.094829936Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11775 for outside:100.66.157.232/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 101",
                 "code": "302016",
                 "kind": "event",
@@ -3700,7 +3700,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -3709,7 +3709,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -3732,7 +3732,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658600500Z",
+                "ingested": "2021-07-19T09:06:25.094831671Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11776 for outside:100.66.178.133/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 126",
                 "code": "302016",
                 "kind": "event",
@@ -3783,7 +3783,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -3792,7 +3792,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -3814,7 +3814,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658601500Z",
+                "ingested": "2021-07-19T09:06:25.094833437Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1453 to outside:100.66.98.44/8266",
                 "code": "305011",
                 "kind": "event",
@@ -3862,7 +3862,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -3871,7 +3871,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -3893,7 +3893,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658602500Z",
+                "ingested": "2021-07-19T09:06:25.094835210Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11777 for outside:100.66.133.112/80 (100.66.133.112/80) to inside:172.31.98.44/1453 (172.31.98.44/1453)",
                 "code": "302013",
                 "kind": "event",
@@ -3946,7 +3946,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -3955,7 +3955,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -3979,7 +3979,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:23.658603500Z",
+                "ingested": "2021-07-19T09:06:25.094836936Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11777 for outside:100.66.133.112/80 to inside:172.31.98.44/1453 duration 0:00:00 bytes 862 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -4031,7 +4031,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -4040,7 +4040,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -4062,7 +4062,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658604500Z",
+                "ingested": "2021-07-19T09:06:25.094838659Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11779 for outside:100.66.204.197/53 (100.66.204.197/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -4115,7 +4115,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -4124,7 +4124,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -4147,7 +4147,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658605500Z",
+                "ingested": "2021-07-19T09:06:25.094840380Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11778 for outside:100.66.157.232/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 104",
                 "code": "302016",
                 "kind": "event",
@@ -4199,7 +4199,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -4208,7 +4208,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -4231,7 +4231,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658606600Z",
+                "ingested": "2021-07-19T09:06:25.094842244Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11779 for outside:100.66.204.197/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 176",
                 "code": "302016",
                 "kind": "event",
@@ -4282,7 +4282,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -4291,7 +4291,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -4313,7 +4313,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658607600Z",
+                "ingested": "2021-07-19T09:06:25.094843975Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1454 to outside:100.66.98.44/8267",
                 "code": "305011",
                 "kind": "event",
@@ -4361,7 +4361,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -4370,7 +4370,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -4392,7 +4392,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658608600Z",
+                "ingested": "2021-07-19T09:06:25.094845707Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11780 for outside:100.66.128.3/80 (100.66.128.3/80) to inside:172.31.98.44/1454 (172.31.98.44/1454)",
                 "code": "302013",
                 "kind": "event",
@@ -4444,7 +4444,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -4453,7 +4453,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -4475,7 +4475,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658610Z",
+                "ingested": "2021-07-19T09:06:25.094847586Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1455 to outside:100.66.98.44/8268",
                 "code": "305011",
                 "kind": "event",
@@ -4523,7 +4523,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -4532,7 +4532,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -4554,7 +4554,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658611Z",
+                "ingested": "2021-07-19T09:06:25.094849353Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11781 for outside:100.66.128.3/80 (100.66.128.3/80) to inside:172.31.98.44/1455 (172.31.98.44/1455)",
                 "code": "302013",
                 "kind": "event",
@@ -4606,7 +4606,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -4615,7 +4615,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -4637,7 +4637,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658612100Z",
+                "ingested": "2021-07-19T09:06:25.094851178Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1456 to outside:100.66.98.44/8269",
                 "code": "305011",
                 "kind": "event",
@@ -4685,7 +4685,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -4694,7 +4694,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -4716,7 +4716,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658613100Z",
+                "ingested": "2021-07-19T09:06:25.094852892Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11782 for outside:100.66.128.3/80 (100.66.128.3/80) to inside:172.31.98.44/1456 (172.31.98.44/1456)",
                 "code": "302013",
                 "kind": "event",
@@ -4769,7 +4769,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -4778,7 +4778,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -4800,7 +4800,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658614100Z",
+                "ingested": "2021-07-19T09:06:25.094854615Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11783 for outside:100.66.100.4/53 (100.66.100.4/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -4853,7 +4853,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -4862,7 +4862,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -4885,7 +4885,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658615100Z",
+                "ingested": "2021-07-19T09:06:25.094856323Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11783 for outside:100.66.100.4/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 104",
                 "code": "302016",
                 "kind": "event",
@@ -4936,7 +4936,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -4945,7 +4945,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -4967,7 +4967,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658616100Z",
+                "ingested": "2021-07-19T09:06:25.094858039Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1457 to outside:100.66.98.44/8270",
                 "code": "305011",
                 "kind": "event",
@@ -5015,7 +5015,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -5024,7 +5024,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -5046,7 +5046,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658617100Z",
+                "ingested": "2021-07-19T09:06:25.094859779Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11784 for outside:100.66.198.40/80 (100.66.198.40/80) to inside:172.31.98.44/1457 (172.31.98.44/1457)",
                 "code": "302013",
                 "kind": "event",
@@ -5098,7 +5098,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -5107,7 +5107,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -5129,7 +5129,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658618200Z",
+                "ingested": "2021-07-19T09:06:25.094861511Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1458 to outside:100.66.98.44/8271",
                 "code": "305011",
                 "kind": "event",
@@ -5177,7 +5177,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -5186,7 +5186,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -5208,7 +5208,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658619200Z",
+                "ingested": "2021-07-19T09:06:25.094863245Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11785 for outside:100.66.198.40/80 (100.66.198.40/80) to inside:172.31.98.44/1458 (172.31.98.44/1458)",
                 "code": "302013",
                 "kind": "event",
@@ -5261,7 +5261,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -5270,7 +5270,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -5292,7 +5292,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658620200Z",
+                "ingested": "2021-07-19T09:06:25.094864986Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11786 for outside:100.66.1.107/53 (100.66.1.107/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -5345,7 +5345,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -5354,7 +5354,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -5378,7 +5378,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:23.658621200Z",
+                "ingested": "2021-07-19T09:06:25.094866695Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11784 for outside:100.66.198.40/80 to inside:172.31.98.44/1457 duration 0:00:00 bytes 593 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -5429,7 +5429,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -5438,7 +5438,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -5460,7 +5460,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658622200Z",
+                "ingested": "2021-07-19T09:06:25.094868465Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1459 to outside:100.66.98.44/8272",
                 "code": "305011",
                 "kind": "event",
@@ -5508,7 +5508,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -5517,7 +5517,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -5539,7 +5539,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658623200Z",
+                "ingested": "2021-07-19T09:06:25.094870253Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11787 for outside:100.66.198.40/80 (100.66.198.40/80) to inside:172.31.98.44/1459 (172.31.98.44/1459)",
                 "code": "302013",
                 "kind": "event",
@@ -5592,7 +5592,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -5601,7 +5601,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -5624,7 +5624,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658624200Z",
+                "ingested": "2021-07-19T09:06:25.094871988Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11786 for outside:100.66.1.107/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 375",
                 "code": "302016",
                 "kind": "event",
@@ -5675,7 +5675,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -5684,7 +5684,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -5706,7 +5706,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658625600Z",
+                "ingested": "2021-07-19T09:06:25.094873752Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1460 to outside:100.66.98.44/8273",
                 "code": "305011",
                 "kind": "event",
@@ -5754,7 +5754,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -5763,7 +5763,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -5785,7 +5785,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658626600Z",
+                "ingested": "2021-07-19T09:06:25.094875462Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11788 for outside:100.66.192.44/80 (100.66.192.44/80) to inside:172.31.98.44/1460 (172.31.98.44/1460)",
                 "code": "302013",
                 "kind": "event",
@@ -5840,7 +5840,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658627600Z",
+                "ingested": "2021-07-19T09:06:25.094877221Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1454 to outside:100.66.98.44/8267 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -5884,7 +5884,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -5893,7 +5893,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -5915,7 +5915,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658628600Z",
+                "ingested": "2021-07-19T09:06:25.094878959Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.156.80/1385 to outside:100.66.98.44/8277",
                 "code": "305011",
                 "kind": "event",
@@ -5963,7 +5963,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -5972,7 +5972,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -5994,7 +5994,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658629600Z",
+                "ingested": "2021-07-19T09:06:25.094880685Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11797 for outside:100.66.19.254/80 (100.66.19.254/80) to inside:172.31.156.80/1385 (172.31.156.80/1385)",
                 "code": "302013",
                 "kind": "event",
@@ -6049,7 +6049,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658630700Z",
+                "ingested": "2021-07-19T09:06:25.094882400Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1455 to outside:100.66.98.44/8268 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -6096,7 +6096,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658631700Z",
+                "ingested": "2021-07-19T09:06:25.094884256Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1456 to outside:100.66.98.44/8269 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -6143,7 +6143,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658632800Z",
+                "ingested": "2021-07-19T09:06:25.094886688Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1457 to outside:100.66.98.44/8270 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -6190,7 +6190,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658633800Z",
+                "ingested": "2021-07-19T09:06:25.094888571Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1458 to outside:100.66.98.44/8271 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -6237,7 +6237,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658634800Z",
+                "ingested": "2021-07-19T09:06:25.094890305Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1459 to outside:100.66.98.44/8272 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -6284,7 +6284,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658635800Z",
+                "ingested": "2021-07-19T09:06:25.094892033Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1460 to outside:100.66.98.44/8273 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -6329,7 +6329,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -6338,7 +6338,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -6362,7 +6362,7 @@
                 "severity": 6,
                 "duration": 325000000000,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:23.658636800Z",
+                "ingested": "2021-07-19T09:06:25.094893764Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11564 for outside:100.66.115.46/80 to inside:172.31.156.80/1382 duration 0:05:25 bytes 575 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -6414,7 +6414,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -6423,7 +6423,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -6447,7 +6447,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:23.658637900Z",
+                "ingested": "2021-07-19T09:06:25.094895508Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11797 for outside:100.66.19.254/80 to inside:172.31.156.80/1385 duration 0:00:00 bytes 5391 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -6498,7 +6498,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -6507,7 +6507,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -6529,7 +6529,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658638900Z",
+                "ingested": "2021-07-19T09:06:25.094897282Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.156.80/1386 to outside:100.66.98.44/8278",
                 "code": "305011",
                 "kind": "event",
@@ -6577,7 +6577,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -6586,7 +6586,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -6608,7 +6608,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658639900Z",
+                "ingested": "2021-07-19T09:06:25.094899098Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11798 for outside:100.66.115.46/80 (100.66.115.46/80) to inside:172.31.156.80/1386 (172.31.156.80/1386)",
                 "code": "302013",
                 "kind": "event",
@@ -6660,7 +6660,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -6669,7 +6669,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -6691,7 +6691,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658640900Z",
+                "ingested": "2021-07-19T09:06:25.094900856Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -6741,7 +6741,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -6750,7 +6750,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -6772,7 +6772,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658641900Z",
+                "ingested": "2021-07-19T09:06:25.094902629Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -6822,7 +6822,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -6831,7 +6831,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -6853,7 +6853,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658642900Z",
+                "ingested": "2021-07-19T09:06:25.094904347Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -6903,7 +6903,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -6912,7 +6912,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -6934,7 +6934,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658643900Z",
+                "ingested": "2021-07-19T09:06:25.094906076Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -6984,7 +6984,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -6993,7 +6993,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -7015,7 +7015,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658644900Z",
+                "ingested": "2021-07-19T09:06:25.094907817Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -7065,7 +7065,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -7074,7 +7074,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -7096,7 +7096,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658646Z",
+                "ingested": "2021-07-19T09:06:25.094909522Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -7146,7 +7146,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -7155,7 +7155,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -7177,7 +7177,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658647Z",
+                "ingested": "2021-07-19T09:06:25.094911262Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -7227,7 +7227,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -7236,7 +7236,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -7258,7 +7258,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658648Z",
+                "ingested": "2021-07-19T09:06:25.094913010Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -7308,7 +7308,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -7317,7 +7317,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -7339,7 +7339,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658649Z",
+                "ingested": "2021-07-19T09:06:25.094914740Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -7389,7 +7389,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -7398,7 +7398,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -7420,7 +7420,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658650Z",
+                "ingested": "2021-07-19T09:06:25.094916454Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -7470,7 +7470,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -7479,7 +7479,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -7501,7 +7501,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658651Z",
+                "ingested": "2021-07-19T09:06:25.094918212Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -7551,7 +7551,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -7560,7 +7560,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -7582,7 +7582,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658652Z",
+                "ingested": "2021-07-19T09:06:25.094919940Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -7632,7 +7632,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -7641,7 +7641,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -7663,7 +7663,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658653Z",
+                "ingested": "2021-07-19T09:06:25.094921698Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.19.254/80 dst inside:172.31.98.44/8277 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -7713,7 +7713,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -7722,7 +7722,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -7744,7 +7744,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658654100Z",
+                "ingested": "2021-07-19T09:06:25.094923445Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1275 to outside:100.66.98.44/8279",
                 "code": "305011",
                 "kind": "event",
@@ -7792,7 +7792,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -7801,7 +7801,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -7823,7 +7823,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658655100Z",
+                "ingested": "2021-07-19T09:06:25.094925168Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11799 for outside:100.66.205.99/80 (100.66.205.99/80) to inside:172.31.98.44/1275 (172.31.98.44/1275)",
                 "code": "302013",
                 "kind": "event",
@@ -7875,7 +7875,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -7884,7 +7884,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -7906,7 +7906,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658691200Z",
+                "ingested": "2021-07-19T09:06:25.094926948Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic UDP translation from inside:172.31.98.44/56132 to outside:100.66.98.44/1190",
                 "code": "305011",
                 "kind": "event",
@@ -7954,7 +7954,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -7963,7 +7963,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -7985,7 +7985,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658692500Z",
+                "ingested": "2021-07-19T09:06:25.094928671Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11800 for outside:100.66.14.30/53 (100.66.14.30/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -8038,7 +8038,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -8047,7 +8047,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -8070,7 +8070,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658693700Z",
+                "ingested": "2021-07-19T09:06:25.094930411Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11800 for outside:100.66.14.30/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 373",
                 "code": "302016",
                 "kind": "event",
@@ -8122,7 +8122,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -8131,7 +8131,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -8153,7 +8153,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658694800Z",
+                "ingested": "2021-07-19T09:06:25.094932151Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11801 for outside:100.66.252.210/53 (100.66.252.210/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -8206,7 +8206,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -8215,7 +8215,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -8238,7 +8238,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658695900Z",
+                "ingested": "2021-07-19T09:06:25.094933951Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11801 for outside:100.66.252.210/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 207",
                 "code": "302016",
                 "kind": "event",
@@ -8289,7 +8289,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -8298,7 +8298,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -8320,7 +8320,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658696900Z",
+                "ingested": "2021-07-19T09:06:25.094935660Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1276 to outside:100.66.98.44/8280",
                 "code": "305011",
                 "kind": "event",
@@ -8368,7 +8368,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -8377,7 +8377,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -8399,7 +8399,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658698Z",
+                "ingested": "2021-07-19T09:06:25.094937440Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11802 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1276 (172.31.98.44/1276)",
                 "code": "302013",
                 "kind": "event",
@@ -8451,7 +8451,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -8460,7 +8460,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -8482,7 +8482,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658698900Z",
+                "ingested": "2021-07-19T09:06:25.094939156Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1277 to outside:100.66.98.44/8281",
                 "code": "305011",
                 "kind": "event",
@@ -8530,7 +8530,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -8539,7 +8539,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -8561,7 +8561,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658699900Z",
+                "ingested": "2021-07-19T09:06:25.094940881Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11803 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1277 (172.31.98.44/1277)",
                 "code": "302013",
                 "kind": "event",
@@ -8614,7 +8614,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -8623,7 +8623,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -8647,7 +8647,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:23.658700900Z",
+                "ingested": "2021-07-19T09:06:25.094942623Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11802 for outside:100.66.98.165/80 to inside:172.31.98.44/1276 duration 0:00:00 bytes 12853 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -8698,7 +8698,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -8707,7 +8707,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -8729,7 +8729,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658701900Z",
+                "ingested": "2021-07-19T09:06:25.094944348Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1278 to outside:100.66.98.44/8282",
                 "code": "305011",
                 "kind": "event",
@@ -8777,7 +8777,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -8786,7 +8786,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -8808,7 +8808,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658702900Z",
+                "ingested": "2021-07-19T09:06:25.094946147Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11804 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1278 (172.31.98.44/1278)",
                 "code": "302013",
                 "kind": "event",
@@ -8861,7 +8861,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -8870,7 +8870,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -8894,7 +8894,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:23.658704Z",
+                "ingested": "2021-07-19T09:06:25.094948142Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11803 for outside:100.66.98.165/80 to inside:172.31.98.44/1277 duration 0:00:00 bytes 5291 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -8945,7 +8945,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -8954,7 +8954,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -8976,7 +8976,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658705Z",
+                "ingested": "2021-07-19T09:06:25.094949863Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1279 to outside:100.66.98.44/8283",
                 "code": "305011",
                 "kind": "event",
@@ -9024,7 +9024,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -9033,7 +9033,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -9055,7 +9055,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658706Z",
+                "ingested": "2021-07-19T09:06:25.094951605Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11805 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1279 (172.31.98.44/1279)",
                 "code": "302013",
                 "kind": "event",
@@ -9108,7 +9108,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -9117,7 +9117,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -9141,7 +9141,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:23.658707100Z",
+                "ingested": "2021-07-19T09:06:25.094953361Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11804 for outside:100.66.98.165/80 to inside:172.31.98.44/1278 duration 0:00:00 bytes 965 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -9193,7 +9193,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -9202,7 +9202,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -9226,7 +9226,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:23.658708100Z",
+                "ingested": "2021-07-19T09:06:25.094955103Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11805 for outside:100.66.98.165/80 to inside:172.31.98.44/1279 duration 0:00:00 bytes 8605 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -9277,7 +9277,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -9286,7 +9286,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -9308,7 +9308,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658709100Z",
+                "ingested": "2021-07-19T09:06:25.094957912Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1280 to outside:100.66.98.44/8284",
                 "code": "305011",
                 "kind": "event",
@@ -9356,7 +9356,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -9365,7 +9365,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -9387,7 +9387,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658710100Z",
+                "ingested": "2021-07-19T09:06:25.094959670Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11806 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1280 (172.31.98.44/1280)",
                 "code": "302013",
                 "kind": "event",
@@ -9440,7 +9440,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -9449,7 +9449,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -9473,7 +9473,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:23.658711500Z",
+                "ingested": "2021-07-19T09:06:25.094961399Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11806 for outside:100.66.98.165/80 to inside:172.31.98.44/1280 duration 0:00:00 bytes 3428 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -9524,7 +9524,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -9533,7 +9533,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -9555,7 +9555,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658712500Z",
+                "ingested": "2021-07-19T09:06:25.094963132Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1281 to outside:100.66.98.44/8285",
                 "code": "305011",
                 "kind": "event",
@@ -9603,7 +9603,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -9612,7 +9612,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -9634,7 +9634,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658713600Z",
+                "ingested": "2021-07-19T09:06:25.094964864Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11807 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1281 (172.31.98.44/1281)",
                 "code": "302013",
                 "kind": "event",
@@ -9686,7 +9686,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -9695,7 +9695,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -9717,7 +9717,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658714600Z",
+                "ingested": "2021-07-19T09:06:25.094966580Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1282 to outside:100.66.98.44/8286",
                 "code": "305011",
                 "kind": "event",
@@ -9765,7 +9765,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -9774,7 +9774,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -9796,7 +9796,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658715600Z",
+                "ingested": "2021-07-19T09:06:25.094968386Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11808 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1282 (172.31.98.44/1282)",
                 "code": "302013",
                 "kind": "event",
@@ -9848,7 +9848,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -9857,7 +9857,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -9879,7 +9879,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658716600Z",
+                "ingested": "2021-07-19T09:06:25.094970138Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1283 to outside:100.66.98.44/8287",
                 "code": "305011",
                 "kind": "event",
@@ -9927,7 +9927,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -9936,7 +9936,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -9958,7 +9958,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658717600Z",
+                "ingested": "2021-07-19T09:06:25.094971864Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11809 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1283 (172.31.98.44/1283)",
                 "code": "302013",
                 "kind": "event",
@@ -10010,7 +10010,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -10019,7 +10019,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -10041,7 +10041,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658718600Z",
+                "ingested": "2021-07-19T09:06:25.094973636Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1284 to outside:100.66.98.44/8288",
                 "code": "305011",
                 "kind": "event",
@@ -10089,7 +10089,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -10098,7 +10098,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -10120,7 +10120,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658719600Z",
+                "ingested": "2021-07-19T09:06:25.094975439Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11810 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1284 (172.31.98.44/1284)",
                 "code": "302013",
                 "kind": "event",
@@ -10173,7 +10173,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -10182,7 +10182,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -10206,7 +10206,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:23.658720600Z",
+                "ingested": "2021-07-19T09:06:25.094977190Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11807 for outside:100.66.98.165/80 to inside:172.31.98.44/1281 duration 0:00:00 bytes 2028 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -10258,7 +10258,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -10267,7 +10267,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -10291,7 +10291,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:23.658721600Z",
+                "ingested": "2021-07-19T09:06:25.094978932Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11808 for outside:100.66.98.165/80 to inside:172.31.98.44/1282 duration 0:00:00 bytes 1085 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -10343,7 +10343,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -10352,7 +10352,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -10376,7 +10376,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:23.658722600Z",
+                "ingested": "2021-07-19T09:06:25.094980674Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11809 for outside:100.66.98.165/80 to inside:172.31.98.44/1283 duration 0:00:00 bytes 868 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -10427,7 +10427,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -10436,7 +10436,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -10458,7 +10458,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658723500Z",
+                "ingested": "2021-07-19T09:06:25.094982424Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1285 to outside:100.66.98.44/8289",
                 "code": "305011",
                 "kind": "event",
@@ -10506,7 +10506,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -10515,7 +10515,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -10537,7 +10537,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658724500Z",
+                "ingested": "2021-07-19T09:06:25.094984207Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11811 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1285 (172.31.98.44/1285)",
                 "code": "302013",
                 "kind": "event",
@@ -10589,7 +10589,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -10598,7 +10598,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -10620,7 +10620,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658725500Z",
+                "ingested": "2021-07-19T09:06:25.094985977Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1286 to outside:100.66.98.44/8290",
                 "code": "305011",
                 "kind": "event",
@@ -10668,7 +10668,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -10677,7 +10677,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -10699,7 +10699,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658726500Z",
+                "ingested": "2021-07-19T09:06:25.094987736Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11812 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1286 (172.31.98.44/1286)",
                 "code": "302013",
                 "kind": "event",
@@ -10752,7 +10752,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -10761,7 +10761,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -10785,7 +10785,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:23.658727500Z",
+                "ingested": "2021-07-19T09:06:25.094989496Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11810 for outside:100.66.98.165/80 to inside:172.31.98.44/1284 duration 0:00:00 bytes 4439 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -10836,7 +10836,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -10845,7 +10845,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -10867,7 +10867,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658728500Z",
+                "ingested": "2021-07-19T09:06:25.094991241Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1287 to outside:100.66.98.44/8291",
                 "code": "305011",
                 "kind": "event",
@@ -10915,7 +10915,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -10924,7 +10924,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -10946,7 +10946,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658729500Z",
+                "ingested": "2021-07-19T09:06:25.094992964Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11813 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1287 (172.31.98.44/1287)",
                 "code": "302013",
                 "kind": "event",
@@ -10999,7 +10999,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -11008,7 +11008,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -11032,7 +11032,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:23.658730500Z",
+                "ingested": "2021-07-19T09:06:25.094994987Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11811 for outside:100.66.98.165/80 to inside:172.31.98.44/1285 duration 0:00:00 bytes 914 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -11084,7 +11084,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -11093,7 +11093,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -11117,7 +11117,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:23.658731400Z",
+                "ingested": "2021-07-19T09:06:25.094996765Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11812 for outside:100.66.98.165/80 to inside:172.31.98.44/1286 duration 0:00:00 bytes 871 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -11169,7 +11169,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -11178,7 +11178,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -11200,7 +11200,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658732500Z",
+                "ingested": "2021-07-19T09:06:25.094998495Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11814 for outside:100.66.100.107/53 (100.66.100.107/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -11252,7 +11252,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -11261,7 +11261,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -11283,7 +11283,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658733500Z",
+                "ingested": "2021-07-19T09:06:25.095000230Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1288 to outside:100.66.98.44/8292",
                 "code": "305011",
                 "kind": "event",
@@ -11331,7 +11331,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -11340,7 +11340,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -11362,7 +11362,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658735Z",
+                "ingested": "2021-07-19T09:06:25.095001973Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11815 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1288 (172.31.98.44/1288)",
                 "code": "302013",
                 "kind": "event",
@@ -11415,7 +11415,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -11424,7 +11424,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -11447,7 +11447,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658735900Z",
+                "ingested": "2021-07-19T09:06:25.095003703Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11814 for outside:100.66.100.107/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 384",
                 "code": "302016",
                 "kind": "event",
@@ -11499,7 +11499,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -11508,7 +11508,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -11530,7 +11530,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658736900Z",
+                "ingested": "2021-07-19T09:06:25.095005519Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11816 for outside:100.66.104.8/53 (100.66.104.8/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -11583,7 +11583,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -11592,7 +11592,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -11615,7 +11615,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658737900Z",
+                "ingested": "2021-07-19T09:06:25.095007254Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11816 for outside:100.66.104.8/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 94",
                 "code": "302016",
                 "kind": "event",
@@ -11666,7 +11666,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -11675,7 +11675,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -11697,7 +11697,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658738900Z",
+                "ingested": "2021-07-19T09:06:25.095008983Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1289 to outside:100.66.98.44/8293",
                 "code": "305011",
                 "kind": "event",
@@ -11745,7 +11745,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -11754,7 +11754,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -11776,7 +11776,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658739900Z",
+                "ingested": "2021-07-19T09:06:25.095010725Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11817 for outside:100.66.123.191/80 (100.66.123.191/80) to inside:172.31.98.44/1289 (172.31.98.44/1289)",
                 "code": "302013",
                 "kind": "event",
@@ -11829,7 +11829,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -11838,7 +11838,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -11862,7 +11862,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:23.658740900Z",
+                "ingested": "2021-07-19T09:06:25.095012450Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11815 for outside:100.66.98.165/80 to inside:172.31.98.44/1288 duration 0:00:00 bytes 945 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -11914,7 +11914,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -11923,7 +11923,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -11947,7 +11947,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:23.658741800Z",
+                "ingested": "2021-07-19T09:06:25.095014251Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11813 for outside:100.66.98.165/80 to inside:172.31.98.44/1287 duration 0:00:00 bytes 13284 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -11999,7 +11999,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -12008,7 +12008,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -12030,7 +12030,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658743Z",
+                "ingested": "2021-07-19T09:06:25.095016004Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11818 for outside:100.66.100.4/53 (100.66.100.4/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -12083,7 +12083,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -12092,7 +12092,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -12115,7 +12115,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658743900Z",
+                "ingested": "2021-07-19T09:06:25.095017764Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11818 for outside:100.66.100.4/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 104",
                 "code": "302016",
                 "kind": "event",
@@ -12166,7 +12166,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -12175,7 +12175,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -12197,7 +12197,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658744900Z",
+                "ingested": "2021-07-19T09:06:25.095019498Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1290 to outside:100.66.98.44/8294",
                 "code": "305011",
                 "kind": "event",
@@ -12245,7 +12245,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -12254,7 +12254,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -12276,7 +12276,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658745900Z",
+                "ingested": "2021-07-19T09:06:25.095021236Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11819 for outside:100.66.198.25/80 (100.66.198.25/80) to inside:172.31.98.44/1290 (172.31.98.44/1290)",
                 "code": "302013",
                 "kind": "event",
@@ -12329,7 +12329,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "NP Identity Ifc"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -12338,7 +12338,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "NP Identity Ifc"
                     }
                 }
             },
@@ -12361,7 +12361,7 @@
             "event": {
                 "severity": 6,
                 "duration": 3526000000000,
-                "ingested": "2021-06-09T10:11:23.658746900Z",
+                "ingested": "2021-07-19T09:06:25.095022972Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 9828 for outside:100.66.48.1/67 to NP Identity Ifc:255.255.255.255/68 duration 0:58:46 bytes 58512",
                 "code": "302016",
                 "kind": "event",
@@ -12415,7 +12415,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658747800Z",
+                "ingested": "2021-07-19T09:06:25.095024721Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1272 to outside:100.66.98.44/8276 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -12460,7 +12460,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -12469,7 +12469,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -12491,7 +12491,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658748800Z",
+                "ingested": "2021-07-19T09:06:25.095026506Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11820 for outside:100.66.3.39/53 (100.66.3.39/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -12544,7 +12544,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -12553,7 +12553,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -12575,7 +12575,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658749800Z",
+                "ingested": "2021-07-19T09:06:25.095029561Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11821 for outside:100.66.162.30/53 (100.66.162.30/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -12628,7 +12628,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -12637,7 +12637,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -12660,7 +12660,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658750900Z",
+                "ingested": "2021-07-19T09:06:25.095031597Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11820 for outside:100.66.3.39/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 168",
                 "code": "302016",
                 "kind": "event",
@@ -12712,7 +12712,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -12721,7 +12721,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -12743,7 +12743,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658751900Z",
+                "ingested": "2021-07-19T09:06:25.095033342Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11822 for outside:100.66.3.39/53 (100.66.3.39/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -12796,7 +12796,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -12805,7 +12805,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -12828,7 +12828,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658752800Z",
+                "ingested": "2021-07-19T09:06:25.095035101Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11821 for outside:100.66.162.30/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 198",
                 "code": "302016",
                 "kind": "event",
@@ -12880,7 +12880,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -12889,7 +12889,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -12912,7 +12912,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658753900Z",
+                "ingested": "2021-07-19T09:06:25.095036934Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11822 for outside:100.66.3.39/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 150",
                 "code": "302016",
                 "kind": "event",
@@ -12964,7 +12964,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -12973,7 +12973,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -12995,7 +12995,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658754800Z",
+                "ingested": "2021-07-19T09:06:25.095038656Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11823 for outside:100.66.48.186/53 (100.66.48.186/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -13048,7 +13048,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -13057,7 +13057,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -13080,7 +13080,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658755800Z",
+                "ingested": "2021-07-19T09:06:25.095040387Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11823 for outside:100.66.48.186/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 84",
                 "code": "302016",
                 "kind": "event",
@@ -13131,7 +13131,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -13140,7 +13140,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -13162,7 +13162,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658756800Z",
+                "ingested": "2021-07-19T09:06:25.095042162Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1291 to outside:100.66.98.44/8295",
                 "code": "305011",
                 "kind": "event",
@@ -13210,7 +13210,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -13219,7 +13219,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -13241,7 +13241,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658758400Z",
+                "ingested": "2021-07-19T09:06:25.095043892Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11824 for outside:100.66.54.190/80 (100.66.54.190/80) to inside:172.31.98.44/1291 (172.31.98.44/1291)",
                 "code": "302013",
                 "kind": "event",
@@ -13294,7 +13294,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -13303,7 +13303,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -13325,7 +13325,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658759400Z",
+                "ingested": "2021-07-19T09:06:25.095045842Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11825 for outside:100.66.254.94/53 (100.66.254.94/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -13378,7 +13378,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -13387,7 +13387,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -13410,7 +13410,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658760400Z",
+                "ingested": "2021-07-19T09:06:25.095047610Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11825 for outside:100.66.254.94/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 188",
                 "code": "302016",
                 "kind": "event",
@@ -13461,7 +13461,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -13470,7 +13470,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -13492,7 +13492,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658761400Z",
+                "ingested": "2021-07-19T09:06:25.095049324Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1292 to outside:100.66.98.44/8296",
                 "code": "305011",
                 "kind": "event",
@@ -13540,7 +13540,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -13549,7 +13549,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -13571,7 +13571,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658762400Z",
+                "ingested": "2021-07-19T09:06:25.095051043Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11826 for outside:100.66.54.190/80 (100.66.54.190/80) to inside:172.31.98.44/1292 (172.31.98.44/1292)",
                 "code": "302013",
                 "kind": "event",
@@ -13623,7 +13623,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -13632,7 +13632,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -13654,7 +13654,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658763400Z",
+                "ingested": "2021-07-19T09:06:25.095052816Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1293 to outside:100.66.98.44/8297",
                 "code": "305011",
                 "kind": "event",
@@ -13702,7 +13702,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -13711,7 +13711,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -13733,7 +13733,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658764400Z",
+                "ingested": "2021-07-19T09:06:25.095054588Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11827 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1293 (172.31.98.44/1293)",
                 "code": "302013",
                 "kind": "event",
@@ -13785,7 +13785,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -13794,7 +13794,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -13816,7 +13816,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658765400Z",
+                "ingested": "2021-07-19T09:06:25.095056325Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1294 to outside:100.66.98.44/8298",
                 "code": "305011",
                 "kind": "event",
@@ -13864,7 +13864,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -13873,7 +13873,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -13895,7 +13895,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658766300Z",
+                "ingested": "2021-07-19T09:06:25.095058049Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11828 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1294 (172.31.98.44/1294)",
                 "code": "302013",
                 "kind": "event",
@@ -13948,7 +13948,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -13957,7 +13957,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -13981,7 +13981,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:23.658767300Z",
+                "ingested": "2021-07-19T09:06:25.095059822Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11827 for outside:100.66.98.165/80 to inside:172.31.98.44/1293 duration 0:00:00 bytes 5964 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -14032,7 +14032,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -14041,7 +14041,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -14063,7 +14063,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658769700Z",
+                "ingested": "2021-07-19T09:06:25.095061585Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1295 to outside:100.66.98.44/8299",
                 "code": "305011",
                 "kind": "event",
@@ -14111,7 +14111,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -14120,7 +14120,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -14142,7 +14142,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658770700Z",
+                "ingested": "2021-07-19T09:06:25.095063345Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11829 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1295 (172.31.98.44/1295)",
                 "code": "302013",
                 "kind": "event",
@@ -14194,7 +14194,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -14203,7 +14203,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -14225,7 +14225,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658771700Z",
+                "ingested": "2021-07-19T09:06:25.095065149Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1296 to outside:100.66.98.44/8300",
                 "code": "305011",
                 "kind": "event",
@@ -14273,7 +14273,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -14282,7 +14282,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -14304,7 +14304,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658772700Z",
+                "ingested": "2021-07-19T09:06:25.095066875Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11830 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1296 (172.31.98.44/1296)",
                 "code": "302013",
                 "kind": "event",
@@ -14357,7 +14357,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -14366,7 +14366,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -14390,7 +14390,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:23.658774Z",
+                "ingested": "2021-07-19T09:06:25.095068592Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11828 for outside:100.66.98.165/80 to inside:172.31.98.44/1294 duration 0:00:00 bytes 6694 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -14442,7 +14442,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -14451,7 +14451,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -14475,7 +14475,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:23.658775Z",
+                "ingested": "2021-07-19T09:06:25.095070333Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11829 for outside:100.66.98.165/80 to inside:172.31.98.44/1295 duration 0:00:00 bytes 1493 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -14527,7 +14527,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -14536,7 +14536,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -14560,7 +14560,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:23.658776Z",
+                "ingested": "2021-07-19T09:06:25.095072079Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11830 for outside:100.66.98.165/80 to inside:172.31.98.44/1296 duration 0:00:00 bytes 893 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -14611,7 +14611,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -14620,7 +14620,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -14642,7 +14642,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658777Z",
+                "ingested": "2021-07-19T09:06:25.095073958Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1297 to outside:100.66.98.44/8301",
                 "code": "305011",
                 "kind": "event",
@@ -14690,7 +14690,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -14699,7 +14699,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -14721,7 +14721,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658778Z",
+                "ingested": "2021-07-19T09:06:25.095075685Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11831 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1297 (172.31.98.44/1297)",
                 "code": "302013",
                 "kind": "event",
@@ -14773,7 +14773,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -14782,7 +14782,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -14804,7 +14804,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658778900Z",
+                "ingested": "2021-07-19T09:06:25.095077426Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1298 to outside:100.66.98.44/8302",
                 "code": "305011",
                 "kind": "event",
@@ -14852,7 +14852,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -14861,7 +14861,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -14883,7 +14883,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658779900Z",
+                "ingested": "2021-07-19T09:06:25.095079166Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11832 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1298 (172.31.98.44/1298)",
                 "code": "302013",
                 "kind": "event",
@@ -14936,7 +14936,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -14945,7 +14945,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -14967,7 +14967,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658780900Z",
+                "ingested": "2021-07-19T09:06:25.095080912Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11833 for outside:100.66.179.9/53 (100.66.179.9/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -15020,7 +15020,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -15029,7 +15029,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -15052,7 +15052,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658782Z",
+                "ingested": "2021-07-19T09:06:25.095082702Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11833 for outside:100.66.179.9/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 150",
                 "code": "302016",
                 "kind": "event",
@@ -15104,7 +15104,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -15113,7 +15113,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -15137,7 +15137,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:23.658783Z",
+                "ingested": "2021-07-19T09:06:25.095084487Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11831 for outside:100.66.98.165/80 to inside:172.31.98.44/1297 duration 0:00:00 bytes 2750 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -15188,7 +15188,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -15197,7 +15197,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -15219,7 +15219,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658784Z",
+                "ingested": "2021-07-19T09:06:25.095086211Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1299 to outside:100.66.98.44/8303",
                 "code": "305011",
                 "kind": "event",
@@ -15267,7 +15267,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -15276,7 +15276,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -15298,7 +15298,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658785Z",
+                "ingested": "2021-07-19T09:06:25.095087942Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11834 for outside:100.66.247.99/80 (100.66.247.99/80) to inside:172.31.98.44/1299 (172.31.98.44/1299)",
                 "code": "302013",
                 "kind": "event",
@@ -15350,7 +15350,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -15359,7 +15359,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -15381,7 +15381,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658786Z",
+                "ingested": "2021-07-19T09:06:25.095089683Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1300 to outside:100.66.98.44/8304",
                 "code": "305011",
                 "kind": "event",
@@ -15429,7 +15429,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -15438,7 +15438,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -15460,7 +15460,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658787Z",
+                "ingested": "2021-07-19T09:06:25.095091477Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11835 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1300 (172.31.98.44/1300)",
                 "code": "302013",
                 "kind": "event",
@@ -15513,7 +15513,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -15522,7 +15522,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -15546,7 +15546,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:23.658788Z",
+                "ingested": "2021-07-19T09:06:25.095093346Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11832 for outside:100.66.98.165/80 to inside:172.31.98.44/1298 duration 0:00:00 bytes 881 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -15598,7 +15598,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -15607,7 +15607,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -15631,7 +15631,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:23.658789Z",
+                "ingested": "2021-07-19T09:06:25.095095112Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11835 for outside:100.66.98.165/80 to inside:172.31.98.44/1300 duration 0:00:00 bytes 2202 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -15682,7 +15682,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -15691,7 +15691,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -15713,7 +15713,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658789900Z",
+                "ingested": "2021-07-19T09:06:25.095096898Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1301 to outside:100.66.98.44/8305",
                 "code": "305011",
                 "kind": "event",
@@ -15761,7 +15761,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -15770,7 +15770,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -15792,7 +15792,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658790900Z",
+                "ingested": "2021-07-19T09:06:25.095098659Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11836 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1301 (172.31.98.44/1301)",
                 "code": "302013",
                 "kind": "event",
@@ -15844,7 +15844,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -15853,7 +15853,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -15875,7 +15875,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658791900Z",
+                "ingested": "2021-07-19T09:06:25.095101016Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1302 to outside:100.66.98.44/8306",
                 "code": "305011",
                 "kind": "event",
@@ -15923,7 +15923,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -15932,7 +15932,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -15954,7 +15954,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658792900Z",
+                "ingested": "2021-07-19T09:06:25.095102796Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11837 for outside:100.66.98.165/80 (100.66.98.165/80) to inside:172.31.98.44/1302 (172.31.98.44/1302)",
                 "code": "302013",
                 "kind": "event",
@@ -16009,7 +16009,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658793900Z",
+                "ingested": "2021-07-19T09:06:25.095104768Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1276 to outside:100.66.98.44/8280 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16056,7 +16056,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658794800Z",
+                "ingested": "2021-07-19T09:06:25.095106483Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1277 to outside:100.66.98.44/8281 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16103,7 +16103,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658795800Z",
+                "ingested": "2021-07-19T09:06:25.095108211Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1278 to outside:100.66.98.44/8282 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16150,7 +16150,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658796900Z",
+                "ingested": "2021-07-19T09:06:25.095121279Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1279 to outside:100.66.98.44/8283 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16197,7 +16197,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658797900Z",
+                "ingested": "2021-07-19T09:06:25.095123681Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1280 to outside:100.66.98.44/8284 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16244,7 +16244,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658798900Z",
+                "ingested": "2021-07-19T09:06:25.095125600Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1281 to outside:100.66.98.44/8285 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16291,7 +16291,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658799800Z",
+                "ingested": "2021-07-19T09:06:25.095127494Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1282 to outside:100.66.98.44/8286 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16338,7 +16338,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658800800Z",
+                "ingested": "2021-07-19T09:06:25.095129365Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1283 to outside:100.66.98.44/8287 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16385,7 +16385,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658801900Z",
+                "ingested": "2021-07-19T09:06:25.095131231Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1284 to outside:100.66.98.44/8288 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16432,7 +16432,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658802900Z",
+                "ingested": "2021-07-19T09:06:25.095133051Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1285 to outside:100.66.98.44/8289 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16479,7 +16479,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658803800Z",
+                "ingested": "2021-07-19T09:06:25.095134905Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1286 to outside:100.66.98.44/8290 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16526,7 +16526,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658804900Z",
+                "ingested": "2021-07-19T09:06:25.095136716Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1287 to outside:100.66.98.44/8291 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16573,7 +16573,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658805900Z",
+                "ingested": "2021-07-19T09:06:25.095138553Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1288 to outside:100.66.98.44/8292 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16620,7 +16620,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658807200Z",
+                "ingested": "2021-07-19T09:06:25.095140350Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1293 to outside:100.66.98.44/8297 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16667,7 +16667,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658808100Z",
+                "ingested": "2021-07-19T09:06:25.095142233Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1294 to outside:100.66.98.44/8298 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16711,7 +16711,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -16720,7 +16720,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -16742,7 +16742,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658809100Z",
+                "ingested": "2021-07-19T09:06:25.095144068Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1304 to outside:100.66.98.44/8308",
                 "code": "305011",
                 "kind": "event",
@@ -16790,7 +16790,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -16799,7 +16799,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -16821,7 +16821,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658810100Z",
+                "ingested": "2021-07-19T09:06:25.095145899Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11840 for outside:100.66.205.99/80 (100.66.205.99/80) to inside:172.31.98.44/1304 (172.31.98.44/1304)",
                 "code": "302013",
                 "kind": "event",
@@ -16876,7 +16876,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658811100Z",
+                "ingested": "2021-07-19T09:06:25.095147747Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1295 to outside:100.66.98.44/8299 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16923,7 +16923,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658812100Z",
+                "ingested": "2021-07-19T09:06:25.095149580Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1296 to outside:100.66.98.44/8300 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -16968,7 +16968,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -16977,7 +16977,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -16999,7 +16999,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658813100Z",
+                "ingested": "2021-07-19T09:06:25.095151396Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11841 for outside:100.66.0.124/53 (100.66.0.124/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -17052,7 +17052,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -17061,7 +17061,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -17083,7 +17083,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658814100Z",
+                "ingested": "2021-07-19T09:06:25.095153215Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11842 for outside:100.66.160.2/53 (100.66.160.2/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
                 "code": "302015",
                 "kind": "event",
@@ -17136,7 +17136,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -17145,7 +17145,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -17168,7 +17168,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658815Z",
+                "ingested": "2021-07-19T09:06:25.095155032Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11841 for outside:100.66.0.124/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 318",
                 "code": "302016",
                 "kind": "event",
@@ -17220,7 +17220,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -17229,7 +17229,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -17252,7 +17252,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:23.658816100Z",
+                "ingested": "2021-07-19T09:06:25.095156935Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11842 for outside:100.66.160.2/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 104",
                 "code": "302016",
                 "kind": "event",
@@ -17303,7 +17303,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -17312,7 +17312,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -17334,7 +17334,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658817Z",
+                "ingested": "2021-07-19T09:06:25.095158782Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1305 to outside:100.66.98.44/8309",
                 "code": "305011",
                 "kind": "event",
@@ -17382,7 +17382,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -17391,7 +17391,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -17413,7 +17413,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658818Z",
+                "ingested": "2021-07-19T09:06:25.095160616Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11843 for outside:100.66.124.24/80 (100.66.124.24/80) to inside:172.31.98.44/1305 (172.31.98.44/1305)",
                 "code": "302013",
                 "kind": "event",
@@ -17468,7 +17468,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658819Z",
+                "ingested": "2021-07-19T09:06:25.095162449Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1297 to outside:100.66.98.44/8301 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -17515,7 +17515,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658820Z",
+                "ingested": "2021-07-19T09:06:25.095164261Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1298 to outside:100.66.98.44/8302 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -17562,7 +17562,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658821Z",
+                "ingested": "2021-07-19T09:06:25.095166101Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1299 to outside:100.66.98.44/8303 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -17609,7 +17609,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658822Z",
+                "ingested": "2021-07-19T09:06:25.095167927Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1300 to outside:100.66.98.44/8304 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -17656,7 +17656,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658823Z",
+                "ingested": "2021-07-19T09:06:25.095169742Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1301 to outside:100.66.98.44/8305 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -17703,7 +17703,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658824Z",
+                "ingested": "2021-07-19T09:06:25.095171548Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1302 to outside:100.66.98.44/8306 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -17750,7 +17750,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658825Z",
+                "ingested": "2021-07-19T09:06:25.095173359Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1303 to outside:100.66.98.44/8307 duration 0:00:30",
                 "code": "305012",
                 "kind": "event",
@@ -17795,7 +17795,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -17804,7 +17804,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -17828,7 +17828,7 @@
                 "severity": 6,
                 "duration": 4000000000,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-06-09T10:11:23.658825900Z",
+                "ingested": "2021-07-19T09:06:25.095175163Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11843 for outside:100.66.124.24/80 to inside:172.31.98.44/1305 duration 0:00:04 bytes 410333 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -17879,7 +17879,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -17888,7 +17888,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -17910,7 +17910,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658827Z",
+                "ingested": "2021-07-19T09:06:25.095176976Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -17960,7 +17960,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -17969,7 +17969,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -17991,7 +17991,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658827900Z",
+                "ingested": "2021-07-19T09:06:25.095178945Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -18041,7 +18041,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -18050,7 +18050,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -18072,7 +18072,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658828900Z",
+                "ingested": "2021-07-19T09:06:25.095180795Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -18122,7 +18122,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "localhost",
@@ -18131,7 +18131,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -18153,7 +18153,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658829900Z",
+                "ingested": "2021-07-19T09:06:25.095182604Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1306 to outside:100.66.98.44/8310",
                 "code": "305011",
                 "kind": "event",
@@ -18201,7 +18201,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -18210,7 +18210,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -18232,7 +18232,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:23.658830900Z",
+                "ingested": "2021-07-19T09:06:25.095184438Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11844 for outside:100.66.124.24/80 (100.66.124.24/80) to inside:172.31.98.44/1306 (172.31.98.44/1306)",
                 "code": "302013",
                 "kind": "event",
@@ -18284,7 +18284,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -18293,7 +18293,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -18315,7 +18315,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658831900Z",
+                "ingested": "2021-07-19T09:06:25.095186260Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -18365,7 +18365,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -18374,7 +18374,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -18396,7 +18396,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658832800Z",
+                "ingested": "2021-07-19T09:06:25.095188184Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -18446,7 +18446,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -18455,7 +18455,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -18477,7 +18477,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658833800Z",
+                "ingested": "2021-07-19T09:06:25.095190150Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -18527,7 +18527,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -18536,7 +18536,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -18558,7 +18558,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658834800Z",
+                "ingested": "2021-07-19T09:06:25.095191962Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -18608,7 +18608,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -18617,7 +18617,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -18639,7 +18639,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658835800Z",
+                "ingested": "2021-07-19T09:06:25.095193803Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -18689,7 +18689,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -18698,7 +18698,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -18720,7 +18720,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658836800Z",
+                "ingested": "2021-07-19T09:06:25.095195616Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -18770,7 +18770,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -18779,7 +18779,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -18801,7 +18801,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658837800Z",
+                "ingested": "2021-07-19T09:06:25.095197461Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -18851,7 +18851,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -18860,7 +18860,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -18882,7 +18882,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658838800Z",
+                "ingested": "2021-07-19T09:06:25.095199866Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -18932,7 +18932,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -18941,7 +18941,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -18963,7 +18963,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658839800Z",
+                "ingested": "2021-07-19T09:06:25.095201688Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19013,7 +19013,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19022,7 +19022,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -19044,7 +19044,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658840800Z",
+                "ingested": "2021-07-19T09:06:25.095203516Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19094,7 +19094,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19103,7 +19103,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -19125,7 +19125,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658841800Z",
+                "ingested": "2021-07-19T09:06:25.095205687Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19175,7 +19175,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19184,7 +19184,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -19206,7 +19206,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658842800Z",
+                "ingested": "2021-07-19T09:06:25.095207685Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19256,7 +19256,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19265,7 +19265,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -19287,7 +19287,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658843800Z",
+                "ingested": "2021-07-19T09:06:25.095209522Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19337,7 +19337,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19346,7 +19346,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -19368,7 +19368,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658844800Z",
+                "ingested": "2021-07-19T09:06:25.095211339Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19418,7 +19418,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19427,7 +19427,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -19449,7 +19449,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658845800Z",
+                "ingested": "2021-07-19T09:06:25.095213154Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19499,7 +19499,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19508,7 +19508,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -19530,7 +19530,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658846800Z",
+                "ingested": "2021-07-19T09:06:25.095214956Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19580,7 +19580,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19589,7 +19589,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -19611,7 +19611,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658847800Z",
+                "ingested": "2021-07-19T09:06:25.095216800Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19661,7 +19661,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19670,7 +19670,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -19692,7 +19692,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658861900Z",
+                "ingested": "2021-07-19T09:06:25.095218795Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19742,7 +19742,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19751,7 +19751,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -19773,7 +19773,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658863200Z",
+                "ingested": "2021-07-19T09:06:25.095220690Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19823,7 +19823,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19832,7 +19832,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -19854,7 +19854,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658864400Z",
+                "ingested": "2021-07-19T09:06:25.095222507Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19904,7 +19904,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19913,7 +19913,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -19935,7 +19935,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658865400Z",
+                "ingested": "2021-07-19T09:06:25.095224316Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -19985,7 +19985,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -19994,7 +19994,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -20016,7 +20016,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658866400Z",
+                "ingested": "2021-07-19T09:06:25.095226133Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -20066,7 +20066,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -20075,7 +20075,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -20097,7 +20097,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658867800Z",
+                "ingested": "2021-07-19T09:06:25.095227944Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -20147,7 +20147,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -20156,7 +20156,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -20178,7 +20178,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658868700Z",
+                "ingested": "2021-07-19T09:06:25.095229910Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -20228,7 +20228,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -20237,7 +20237,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -20259,7 +20259,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658869800Z",
+                "ingested": "2021-07-19T09:06:25.095231714Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -20309,7 +20309,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -20318,7 +20318,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -20340,7 +20340,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658870800Z",
+                "ingested": "2021-07-19T09:06:25.095233535Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -20390,7 +20390,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -20399,7 +20399,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -20421,7 +20421,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658871800Z",
+                "ingested": "2021-07-19T09:06:25.095235326Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -20471,7 +20471,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -20480,7 +20480,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -20502,7 +20502,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658872800Z",
+                "ingested": "2021-07-19T09:06:25.095237123Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -20552,7 +20552,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -20561,7 +20561,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -20583,7 +20583,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658873800Z",
+                "ingested": "2021-07-19T09:06:25.095239018Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -20633,7 +20633,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -20642,7 +20642,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -20664,7 +20664,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658874800Z",
+                "ingested": "2021-07-19T09:06:25.095240855Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -20714,7 +20714,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -20723,7 +20723,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -20745,7 +20745,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658875800Z",
+                "ingested": "2021-07-19T09:06:25.095242666Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -20795,7 +20795,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -20804,7 +20804,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -20826,7 +20826,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658878200Z",
+                "ingested": "2021-07-19T09:06:25.095244498Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -20876,7 +20876,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "localhost",
@@ -20885,7 +20885,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -20907,7 +20907,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:23.658879200Z",
+                "ingested": "2021-07-19T09:06:25.095246300Z",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-106023: Deny tcp src outside:100.66.124.24/80 dst inside:172.31.98.44/8309 by access-group \"inbound\" [0x0, 0x0]",
                 "code": "106023",
                 "kind": "event",

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-dns.log-expected.json
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-dns.log-expected.json
@@ -52,7 +52,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "siem-ftd",
@@ -61,7 +61,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -87,7 +87,7 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:31.564034900Z",
+                "ingested": "2021-07-19T09:06:44.351787667Z",
                 "original": "2019-08-26T23:11:03Z siem-ftd  %FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 57379, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 145, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSRecordType: a host address, DNS_TTL: 70",
                 "code": "430003",
                 "kind": "event",
@@ -198,7 +198,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "siem-ftd",
@@ -207,7 +207,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -233,7 +233,7 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:31.564039800Z",
+                "ingested": "2021-07-19T09:06:44.351793065Z",
                 "original": "2019-08-26T23:11:03Z siem-ftd  %FTD-1-430003: AccessControlRuleAction: Allow, AccessControlRuleReason: Intrusion Monitor, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 51389, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, IPSCount: 1, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 193, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSRecordType: IP6 Address, DNS_TTL: 299",
                 "code": "430003",
                 "kind": "event",
@@ -346,7 +346,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "siem-ftd",
@@ -355,7 +355,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -381,7 +381,7 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:31.564042600Z",
+                "ingested": "2021-07-19T09:06:44.351795230Z",
                 "original": "2019-08-26T23:11:03Z siem-ftd  %FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 53033, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 166, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSRecordType: the canonical name for an alias, DNS_TTL: 899",
                 "code": "430003",
                 "kind": "event",
@@ -492,7 +492,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "siem-ftd",
@@ -501,7 +501,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -527,7 +527,7 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:31.564043600Z",
+                "ingested": "2021-07-19T09:06:44.351797116Z",
                 "original": "2019-08-26T23:11:03Z siem-ftd  %FTD-1-430003: AccessControlRuleAction: Allow, AccessControlRuleReason: Intrusion Monitor, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 55371, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, IPSCount: 1, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 97, ResponderBytes: 200, NAPPolicy: Balanced Security and Connectivity, DNSQuery: www.elastic.co, DNSRecordType: a host address, DNS_TTL: 12",
                 "code": "430003",
                 "kind": "event",
@@ -640,7 +640,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "siem-ftd",
@@ -649,7 +649,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -675,7 +675,7 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:31.564044600Z",
+                "ingested": "2021-07-19T09:06:44.351798952Z",
                 "original": "2019-08-26T23:11:03Z siem-ftd  %FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 60441, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 193, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSRecordType: IP6 Address, DNS_TTL: 299, DNSResponseType: No error",
                 "code": "430003",
                 "kind": "event",
@@ -787,7 +787,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "siem-ftd",
@@ -796,7 +796,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -822,7 +822,7 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:31.564045600Z",
+                "ingested": "2021-07-19T09:06:44.351800777Z",
                 "original": "2019-08-26T23:11:03Z siem-ftd  %FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 59714, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 166, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSRecordType: the canonical name for an alias, DNS_TTL: 658",
                 "code": "430003",
                 "kind": "event",
@@ -933,7 +933,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "siem-ftd",
@@ -942,7 +942,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -968,7 +968,7 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:31.564046500Z",
+                "ingested": "2021-07-19T09:06:44.351802641Z",
                 "original": "2019-08-26T23:11:03Z siem-ftd  %FTD-1-430003: AccessControlRuleAction: Allow, AccessControlRuleReason: Intrusion Monitor, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 55105, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, IPSCount: 1, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 199, NAPPolicy: Balanced Security and Connectivity, DNSResponseType: Non-Existent Domain, DNSQuery: elastic.co, DNSRecordType: mail exchange, DNS_TTL: 299",
                 "code": "430003",
                 "kind": "event",
@@ -1082,7 +1082,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "siem-ftd",
@@ -1091,7 +1091,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1117,7 +1117,7 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:31.564047500Z",
+                "ingested": "2021-07-19T09:06:44.351804509Z",
                 "original": "2019-08-26T23:11:03Z siem-ftd  %FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 57141, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 221, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSRecordType: an authoritative name server, DNS_TTL: 21599",
                 "code": "430003",
                 "kind": "event",
@@ -1228,7 +1228,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "siem-ftd",
@@ -1237,7 +1237,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1263,7 +1263,7 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:31.564048500Z",
+                "ingested": "2021-07-19T09:06:44.351806300Z",
                 "original": "2019-08-26T23:11:03Z siem-ftd  %FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 47260, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 166, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSResponseType: Server Failure, DNSRecordType: marks the start of a zone of authority, DNS_TTL: 899",
                 "code": "430003",
                 "kind": "event",
@@ -1375,7 +1375,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "siem-ftd",
@@ -1384,7 +1384,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1410,7 +1410,7 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:31.564049400Z",
+                "ingested": "2021-07-19T09:06:44.351808085Z",
                 "original": "2019-08-26T23:11:03Z siem-ftd  %FTD-1-430003: AccessControlRuleAction: Allow, AccessControlRuleReason: Intrusion Monitor, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 58082, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, IPSCount: 1, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 722, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSRecordType: text strings, DNS_TTL: 299",
                 "code": "430003",
                 "kind": "event",
@@ -1526,7 +1526,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "siem-ftd",
@@ -1535,7 +1535,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1561,7 +1561,7 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:31.564050500Z",
+                "ingested": "2021-07-19T09:06:44.351809886Z",
                 "original": "2019-08-26T23:11:03Z siem-ftd  %FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 205.251.196.144, SrcPort: 33973, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 98, ResponderBytes: 75, NAPPolicy: Balanced Security and Connectivity, DNSQuery: refusedthis.com, DNSRecordType: a host address, DNSResponseType: Query Refused",
                 "code": "430003",
                 "kind": "event",
@@ -1668,7 +1668,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "siem-ftd",
@@ -1677,7 +1677,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1703,7 +1703,7 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:31.564051600Z",
+                "ingested": "2021-07-19T09:06:44.351812056Z",
                 "original": "2019-08-26T23:11:03Z siem-ftd  %FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 39541, DstPort: 53, Protocol: tcp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 6, ResponderPackets: 4, InitiatorBytes: 457, ResponderBytes: 313, NAPPolicy: Balanced Security and Connectivity, DNSResponseType: Server Failure",
                 "code": "430003",
                 "kind": "event",
@@ -1812,7 +1812,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "siem-ftd",
@@ -1821,7 +1821,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1847,7 +1847,7 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:31.564052500Z",
+                "ingested": "2021-07-19T09:06:44.351813895Z",
                 "original": "2019-08-26T23:11:03Z siem-ftd  %FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 9.9.9.9, SrcPort: 41672, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 107, ResponderBytes: 180, NAPPolicy: Balanced Security and Connectivity, DNSQuery: laskdfjlaksdf.elastic.co, DNSRecordType: a host address, DNSResponseType: Non-Existent Domain, DNS_TTL: 900",
                 "code": "430003",
                 "kind": "event",
@@ -1959,7 +1959,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "siem-ftd",
@@ -1968,7 +1968,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1994,7 +1994,7 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:31.564053500Z",
+                "ingested": "2021-07-19T09:06:44.351815726Z",
                 "original": "2019-08-26T23:11:03Z siem-ftd  %FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 9.9.9.9, SrcPort: 59577, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 104, ResponderBytes: 108, NAPPolicy: Balanced Security and Connectivity, DNSQuery: ns-1168.awsdns-18.org, DNSRecordType: a host address, DNS_TTL: 31694",
                 "code": "430003",
                 "kind": "event",
@@ -2105,7 +2105,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "siem-ftd",
@@ -2114,7 +2114,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2140,7 +2140,7 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:31.564054500Z",
+                "ingested": "2021-07-19T09:06:44.351817513Z",
                 "original": "2019-08-26T23:11:03Z siem-ftd  %FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 9.9.9.9, SrcPort: 35998, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 101, ResponderBytes: 162, NAPPolicy: Balanced Security and Connectivity, DNSQuery: _http._tcp.security.ubuntu.com, DNSRecordType: Server Selection, DNSResponseType: Non-Existent Domain, DNS_TTL: 946",
                 "code": "430003",
                 "kind": "event",
@@ -2252,7 +2252,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "siem-ftd",
@@ -2261,7 +2261,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2287,7 +2287,7 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:31.564055400Z",
+                "ingested": "2021-07-19T09:06:44.351819338Z",
                 "original": "2019-08-26T23:11:03Z siem-ftd  %FTD-1-430003: AccessControlRuleAction: Allow, AccessControlRuleReason: Intrusion Monitor, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 55105, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, IPSCount: 1, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 199, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSRecordType: mail exchange, DNS_TTL: 299",
                 "code": "430003",
                 "kind": "event",
@@ -2400,7 +2400,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "siem-ftd",
@@ -2409,7 +2409,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2435,7 +2435,7 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:31.564056500Z",
+                "ingested": "2021-07-19T09:06:44.351821378Z",
                 "original": "2019-08-26T23:11:03Z siem-ftd  %FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 47260, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 166, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSRecordType: marks the start of a zone of authority, DNS_TTL: 899",
                 "code": "430003",
                 "kind": "event",
@@ -2546,7 +2546,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "siem-ftd",
@@ -2555,7 +2555,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2581,7 +2581,7 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:31.564057500Z",
+                "ingested": "2021-07-19T09:06:44.351823157Z",
                 "original": "2019-08-26T23:11:03Z siem-ftd  %FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 53033, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 166, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSRecordType: the canonical name for an alias, DNS_TTL: 899",
                 "code": "430003",
                 "kind": "event",
@@ -2692,7 +2692,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "siem-ftd",
@@ -2701,7 +2701,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2727,7 +2727,7 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:31.564058400Z",
+                "ingested": "2021-07-19T09:06:44.351824930Z",
                 "original": "2019-08-26T23:11:03Z siem-ftd  %FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 57141, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 221, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSRecordType: an authoritative name server, DNS_TTL: 21599",
                 "code": "430003",
                 "kind": "event",
@@ -2837,7 +2837,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "siem-ftd",
@@ -2846,7 +2846,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2872,7 +2872,7 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:31.564059400Z",
+                "ingested": "2021-07-19T09:06:44.351826720Z",
                 "original": "2019-08-26T23:11:03Z siem-ftd  %FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 46093, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 131, NAPPolicy: Balanced Security and Connectivity, DNSRecordType: a domain name pointer, DNS_TTL: 59",
                 "code": "430003",
                 "kind": "event",
@@ -2982,7 +2982,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "siem-ftd",
@@ -2991,7 +2991,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -3017,7 +3017,7 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:31.564060400Z",
+                "ingested": "2021-07-19T09:06:44.351828609Z",
                 "original": "2019-08-26T23:11:03Z siem-ftd  %FTD-1-430003: AccessControlRuleAction: Allow, AccessControlRuleReason: Intrusion Monitor, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 58082, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, IPSCount: 1, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 93, ResponderBytes: 722, NAPPolicy: Balanced Security and Connectivity, DNSQuery: elastic.co, DNSRecordType: text strings, DNS_TTL: 299",
                 "code": "430003",
                 "kind": "event",

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-filtered.log-expected.json
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-filtered.log-expected.json
@@ -31,7 +31,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.562561400Z",
+                "ingested": "2021-07-19T09:06:46.767202337Z",
                 "original": "Jan  1 2019 01:00:27 beats asa[1234]: %FTD-7-999999: This message is not filtered.",
                 "code": "999999",
                 "kind": "event",
@@ -72,7 +72,7 @@
             },
             "event": {
                 "severity": 8,
-                "ingested": "2021-06-09T10:11:32.562566600Z",
+                "ingested": "2021-07-19T09:06:46.767208026Z",
                 "original": "Jan  1 2019 01:00:30 beats asa[1234]: %FTD-8-999999: This phony message is dropped due to log level.",
                 "code": "999999",
                 "kind": "event",

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-firepower-management.log-expected.json
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-firepower-management.log-expected.json
@@ -29,7 +29,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598366800Z",
+                "ingested": "2021-07-19T09:06:46.853583009Z",
                 "original": "\u003c14\u003eAug 14 2019 13:56:30 platformSettingEdit.cgi: siem-management: admin@10.0.255.31, System \u003e Configuration \u003e Configuration \u003e /platinum/platformSettingEdit.cgi?type=AuditLog, Page View\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -66,7 +66,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598371300Z",
+                "ingested": "2021-07-19T09:06:46.853589347Z",
                 "original": "\u003c14\u003eAug 14 2019 13:57:19 platformSettingEdit.cgi: siem-management: admin@10.0.255.31, System \u003e Configuration \u003e Configuration \u003e /platinum/platformSettingEdit.cgi?type=Banner, Page View\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -103,7 +103,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598372500Z",
+                "ingested": "2021-07-19T09:06:46.853591547Z",
                 "original": "\u003c14\u003eAug 14 2019 13:57:26 ChangeReconciliation.cgi: siem-management: admin@10.0.255.31, System \u003e Configuration \u003e Configuration \u003e /platinum/ChangeReconciliation.cgi, Page View\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -140,7 +140,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598373500Z",
+                "ingested": "2021-07-19T09:06:46.853593458Z",
                 "original": "\u003c14\u003eAug 14 2019 13:57:34 platformSettingEdit.cgi: siem-management: admin@10.0.255.31, System \u003e Configuration \u003e Configuration \u003e /platinum/platformSettingEdit.cgi?type=IntrusionPolicyPrefs, Page View\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -177,7 +177,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598374500Z",
+                "ingested": "2021-07-19T09:06:46.853595280Z",
                 "original": "\u003c14\u003eAug 14 2019 13:57:43 lights_out_mgmt.cgi: siem-management: admin@10.0.255.31, System \u003e Configuration \u003e Configuration \u003e /admin/lights_out_mgmt.cgi, Page View\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -214,7 +214,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598375500Z",
+                "ingested": "2021-07-19T09:06:46.853597076Z",
                 "original": "\u003c14\u003eAug 14 2019 13:58:02 mojo_server.pl: siem-management: admin@10.0.255.31, Cloud Services, View url filtering settings\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -251,7 +251,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598376500Z",
+                "ingested": "2021-07-19T09:06:46.853598889Z",
                 "original": "\u003c14\u003eAug 14 2019 13:58:02 mojo_server.pl: siem-management: admin@10.0.255.31, Cloud Services, View amp settings\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -288,7 +288,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598377500Z",
+                "ingested": "2021-07-19T09:06:46.853600685Z",
                 "original": "\u003c14\u003eAug 14 2019 13:58:20 mojo_server.pl: siem-management: admin@10.0.255.31, System \u003e Monitoring \u003e Syslog, Page View\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -325,7 +325,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598379100Z",
+                "ingested": "2021-07-19T09:06:46.853602476Z",
                 "original": "\u003c14\u003eAug 14 2019 13:58:41 mojo_server.pl: siem-management: admin@10.0.255.31, Devices \u003e Device Management, Page View\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -362,7 +362,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598380Z",
+                "ingested": "2021-07-19T09:06:46.853604314Z",
                 "original": "\u003c14\u003eAug 14 2019 13:58:47 sfdccsm: siem-management: admin@10.0.255.31, Devices \u003e Device Management \u003e NGFW Interfaces, Page View\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -399,7 +399,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598381100Z",
+                "ingested": "2021-07-19T09:06:46.853606120Z",
                 "original": "\u003c14\u003eAug 14 2019 13:58:52 mojo_server.pl: siem-management: admin@10.0.255.31, Devices \u003e Device Management \u003e NGFW Device Summary, Page View\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -436,7 +436,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598382200Z",
+                "ingested": "2021-07-19T09:06:46.853608336Z",
                 "original": "\u003c14\u003eAug 14 2019 13:58:54 mojo_server.pl: siem-management: admin@10.0.255.31, Devices \u003e Device Management \u003e NGFW Device Summary, Page View\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -473,7 +473,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598383200Z",
+                "ingested": "2021-07-19T09:06:46.853610246Z",
                 "original": "\u003c14\u003eAug 14 2019 13:59:10 sfdccsm: siem-management: admin@10.0.255.31, Devices \u003e Platform Settings, Page View\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -510,7 +510,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598384200Z",
+                "ingested": "2021-07-19T09:06:46.853612079Z",
                 "original": "\u003c14\u003eAug 14 2019 13:59:15 sfdccsm: siem-management: admin@10.0.255.31, Devices \u003e Platform Settings \u003e Platform Settings Editor, Page View\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -547,7 +547,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598385100Z",
+                "ingested": "2021-07-19T09:06:46.853613918Z",
                 "original": "\u003c14\u003eAug 14 2019 14:00:37 sfdccsm: siem-management: admin@10.0.255.31, Devices \u003e Platform Settings \u003e Platform Settings Editor, Save Policy ftd-policy\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -584,7 +584,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598386100Z",
+                "ingested": "2021-07-19T09:06:46.853615727Z",
                 "original": "\u003c14\u003eAug 14 2019 14:00:37 sfdccsm: siem-management: admin@10.0.255.31, Devices \u003e Platform Settings \u003e Platform Settings Editor, Modified: Syslog\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -621,7 +621,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598387200Z",
+                "ingested": "2021-07-19T09:06:46.853617781Z",
                 "original": "\u003c14\u003eAug 14 2019 14:00:37 sfdccsm: siem-management: admin@10.0.255.31, Devices \u003e Platform Settings \u003e Platform Settings Editor, Page View\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -658,7 +658,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598388200Z",
+                "ingested": "2021-07-19T09:06:46.853619586Z",
                 "original": "\u003c14\u003eAug 14 2019 14:01:12 sfdccsm: siem-management: admin@10.0.255.31, Devices \u003e Platform Settings \u003e Platform Settings Editor, Save Policy ftd-policy\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -695,7 +695,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598389200Z",
+                "ingested": "2021-07-19T09:06:46.853621387Z",
                 "original": "\u003c14\u003eAug 14 2019 14:01:12 sfdccsm: siem-management: admin@10.0.255.31, Devices \u003e Platform Settings \u003e Platform Settings Editor, Modified: Syslog\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -732,7 +732,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598390200Z",
+                "ingested": "2021-07-19T09:06:46.853623212Z",
                 "original": "\u003c14\u003eAug 14 2019 14:01:13 sfdccsm: siem-management: admin@10.0.255.31, Devices \u003e Platform Settings \u003e Platform Settings Editor, Page View\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -769,7 +769,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598391100Z",
+                "ingested": "2021-07-19T09:06:46.853625051Z",
                 "original": "\u003c14\u003eAug 14 2019 14:01:20 sfdccsm: siem-management: csm_processes@Default User IP, Login, Login Success\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -806,7 +806,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598392100Z",
+                "ingested": "2021-07-19T09:06:46.853626919Z",
                 "original": "\u003c14\u003eAug 14 2019 14:01:31 ActionQueueScrape.pl: siem-management: csm_processes@Default User IP, Login, Login Success\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -843,7 +843,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598393100Z",
+                "ingested": "2021-07-19T09:06:46.853628745Z",
                 "original": "\u003c14\u003eAug 14 2019 14:01:31 ActionQueueScrape.pl: siem-management: admin@localhost, Task Queue, Successful task completion : Pre-deploy Global Configuration Generation\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -880,7 +880,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598394100Z",
+                "ingested": "2021-07-19T09:06:46.853630717Z",
                 "original": "\u003c14\u003eAug 14 2019 14:01:35 ActionQueueScrape.pl: siem-management: csm_processes@Default User IP, Login, Login Success\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -917,7 +917,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598395100Z",
+                "ingested": "2021-07-19T09:06:46.853632547Z",
                 "original": "\u003c14\u003eAug 14 2019 14:01:36 ActionQueueScrape.pl: siem-management: admin@localhost, Task Queue, Successful task completion : Pre-deploy Device Configuration for siem-ftd\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -954,7 +954,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598396100Z",
+                "ingested": "2021-07-19T09:06:46.853634351Z",
                 "original": "\u003c14\u003eAug 14 2019 14:01:55 mojo_server.pl: siem-management: admin@10.0.255.31, System \u003e Configuration \u003e Configuration, Page View\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -991,7 +991,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598397100Z",
+                "ingested": "2021-07-19T09:06:46.853636151Z",
                 "original": "\u003c14\u003eAug 14 2019 14:01:56 sfdccsm: siem-management: admin@localhost, Task Queue, Policy Deployment to siem-ftd - SUCCESS\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -1028,7 +1028,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598398Z",
+                "ingested": "2021-07-19T09:06:46.853637993Z",
                 "original": "\u003c14\u003eAug 14 2019 14:01:57 sfdccsm: siem-management: csm_processes@Default User IP, Login, Login Success\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -1065,7 +1065,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598399Z",
+                "ingested": "2021-07-19T09:06:46.853639810Z",
                 "original": "\u003c14\u003eAug 14 2019 14:02:03 mojo_server.pl: siem-management: admin@10.0.255.31, System \u003e Monitoring \u003e Syslog, Page View\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -1102,7 +1102,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598400900Z",
+                "ingested": "2021-07-19T09:06:46.853641619Z",
                 "original": "\u003c14\u003eAug 14 2019 14:02:11 index.cgi: siem-management: admin@10.0.255.31, System \u003e Monitoring \u003e Audit, Page View\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -1139,7 +1139,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598401900Z",
+                "ingested": "2021-07-19T09:06:46.853643431Z",
                 "original": "\u003c14\u003eAug 14 2019 14:02:19 mojo_server.pl: siem-management: admin@10.0.255.31, System \u003e Configuration \u003e Configuration, Page View\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -1176,7 +1176,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598402900Z",
+                "ingested": "2021-07-19T09:06:46.853645258Z",
                 "original": "\u003c14\u003eAug 14 2019 14:02:31 platformSettingEdit.cgi: siem-management: admin@10.0.255.31, System \u003e Configuration \u003e Configuration \u003e /platinum/platformSettingEdit.cgi?type=AuditLog, Page View\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -1213,7 +1213,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598403900Z",
+                "ingested": "2021-07-19T09:06:46.853647100Z",
                 "original": "\u003c14\u003eAug 14 2019 14:02:38 platformSettingEdit.cgi: siem-management: admin@10.0.255.31, Devices \u003e Platform Settings \u003e Local System Configuration, Save Local System Configuration\u0000x0a\u0000x00",
                 "code": ""
             },
@@ -1251,7 +1251,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:32.598404900Z",
+                "ingested": "2021-07-19T09:06:46.853648929Z",
                 "original": "\u003c14.2\u003eAug 14 2019 14:02:38 platformSettingEdit.cgi: siem-management: admin@10.0.255.31, Devices \u003e Platform Settings \u003e Audit Log Settings \u003e  Modified: Send Audit Log to Syslog enabled \u003e Disabled",
                 "code": ""
             },

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-intrusion.log-expected.json
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-intrusion.log-expected.json
@@ -27,7 +27,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "firepower",
@@ -36,7 +36,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -64,7 +64,7 @@
             },
             "event": {
                 "severity": 0,
-                "ingested": "2021-06-09T10:11:33.111979400Z",
+                "ingested": "2021-07-19T09:06:48.155993511Z",
                 "original": "2019-08-16T09:54:00Z firepower  %FTD-0-430001: SrcIP: 10.0.1.20, DstIP: 10.0.100.30, SrcPort: 55644, DstPort: 80, Protocol: tcp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, Priority: 1, GID: 1, SID: 17279, Revision: 12, Message: SERVER-WEBAPP Ipswitch WhatsUp Small Business directory traversal attempt, Classification: Attempted User Privilege Gain, User: No Authentication Required, Client: Firefox, ApplicationProtocol: HTTP, IntrusionPolicy: intrusion-policy, ACPolicy: default, NAPPolicy: Balanced Security and Connectivity",
                 "code": "430001",
                 "kind": "alert",
@@ -141,7 +141,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "firepower",
@@ -150,7 +150,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -178,7 +178,7 @@
             },
             "event": {
                 "severity": 0,
-                "ingested": "2021-06-09T10:11:33.111984800Z",
+                "ingested": "2021-07-19T09:06:48.155999980Z",
                 "original": "2019-08-16T09:57:02Z firepower  %FTD-0-430001: SrcIP: 10.0.1.20, DstIP: 10.0.100.30, SrcPort: 55868, DstPort: 80, Protocol: tcp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, Priority: 1, GID: 1, SID: 17279, Revision: 12, Message: SERVER-WEBAPP Ipswitch WhatsUp Small Business directory traversal attempt, Classification: Attempted User Privilege Gain, User: No Authentication Required, Client: Firefox, ApplicationProtocol: HTTP, IntrusionPolicy: intrusion-policy, ACPolicy: default, NAPPolicy: Balanced Security and Connectivity",
                 "code": "430001",
                 "kind": "alert",
@@ -253,7 +253,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "firepower",
@@ -262,7 +262,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -290,7 +290,7 @@
             },
             "event": {
                 "severity": 0,
-                "ingested": "2021-06-09T10:11:33.111986Z",
+                "ingested": "2021-07-19T09:06:48.156002100Z",
                 "original": "2019-08-16T10:04:44Z firepower  %FTD-0-430001: SrcIP: 10.0.100.30, DstIP: 10.0.1.20, SrcPort: 21, DstPort: 39114, Protocol: tcp, IngressInterface: outside, EgressInterface: inside, IngressZone: output-zone, EgressZone: input-zone, Priority: 3, GID: 1, SID: 13360, Revision: 6, Message: APP-DETECT failed FTP login attempt, Classification: Misc Activity, User: No Authentication Required, IntrusionPolicy: intrusion-policy, ACPolicy: default, NAPPolicy: Balanced Security and Connectivity",
                 "code": "430001",
                 "kind": "alert",
@@ -363,7 +363,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "firepower",
@@ -372,7 +372,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -400,7 +400,7 @@
             },
             "event": {
                 "severity": 0,
-                "ingested": "2021-06-09T10:11:33.111987100Z",
+                "ingested": "2021-07-19T09:06:48.156011291Z",
                 "original": "2019-08-16T10:09:47Z firepower  %FTD-0-430001: SrcIP: 10.0.100.30, DstIP: 10.0.1.20, SrcPort: 21, DstPort: 40740, Protocol: 6, IngressInterface: outside, EgressInterface: inside, IngressZone: output-zone, EgressZone: input-zone, Priority: 3, GID: 1, SID: 13360, Revision: 6, Message: APP-DETECT failed FTP login attempt, Classification: Misc Activity, User: No Authentication Required, IntrusionPolicy: intrusion-policy, ACPolicy: default, NAPPolicy: Balanced Security and Connectivity",
                 "code": "430001",
                 "kind": "alert",

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-no-type-id.log-expected.json
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-no-type-id.log-expected.json
@@ -48,7 +48,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:33.251756500Z",
+                "ingested": "2021-07-19T09:06:48.523888221Z",
                 "original": "Jan 11 2018 01:00:27 beats ftd[1234]: ApplicationProtocol: http, Client: webserver, DstIP: 10.8.12.47, SrcIP: 10.1.123.45, Message: Intrusion attempt",
                 "code": "430001",
                 "kind": "alert",
@@ -109,7 +109,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:33.251762400Z",
+                "ingested": "2021-07-19T09:06:48.523894630Z",
                 "original": "Jan 11 2018 01:00:27 beats ftd[1234]: HTTPResponse: 404, Message: Some message here (1:36330:2).",
                 "code": "430001",
                 "kind": "alert",
@@ -167,7 +167,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-06-09T10:11:33.251763700Z",
+                "ingested": "2021-07-19T09:06:48.523896846Z",
                 "original": "Jan 11 2018 01:00:27 beats ftd[1234]: HTTPResponse: 404, Message: Some message here (1:36330:2), Empty: ,FileCount:, IngressZone:",
                 "code": "430002",
                 "kind": "event",
@@ -243,7 +243,7 @@
             },
             "event": {
                 "severity": 3,
-                "ingested": "2021-06-09T10:11:33.251764700Z",
+                "ingested": "2021-07-19T09:06:48.523898756Z",
                 "original": "Jan 11 2018 01:00:27 beats ftd[1234]: %ASA-3-430005 Message: This one has a type id, HTTPResponse: 404, Message: And two messages, SrcIP: 127.0.0.1, DstIP: 192.168.3.33, SrcPort: 512, DstPort: 64311",
                 "code": "430005",
                 "kind": "alert",

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-not-ip.log-expected.json
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-not-ip.log-expected.json
@@ -29,7 +29,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "OUTSIDE"
+                        "name": "LB-DMZ"
                     }
                 },
                 "product": "asa",
@@ -37,7 +37,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "LB-DMZ"
+                        "name": "OUTSIDE"
                     }
                 }
             },
@@ -55,7 +55,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:33.358167500Z",
+                "ingested": "2021-07-19T09:06:48.766885781Z",
                 "original": "\u003c165\u003eOct 04 2019 15:27:55: %ASA-5-106100: access-list AL-DMZ-LB-IN denied tcp LB-DMZ/WHAT-IS-THIS-A-HOSTNAME-192.0.2.244(27218) -\u003e OUTSIDE/203.0.113.42(53) hit-cnt 1 first hit [0x16847359, 0x00000000]",
                 "code": "106100",
                 "kind": "event",
@@ -120,7 +120,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:33.358172600Z",
+                "ingested": "2021-07-19T09:06:48.766891794Z",
                 "original": "Jan  1 2020 10:42:53 localhost : %ASA-6-302021: Teardown ICMP connection for faddr 172.24.177.29/0 gaddr mydomain.example.net/17233 laddr 192.168.132.46/17233",
                 "code": "302021",
                 "kind": "event",
@@ -170,7 +170,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "wan"
+                        "name": "eth0"
                     }
                 },
                 "hostname": "localhost",
@@ -179,7 +179,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "eth0"
+                        "name": "wan"
                     }
                 }
             },
@@ -202,7 +202,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:33.358173900Z",
+                "ingested": "2021-07-19T09:06:48.766893926Z",
                 "original": "Jan  2 2020 11:33:20 localhost : %ASA-4-338204: Dynamic filter dropped greylisted TCP traffic from eth0:10.10.10.1/1234 (source.example.net/11234) to wan:172.24.177.3/80 (www.example.org/80), destination malicious address resolved from dynamic list: example.org, threat-level: high, category: malware",
                 "code": "338204",
                 "kind": "event",

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-sample.log-expected.json
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-sample.log-expected.json
@@ -24,7 +24,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 },
                 "product": "asa",
@@ -32,7 +32,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 }
             },
@@ -48,7 +48,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:33.451562700Z",
+                "ingested": "2021-07-19T09:06:48.994086451Z",
                 "original": "Apr 15 2013 09:36:50: %FTD-4-106023: Deny tcp src dmz:10.1.2.30/63016 dst outside:192.0.0.8/53 by access-group \"acl_dmz\" [0xe3aab522, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -94,7 +94,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 },
                 "product": "asa",
@@ -102,7 +102,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 }
             },
@@ -118,7 +118,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:33.451568200Z",
+                "ingested": "2021-07-19T09:06:48.994092726Z",
                 "original": "Apr 15 2013 09:36:50: %FTD-4-106023: Deny tcp src dmz:10.1.2.30/63016 dst outside:192.0.0.8/53 type 3, code 0, by access-group \"acl_dmz\" [0xe3aab522, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -164,7 +164,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -172,7 +172,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -188,7 +188,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:33.451569800Z",
+                "ingested": "2021-07-19T09:06:48.994094922Z",
                 "original": "Apr 15 2014 09:34:34 EDT: %FTD-session-5-106100: access-list acl_in permitted tcp inside/10.1.2.16(2241) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -235,7 +235,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "INT-FW01",
@@ -244,7 +244,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -266,7 +266,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:33.451570900Z",
+                "ingested": "2021-07-19T09:06:48.994096834Z",
                 "original": "Apr 24 2013 16:00:28 INT-FW01 : %FTD-6-106100: access-list inside denied udp inside/172.29.2.101(1039) -\u003e outside/192.0.2.10(53) hit-cnt 1 first hit [0xd820e56a, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -312,7 +312,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "INT-FW01",
@@ -321,7 +321,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -343,7 +343,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:33.451571900Z",
+                "ingested": "2021-07-19T09:06:48.994098624Z",
                 "original": "Apr 24 2013 16:00:27 INT-FW01 : %FTD-6-106100: access-list inside permitted udp inside/172.29.2.3(1065) -\u003e outside/192.0.2.57(53) hit-cnt 144 300-second interval [0xe982c7a4, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -413,7 +413,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:33.451573Z",
+                "ingested": "2021-07-19T09:06:48.994100450Z",
                 "original": "Apr 29 2013 12:59:50: %FTD-6-305011: Built dynamic TCP translation from outside:10.123.3.42/4952 to outside:192.0.2.130/12834",
                 "code": "305011",
                 "kind": "event",
@@ -484,7 +484,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:33.451574100Z",
+                "ingested": "2021-07-19T09:06:48.994102296Z",
                 "original": "Apr 29 2013 12:59:50: %FTD-6-302013: Built outbound TCP connection 89743274 for outside:192.0.2.43/443 (192.0.2.43/443) to outside:10.123.3.42/4952 (10.123.3.42/12834)",
                 "code": "302013",
                 "kind": "event",
@@ -556,7 +556,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:33.451575100Z",
+                "ingested": "2021-07-19T09:06:48.994104178Z",
                 "original": "Apr 29 2013 12:59:50: %FTD-6-305011: Built dynamic UDP translation from outside:10.123.1.35/52925 to outside:192.0.2.130/25882",
                 "code": "305011",
                 "kind": "event",
@@ -631,7 +631,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:33.451576100Z",
+                "ingested": "2021-07-19T09:06:48.994106029Z",
                 "original": "Apr 29 2013 12:59:50: %FTD-6-302015: Built outbound UDP connection 89743275 for outside:192.0.2.222/53 (192.0.2.43/53) to outside:10.123.1.35/52925 (10.123.1.35/25882)",
                 "code": "302015",
                 "kind": "event",
@@ -703,7 +703,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:33.451577600Z",
+                "ingested": "2021-07-19T09:06:48.994107813Z",
                 "original": "Apr 29 2013 12:59:50: %FTD-6-305011: Built dynamic TCP translation from outside:10.123.3.42/4953 to outside:192.0.2.130/45392",
                 "code": "305011",
                 "kind": "event",
@@ -776,7 +776,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:33.451578600Z",
+                "ingested": "2021-07-19T09:06:48.994109640Z",
                 "original": "Apr 29 2013 12:59:50: %FTD-6-302013: Built outbound TCP connection 89743276 for outside:192.0.2.1/80 (192.0.2.1/80) to outside:10.123.3.42/4953 (10.123.3.130/45392)",
                 "code": "302013",
                 "kind": "event",
@@ -825,7 +825,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "product": "asa",
@@ -833,7 +833,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -850,7 +850,7 @@
             "event": {
                 "severity": 6,
                 "duration": 5025000000000,
-                "ingested": "2021-06-09T10:11:33.451579800Z",
+                "ingested": "2021-07-19T09:06:48.994111745Z",
                 "original": "Apr 29 2013 12:59:50: %FTD-6-302016: Teardown UDP connection 89743275 for outside:192.0.2.222/53 to inside:10.123.1.35/52925 duration 1:23:45 bytes 140",
                 "code": "302016",
                 "kind": "event",
@@ -898,7 +898,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "product": "asa",
@@ -906,7 +906,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -923,7 +923,7 @@
             "event": {
                 "severity": 6,
                 "duration": 36000000000000,
-                "ingested": "2021-06-09T10:11:33.451580800Z",
+                "ingested": "2021-07-19T09:06:48.994113602Z",
                 "original": "Apr 29 2013 12:59:50: %FTD-6-302016: Teardown UDP connection 666 for outside:192.0.2.222/53 user1 to inside:10.123.1.35/52925 user2 duration 10:00:00 bytes 9999999",
                 "code": "302016",
                 "kind": "event",
@@ -991,7 +991,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:33.451581800Z",
+                "ingested": "2021-07-19T09:06:48.994115397Z",
                 "original": "Jun 04 2011 21:59:52 FJSG2NRFW01 : %FTD-6-302021: Teardown ICMP connection for faddr 172.24.177.29/0 gaddr 192.168.132.46/17233 laddr 192.168.132.46/17233",
                 "code": "302021",
                 "kind": "event",
@@ -1034,7 +1034,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -1042,7 +1042,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1058,7 +1058,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:33.451584900Z",
+                "ingested": "2021-07-19T09:06:48.994117184Z",
                 "original": "Apr 29 2013 12:59:50: %FTD-6-305011: Built dynamic TCP translation from inside:192.168.3.42/4954 to outside:192.0.0.130/10879",
                 "code": "305011",
                 "kind": "event",
@@ -1106,7 +1106,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "product": "asa",
@@ -1114,7 +1114,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -1131,7 +1131,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:33.451586Z",
+                "ingested": "2021-07-19T09:06:48.994119011Z",
                 "original": "Apr 29 2013 12:59:50: %FTD-6-302013: Built outbound TCP connection 89743277 for outside:192.0.0.17/80 (192.0.0.17/80) to inside:192.168.3.42/4954 (10.0.0.130/10879)",
                 "code": "302013",
                 "kind": "event",
@@ -1195,7 +1195,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:33.451587Z",
+                "ingested": "2021-07-19T09:06:48.994120971Z",
                 "original": "Apr 30 2013 09:22:33: %FTD-2-106007: Deny inbound UDP from 192.0.0.66/12981 to 10.1.2.60/53 due to DNS Query",
                 "code": "106007",
                 "kind": "event",
@@ -1237,7 +1237,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -1245,7 +1245,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1261,7 +1261,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:33.451588100Z",
+                "ingested": "2021-07-19T09:06:48.994122823Z",
                 "original": "Apr 30 2013 09:22:38: %FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2006) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -1307,7 +1307,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -1315,7 +1315,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1331,7 +1331,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:33.451589100Z",
+                "ingested": "2021-07-19T09:06:48.994124613Z",
                 "original": "Apr 30 2013 09:22:38: %FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49734) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -1377,7 +1377,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -1385,7 +1385,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1401,7 +1401,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:33.451590100Z",
+                "ingested": "2021-07-19T09:06:48.994126416Z",
                 "original": "Apr 30 2013 09:22:39: %FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49735) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -1447,7 +1447,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -1455,7 +1455,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1471,7 +1471,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:33.451591100Z",
+                "ingested": "2021-07-19T09:06:48.994128200Z",
                 "original": "Apr 30 2013 09:22:39: %FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49736) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -1517,7 +1517,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -1525,7 +1525,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1541,7 +1541,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:33.451592100Z",
+                "ingested": "2021-07-19T09:06:48.994130050Z",
                 "original": "Apr 30 2013 09:22:39: %FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49737) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -1587,7 +1587,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -1595,7 +1595,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1611,7 +1611,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:33.451593300Z",
+                "ingested": "2021-07-19T09:06:48.994131861Z",
                 "original": "Apr 30 2013 09:22:40: %FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49738) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -1657,7 +1657,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -1665,7 +1665,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1681,7 +1681,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:33.451594300Z",
+                "ingested": "2021-07-19T09:06:48.994133818Z",
                 "original": "Apr 30 2013 09:22:41: %FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49746) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -1727,7 +1727,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -1735,7 +1735,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1751,7 +1751,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:33.451595400Z",
+                "ingested": "2021-07-19T09:06:48.994135627Z",
                 "original": "Apr 30 2013 09:22:47: %FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2007) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -1797,7 +1797,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -1805,7 +1805,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "dmz"
                     }
                 }
             },
@@ -1821,7 +1821,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:33.451596400Z",
+                "ingested": "2021-07-19T09:06:48.994137426Z",
                 "original": "Apr 30 2013 09:22:48: %FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.13(43013) -\u003e dmz/192.168.33.31(25) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -1867,7 +1867,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -1875,7 +1875,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1891,7 +1891,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:33.451597400Z",
+                "ingested": "2021-07-19T09:06:48.994139240Z",
                 "original": "Apr 30 2013 09:22:56: %FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2008) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -1936,14 +1936,14 @@
                 "direction": "inbound"
             },
             "observer": {
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "inside"
                     }
-                }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2013-04-30T09:23:02.000Z",
             "ecs": {
@@ -1957,7 +1957,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:33.451598500Z",
+                "ingested": "2021-07-19T09:06:48.994141032Z",
                 "original": "Apr 30 2013 09:23:02: %FTD-2-106006: Deny inbound UDP from 192.0.2.66/137 to 10.1.2.42/137 on interface inside",
                 "code": "106006",
                 "kind": "event",
@@ -2017,7 +2017,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:33.451599500Z",
+                "ingested": "2021-07-19T09:06:48.994142817Z",
                 "original": "Apr 30 2013 09:23:03: %FTD-2-106007: Deny inbound UDP from 192.0.2.66/12981 to 10.1.5.60/53 due to DNS Query",
                 "code": "106007",
                 "kind": "event",
@@ -2059,7 +2059,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -2067,7 +2067,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2083,7 +2083,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:33.451601100Z",
+                "ingested": "2021-07-19T09:06:48.994144637Z",
                 "original": "Apr 30 2013 09:23:06: %FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2009) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -2129,7 +2129,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -2137,7 +2137,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2153,7 +2153,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:33.451602100Z",
+                "ingested": "2021-07-19T09:06:48.994146438Z",
                 "original": "Apr 30 2013 09:23:08: %FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.46(49776) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -2199,7 +2199,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -2207,7 +2207,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2223,7 +2223,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:33.451603100Z",
+                "ingested": "2021-07-19T09:06:48.994148228Z",
                 "original": "Apr 30 2013 09:23:15: %FTD-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2010) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -2269,7 +2269,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -2277,7 +2277,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2293,7 +2293,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:33.451604100Z",
+                "ingested": "2021-07-19T09:06:48.994150022Z",
                 "original": "Apr 30 2013 09:23:24: %FTD-5-106100: access-list acl_in denied tcp inside/10.0.0.16(2011) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -2339,7 +2339,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -2347,7 +2347,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2363,7 +2363,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:33.451605100Z",
+                "ingested": "2021-07-19T09:06:48.994151808Z",
                 "original": "Apr 30 2013 09:23:34: %FTD-5-106100: access-list acl_in denied tcp inside/10.0.0.16(2012) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -2409,7 +2409,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "product": "asa",
@@ -2417,7 +2417,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -2433,7 +2433,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:33.451606100Z",
+                "ingested": "2021-07-19T09:06:48.994153758Z",
                 "original": "Apr 30 2013 09:23:40: %FTD-4-106023: Deny tcp src outside:192.0.2.126/53638 dst inside:10.0.0.132/8111 by access-group \"acl_out\" [0x71761f18, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -2479,7 +2479,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "product": "asa",
@@ -2487,7 +2487,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -2503,7 +2503,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:33.451607800Z",
+                "ingested": "2021-07-19T09:06:48.994157201Z",
                 "original": "Apr 30 2013 09:23:41: %FTD-4-106023: Deny tcp src outside:192.0.2.126/53638 dst inside:10.0.0.132/8111 by access-group \"acl_out\" [0x71761f18, 0x0]",
                 "code": "106023",
                 "kind": "event",
@@ -2549,7 +2549,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -2557,7 +2557,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2573,7 +2573,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:33.451608900Z",
+                "ingested": "2021-07-19T09:06:48.994159038Z",
                 "original": "Apr 30 2013 09:23:43: %FTD-5-106100: access-list acl_in est-allowed tcp inside/10.0.0.46(49840) -\u003e outside/192.0.0.88(40443) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -2619,7 +2619,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -2627,7 +2627,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2643,7 +2643,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:33.451609900Z",
+                "ingested": "2021-07-19T09:06:48.994160875Z",
                 "original": "Apr 30 2013 09:23:43: %FTD-5-106100: access-list acl_in est-allowed tcp inside/10.0.0.16(2013) -\u003e outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -2689,7 +2689,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -2697,7 +2697,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -2713,7 +2713,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:33.451611Z",
+                "ingested": "2021-07-19T09:06:48.994162672Z",
                 "original": "Apr 15 2018 09:34:34 EDT: %FTD-session-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2241) -\u003e outside/192.0.0.99(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]",
                 "code": "106100",
                 "kind": "event",
@@ -2761,7 +2761,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "identity"
+                        "name": "outside"
                     }
                 },
                 "hostname": "127.0.0.1",
@@ -2770,7 +2770,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "identity"
                     }
                 }
             },
@@ -2792,7 +2792,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:33.451612Z",
+                "ingested": "2021-07-19T09:06:48.994164482Z",
                 "original": "Dec 11 2018 08:01:24 127.0.0.1: %FTD-6-302015: Built outbound UDP connection 447235 for outside:192.168.77.12/11180 (192.168.77.12/11180) to identity:10.0.13.13/80 (10.0.13.13/80)",
                 "code": "302015",
                 "kind": "event",
@@ -2840,7 +2840,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 },
                 "hostname": "127.0.0.1",
@@ -2849,7 +2849,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 }
             },
@@ -2871,7 +2871,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:33.451613Z",
+                "ingested": "2021-07-19T09:06:48.994166278Z",
                 "original": "Dec 11 2018 08:01:24 127.0.0.1: %FTD-4-106023: Deny udp src dmz:192.168.1.33/5555 dst outside:192.0.0.12/53 by access-group \"dmz\" [0x123a465e, 0x4c7bf613]",
                 "code": "106023",
                 "kind": "event",
@@ -2917,7 +2917,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 },
                 "hostname": "127.0.0.1",
@@ -2926,7 +2926,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 }
             },
@@ -2948,7 +2948,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:33.451614Z",
+                "ingested": "2021-07-19T09:06:48.994168077Z",
                 "original": "Dec 11 2018 08:01:24 127.0.0.1: %FTD-4-106023: Deny udp src dmz:192.168.1.33/5555 dst outside:192.0.0.12/53 by access-group \"dmz\" [0x123a465e, 0x4c7bf613]",
                 "code": "106023",
                 "kind": "event",
@@ -2995,7 +2995,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 },
                 "hostname": "127.0.0.1",
@@ -3004,7 +3004,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 }
             },
@@ -3026,7 +3026,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:33.451615Z",
+                "ingested": "2021-07-19T09:06:48.994169878Z",
                 "original": "Dec 11 2018 08:01:31 127.0.0.1: %FTD-6-302013: Built outbound TCP connection 447236 for outside:192.0.2.222/1234 (192.0.2.222/1234) to dmz:OCSP_Server/5678 (OCSP_Server/5678)",
                 "code": "302013",
                 "kind": "event",
@@ -3075,7 +3075,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 },
                 "hostname": "127.0.0.1",
@@ -3084,7 +3084,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 }
             },
@@ -3106,7 +3106,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:33.451616Z",
+                "ingested": "2021-07-19T09:06:48.994171698Z",
                 "original": "Dec 11 2018 08:01:31 127.0.0.1: %FTD-6-302013: Built outbound TCP connection 447236 for outside:192.0.2.222/1234 (192.0.2.222/1234) to dmz:OCSP_Server/5678 (OCSP_Server/5678)",
                 "code": "302013",
                 "kind": "event",
@@ -3155,7 +3155,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 },
                 "hostname": "127.0.0.1",
@@ -3164,7 +3164,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 }
             },
@@ -3188,7 +3188,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:33.451617Z",
+                "ingested": "2021-07-19T09:06:48.994173517Z",
                 "original": "Dec 11 2018 08:01:31 127.0.0.1: %FTD-6-302014: Teardown TCP connection 447236 for outside:192.0.2.222/1234 to dmz:192.168.1.34/5678 duration 0:00:00 bytes 14804 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -3236,7 +3236,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 },
                 "hostname": "127.0.0.1",
@@ -3245,7 +3245,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 }
             },
@@ -3269,7 +3269,7 @@
                 "severity": 6,
                 "duration": 68000000000,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:33.451618Z",
+                "ingested": "2021-07-19T09:06:48.994175314Z",
                 "original": "Dec 11 2018 08:01:38 127.0.0.1: %FTD-6-302014: Teardown TCP connection 447234 for outside:192.0.2.222/1234 to dmz:192.168.1.35/5678 duration 0:01:08 bytes 134781 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -3317,7 +3317,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 },
                 "hostname": "127.0.0.1",
@@ -3326,7 +3326,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 }
             },
@@ -3350,7 +3350,7 @@
                 "severity": 6,
                 "duration": 68000000000,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:33.451619Z",
+                "ingested": "2021-07-19T09:06:48.994177134Z",
                 "original": "Dec 11 2018 08:01:38 127.0.0.1: %FTD-6-302014: Teardown TCP connection 447234 for outside:192.0.2.222/1234 to dmz:192.168.1.35/5678 duration 0:01:08 bytes 134781 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -3395,15 +3395,15 @@
                 "transport": "tcp"
             },
             "observer": {
-                "hostname": "127.0.0.1",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "outside"
                     }
-                }
+                },
+                "hostname": "127.0.0.1",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2018-12-11T08:01:38.000Z",
             "ecs": {
@@ -3423,7 +3423,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:33.451620Z",
+                "ingested": "2021-07-19T09:06:48.994178930Z",
                 "original": "Dec 11 2018 08:01:38 127.0.0.1: %FTD-6-106015: Deny TCP (no connection) from 192.0.2.222/1234 to 192.168.1.34/5679 flags RST  on interface outside",
                 "code": "106015",
                 "kind": "event",
@@ -3465,15 +3465,15 @@
                 "transport": "tcp"
             },
             "observer": {
-                "hostname": "127.0.0.1",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "outside"
                     }
-                }
+                },
+                "hostname": "127.0.0.1",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2018-12-11T08:01:38.000Z",
             "ecs": {
@@ -3493,7 +3493,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:33.451621500Z",
+                "ingested": "2021-07-19T09:06:48.994180767Z",
                 "original": "Dec 11 2018 08:01:38 127.0.0.1: %FTD-6-106015: Deny TCP (no connection) from 192.0.2.222/1234 to 192.168.1.34/5679 flags RST  on interface outside",
                 "code": "106015",
                 "kind": "event",
@@ -3537,7 +3537,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 },
                 "hostname": "127.0.0.1",
@@ -3546,7 +3546,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 }
             },
@@ -3568,7 +3568,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:33.451622600Z",
+                "ingested": "2021-07-19T09:06:48.994182571Z",
                 "original": "Dec 11 2018 08:01:39 127.0.0.1: %FTD-4-106023: Deny udp src dmz:192.168.1.34/5679 dst outside:192.0.0.12/5000 by access-group \"dmz\" [0x123a465e, 0x8c20f21]",
                 "code": "106023",
                 "kind": "event",
@@ -3615,7 +3615,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 },
                 "hostname": "127.0.0.1",
@@ -3624,7 +3624,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 }
             },
@@ -3646,7 +3646,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:33.451623600Z",
+                "ingested": "2021-07-19T09:06:48.994184522Z",
                 "original": "Dec 11 2018 08:01:53 127.0.0.1: %FTD-6-302013: Built outbound TCP connection 447237 for outside:192.0.2.222/1234 (192.0.2.222/1234) to dmz:192.168.1.34/65000 (192.168.1.34/65000)",
                 "code": "302013",
                 "kind": "event",
@@ -3695,7 +3695,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 },
                 "hostname": "127.0.0.1",
@@ -3704,7 +3704,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 }
             },
@@ -3726,7 +3726,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-06-09T10:11:33.451624600Z",
+                "ingested": "2021-07-19T09:06:48.994186306Z",
                 "original": "Dec 11 2018 08:01:53 127.0.0.1: %FTD-6-302013: Built outbound TCP connection 447237 for outside:192.0.2.222/1234 (192.0.2.222/1234) to dmz:192.168.1.34/65000 (192.168.1.34/65000)",
                 "code": "302013",
                 "kind": "event",
@@ -3775,7 +3775,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "dmz"
+                        "name": "outside"
                     }
                 },
                 "hostname": "127.0.0.1",
@@ -3784,7 +3784,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "dmz"
                     }
                 }
             },
@@ -3808,7 +3808,7 @@
                 "severity": 6,
                 "duration": 86399000000000,
                 "reason": "TCP FINs",
-                "ingested": "2021-06-09T10:11:33.451625600Z",
+                "ingested": "2021-07-19T09:06:48.994188130Z",
                 "original": "Dec 11 2018 08:01:53 127.0.0.1: %FTD-6-302014: Teardown TCP connection 447237 for outside:192.0.2.222/1234 to dmz:10.10.10.10/1235 duration 23:59:59 bytes 11420 TCP FINs",
                 "code": "302014",
                 "kind": "event",
@@ -3856,7 +3856,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "product": "asa",
@@ -3864,7 +3864,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -3881,7 +3881,7 @@
             "event": {
                 "severity": 6,
                 "duration": 122000000000,
-                "ingested": "2021-06-09T10:11:33.451626600Z",
+                "ingested": "2021-07-19T09:06:48.994189927Z",
                 "original": "Aug 15 2012 23:30:09: %FTD-6-302016: Teardown UDP connection 40 for outside:10.44.4.4/500 to inside:10.44.2.2/500 duration 0:02:02 bytes 1416",
                 "code": "302016",
                 "kind": "event",
@@ -3920,15 +3920,15 @@
                 "preserve_original_event"
             ],
             "observer": {
-                "hostname": "GIFRCHN01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "Mobile_Traffic"
                     }
-                }
+                },
+                "hostname": "GIFRCHN01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2014-09-12T06:50:53.000Z",
             "ecs": {
@@ -3948,7 +3948,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:33.451627600Z",
+                "ingested": "2021-07-19T09:06:48.994191735Z",
                 "original": "Sep 12 2014 06:50:53 GIFRCHN01 : %FTD-2-106016: Deny IP spoof from (0.0.0.0) to 192.88.99.47 on interface Mobile_Traffic",
                 "code": "106016",
                 "kind": "event",
@@ -3984,15 +3984,15 @@
                 "preserve_original_event"
             ],
             "observer": {
-                "hostname": "GIFRCHN01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "Mobile_Traffic"
                     }
-                }
+                },
+                "hostname": "GIFRCHN01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2014-09-12T06:51:01.000Z",
             "ecs": {
@@ -4012,7 +4012,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:33.451628700Z",
+                "ingested": "2021-07-19T09:06:48.994193552Z",
                 "original": "Sep 12 2014 06:51:01 GIFRCHN01 : %FTD-2-106016: Deny IP spoof from (0.0.0.0) to 192.88.99.57 on interface Mobile_Traffic",
                 "code": "106016",
                 "kind": "event",
@@ -4048,15 +4048,15 @@
                 "preserve_original_event"
             ],
             "observer": {
-                "hostname": "GIFRCHN01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "Mobile_Traffic"
                     }
-                }
+                },
+                "hostname": "GIFRCHN01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2014-09-12T06:51:05.000Z",
             "ecs": {
@@ -4076,7 +4076,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:33.451629700Z",
+                "ingested": "2021-07-19T09:06:48.994195355Z",
                 "original": "Sep 12 2014 06:51:05 GIFRCHN01 : %FTD-2-106016: Deny IP spoof from (0.0.0.0) to 192.88.99.47 on interface Mobile_Traffic",
                 "code": "106016",
                 "kind": "event",
@@ -4112,15 +4112,15 @@
                 "preserve_original_event"
             ],
             "observer": {
-                "hostname": "GIFRCHN01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "Mobile_Traffic"
                     }
-                }
+                },
+                "hostname": "GIFRCHN01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2014-09-12T06:51:05.000Z",
             "ecs": {
@@ -4140,7 +4140,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:33.451630700Z",
+                "ingested": "2021-07-19T09:06:48.994197207Z",
                 "original": "Sep 12 2014 06:51:05 GIFRCHN01 : %FTD-2-106016: Deny IP spoof from (0.0.0.0) to 192.88.99.47 on interface Mobile_Traffic",
                 "code": "106016",
                 "kind": "event",
@@ -4176,15 +4176,15 @@
                 "preserve_original_event"
             ],
             "observer": {
-                "hostname": "GIFRCHN01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "Mobile_Traffic"
                     }
-                }
+                },
+                "hostname": "GIFRCHN01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2014-09-12T06:51:06.000Z",
             "ecs": {
@@ -4204,7 +4204,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:33.451631700Z",
+                "ingested": "2021-07-19T09:06:48.994199043Z",
                 "original": "Sep 12 2014 06:51:06 GIFRCHN01 : %FTD-2-106016: Deny IP spoof from (0.0.0.0) to 192.88.99.57 on interface Mobile_Traffic",
                 "code": "106016",
                 "kind": "event",
@@ -4240,15 +4240,15 @@
                 "preserve_original_event"
             ],
             "observer": {
-                "hostname": "GIFRCHN01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "Mobile_Traffic"
                     }
-                }
+                },
+                "hostname": "GIFRCHN01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2014-09-12T06:51:17.000Z",
             "ecs": {
@@ -4268,7 +4268,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:33.451632800Z",
+                "ingested": "2021-07-19T09:06:48.994200842Z",
                 "original": "Sep 12 2014 06:51:17 GIFRCHN01 : %FTD-2-106016: Deny IP spoof from (0.0.0.0) to 192.88.99.57 on interface Mobile_Traffic",
                 "code": "106016",
                 "kind": "event",
@@ -4304,15 +4304,15 @@
                 "preserve_original_event"
             ],
             "observer": {
-                "hostname": "GIFRCHN01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "Mobile_Traffic"
                     }
-                }
+                },
+                "hostname": "GIFRCHN01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2014-09-12T06:52:48.000Z",
             "ecs": {
@@ -4332,7 +4332,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:33.451633700Z",
+                "ingested": "2021-07-19T09:06:48.994202637Z",
                 "original": "Sep 12 2014 06:52:48 GIFRCHN01 : %FTD-2-106016: Deny IP spoof from (0.0.0.0) to 192.168.1.255 on interface Mobile_Traffic",
                 "code": "106016",
                 "kind": "event",
@@ -4368,15 +4368,15 @@
                 "preserve_original_event"
             ],
             "observer": {
-                "hostname": "GIFRCHN01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "Mobile_Traffic"
                     }
-                }
+                },
+                "hostname": "GIFRCHN01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2014-09-12T06:53:00.000Z",
             "ecs": {
@@ -4396,7 +4396,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-06-09T10:11:33.451634800Z",
+                "ingested": "2021-07-19T09:06:48.994204439Z",
                 "original": "Sep 12 2014 06:53:00 GIFRCHN01 : %FTD-2-106016: Deny IP spoof from (0.0.0.0) to 192.168.1.255 on interface Mobile_Traffic",
                 "code": "106016",
                 "kind": "event",
@@ -4440,7 +4440,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 },
                 "hostname": "GIFRCHN01",
@@ -4449,7 +4449,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 }
             },
@@ -4471,7 +4471,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:33.451635800Z",
+                "ingested": "2021-07-19T09:06:48.994206215Z",
                 "original": "Sep 12 2014 06:53:01 GIFRCHN01 : %FTD-4-106023: Deny tcp src outside:192.0.2.95/24069 dst inside:10.32.112.125/25 by access-group \"PERMIT_IN\" [0x0, 0x0]\"",
                 "code": "106023",
                 "kind": "event",
@@ -4509,15 +4509,15 @@
                 "transport": "icmp"
             },
             "observer": {
-                "hostname": "GIFRCHN01",
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "Outside"
                     }
-                }
+                },
+                "hostname": "GIFRCHN01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2014-09-12T06:53:02.000Z",
             "ecs": {
@@ -4536,7 +4536,7 @@
             },
             "event": {
                 "severity": 3,
-                "ingested": "2021-06-09T10:11:33.451636800Z",
+                "ingested": "2021-07-19T09:06:48.994208006Z",
                 "original": "Sep 12 2014 06:53:02 GIFRCHN01 : %FTD-3-313001: Denied ICMP type=3, code=3 from 10.2.3.5 on interface Outside",
                 "code": "313001",
                 "kind": "event",
@@ -4578,14 +4578,14 @@
                 "transport": "icmp"
             },
             "observer": {
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "inside"
                     }
-                }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2015-01-14T13:16:13.000Z",
             "ecs": {
@@ -4599,7 +4599,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:33.451637800Z",
+                "ingested": "2021-07-19T09:06:48.994209824Z",
                 "original": "Jan 14 2015 13:16:13: %FTD-4-313004: Denied ICMP type=0, from laddr 172.16.30.2 on interface inside to 172.16.1.10: no matching session",
                 "code": "313004",
                 "kind": "event",
@@ -4652,7 +4652,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -4660,7 +4660,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -4680,7 +4680,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:33.451638800Z",
+                "ingested": "2021-07-19T09:06:48.994211693Z",
                 "original": "Jan 14 2015 13:16:14: %FTD-4-338002: Dynamic Filter permitted black listed TCP traffic from inside:10.1.1.45/6798 (192.88.99.1/7890) to outside:192.88.99.129/80 (192.88.99.129/80), destination 192.88.99.129 resolved from dynamic list: bad.example.com",
                 "code": "338002",
                 "kind": "event",
@@ -4736,7 +4736,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outsidet"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -4744,7 +4744,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outsidet"
                     }
                 }
             },
@@ -4762,7 +4762,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:33.451640100Z",
+                "ingested": "2021-07-19T09:06:48.994213531Z",
                 "original": "Jan 14 2015 13:16:14: %FTD-4-338004: Dynamic Filter monitored blacklisted TCP traffic from inside:10.1.1.1/33340 (10.2.1.1/33340) to outsidet:192.0.2.223/80 (192.0.2.225/80), destination 192.0.2.223 resolved from dynamic list: 192.0.2.223/255.255.255.255, threat-level: very-high, category: Malware",
                 "code": "338004",
                 "kind": "event",
@@ -4819,7 +4819,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outsidet"
+                        "name": "inside"
                     }
                 },
                 "product": "asa",
@@ -4827,7 +4827,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outsidet"
                     }
                 }
             },
@@ -4844,7 +4844,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-06-09T10:11:33.451641100Z",
+                "ingested": "2021-07-19T09:06:48.994215355Z",
                 "original": "Jan 14 2015 13:16:14: %FTD-4-338008: Dynamic Filter dropped blacklisted TCP traffic from inside:10.1.1.1/33340 (10.2.1.1/33340) to outsidet:192.0.2.223/80 (192.0.2.223/8080), destination 192.0.2.223 resolved from dynamic list: 192.0.2.223/255.255.255.255, threat-level: very-high, category: Malware",
                 "code": "338008",
                 "kind": "event",
@@ -4908,7 +4908,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:33.451642100Z",
+                "ingested": "2021-07-19T09:06:48.994217158Z",
                 "original": "Nov 16 2009 14:12:35: %FTD-5-304001: 10.30.30.30 Accessed URL 192.0.2.1:/app",
                 "code": "304001",
                 "kind": "event",
@@ -4964,7 +4964,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:33.451643100Z",
+                "ingested": "2021-07-19T09:06:48.994218952Z",
                 "original": "Nov 16 2009 14:12:36: %FTD-5-304001: 10.5.111.32 Accessed URL 192.0.2.32:http://example.com",
                 "code": "304001",
                 "kind": "event",
@@ -5005,14 +5005,14 @@
                 "preserve_original_event"
             ],
             "observer": {
-                "product": "asa",
-                "type": "firewall",
-                "vendor": "Cisco",
-                "egress": {
+                "ingress": {
                     "interface": {
                         "name": "inside"
                     }
-                }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "@timestamp": "2009-11-16T14:12:37.000Z",
             "ecs": {
@@ -5026,7 +5026,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-06-09T10:11:33.451644100Z",
+                "ingested": "2021-07-19T09:06:48.994220795Z",
                 "original": "Nov 16 2009 14:12:37: %FTD-5-304002: Access denied URL http://www.example.net/images/favicon.ico SRC 10.69.6.39 DEST 192.0.0.19 on interface inside",
                 "code": "304002",
                 "kind": "event",

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-security-connection.log-expected.json
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-security-connection.log-expected.json
@@ -28,7 +28,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "input"
+                        "name": "output"
                     }
                 },
                 "hostname": "firepower",
@@ -37,7 +37,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "output"
+                        "name": "input"
                     }
                 }
             },
@@ -62,7 +62,7 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-06-09T10:11:35.406287500Z",
+                "ingested": "2021-07-19T09:06:53.873358281Z",
                 "original": "2019-08-15T16:03:31Z firepower  %FTD-1-430002: AccessControlRuleAction: Allow, SrcIP: 10.0.100.30, DstIP: 10.0.1.20, ICMPType: Echo Request, ICMPCode: No Code, Protocol: icmp, IngressInterface: output, EgressInterface: input, IngressZone: output-zone, EgressZone: input-zone, ACPolicy: default, AccessControlRuleName: Rule-1, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: ICMP client, ApplicationProtocol: ICMP, InitiatorPackets: 1, ResponderPackets: 0, InitiatorBytes: 98, ResponderBytes: 0, NAPPolicy: Balanced Security and Connectivity",
                 "code": "430002",
                 "kind": "event",
@@ -143,7 +143,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "input"
+                        "name": "output"
                     }
                 },
                 "hostname": "firepower",
@@ -152,7 +152,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "output"
+                        "name": "input"
                     }
                 }
             },
@@ -178,7 +178,7 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:35.406294600Z",
+                "ingested": "2021-07-19T09:06:53.873363825Z",
                 "original": "2019-08-15T16:05:33Z firepower  %FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.100.30, DstIP: 10.0.1.20, ICMPType: Echo Request, ICMPCode: No Code, Protocol: icmp, IngressInterface: output, EgressInterface: input, IngressZone: output-zone, EgressZone: input-zone, ACPolicy: default, AccessControlRuleName: Rule-1, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: ICMP client, ApplicationProtocol: ICMP, ConnectionDuration: 0, InitiatorPackets: 1, ResponderPackets: 1, InitiatorBytes: 98, ResponderBytes: 98, NAPPolicy: Balanced Security and Connectivity",
                 "code": "430003",
                 "kind": "event",
@@ -286,7 +286,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "firepower",
@@ -295,7 +295,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -320,7 +320,7 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-06-09T10:11:35.406295900Z",
+                "ingested": "2021-07-19T09:06:53.873366012Z",
                 "original": "2019-08-15T16:05:37Z firepower  %FTD-1-430002: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 50074, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Rule-1, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, InitiatorPackets: 1, ResponderPackets: 0, InitiatorBytes: 106, ResponderBytes: 0, NAPPolicy: Balanced Security and Connectivity, DNSQuery: eu-central-1.ec2.archive.ubuntu.com, DNSRecordType: a host address",
                 "code": "430002",
                 "kind": "event",
@@ -427,7 +427,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "firepower",
@@ -436,7 +436,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -462,7 +462,7 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:35.406297Z",
+                "ingested": "2021-07-19T09:06:53.873443908Z",
                 "original": "2019-08-15T16:07:00Z firepower  %FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 8.8.8.8, SrcPort: 49264, DstPort: 53, Protocol: udp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Rule-1, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, Client: DNS client, ApplicationProtocol: DNS, ConnectionDuration: 0, InitiatorPackets: 2, ResponderPackets: 2, InitiatorBytes: 164, ResponderBytes: 314, NAPPolicy: Balanced Security and Connectivity, DNSQuery: siem-inside, DNSRecordType: a host address, DNSResponseType: Non-Existent Domain, DNS_TTL: 86395",
                 "code": "430003",
                 "kind": "event",
@@ -568,7 +568,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "firepower",
@@ -577,7 +577,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -602,7 +602,7 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-06-09T10:11:35.406298500Z",
+                "ingested": "2021-07-19T09:06:53.873452443Z",
                 "original": "2019-08-15T16:07:18Z firepower  %FTD-1-430002: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 52.59.244.233, SrcPort: 43228, DstPort: 80, Protocol: tcp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Rule-1, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, InitiatorPackets: 2, ResponderPackets: 1, InitiatorBytes: 140, ResponderBytes: 74, NAPPolicy: Balanced Security and Connectivity",
                 "code": "430002",
                 "kind": "event",
@@ -711,7 +711,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "firepower",
@@ -720,7 +720,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -751,7 +751,7 @@
             "event": {
                 "severity": 1,
                 "duration": 1000000000,
-                "ingested": "2021-06-09T10:11:35.406299600Z",
+                "ingested": "2021-07-19T09:06:53.873454944Z",
                 "original": "2019-08-15T16:07:19Z firepower  %FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 52.59.244.233, SrcPort: 43228, DstPort: 80, Protocol: tcp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Rule-1, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, UserAgent: Debian APT-HTTP/1.3 (1.6.11), Client: Advanced Packaging Tool, ClientVersion: 1.3, ApplicationProtocol: HTTP, WebApplication: Ubuntu, ConnectionDuration: 1, InitiatorPackets: 1359, ResponderPackets: 29001, InitiatorBytes: 97454, ResponderBytes: 41319018, NAPPolicy: Balanced Security and Connectivity, HTTPResponse: 200, ReferencedHost: eu-central-1.ec2.archive.ubuntu.com, URL: http://eu-central-1.ec2.archive.ubuntu.com/ubuntu/pool/main/m/manpages/manpages-dev_4.15-1_all.deb",
                 "code": "430003",
                 "kind": "event",
@@ -862,7 +862,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "firepower",
@@ -871,7 +871,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -896,7 +896,7 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-06-09T10:11:35.406300600Z",
+                "ingested": "2021-07-19T09:06:53.873457118Z",
                 "original": "2019-08-16T09:33:15Z firepower  %FTD-1-430002: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 213.211.198.62, SrcPort: 46000, DstPort: 80, Protocol: tcp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Rule-1, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, InitiatorPackets: 2, ResponderPackets: 1, InitiatorBytes: 140, ResponderBytes: 74, NAPPolicy: Balanced Security and Connectivity",
                 "code": "430002",
                 "kind": "event",
@@ -1002,7 +1002,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "outside"
+                        "name": "inside"
                     }
                 },
                 "hostname": "firepower",
@@ -1011,7 +1011,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "inside"
+                        "name": "outside"
                     }
                 }
             },
@@ -1042,7 +1042,7 @@
             "event": {
                 "severity": 1,
                 "duration": 0,
-                "ingested": "2021-06-09T10:11:35.406301800Z",
+                "ingested": "2021-07-19T09:06:53.873459202Z",
                 "original": "2019-08-16T09:33:15Z firepower  %FTD-1-430003: AccessControlRuleAction: Allow, SrcIP: 10.0.1.20, DstIP: 213.211.198.62, SrcPort: 46000, DstPort: 80, Protocol: tcp, IngressInterface: inside, EgressInterface: outside, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Rule-1, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, UserAgent: curl/7.58.0, Client: cURL, ClientVersion: 7.58.0, ApplicationProtocol: HTTP, ConnectionDuration: 0, InitiatorPackets: 6, ResponderPackets: 4, InitiatorBytes: 503, ResponderBytes: 690, NAPPolicy: Balanced Security and Connectivity, HTTPResponse: 200, ReferencedHost: www.eicar.org, URL: http://www.eicar.org/download/eicar_com.zip",
                 "code": "430003",
                 "kind": "event",
@@ -1132,7 +1132,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "input"
+                        "name": "output"
                     }
                 },
                 "hostname": "firepower",
@@ -1141,7 +1141,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "output"
+                        "name": "input"
                     }
                 }
             },
@@ -1166,7 +1166,7 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-06-09T10:11:35.406302700Z",
+                "ingested": "2021-07-19T09:06:53.873461054Z",
                 "original": "2019-08-16T09:35:15Z firepower  %FTD-1-430002: AccessControlRuleAction: Block, SrcIP: 10.0.100.30, DstIP: 10.0.1.20, ICMPType: Echo Request, ICMPCode: No Code, Protocol: icmp, IngressInterface: output, EgressInterface: input, IngressZone: output-zone, EgressZone: input-zone, ACPolicy: default, AccessControlRuleName: Block-inbound-ICMP, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, InitiatorPackets: 0, ResponderPackets: 0, InitiatorBytes: 0, ResponderBytes: 0, NAPPolicy: Balanced Security and Connectivity",
                 "code": "430002",
                 "kind": "event",
@@ -1258,7 +1258,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "output"
+                        "name": "input"
                     }
                 },
                 "hostname": "siem-ftd",
@@ -1267,7 +1267,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "input"
+                        "name": "output"
                     }
                 }
             },
@@ -1298,7 +1298,7 @@
             "event": {
                 "severity": 1,
                 "duration": 1000000000,
-                "ingested": "2021-06-09T10:11:35.406303700Z",
+                "ingested": "2021-07-19T09:06:53.873467586Z",
                 "original": "Aug 14 2019 15:09:41 siem-ftd  %FTD-1-430003: AccessControlRuleAction: Block, AccessControlRuleReason: File Block, SrcIP: 10.0.1.20, DstIP: 10.0.100.30, SrcPort: 41544, DstPort: 8000, Protocol: tcp, IngressInterface: input, EgressInterface: output, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, UserAgent: curl/7.58.0, Client: cURL, ClientVersion: 7.58.0, ApplicationProtocol: HTTP, ConnectionDuration: 1, FileCount: 1, InitiatorPackets: 4, ResponderPackets: 7, InitiatorBytes: 365, ResponderBytes: 1927, NAPPolicy: Balanced Security and Connectivity, HTTPResponse: 200, ReferencedHost: 10.0.100.30:8000, URL: http://10.0.100.30:8000/eicar_com.zip",
                 "code": "430003",
                 "kind": "event",

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-security-file-malware.log-expected.json
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-security-file-malware.log-expected.json
@@ -61,7 +61,7 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-06-09T10:11:35.839807700Z",
+                "ingested": "2021-07-19T09:06:54.935852844Z",
                 "original": "Aug 14 2019 14:54:25 siem-ftd  %FTD-1-430004: SrcIP: 10.0.1.20, DstIP: 10.0.100.30, SrcPort: 41522, DstPort: 8000, Protocol: tcp, FileDirection: Download, FileAction: Detect, FileName: exploit.exe, FileType: ELF, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-14T14:54:24Z, FilePolicy: malware-and-file-policy, FileSandboxStatus: File Size Is Too Small, URI: http://10.0.100.30:8000/exploit.exe",
                 "code": "430004",
                 "kind": "alert",
@@ -163,7 +163,7 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-06-09T10:11:35.839813100Z",
+                "ingested": "2021-07-19T09:06:54.935865544Z",
                 "original": "Aug 14 2019 14:55:02 siem-ftd  %FTD-1-430004: SrcIP: 10.0.1.20, DstIP: 10.0.100.30, SrcPort: 41526, DstPort: 8000, Protocol: tcp, FileDirection: Download, FileAction: Detect, FileName: exploit.exe, FileType: ELF, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-14T14:55:01Z, FilePolicy: malware-and-file-policy, FileSandboxStatus: File Size Is Too Small, URI: http://10.0.100.30:8000/exploit.exe",
                 "code": "430004",
                 "kind": "alert",
@@ -265,7 +265,7 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-06-09T10:11:35.839814400Z",
+                "ingested": "2021-07-19T09:06:54.935868496Z",
                 "original": "Aug 14 2019 15:00:29 siem-ftd  %FTD-1-430004: SrcIP: 10.0.1.20, DstIP: 10.0.100.30, SrcPort: 41530, DstPort: 8000, Protocol: tcp, FileDirection: Download, FileAction: Detect, FileName: eicar.com, FileType: EICAR, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-14T15:00:27Z, FilePolicy: malware-and-file-policy, FileSandboxStatus: File Size Is Too Small, URI: http://10.0.100.30:8000/eicar.com",
                 "code": "430004",
                 "kind": "alert",
@@ -367,7 +367,7 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-06-09T10:11:35.839815400Z",
+                "ingested": "2021-07-19T09:06:54.935870547Z",
                 "original": "Aug 14 2019 15:01:41 siem-ftd  %FTD-1-430004: SrcIP: 10.0.1.20, DstIP: 10.0.100.30, SrcPort: 41534, DstPort: 8000, Protocol: tcp, FileDirection: Download, FileAction: Detect, FileName: eicar.com.txt, FileType: EICAR, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-14T15:01:40Z, FilePolicy: malware-and-file-policy, FileSandboxStatus: File Size Is Too Small, URI: http://10.0.100.30:8000/eicar.com.txt",
                 "code": "430004",
                 "kind": "alert",
@@ -476,7 +476,7 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-06-09T10:11:35.839816500Z",
+                "ingested": "2021-07-19T09:06:54.935872479Z",
                 "original": "Aug 14 2019 15:03:28 siem-ftd  %FTD-1-430004: SrcIP: 10.0.1.20, DstIP: 10.0.100.30, SrcPort: 41540, DstPort: 8000, Protocol: tcp, FileDirection: Download, FileAction: Detect, FileSHA256: 2546dcffc5ad854d4ddc64fbf056871cd5a00f2471cb7a5bfd4ac23b6e9eedad, ThreatName: Unknown, FileName: eicar_com.zip, FileType: ZIP, FileSize: 184, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-14T15:03:27Z, FilePolicy: malware-and-file-policy, FileSandboxStatus: File Size Is Too Small, URI: http://10.0.100.30:8000/eicar_com.zip",
                 "code": "430004",
                 "kind": "alert",
@@ -589,7 +589,7 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-06-09T10:11:35.839817600Z",
+                "ingested": "2021-07-19T09:06:54.935874404Z",
                 "original": "Aug 14 2019 15:03:33 siem-ftd  %FTD-1-430004: SrcIP: 10.0.1.20, DstIP: 10.0.100.30, SrcPort: 41542, DstPort: 8000, Protocol: tcp, FileDirection: Download, FileAction: Detect, FileSHA256: 2546dcffc5ad854d4ddc64fbf056871cd5a00f2471cb7a5bfd4ac23b6e9eedad, ThreatName: Unknown, FileName: eicar_com.zip, FileType: ZIP, FileSize: 184, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-14T15:03:31Z, FilePolicy: malware-and-file-policy, FileSandboxStatus: File Size Is Too Small, URI: http://10.0.100.30:8000/eicar_com.zip",
                 "code": "430004",
                 "kind": "alert",
@@ -702,7 +702,7 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-06-09T10:11:35.839818600Z",
+                "ingested": "2021-07-19T09:06:54.935876299Z",
                 "original": "Aug 14 2019 15:09:43 siem-ftd  %FTD-1-430005: SrcIP: 10.0.1.20, DstIP: 10.0.100.30, SrcPort: 41544, DstPort: 8000, Protocol: tcp, FileDirection: Download, FileAction: Malware Block, FileSHA256: 2546dcffc5ad854d4ddc64fbf056871cd5a00f2471cb7a5bfd4ac23b6e9eedad, SHA_Disposition: Malware, SperoDisposition: Spero detection not performed on file, ThreatName: Win.Ransomware.Eicar::95.sbx.tg, ThreatScore: 76, FileName: eicar_com.zip, FileType: ZIP, FileSize: 184, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-14T15:09:40Z, FilePolicy: malware-and-file-policy, FileSandboxStatus: File Size Is Too Small, URI: http://10.0.100.30:8000/eicar_com.zip",
                 "code": "430005",
                 "kind": "alert",
@@ -836,7 +836,7 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-06-09T10:11:35.839819600Z",
+                "ingested": "2021-07-19T09:06:54.935878168Z",
                 "original": "2019-08-16T09:39:03Z firepower  %FTD-1-430005: SrcIP: 10.0.1.20, DstIP: 213.211.198.62, SrcPort: 46004, DstPort: 80, Protocol: tcp, FileDirection: Download, FileAction: Malware Cloud Lookup, FileSHA256: 2546dcffc5ad854d4ddc64fbf056871cd5a00f2471cb7a5bfd4ac23b6e9eedad, SHA_Disposition: Unavailable, SperoDisposition: Spero detection not performed on file, ThreatName: Win.Ransomware.Eicar::95.sbx.tg, FileName: eicar_com.zip, FileType: ZIP, FileSize: 184, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-16T09:39:02Z, FilePolicy: malware-and-file-policy, FileStorageStatus: Not Stored (Disposition Was Pending), FileSandboxStatus: File Size Is Too Small, URI: http://www.eicar.org/download/eicar_com.zip",
                 "code": "430005",
                 "kind": "alert",
@@ -950,7 +950,7 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-06-09T10:11:35.839820600Z",
+                "ingested": "2021-07-19T09:06:54.935880107Z",
                 "original": "2019-08-16T09:40:45Z firepower  %FTD-1-430005: SrcIP: 10.0.1.20, DstIP: 10.0.100.30, SrcPort: 55378, DstPort: 80, Protocol: tcp, FileDirection: Download, FileAction: Malware Cloud Lookup, FileSHA256: 9a04a82eb19ad382f9e9dbafa498c6b4291f93cfe98d9e8b2915af99c06ffcd7, SHA_Disposition: Unavailable, SperoDisposition: Spero detection not performed on file, ThreatName: Unknown, FileName: dd3dee576d0cb4abfed00f97f0c71c1d, FileType: PDF, FileSize: 278987, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-16T09:40:45Z, FilePolicy: malware-and-file-policy, FileStorageStatus: Not Stored (Disposition Was Pending), FileSandboxStatus: Sent for Analysis, FileStaticAnalysisStatus: Failed to Send, URI: http://10.0.100.30/public/infected/dd3dee576d0cb4abfed00f97f0c71c1d",
                 "code": "430005",
                 "kind": "alert",
@@ -1082,7 +1082,7 @@
             },
             "event": {
                 "severity": 1,
-                "ingested": "2021-06-09T10:11:35.839821600Z",
+                "ingested": "2021-07-19T09:06:54.935882011Z",
                 "original": "2019-08-16T09:42:07Z firepower  %FTD-1-430005: SrcIP: 10.0.1.20, DstIP: 18.197.225.123, SrcPort: 47926, DstPort: 80, Protocol: tcp, FileDirection: Download, FileAction: Malware Cloud Lookup, FileSHA256: 9a04a82eb19ad382f9e9dbafa498c6b4291f93cfe98d9e8b2915af99c06ffcd7, SHA_Disposition: Malware, SperoDisposition: Spero detection not performed on file, ThreatName: Pdf.Exploit.Pdfka::100.sbx.tg, ThreatScore: 100, FileName: dd3dee576d0cb4abfed00f97f0c71c1d, FileType: PDF, FileSize: 278987, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-16T09:42:06Z, FilePolicy: malware-and-file-policy, FileSandboxStatus: Failed to Send, URI: http://18.197.225.123/public/infected/dd3dee576d0cb4abfed00f97f0c71c1d",
                 "code": "430005",
                 "kind": "alert",

--- a/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-security-malware-site.log-expected.json
+++ b/packages/cisco/data_stream/ftd/_dev/test/pipeline/test-security-malware-site.log-expected.json
@@ -70,7 +70,7 @@
             "observer": {
                 "ingress": {
                     "interface": {
-                        "name": "s1p2"
+                        "name": "s1p1"
                     }
                 },
                 "hostname": "CISCO-SENSOR-3D",
@@ -79,7 +79,7 @@
                 "vendor": "Cisco",
                 "egress": {
                     "interface": {
-                        "name": "s1p1"
+                        "name": "s1p2"
                     }
                 }
             },
@@ -110,7 +110,7 @@
             "event": {
                 "severity": 0,
                 "duration": 20000000000,
-                "ingested": "2021-06-09T10:11:36.196097700Z",
+                "ingested": "2021-07-19T09:06:55.879883471Z",
                 "original": "2020-03-01T01:02:36Z CISCO-SENSOR-3D Alerts %NGIPS-0-430003: DeviceUUID: 1c8ff662-08f3-11e4-85c0-bc960372972f, AccessControlRuleAction: Allow, AccessControlRuleReason: IP Monitor, SrcIP: 3.3.3.3, DstIP: 2.2.2.2, SrcPort: 65090, DstPort: 80, Protocol: tcp, IngressInterface: s1p1, EgressInterface: s1p2, IngressZone: Inside-DMZ-Interface-Inline, EgressZone: Inside-DMZ-Interface-Inline, ACPolicy: COOL-POLICY-3D, AccessControlRuleName: Inside DMZ-Rule-Inline, Prefilter Policy: Unknown, User: No Authentication Required, UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36, Client: Chrome, ClientVersion: 80.0.3987.87, ApplicationProtocol: HTTP, ConnectionDuration: 20, InitiatorPackets: 4, ResponderPackets: 4, InitiatorBytes: 729, ResponderBytes: 246, NAPPolicy: State-Backbone, SecIntMatchingIP: Destination, IPReputationSICategory: Malware, HTTPReferer: http://eyedropper-color-pick.info/mk?c=1581483445764, ReferencedHost: eyedropper-color-pick.info, URL: http://bad-malwaresite-grr.info/favicon.ico",
                 "code": "430003",
                 "kind": "event",

--- a/packages/cisco/data_stream/ftd/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco/data_stream/ftd/elasticsearch/ingest_pipeline/default.yml
@@ -1849,11 +1849,11 @@ processors:
       ignore_empty_value: true
   - set:
       field: observer.egress.interface.name
-      value: "{{ cisco.ftd.source_interface }}"
+      value: "{{ cisco.ftd.destination_interface }}"
       ignore_empty_value: true
   - set:
       field: observer.ingress.interface.name
-      value: "{{ cisco.ftd.destination_interface }}"
+      value: "{{ cisco.ftd.source_interface }}"
       ignore_empty_value: true
   - append:
       field: related.ip

--- a/packages/cisco/data_stream/ftd/sample_event.json
+++ b/packages/cisco/data_stream/ftd/sample_event.json
@@ -1,16 +1,15 @@
 {
     "@timestamp": "2019-08-16T09:39:03.000Z",
     "agent": {
-        "ephemeral_id": "f5535a1f-52da-44d4-a626-f85bbdc25e74",
+        "ephemeral_id": "915b9d78-907c-4615-90f8-e2997777f537",
         "hostname": "docker-fleet-agent",
-        "id": "37c96a8c-c323-4db5-b898-9ba84c49e2ea",
+        "id": "3c803d12-46a2-48a4-a206-8fd3630cc2a9",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "7.14.0"
     },
     "cisco": {
         "ftd": {
-            "message_id": "430005",
             "rule_name": "malware-and-file-policy",
             "security": {
                 "application_protocol": "HTTP",
@@ -68,23 +67,24 @@
         "port": 80
     },
     "ecs": {
-        "version": "1.9.0"
+        "version": "1.10.0"
     },
     "elastic_agent": {
-        "id": "732b7efe-6d7b-40fc-bbfe-799296be9d11",
+        "id": "3c803d12-46a2-48a4-a206-8fd3630cc2a9",
         "snapshot": true,
         "version": "7.14.0"
     },
     "event": {
         "action": "malware-detected",
+        "agent_id_status": "verified",
         "category": [
             "malware"
         ],
         "code": "430005",
         "dataset": "cisco.ftd",
-        "ingested": "2021-06-03T09:24:01.526093450Z",
+        "ingested": "2021-07-19T08:56:32.448763106Z",
         "kind": "alert",
-        "original": "%FTD-1-430005: SrcIP: 10.0.1.20, DstIP: 213.211.198.62, SrcPort: 46004, DstPort: 80, Protocol: tcp, FileDirection: Download, FileAction: Malware Cloud Lookup, FileSHA256: 2546dcffc5ad854d4ddc64fbf056871cd5a00f2471cb7a5bfd4ac23b6e9eedad, SHA_Disposition: Unavailable, SperoDisposition: Spero detection not performed on file, ThreatName: Win.Ransomware.Eicar::95.sbx.tg, FileName: eicar_com.zip, FileType: ZIP, FileSize: 184, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-16T09:39:02Z, FilePolicy: malware-and-file-policy, FileStorageStatus: Not Stored (Disposition Was Pending), FileSandboxStatus: File Size Is Too Small, URI: http://www.eicar.org/download/eicar_com.zip",
+        "original": "2019-08-16T09:39:03Z firepower  %FTD-1-430005: SrcIP: 10.0.1.20, DstIP: 213.211.198.62, SrcPort: 46004, DstPort: 80, Protocol: tcp, FileDirection: Download, FileAction: Malware Cloud Lookup, FileSHA256: 2546dcffc5ad854d4ddc64fbf056871cd5a00f2471cb7a5bfd4ac23b6e9eedad, SHA_Disposition: Unavailable, SperoDisposition: Spero detection not performed on file, ThreatName: Win.Ransomware.Eicar::95.sbx.tg, FileName: eicar_com.zip, FileType: ZIP, FileSize: 184, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-16T09:39:02Z, FilePolicy: malware-and-file-policy, FileStorageStatus: Not Stored (Disposition Was Pending), FileSandboxStatus: File Size Is Too Small, URI: http://www.eicar.org/download/eicar_com.zip\n",
         "severity": 1,
         "start": "2019-08-16T09:39:02Z",
         "timezone": "+00:00",
@@ -100,26 +100,8 @@
         "size": 184
     },
     "host": {
-        "architecture": "x86_64",
-        "containerized": true,
         "hostname": "firepower",
-        "id": "f46ddd9d65ff20633d9c337909855778",
-        "ip": [
-            "172.19.0.7"
-        ],
-        "mac": [
-            "02:42:ac:13:00:07"
-        ],
-        "name": "docker-fleet-agent",
-        "os": {
-            "codename": "Core",
-            "family": "redhat",
-            "kernel": "5.10.25-linuxkit",
-            "name": "CentOS Linux",
-            "platform": "centos",
-            "type": "linux",
-            "version": "7 (Core)"
-        }
+        "name": "docker-fleet-agent"
     },
     "input": {
         "type": "udp"
@@ -127,7 +109,7 @@
     "log": {
         "level": "alert",
         "source": {
-            "address": "172.19.0.4:46787"
+            "address": "172.23.0.4:41328"
         }
     },
     "network": {
@@ -163,11 +145,16 @@
         "port": 46004
     },
     "tags": [
+        "preserve_original_event",
         "cisco-ftd",
-        "preserve_original_event"
+        "forwarded"
     ],
     "url": {
-        "original": "http://www.eicar.org/download/eicar_com.zip"
+        "domain": "www.eicar.org",
+        "extension": "zip",
+        "original": "http://www.eicar.org/download/eicar_com.zip",
+        "path": "/download/eicar_com.zip",
+        "scheme": "http"
     },
     "user": {
         "id": "No Authentication Required",

--- a/packages/cisco/data_stream/ios/_dev/test/pipeline/test-cisco-ios.log-expected.json
+++ b/packages/cisco/data_stream/ios/_dev/test/pipeline/test-cisco-ios.log-expected.json
@@ -38,7 +38,7 @@
             "event": {
                 "severity": 6,
                 "sequence": 585917,
-                "ingested": "2021-06-09T10:11:36.356972400Z",
+                "ingested": "2021-07-19T09:06:56.360370014Z",
                 "original": "Feb  8 04:00:48 198.51.100.2 585917: Feb  8 04:00:47.272: %SEC-6-IPACCESSLOGRP: list 177 denied igmp 198.51.100.197 -\u003e 224.0.0.22, 1 packet",
                 "code": "IPACCESSLOGRP",
                 "provider": "firewall",
@@ -94,7 +94,7 @@
             "event": {
                 "severity": 6,
                 "sequence": 585918,
-                "ingested": "2021-06-09T10:11:36.356977500Z",
+                "ingested": "2021-07-19T09:06:56.360375335Z",
                 "original": "Feb  9 04:00:48 198.51.100.2 585918: Feb  9 04:00:47.272: %SEC-6-IPACCESSLOGSP: list INBOUND-ON-F11 denied igmp 198.51.100.2 -\u003e 224.0.0.2 (20), 1 packet",
                 "code": "IPACCESSLOGSP",
                 "provider": "firewall",
@@ -146,7 +146,7 @@
             "event": {
                 "severity": 6,
                 "sequence": 585919,
-                "ingested": "2021-06-09T10:11:36.356978800Z",
+                "ingested": "2021-07-19T09:06:56.360377543Z",
                 "original": "Feb 10 04:00:48 198.51.100.2 585919: Feb 10 04:00:47.272: %SEC-6-IPACCESSLOGNP: list 171 denied 0 198.51.100.1 -\u003e 255.255.255.255, 1 packet",
                 "code": "IPACCESSLOGNP",
                 "provider": "firewall",
@@ -201,7 +201,7 @@
             "event": {
                 "severity": 6,
                 "sequence": 585920,
-                "ingested": "2021-06-09T10:11:36.356979800Z",
+                "ingested": "2021-07-19T09:06:56.360379550Z",
                 "original": "May  3 19:11:33 198.51.100.2 585920: May  3 19:11:32.619: %IPV6-6-ACCESSLOGP: list ACL-IPv6-E0/0-IN/10 permitted tcp 2001:DB8::3(1027) -\u003e 2001:DB8:1000::1(22), 9 packets",
                 "code": "ACCESSLOGP",
                 "provider": "firewall",
@@ -256,7 +256,7 @@
             "event": {
                 "severity": 6,
                 "sequence": 1663303,
-                "ingested": "2021-06-09T10:11:36.356980800Z",
+                "ingested": "2021-07-19T09:06:56.360381464Z",
                 "original": "Jun 20 02:41:40 198.51.100.2 1663303: Jun 20 02:41:39.326: %SEC-6-IPACCESSLOGP: list 177 denied udp 198.51.100.195(55250) -\u003e 198.51.100.255(15600), 1 packet",
                 "code": "IPACCESSLOGP",
                 "provider": "firewall",
@@ -313,7 +313,7 @@
             "event": {
                 "severity": 6,
                 "sequence": 1663304,
-                "ingested": "2021-06-09T10:11:36.356981800Z",
+                "ingested": "2021-07-19T09:06:56.360387855Z",
                 "original": "Jun 20 02:41:45 198.51.100.2 1663304: Jun 20 02:41:44.921: %SEC-6-IPACCESSLOGDP: list 151 denied icmp 198.51.100.1 -\u003e 198.51.100.2 (3/4), 1 packet",
                 "code": "IPACCESSLOGDP",
                 "provider": "firewall",
@@ -368,7 +368,7 @@
             "event": {
                 "severity": 6,
                 "sequence": 1663312,
-                "ingested": "2021-06-09T10:11:36.356982800Z",
+                "ingested": "2021-07-19T09:06:56.360389813Z",
                 "original": "Jun 20 02:42:28 198.51.100.2 1663312: Jun 20 02:42:27.342: %SEC-6-IPACCESSLOGP: list 177 denied udp 198.51.100.195(54309) -\u003e 198.51.100.255(15600), 1 packet",
                 "code": "IPACCESSLOGP",
                 "provider": "firewall",
@@ -396,7 +396,7 @@
             "event": {
                 "severity": 6,
                 "sequence": 1663313,
-                "ingested": "2021-06-09T10:11:36.356983800Z",
+                "ingested": "2021-07-19T09:06:56.360391731Z",
                 "original": "Jun 20 02:42:28 198.51.100.2 1663313: Jun 20 02:42:28.374: %SEC-6-IPACCESSLOGRL: access-list logging rate-limited or missed 18 packets",
                 "code": "IPACCESSLOGRL",
                 "provider": "firewall",
@@ -453,7 +453,7 @@
             "event": {
                 "severity": 6,
                 "sequence": 1663314,
-                "ingested": "2021-06-09T10:11:36.356984800Z",
+                "ingested": "2021-07-19T09:06:56.360393643Z",
                 "original": "Jun 20 02:42:34 198.51.100.2 1663314: Jun 20 02:42:33.340: %SEC-6-IPACCESSLOGP: list 177 denied udp 198.51.100.195(43989) -\u003e 198.51.100.255(15600), 1 packet",
                 "code": "IPACCESSLOGP",
                 "provider": "firewall",
@@ -523,7 +523,7 @@
             "event": {
                 "severity": 6,
                 "sequence": 1663321,
-                "ingested": "2021-06-09T10:11:36.356985800Z",
+                "ingested": "2021-07-19T09:06:56.360395532Z",
                 "original": "Jun 20 02:43:09 198.51.100.2 1663321: Jun 20 02:43:08.454: %SEC-6-IPACCESSLOGP: list 150 denied tcp 198.51.100.12(59832) -\u003e 172.217.10.46(80), 1 packet",
                 "code": "IPACCESSLOGP",
                 "provider": "firewall",
@@ -551,7 +551,7 @@
             "event": {
                 "severity": 6,
                 "sequence": 1663325,
-                "ingested": "2021-06-09T10:11:36.356986800Z",
+                "ingested": "2021-07-19T09:06:56.360397394Z",
                 "original": "Jun 20 02:43:29 198.51.100.2 1663325: Jun 20 02:43:28.403: %SEC-6-IPACCESSLOGRL: access-list logging rate-limited or missed 23 packets",
                 "code": "IPACCESSLOGRL",
                 "provider": "firewall",
@@ -610,7 +610,7 @@
             "event": {
                 "severity": 6,
                 "sequence": 1663326,
-                "ingested": "2021-06-09T10:11:36.356987900Z",
+                "ingested": "2021-07-19T09:06:56.360399550Z",
                 "original": "Jun 20 02:43:29 198.51.100.2 1663326: Jun 20 02:43:28.403: %SEC-6-IPACCESSLOGDP: list 150 denied icmp 198.51.100.12 -\u003e 198.51.100.1 (3/3), 32 packets",
                 "code": "IPACCESSLOGDP",
                 "provider": "firewall",
@@ -680,7 +680,7 @@
             "event": {
                 "severity": 6,
                 "sequence": 1663327,
-                "ingested": "2021-06-09T10:11:36.356988900Z",
+                "ingested": "2021-07-19T09:06:56.360401431Z",
                 "original": "Jun 20 02:43:30 198.51.100.2 1663327: Jun 20 02:43:29.451: %SEC-6-IPACCESSLOGP: list 150 denied tcp 198.51.100.12(59834) -\u003e 172.217.10.46(80), 1 packet",
                 "code": "IPACCESSLOGP",
                 "provider": "firewall",
@@ -733,7 +733,7 @@
             "event": {
                 "severity": 5,
                 "sequence": 1991219,
-                "ingested": "2021-06-09T10:11:36.356989900Z",
+                "ingested": "2021-07-19T09:06:56.360403294Z",
                 "original": "Mar 24 18:06:03 198.51.100.2 1991219: Mar 24 18:06:03.424 UTC: %SEC_LOGIN-5-LOGIN_SUCCESS: Login Success [user: john.smith] [Source: 10.2.55.3] [localport: 22] at 12:06:03 MST Wed Mar 24 2021",
                 "code": "LOGIN_SUCCESS",
                 "provider": "firewall",
@@ -776,7 +776,7 @@
             "event": {
                 "severity": 6,
                 "sequence": 1991220,
-                "ingested": "2021-06-09T10:11:36.356990900Z",
+                "ingested": "2021-07-19T09:06:56.360405194Z",
                 "original": "Mar 24 18:06:00 198.51.100.2 1991220: Mar 24 18:06:00.364 UTC: %SYS-6-LOGOUT: User john.smith has exited tty session 5(10.5.36.9)",
                 "code": "LOGOUT",
                 "provider": "firewall",
@@ -835,7 +835,7 @@
                 "severity": 6,
                 "sequence": 1991221,
                 "reason": "Invalid RP",
-                "ingested": "2021-06-09T10:11:36.356992Z",
+                "ingested": "2021-07-19T09:06:56.360407101Z",
                 "original": "Mar 24 17:37:39 198.51.100.2 1991221: Mar 24 17:37:39 UTC: %PIM-SW1-6-INVALID_RP_JOIN: Received (*, 10.36.2.78) Join from 10.4.5.66 for invalid RP 10.3.66.3",
                 "code": "INVALID_RP_JOIN",
                 "provider": "firewall",
@@ -892,7 +892,7 @@
                 "severity": 6,
                 "sequence": 1991221,
                 "reason": "Invalid RP",
-                "ingested": "2021-06-09T10:11:36.356993Z",
+                "ingested": "2021-07-19T09:06:56.360409151Z",
                 "original": "Mar 24 17:37:39 198.51.100.2 1991221: Mar 24 17:37:39 UTC: %PIM-SW1-6-INVALID_RP_JOIN: Received (10.50.22.5, 10.36.2.78) Join from 10.4.5.66 for invalid RP 10.3.66.3",
                 "code": "INVALID_RP_JOIN",
                 "provider": "firewall",
@@ -930,7 +930,7 @@
             "event": {
                 "severity": 4,
                 "sequence": 1991217,
-                "ingested": "2021-06-09T10:11:36.356994Z",
+                "ingested": "2021-07-19T09:06:56.360411008Z",
                 "original": "Mar 24 12:09:35 198.51.100.2 1991217: Mar 24 12:09:35.367: %OSPF-4-NOVALIDKEY: No valid authentication send key is available on interface eth0",
                 "code": "NOVALIDKEY",
                 "provider": "firewall",
@@ -960,7 +960,7 @@
             "event": {
                 "severity": 6,
                 "sequence": 1991218,
-                "ingested": "2021-06-09T10:11:36.356995Z",
+                "ingested": "2021-07-19T09:06:56.360413029Z",
                 "original": "Mar 24 12:06:47 198.51.100.2 1991218: Mar 24 12:06:47.099: %CCH323-6-CALL_PRESERVED: cch323_h225_handle_conn_loss: H.323 call preserved due to socket closure or error, Call Id = 6527, fd = 19",
                 "code": "CALL_PRESERVED",
                 "provider": "firewall",

--- a/packages/cisco/data_stream/ios/sample_event.json
+++ b/packages/cisco/data_stream/ios/sample_event.json
@@ -1,9 +1,9 @@
 {
-    "@timestamp": "2021-06-03T09:25:42.537Z",
+    "@timestamp": "2021-07-19T08:58:29.370Z",
     "agent": {
-        "ephemeral_id": "f5535a1f-52da-44d4-a626-f85bbdc25e74",
+        "ephemeral_id": "7e9d4c95-b972-479d-bc6c-2ac0d05f3eb1",
         "hostname": "docker-fleet-agent",
-        "id": "37c96a8c-c323-4db5-b898-9ba84c49e2ea",
+        "id": "3c803d12-46a2-48a4-a206-8fd3630cc2a9",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "7.14.0"
@@ -24,46 +24,29 @@
         "ip": "224.0.0.22"
     },
     "ecs": {
-        "version": "1.9.0"
+        "version": "1.10.0"
     },
     "elastic_agent": {
-        "id": "732b7efe-6d7b-40fc-bbfe-799296be9d11",
+        "id": "3c803d12-46a2-48a4-a206-8fd3630cc2a9",
         "snapshot": true,
         "version": "7.14.0"
     },
     "event": {
         "action": "deny",
+        "agent_id_status": "verified",
         "category": "network",
         "code": "IPACCESSLOGRP",
         "dataset": "cisco.ios",
-        "ingested": "2021-06-03T09:25:43.560570635Z",
+        "ingested": "2021-07-19T08:58:30.397370366Z",
         "original": "Feb  8 04:00:48 198.51.100.2 585917: Feb  8 04:00:47.272: %SEC-6-IPACCESSLOGRP: list 177 denied igmp 198.51.100.197 -\u003e 224.0.0.22, 1 packet\n",
         "provider": "firewall",
         "sequence": 585917,
         "severity": 6,
-        "type": "info"
+        "timezone": "+00:00",
+        "type": "denied"
     },
     "host": {
-        "architecture": "x86_64",
-        "containerized": true,
-        "hostname": "docker-fleet-agent",
-        "id": "f46ddd9d65ff20633d9c337909855778",
-        "ip": [
-            "172.19.0.7"
-        ],
-        "mac": [
-            "02:42:ac:13:00:07"
-        ],
-        "name": "docker-fleet-agent",
-        "os": {
-            "codename": "Core",
-            "family": "redhat",
-            "kernel": "5.10.25-linuxkit",
-            "name": "CentOS Linux",
-            "platform": "centos",
-            "type": "linux",
-            "version": "7 (Core)"
-        }
+        "name": "docker-fleet-agent"
     },
     "input": {
         "type": "udp"
@@ -93,7 +76,8 @@
         "packets": 1
     },
     "tags": [
+        "preserve_original_event",
         "cisco-ios",
-        "preserve_original_event"
+        "forwarded"
     ]
 }

--- a/packages/cisco/data_stream/meraki/_dev/test/pipeline/test-generated.log-expected.json
+++ b/packages/cisco/data_stream/meraki/_dev/test/pipeline/test-generated.log-expected.json
@@ -6,7 +6,7 @@
             },
             "message": "modtempo 1454047799.olab nto_ security_event olaborissecurity_event tur url=https://example.org/odoco/ria.jpg?ritin=uredolor#tatemac src=10.15.44.253:5078 dst=10.193.124.51:5293 mac=01:00:5e:28:ae:7d name=psa sha256=umq disposition=ntium action=deny",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698782600Z"
+                "ingested": "2021-07-19T09:06:57.318322723Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -18,7 +18,7 @@
             },
             "message": "umdo 1455282753.itessequ vol_ events dhcp lease of ip 10.102.218.31 from server mac 01:00:5e:9c:c2:9c for client mac 01:00:5e:0f:87:e3 from router 10.15.16.212 on subnet ameaqu with dns aqu",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698787300Z"
+                "ingested": "2021-07-19T09:06:57.318328522Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -30,7 +30,7 @@
             },
             "message": "uipexea 1456517708.tatio minim_ flows ceroinBC flows src=10.179.60.216 dst=10.69.53.104 protocol=udp pattern: 0 reprehe",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698788600Z"
+                "ingested": "2021-07-19T09:06:57.318330876Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -42,7 +42,7 @@
             },
             "message": "mipsu 1457752662.consec taliquip_ flows radip flows block src=10.155.236.240 dst=10.112.46.169 mac=01:00:5e:7a:74:89 protocol=ipv6 type=roidents ",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698789800Z"
+                "ingested": "2021-07-19T09:06:57.318332842Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -54,7 +54,7 @@
             },
             "message": "obeataev 1458987616.lor uidexea_appliance events MAC 01:00:5e:e1:89:ac and MAC 01:00:5e:a3:d9:ac both claim IP: 10.14.107.140",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698790900Z"
+                "ingested": "2021-07-19T09:06:57.318334770Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -66,7 +66,7 @@
             },
             "message": "iutal 1460222571.dexe urerep events content_filtering_block url='https://api.example.org/liqu/lorem.gif?ueipsaqu=uidolore#niamqu' category0='ari' server='10.108.180.105:5098' client_mac='01:00:5e:40:9b:83'",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698791900Z"
+                "ingested": "2021-07-19T09:06:57.318336673Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -78,7 +78,7 @@
             },
             "message": "ipit 1461457525.idexea riat_appliance events MAC 01:00:5e:25:4f:e4 and MAC 01:00:5e:3f:49:e4 both claim IP: 10.149.88.198",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698793Z"
+                "ingested": "2021-07-19T09:06:57.318338594Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -90,7 +90,7 @@
             },
             "message": "ntsuntin 1462692479.aecatcup animi events dhcp release for mac 01:00:5e:e3:10:34",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698794Z"
+                "ingested": "2021-07-19T09:06:57.318340690Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -102,7 +102,7 @@
             },
             "message": "orsitame 1463927433.quiratio ite events MAC 01:00:5e:48:62:22 and MAC 01:00:5e:9f:b6:a6 both claim IP: 10.243.206.225",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698795Z"
+                "ingested": "2021-07-19T09:06:57.318342807Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -114,7 +114,7 @@
             },
             "message": "olupta turveli.toccae tatno_ ids-alerts taliqu ids-alerts signature=temUten priority=ccusan timestamp=1465162388.iqudirection=outbound protocol=icmp src=10.131.82.116:7307",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698796100Z"
+                "ingested": "2021-07-19T09:06:57.318344851Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -126,7 +126,7 @@
             },
             "message": "uaera 1466397342.sitas ehenderi_ security_event atquovosecurity_event iumto url=https://www5.example.net/sun/essecill.html?saute=vel#quu src=10.210.213.18:7616 dst=10.134.0.141:2703 mac=01:00:5e:aa:42:fa name=idolores sha256=llumquid disposition=tation action=accept",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698797100Z"
+                "ingested": "2021-07-19T09:06:57.318346782Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -138,7 +138,7 @@
             },
             "message": "omn ipsumq.atcu oremagna_ security_event remipsum security_event liq signature=ist priority=tnon timestamp=1467632296.ionul shost=01:00:5e:c8:9c:2f direction=outbound protocol=udp src=10.163.72.17 dst=10.74.237.180 message:nsequu",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698798200Z"
+                "ingested": "2021-07-19T09:06:57.318349047Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -150,7 +150,7 @@
             },
             "message": "omm 1468867250.idestla Nemoeni_appliance events MAC 01:00:5e:c4:69:7f and MAC 01:00:5e:e2:67:d2 both claim IP: 10.72.31.26",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698799200Z"
+                "ingested": "2021-07-19T09:06:57.318350932Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -162,7 +162,7 @@
             },
             "message": "agna tionemu.eomnisis mqui ids-alerts signature=civeli priority=errorsi timestamp=1470102205.desdirection=internal protocol=tcp src=10.70.95.74:4290",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698800200Z"
+                "ingested": "2021-07-19T09:06:57.318352814Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -174,7 +174,7 @@
             },
             "message": "olupt 1471337159.dit sumquiad events MAC 01:00:5e:ea:e8:7a and MAC 01:00:5e:9c:d2:4a both claim IP: 10.17.21.125",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698801300Z"
+                "ingested": "2021-07-19T09:06:57.318354694Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -186,7 +186,7 @@
             },
             "message": "amqu 1472572113.uines nsec events dhcp lease of ip 10.85.10.165 from server mac 01:00:5e:63:93:48 for client mac 01:00:5e:46:17:35 from router 10.53.150.119 on subnet uiineavo with dns tisetq",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698802300Z"
+                "ingested": "2021-07-19T09:06:57.318356610Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -198,7 +198,7 @@
             },
             "message": "giatquov eritquii.dexeac iscinge ids-alerts signature=atvol priority=umiur timestamp=1473807067.imadprotocol=igmp src=10.88.231.224 dst=10.187.77.245message: iadese",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698803300Z"
+                "ingested": "2021-07-19T09:06:57.318360737Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -210,7 +210,7 @@
             },
             "message": "agnaali 1475042022.gnam tat events content_filtering_block url='https://internal.example.com/quae/maccusa.htm?rQuisau=idex#xerci' category0='aqu' server='10.186.58.115:7238' client_mac='01:00:5e:8f:16:6d'",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698804400Z"
+                "ingested": "2021-07-19T09:06:57.318362696Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -222,7 +222,7 @@
             },
             "message": "apariat 1476276976.tlabore untmolli_ events dhcp lease of ip 10.219.84.37 from server mac 01:00:5e:e8:bf:69 for client mac 01:00:5e:87:e1:a0 from router 10.205.47.51 on subnet uovolup with dns samvolu",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698805400Z"
+                "ingested": "2021-07-19T09:06:57.318364577Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -234,7 +234,7 @@
             },
             "message": "ento 1477511930.pic evita events MAC 01:00:5e:ce:61:db and MAC 01:00:5e:ec:f8:cc both claim IP: 10.3.134.237",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698806500Z"
+                "ingested": "2021-07-19T09:06:57.318366481Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -246,7 +246,7 @@
             },
             "message": "tmo 1478746884.fficiade uscipit events aid=vitaedi arp_resp=fugitse arp_src=veniamq auth_neg_dur=one auth_neg_failed=etMalor channel=ipi dns_req_rtt=reseos dns_resp=pariatu dns_server=tin duration=48.123000 full_conn=oquisqu identity=sperna ip_resp=eabilloi ip_src=10.182.178.217 is_8021x=tlab is_wpa=volupt last_auth_ago=osqui radio=xerc reason=iutali rssi=fdeFi type=texp vap=tasuntex client_mac=01:00:5e:e3:b1:24 client_ip=10.194.114.58 instigator=ectio http_resp=dutper dhcp_lease_completed=lamcolab dhcp_ip=ati dhcp_server=tlabo dhcp_server_mac=uames dhcp_resp=iduntu url=https://internal.example.net/ris/uamqu.txt?liqui=quioffi#uptate category0=ncidid server=10.63.194.87 vpn_type=quisno connectivity=sin",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698807500Z"
+                "ingested": "2021-07-19T09:06:57.318368418Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -258,7 +258,7 @@
             },
             "message": "emvel 1479981839.tmollita fde events aid=nsecte arp_resp=inculpa arp_src=abo auth_neg_dur=veniamqu auth_neg_failed=nse channel=non dns_req_rtt=paquioff dns_resp=mquisnos dns_server=maven duration=71.798000 full_conn=atcu identity=labor ip_resp=didunt ip_src=10.153.0.77 is_8021x=udan is_wpa=orema last_auth_ago=invento radio=qua reason=aturQui rssi=utlabor type=rau vap=idex client_mac=01:00:5e:9e:7b:a4 client_ip=10.105.88.20 instigator=ecte http_resp=tinvolu dhcp_lease_completed=iurer dhcp_ip=iciadese dhcp_server=quidolor dhcp_server_mac=tessec dhcp_resp=olupta url=https://mail.example.com/icabo/itatio.jpg?eleum=sintoc#volupt category0=siste server=10.163.154.210 vpn_type=ept connectivity=iumtotam",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698809300Z"
+                "ingested": "2021-07-19T09:06:57.318370315Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -270,7 +270,7 @@
             },
             "message": "ionevo 1481216793.ugiatnu ciati_appliance events MAC 01:00:5e:b8:7a:96 and MAC 01:00:5e:b9:6b:a8 both claim IP: 10.73.69.176",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698847100Z"
+                "ingested": "2021-07-19T09:06:57.318372187Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -282,7 +282,7 @@
             },
             "message": "spi 1482451747.stquido ommodico_ flows ese flows allow src=10.145.248.111 dst=10.57.6.252 mac=01:00:5e:94:6a:cf protocol=udp ",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698848400Z"
+                "ingested": "2021-07-19T09:06:57.318374272Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -294,7 +294,7 @@
             },
             "message": "smo etcons.iusmodi uamest_ security_event uiac security_event epte signature=idolo priority=quinesc timestamp=1483686701.madmi shost=01:00:5e:1c:4c:64 direction=internal protocol=icmp src=10.31.77.157 dst=10.12.182.70 message:tev",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698849600Z"
+                "ingested": "2021-07-19T09:06:57.318376267Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -306,7 +306,7 @@
             },
             "message": "nisiuta 1484921656.roid inibusB flows cancel",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698850600Z"
+                "ingested": "2021-07-19T09:06:57.318378206Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -318,7 +318,7 @@
             },
             "message": "str 1486156610.idolore pid_ flows cteturad flows deny src=10.93.68.231 dst=10.135.217.12 mac=01:00:5e:4a:69:5b protocol=ipv6 type=archite ",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698851500Z"
+                "ingested": "2021-07-19T09:06:57.318380194Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -330,7 +330,7 @@
             },
             "message": "amnih 1487391564.ium esciuntN_ events dhcp release for mac 01:00:5e:8b:99:98",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698852500Z"
+                "ingested": "2021-07-19T09:06:57.318382141Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -342,7 +342,7 @@
             },
             "message": "isnost 1488626519.queips ncidi_ flows iscinge flows src=10.247.30.212 dst=10.66.89.5 mac=01:00:5e:7f:65:da protocol=igmp pattern: 1 borios",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698853500Z"
+                "ingested": "2021-07-19T09:06:57.318384064Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -354,7 +354,7 @@
             },
             "message": "oin 1489861473.mvenia madminim events IDS: fugitsed",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698854500Z"
+                "ingested": "2021-07-19T09:06:57.318385940Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -366,7 +366,7 @@
             },
             "message": "dmin fugi.quia iduntu security_event idestlab signature=rnatur priority=ofdeFin timestamp=1491096427.essequam dhost=01:00:5e:c1:53:b1 direction=inbound protocol=tcp src=10.221.102.245 dst=10.173.136.186 message:naal",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698855500Z"
+                "ingested": "2021-07-19T09:06:57.318387828Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -378,7 +378,7 @@
             },
             "message": "umqu tinv.adipisc uscipitl_ ids-alerts ritatise ids-alerts signature=uamei priority=siut timestamp=1492331381.ciad dhost=01:00:5e:1f:c6:29 direction=external protocol=udp src=10.58.64.108 dst=10.54.37.86 message: entorev",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698856500Z"
+                "ingested": "2021-07-19T09:06:57.318389704Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -390,7 +390,7 @@
             },
             "message": "velitess 1493566336.naali uunturm_ flows veli flows block src=10.147.76.202 dst=10.163.93.20 mac=01:00:5e:1d:85:ec protocol=ipv6 sport=1085 dport=3141 ",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698857400Z"
+                "ingested": "2021-07-19T09:06:57.318392453Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -402,7 +402,7 @@
             },
             "message": "iumdol tpersp.stla uptatema_ security_event uradi security_event tot signature=llamco priority=nea timestamp=1494801290.psum dhost=01:00:5e:35:71:1e direction=internal protocol=icmp src=10.0.200.27:5905 dst=10.183.44.198:1702 message:asiarc",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698858400Z"
+                "ingested": "2021-07-19T09:06:57.318394459Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -414,7 +414,7 @@
             },
             "message": "tiaec 1496036244.rumwrit icabo_ events dhcp lease of ip 10.148.124.84 from server mac 01:00:5e:0b:2c:22 for client mac 01:00:5e:06:12:98 from router 10.28.144.180 on subnet ritin with dns temporin",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698859500Z"
+                "ingested": "2021-07-19T09:06:57.318396497Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -426,7 +426,7 @@
             },
             "message": "ica 1497271198.lillum remips_appliance events aid=uisaute arp_resp=imide arp_src=poriss auth_neg_dur=tvolup auth_neg_failed=itesseq channel=dictasun dns_req_rtt=veniamqu dns_resp=rum dns_server=quaea duration=165.611000 full_conn=mvel identity=nof ip_resp=usmodi ip_src=10.204.230.166 is_8021x=dat is_wpa=aincidu last_auth_ago=nimadmin radio=isiu reason=licabo rssi=enimadmi type=utaliqu vap=dic client_mac=01:00:5e:bb:60:a6 client_ip=10.62.71.118 instigator=ineavol http_resp=iosa dhcp_lease_completed=boNemoe dhcp_ip=onsequ dhcp_server=equinesc dhcp_server_mac=cab dhcp_resp=atisund url=https://example.net/ites/isetq.gif?nisiut=tur#avolupt category0=ariatur server=10.98.194.212 vpn_type=nimave connectivity=isciv",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698860400Z"
+                "ingested": "2021-07-19T09:06:57.318398565Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -438,7 +438,7 @@
             },
             "message": "dipisci 1498506153.spernatu admi events content_filtering_block url='https://www.example.org/ueipsa/tae.html?eriti=atcupi#corpori' category0='borisnis' server='10.197.13.39:5912'",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698861400Z"
+                "ingested": "2021-07-19T09:06:57.318400449Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -450,7 +450,7 @@
             },
             "message": "itsedd 1499741107.leumiur eratvol events dhcp release for mac 01:00:5e:fd:84:bb",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698862400Z"
+                "ingested": "2021-07-19T09:06:57.318402353Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -462,7 +462,7 @@
             },
             "message": "leumiu tla.item nimid ids-alerts signature=dat priority=periam timestamp=1500976061.dquprotocol=icmp src=10.242.77.170 dst=10.150.245.88message: orisn",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698863400Z"
+                "ingested": "2021-07-19T09:06:57.318404277Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -474,7 +474,7 @@
             },
             "message": "sitam rad.loi isc_ ids-alerts volupt ids-alerts signature=rem priority=idid timestamp=1502211015.tesse shost=01:00:5e:9d:eb:fb direction=external protocol=tcp src=10.247.139.239 dst=10.180.195.43 message: tenatuse",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698864500Z"
+                "ingested": "2021-07-19T09:06:57.318406170Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -486,7 +486,7 @@
             },
             "message": "tore 1503445970.elits consequa events dhcp release for mac 01:00:5e:50:48:c4",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698865400Z"
+                "ingested": "2021-07-19T09:06:57.318408083Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -498,7 +498,7 @@
             },
             "message": "undeom uamnihi.risnis uov_ ids-alerts isn ids-alerts signature=sBono priority=loremqu timestamp=1504680924.teturprotocol=rdp src=10.94.6.140 dst=10.147.15.213message: uptat",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698866400Z"
+                "ingested": "2021-07-19T09:06:57.318410091Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -510,7 +510,7 @@
             },
             "message": "itasper 1505915878.uae mve_ flows obeata flows block src=10.230.6.127 dst=10.111.157.56 mac=01:00:5e:39:a7:fc protocol=icmp type=aliquamq ",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698867900Z"
+                "ingested": "2021-07-19T09:06:57.318412002Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -522,7 +522,7 @@
             },
             "message": "archite 1507150832.remq veniamq events aid=occ arp_resp=oloreseo arp_src=iruredol auth_neg_dur=veniamqu auth_neg_failed=licaboN channel=atquo dns_req_rtt=cupi dns_resp=strude dns_server=eritin duration=85.513000 full_conn=litsedq identity=nderiti ip_resp=ntNe ip_src=10.179.40.170 is_8021x=olorema is_wpa=mollita last_auth_ago=tatem radio=iae reason=quido rssi=emip type=inBC vap=mol client_mac=01:00:5e:58:2d:1c client_ip=10.153.81.206 instigator=rsita http_resp=nsequun dhcp_lease_completed=eetd dhcp_ip=illu dhcp_server=iatqu dhcp_server_mac=lorsi dhcp_resp=repreh url=https://www.example.net/irured/illumqui.txt?tionula=ritqu#ecatcupi category0=uamei server=10.193.219.34 vpn_type=onse connectivity=olorem",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698868900Z"
+                "ingested": "2021-07-19T09:06:57.318413969Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -534,7 +534,7 @@
             },
             "message": "umwritte 1508385787.vol oremquel_appliance events MAC 01:00:5e:16:5e:b1 and MAC 01:00:5e:ee:e8:77 both claim IP: 10.255.199.16",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698869900Z"
+                "ingested": "2021-07-19T09:06:57.318415902Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -546,7 +546,7 @@
             },
             "message": "unte 1509620741.uamnihil llam_appliance events MAC 01:00:5e:ee:1d:77 and MAC 01:00:5e:f1:21:bd both claim IP: 10.94.88.5",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698870900Z"
+                "ingested": "2021-07-19T09:06:57.318425091Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -558,7 +558,7 @@
             },
             "message": "esci 1510855695.uov quaeab_ events IDS: moles",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698871800Z"
+                "ingested": "2021-07-19T09:06:57.318431203Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -570,7 +570,7 @@
             },
             "message": "accusa 1512090649.natu liquid events IDS: enim",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698872800Z"
+                "ingested": "2021-07-19T09:06:57.318434018Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -582,7 +582,7 @@
             },
             "message": "dquiaco nibus.vitaed ser security_event etconsec signature=elillum priority=upt timestamp=1513325604.rnat dhost=01:00:5e:01:60:e0 direction=internal protocol=ipv6 src=10.90.99.245 dst=10.124.63.4 message:pta",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698873800Z"
+                "ingested": "2021-07-19T09:06:57.318439374Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -594,7 +594,7 @@
             },
             "message": "tetura 1514560558.imadmini moe_appliance events content_filtering_block url='https://mail.example.net/uat/lupta.html?uptassit=ncidi#tlabori' category0='laudan' server='10.249.7.146:2010'",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698874800Z"
+                "ingested": "2021-07-19T09:06:57.318441834Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -606,7 +606,7 @@
             },
             "message": "lapar 1515795512.ritati edquia_appliance events IDS: itesse",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698875900Z"
+                "ingested": "2021-07-19T09:06:57.318444124Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -618,7 +618,7 @@
             },
             "message": "amvolu mip.tion tobeatae_ security_event Utenima security_event iqua signature=luptat priority=deriti timestamp=1517030466.sintocc dhost=01:00:5e:c9:b7:22 direction=inbound protocol=icmp src=10.196.96.162 dst=10.81.234.34 message:equuntur",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698876800Z"
+                "ingested": "2021-07-19T09:06:57.318446164Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -630,7 +630,7 @@
             },
             "message": "uide 1518265421.scivel henderi_appliance events IDS: iusmodt",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698877800Z"
+                "ingested": "2021-07-19T09:06:57.318448051Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -642,7 +642,7 @@
             },
             "message": "tiumd 1519500375.ntmoll mexer events dhcp lease of ip 10.40.101.224 from server mac 01:00:5e:0a:df:72 for client mac 01:00:5e:7c:01:ab with hostname remips188.api.invalid from router 10.78.199.43 on subnet ehender with dns ilmole",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698878800Z"
+                "ingested": "2021-07-19T09:06:57.318449950Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -654,7 +654,7 @@
             },
             "message": "runtmo 1520735329.ore isund_appliance events MAC 01:00:5e:17:87:3e and MAC 01:00:5e:5f:c1:3e both claim IP: 10.244.29.119",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698879700Z"
+                "ingested": "2021-07-19T09:06:57.318451848Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -666,7 +666,7 @@
             },
             "message": "tutlabor 1521970284.reseosq gna_ flows pteurs flows deny src=10.83.131.245 dst=10.39.172.93 mac=01:00:5e:c4:12:c7 protocol=udp type=uido ",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698880700Z"
+                "ingested": "2021-07-19T09:06:57.318453778Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -678,7 +678,7 @@
             },
             "message": "osquira 1523205238.umd sciveli_ events dhcp lease of ip 10.86.188.179 from server mac 01:00:5e:48:4b:78 for client mac 01:00:5e:7e:cd:15 from router 10.201.168.116 on subnet umiure with dns laborum",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698881600Z"
+                "ingested": "2021-07-19T09:06:57.318455700Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -690,7 +690,7 @@
             },
             "message": "umdolors 1524440192.lumdo acom_ security_event umexercisecurity_event duntut url=https://mail.example.com/prehend/eufug.htm?eufug=est#civelits src=10.148.211.222:2053 dst=10.122.204.151:3903 mac=01:00:5e:c3:a0:dc name=ine sha256=urerepre disposition=asnulap action=deny",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698882600Z"
+                "ingested": "2021-07-19T09:06:57.318457679Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -702,7 +702,7 @@
             },
             "message": "atnul 1525675146.umfugi stquidol_ flows luptatem flows accept",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698883700Z"
+                "ingested": "2021-07-19T09:06:57.318459592Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -714,7 +714,7 @@
             },
             "message": "essequam ueporro.aliqu upt ids-alerts signature=orum priority=Bonoru timestamp=1526910101.madminimprotocol=ipv6-icmp src=10.97.46.16 dst=10.120.4.9message: teni",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698884700Z"
+                "ingested": "2021-07-19T09:06:57.318461514Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -726,7 +726,7 @@
             },
             "message": "lorsitam tanimid.onpr litseddo_ ids-alerts oremqu ids-alerts signature=idex priority=radip timestamp=1528145055.uptaprotocol=ipv6-icmp src=10.171.206.139 dst=10.165.173.162message: lestia",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698885600Z"
+                "ingested": "2021-07-19T09:06:57.318463427Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -738,7 +738,7 @@
             },
             "message": "inibusB 1529380009.nostrud cteturad events dhcp lease of ip 10.150.163.151 from server mac 01:00:5e:72:b7:79 for client mac 01:00:5e:f2:d3:12 with hostname uames4985.mail.localdomain from router 10.144.57.239 on subnet oinBCSed with dns orem",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698886700Z"
+                "ingested": "2021-07-19T09:06:57.318465372Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -750,7 +750,7 @@
             },
             "message": "eritq rehen.ipsamvol elillum_ ids-alerts tco ids-alerts signature=tvol priority=oluptate timestamp=1530614963.lit shost=01:00:5e:ac:6d:d3 direction=unknown protocol=igmp src=10.52.202.158 dst=10.54.44.231 message: Ute",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698887600Z"
+                "ingested": "2021-07-19T09:06:57.318467269Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -762,7 +762,7 @@
             },
             "message": "runtm 1531849918.eturadip olorsi_ events MAC 01:00:5e:67:1d:0f and MAC 01:00:5e:f0:a9:cd both claim IP: 10.101.183.86",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698888600Z"
+                "ingested": "2021-07-19T09:06:57.318477496Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -774,7 +774,7 @@
             },
             "message": "inesciu 1533084872.quid atcupid_ flows orem flows src=10.71.22.225 dst=10.4.76.100 protocol=ggp pattern: allow serrorsi",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698889600Z"
+                "ingested": "2021-07-19T09:06:57.318479911Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -786,7 +786,7 @@
             },
             "message": "lamco 1534319826.cit siar events MAC 01:00:5e:80:cd:ca and MAC 01:00:5e:45:aa:51 both claim IP: 10.83.130.95",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698890500Z"
+                "ingested": "2021-07-19T09:06:57.318481820Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -798,7 +798,7 @@
             },
             "message": "hite 1535554780.ianonnum nofdeFi events aid=henderit arp_resp=remq arp_src=unt auth_neg_dur=tla auth_neg_failed=arch channel=lite dns_req_rtt=ugia dns_resp=meum dns_server=borumSec duration=91.439000 full_conn=nvolupta identity=tev ip_resp=nre ip_src=10.2.110.73 is_8021x=eturadip is_wpa=ent last_auth_ago=rumSecti radio=Utenima reason=olore rssi=orumS type=olor vap=radip client_mac=01:00:5e:59:bf:36 client_ip=10.230.98.81 instigator=aaliquaU http_resp=olu dhcp_lease_completed=iameaque dhcp_ip=identsun dhcp_server=ender dhcp_server_mac=inc dhcp_resp=tect url=https://www.example.net/doconse/eni.html?mSec=smoditem#tatisetq category0=uidolo server=10.103.49.129 vpn_type=oquisq connectivity=abori",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698891500Z"
+                "ingested": "2021-07-19T09:06:57.318483746Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -810,7 +810,7 @@
             },
             "message": "dunt 1536789735.ames amni events aid=tatio arp_resp=amquisno arp_src=modoc auth_neg_dur=magnam auth_neg_failed=uinesc channel=cid dns_req_rtt=emi dns_resp=Bonorum dns_server=lesti duration=59.289000 full_conn=iosamni identity=idu ip_resp=sis ip_src=10.158.61.228 is_8021x=tsedquia is_wpa=its last_auth_ago=umdolor radio=isiu reason=assi rssi=eserun type=rvelill vap=lupta client_mac=01:00:5e:e6:a6:a2 client_ip=10.186.16.20 instigator=tisu http_resp=remagnam dhcp_lease_completed=nvolupt dhcp_ip=meiusm dhcp_server=nidolo dhcp_server_mac=atquovol dhcp_resp=quunt url=https://www.example.com/seq/moll.htm?sunt=dquianon#urExc category0=tDuis server=10.132.176.96 vpn_type=aria connectivity=inim",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698892500Z"
+                "ingested": "2021-07-19T09:06:57.318485737Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -822,7 +822,7 @@
             },
             "message": "oremeumf 1538024689.lesti sintocca events dhcp lease of ip 10.105.136.146 from server mac 01:00:5e:bb:aa:f6 for client mac 01:00:5e:69:92:4a with hostname lors2232.api.example from router 10.46.217.155 on subnet amnihil with dns orissus",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698893500Z"
+                "ingested": "2021-07-19T09:06:57.318487628Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -834,7 +834,7 @@
             },
             "message": "nimadmin 1539259643.lumqui quiavolu flows src=10.245.199.23 dst=10.123.62.215 mac=01:00:5e:1f:7f:1d protocol=udp pattern: 0 iusmodt",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698894400Z"
+                "ingested": "2021-07-19T09:06:57.318489507Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -846,7 +846,7 @@
             },
             "message": "rep 1540494597.remap deri flows cancel src=10.239.105.121 dst=10.70.7.23 mac=01:00:5e:8e:82:f0 protocol=ipv6 ",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698895400Z"
+                "ingested": "2021-07-19T09:06:57.318491420Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -858,7 +858,7 @@
             },
             "message": "idexeac 1541729552.nimadmin midest_appliance events aid=modt arp_resp=iduntutl arp_src=rsitam auth_neg_dur=xercit auth_neg_failed=ulpaquio channel=itqu dns_req_rtt=minimav dns_resp=smodtem dns_server=roquisqu duration=116.294000 full_conn=iquid identity=evo ip_resp=mcorpori ip_src=10.196.176.243 is_8021x=itesse is_wpa=expl last_auth_ago=essecill radio=totamre reason=rpo rssi=velites type=nonpro vap=nula client_mac=01:00:5e:99:a6:b4 client_ip=10.90.50.149 instigator=nemulla http_resp=asp dhcp_lease_completed=dexercit dhcp_ip=amn dhcp_server=itessequ dhcp_server_mac=porissu dhcp_resp=umd url=https://www.example.net/sectetur/edquian.html?turQuis=taevi#uames category0=tconsec server=10.16.230.121 vpn_type=laboree connectivity=udantiu",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698896300Z"
+                "ingested": "2021-07-19T09:06:57.318493301Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -870,7 +870,7 @@
             },
             "message": "ttenb olor.quiav gna security_event Nem signature=tdolorem priority=eacomm timestamp=1542964506.upidata dhost=01:00:5e:6a:c8:f8 direction=unknown protocol=ipv6 src=10.246.152.72:4293 dst=10.34.62.190:1641 message:eve",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698897300Z"
+                "ingested": "2021-07-19T09:06:57.318495236Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -882,7 +882,7 @@
             },
             "message": "quisn 1544199460.rem ulamcola events dhcp no offers for mac 01:00:5e:67:fc:cb",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698898300Z"
+                "ingested": "2021-07-19T09:06:57.318497114Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -894,7 +894,7 @@
             },
             "message": "eruntmo 1545434414.nimve usanti_ events dhcp release for mac 01:00:5e:7d:de:f7",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698899500Z"
+                "ingested": "2021-07-19T09:06:57.318499299Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -906,7 +906,7 @@
             },
             "message": "uatu 1546669369.olupta consequu_ events dhcp release for mac 01:00:5e:6b:96:f2",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698900400Z"
+                "ingested": "2021-07-19T09:06:57.318501181Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -918,7 +918,7 @@
             },
             "message": "sitam inibusBo.illoin emUtenim ids-alerts signature=ende priority=dexea timestamp=1547904323.acoprotocol=ipv6 src=10.244.32.189 dst=10.121.9.5message: uptas",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698902300Z"
+                "ingested": "2021-07-19T09:06:57.318503093Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -930,7 +930,7 @@
             },
             "message": "edol 1549139277.sequuntu quameius_ events content_filtering_block url='https://www.example.com/totamrem/aliqu.htm?sBonorum=moenimi#lor' category0='auto' server='10.41.124.15:333'",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698903300Z"
+                "ingested": "2021-07-19T09:06:57.318505003Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -942,7 +942,7 @@
             },
             "message": "antium 1550374232.remaper eseosq events dhcp no offers for mac 01:00:5e:c3:77:27",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698904300Z"
+                "ingested": "2021-07-19T09:06:57.318506968Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -954,7 +954,7 @@
             },
             "message": "oditau 1551609186.onsec dit events MAC 01:00:5e:19:86:21 and MAC 01:00:5e:ed:ed:79 both claim IP: 10.43.235.230",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698905300Z"
+                "ingested": "2021-07-19T09:06:57.318509546Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -966,7 +966,7 @@
             },
             "message": "asper dictasun.psa lorese_ ids-alerts ctobeat ids-alerts signature=onsec priority=idestl timestamp=1552844140.litani shost=01:00:5e:a0:b2:c9 direction=unknown protocol=icmp src=10.199.19.205:5823 dst=10.103.91.159:7116 message: ntut",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698906300Z"
+                "ingested": "2021-07-19T09:06:57.318511661Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -978,7 +978,7 @@
             },
             "message": "estiaec 1554079094.pitlabo tas_appliance flows src=10.17.111.91 dst=10.65.0.157 mac=01:00:5e:49:c4:17 protocol=udp pattern: 1 nostrum",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698907200Z"
+                "ingested": "2021-07-19T09:06:57.318513794Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -990,7 +990,7 @@
             },
             "message": "ercitati 1555314049.atem serro flows cancel",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698908200Z"
+                "ingested": "2021-07-19T09:06:57.318515838Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -1002,7 +1002,7 @@
             },
             "message": "amquaera 1556549003.rsitamet leumiur events MAC 01:00:5e:fd:79:9e and MAC 01:00:5e:4d:c0:dd both claim IP: 10.20.130.88",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698909300Z"
+                "ingested": "2021-07-19T09:06:57.318517772Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -1014,7 +1014,7 @@
             },
             "message": "abill ametcon.ofdeFini tasnu_ ids-alerts tionev ids-alerts signature=uasiarch priority=velites timestamp=1557783957.uredolorprotocol=ipv6 src=10.177.64.152 dst=10.140.242.86message: temporin",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698910300Z"
+                "ingested": "2021-07-19T09:06:57.318519678Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -1026,7 +1026,7 @@
             },
             "message": "lor nvolupt.dquia ora_ security_event dipi security_event ecatc signature=quovolu priority=ite timestamp=1559018911.itse shost=01:00:5e:b8:73:c8 direction=external protocol=icmp src=10.199.103.185:2449 dst=10.51.121.223:24 message:stenat",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698911200Z"
+                "ingested": "2021-07-19T09:06:57.318521638Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -1038,7 +1038,7 @@
             },
             "message": "saq 1560253866.asiarch ssuscipi events MAC 01:00:5e:93:48:61 and MAC 01:00:5e:21:c2:55 both claim IP: 10.126.242.58",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698912200Z"
+                "ingested": "2021-07-19T09:06:57.318523521Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -1050,7 +1050,7 @@
             },
             "message": "tlab 1561488820.vel ionevo events dhcp release for mac 01:00:5e:8a:1a:f9",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698913200Z"
+                "ingested": "2021-07-19T09:06:57.318525448Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -1062,7 +1062,7 @@
             },
             "message": "aeab 1562723774.uradipis aerat_ flows uira flows deny src=10.121.37.244 dst=10.113.152.241 mac=01:00:5e:9c:86:62 protocol=udp type=utaliqui ",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698914100Z"
+                "ingested": "2021-07-19T09:06:57.318527459Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -1074,7 +1074,7 @@
             },
             "message": "nesciu 1563958728.mali roinBCSe_appliance events aid=eetdolor arp_resp=tpersp arp_src=assi auth_neg_dur=rch auth_neg_failed=psa channel=nreprehe dns_req_rtt=pidatatn dns_resp=isno dns_server=luptatev duration=39.622000 full_conn=lla identity=urau ip_resp=aeca ip_src=10.247.118.132 is_8021x=atcupi is_wpa=enima last_auth_ago=uptateve radio=fugitsed reason=lumqui rssi=ectet type=ionu vap=eratv client_mac=01:00:5e:10:8b:c3 client_ip=10.153.33.99 instigator=liq http_resp=xerc dhcp_lease_completed=atisetqu dhcp_ip=squir dhcp_server=gnaaliq dhcp_server_mac=quam dhcp_resp=deriti url=https://www5.example.org/eturadi/umS.txt?mSecti=henderi#taevitae category0=tevel server=10.254.96.130 vpn_type=ita connectivity=iquipexe",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698915100Z"
+                "ingested": "2021-07-19T09:06:57.318529398Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -1086,7 +1086,7 @@
             },
             "message": "tot 1565193683.reme emeumfu events aid=inBCSedu arp_resp=ita arp_src=ade auth_neg_dur=nihilmol auth_neg_failed=nder channel=ano dns_req_rtt=rumexer dns_resp=eab dns_server=iaconseq duration=18.963000 full_conn=eli identity=rissusci ip_resp=ectetur ip_src=10.101.13.122 is_8021x=oconsequ is_wpa=roqui last_auth_ago=oluptate radio=ntut reason=mremaper rssi=uteirur type=ntium vap=ide client_mac=01:00:5e:95:ae:d0 client_ip=10.78.143.52 instigator=ntiumdol http_resp=conse dhcp_lease_completed=aturve dhcp_ip=edqui dhcp_server=tvolu dhcp_server_mac=psu dhcp_resp=strud url=https://internal.example.org/fdeFi/ratv.htm?sequatu=tiumtot#tate category0=udanti server=10.200.98.243 vpn_type=cteturad connectivity=umq",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698916100Z"
+                "ingested": "2021-07-19T09:06:57.318531386Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -1098,7 +1098,7 @@
             },
             "message": "oinvento 1566428637.mporin orissusc_appliance events content_filtering_block url='https://www5.example.net/uov/pariat.htm?litsed=lumd#tiaec' category0='lorem' server='10.247.205.185:7676' client_mac='01:00:5e:6f:21:c8'",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698917100Z"
+                "ingested": "2021-07-19T09:06:57.318533416Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -1110,7 +1110,7 @@
             },
             "message": "metMa emoen.ptate mipsumqu_ ids-alerts ccusa ids-alerts signature=billo priority=doloremi timestamp=1567663591.ectetura dhost=01:00:5e:0a:88:bb direction=inbound protocol=ipv6 src=10.195.90.73:3914 dst=10.147.165.30:7662 message: idents",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698918100Z"
+                "ingested": "2021-07-19T09:06:57.318535344Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -1122,7 +1122,7 @@
             },
             "message": "veniamqu 1568898545.iconsequ ueporr_appliance events IDS: empor",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698919100Z"
+                "ingested": "2021-07-19T09:06:57.318537217Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -1134,7 +1134,7 @@
             },
             "message": "atDuisa mipsa.uas iat ids-alerts signature=hite priority=adipis timestamp=1570133500.abo dhost=01:00:5e:dd:cb:5b direction=inbound protocol=udp src=10.137.166.97 dst=10.162.202.14 message: ipsaqua",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698920Z"
+                "ingested": "2021-07-19T09:06:57.318539100Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -1146,7 +1146,7 @@
             },
             "message": "deom 1571368454.tiumdo rautod_appliance events content_filtering_block url='https://www5.example.com/illoinve/etcon.htm?nevolup=erspici#itinvolu' category0='adeserun' server='10.227.135.142:6598'",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698921Z"
+                "ingested": "2021-07-19T09:06:57.318541440Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -1158,7 +1158,7 @@
             },
             "message": "orese 1572603408.umdolore umqui_appliance events MAC 01:00:5e:f1:b8:3a and MAC 01:00:5e:37:9c:af both claim IP: 10.199.29.19",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698922Z"
+                "ingested": "2021-07-19T09:06:57.318543577Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -1170,7 +1170,7 @@
             },
             "message": "explicab 1573838362.samvolu teiru_appliance events dhcp no offers for mac 01:00:5e:b8:06:92",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698923Z"
+                "ingested": "2021-07-19T09:06:57.318545452Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -1182,7 +1182,7 @@
             },
             "message": "rissusci 1575073317.uaturQ iusmod_ events aid=mips arp_resp=iduntutl arp_src=mipsumd auth_neg_dur=eiusmo auth_neg_failed=quelauda channel=rcit dns_req_rtt=dolo dns_resp=ulamc dns_server=doe duration=10.574000 full_conn=remquela identity=toreve ip_resp=squirat ip_src=10.85.59.172 is_8021x=mto is_wpa=iae last_auth_ago=dent radio=Uten reason=tatiset rssi=sequat type=modoco vap=beataevi client_mac=01:00:5e:92:d8:95 client_ip=10.158.215.216 instigator=deritin http_resp=ptate dhcp_lease_completed=lloi dhcp_ip=nseq dhcp_server=equunt dhcp_server_mac=tutla dhcp_resp=usmod url=https://example.com/qui/itse.gif?orsitame=tasn#exeaco category0=upta server=10.75.122.111 vpn_type=reprehe connectivity=deFinib",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698924Z"
+                "ingested": "2021-07-19T09:06:57.318547323Z"
             },
             "tags": [
                 "preserve_original_event"
@@ -1194,7 +1194,7 @@
             },
             "message": "orr 1576308271.pre aute events IDS: rchite",
             "event": {
-                "ingested": "2021-06-09T10:11:36.698924900Z"
+                "ingested": "2021-07-19T09:06:57.318549217Z"
             },
             "tags": [
                 "preserve_original_event"

--- a/packages/cisco/data_stream/meraki/sample_event.json
+++ b/packages/cisco/data_stream/meraki/sample_event.json
@@ -1,9 +1,9 @@
 {
     "@timestamp": "2016-01-29T06:09:59.000Z",
     "agent": {
-        "ephemeral_id": "f5535a1f-52da-44d4-a626-f85bbdc25e74",
+        "ephemeral_id": "9b0d0418-f480-4f0b-8017-4cb9d88c01d7",
         "hostname": "docker-fleet-agent",
-        "id": "37c96a8c-c323-4db5-b898-9ba84c49e2ea",
+        "id": "3c803d12-46a2-48a4-a206-8fd3630cc2a9",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "7.14.0"
@@ -20,18 +20,19 @@
         "port": 5293
     },
     "ecs": {
-        "version": "1.9.0"
+        "version": "1.10.0"
     },
     "elastic_agent": {
-        "id": "732b7efe-6d7b-40fc-bbfe-799296be9d11",
+        "id": "3c803d12-46a2-48a4-a206-8fd3630cc2a9",
         "snapshot": true,
         "version": "7.14.0"
     },
     "event": {
         "action": "deny\n",
+        "agent_id_status": "verified",
         "code": "security_event",
         "dataset": "cisco.meraki",
-        "ingested": "2021-06-03T09:28:46.590942659Z",
+        "ingested": "2021-07-19T09:02:10.469724425Z",
         "original": "modtempo 1454047799.olab nto_ security_event olaborissecurity_event tur url=https://example.org/odoco/ria.jpg?ritin=uredolor#tatemac src=10.15.44.253:5078 dst=10.193.124.51:5293 mac=01:00:5e:28:ae:7d name=psa sha256=umq disposition=ntium action=deny\n",
         "timezone": "+00:00"
     },
@@ -43,7 +44,7 @@
     },
     "log": {
         "source": {
-            "address": "172.19.0.4:37952"
+            "address": "172.23.0.4:44394"
         }
     },
     "observer": {
@@ -56,8 +57,8 @@
             "docker-fleet-agent"
         ],
         "ip": [
-            "10.15.44.253",
-            "10.193.124.51"
+            "10.193.124.51",
+            "10.15.44.253"
         ]
     },
     "rsa": {
@@ -86,9 +87,9 @@
         "port": 5078
     },
     "tags": [
+        "preserve_original_event",
         "cisco-meraki",
-        "forwarded",
-        "preserve_original_event"
+        "forwarded"
     ],
     "url": {
         "original": "https://example.org/odoco/ria.jpg?ritin=uredolor#tatemac"

--- a/packages/cisco/data_stream/nexus/sample_event.json
+++ b/packages/cisco/data_stream/nexus/sample_event.json
@@ -1,9 +1,9 @@
 {
-    "@timestamp": "2021-06-03T09:31:40.532Z",
+    "@timestamp": "2021-07-19T09:05:27.398Z",
     "agent": {
-        "ephemeral_id": "f5535a1f-52da-44d4-a626-f85bbdc25e74",
+        "ephemeral_id": "9cae1736-608e-4d97-9238-c5acffac7d36",
         "hostname": "docker-fleet-agent",
-        "id": "37c96a8c-c323-4db5-b898-9ba84c49e2ea",
+        "id": "3c803d12-46a2-48a4-a206-8fd3630cc2a9",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "7.14.0"
@@ -14,17 +14,18 @@
         "type": "logs"
     },
     "ecs": {
-        "version": "1.9.0"
+        "version": "1.10.0"
     },
     "elastic_agent": {
-        "id": "732b7efe-6d7b-40fc-bbfe-799296be9d11",
+        "id": "3c803d12-46a2-48a4-a206-8fd3630cc2a9",
         "snapshot": true,
         "version": "7.14.0"
     },
     "event": {
+        "agent_id_status": "verified",
         "code": "pam_aaa",
         "dataset": "cisco.nexus",
-        "ingested": "2021-06-03T09:31:41.553114054Z",
+        "ingested": "2021-07-19T09:05:28.421638917Z",
         "original": "2012 Dec 18 14:51:08 Nexus5010-B %AUTHPRIV-3-SYSTEM_MSG: pam_aaa:Authentication failed for user en from 2.2.2.1 - login\n",
         "timezone": "+00:00"
     },
@@ -36,7 +37,7 @@
     },
     "log": {
         "source": {
-            "address": "172.19.0.4:46985"
+            "address": "172.23.0.4:37919"
         }
     },
     "observer": {
@@ -58,8 +59,8 @@
         }
     },
     "tags": [
+        "preserve_original_event",
         "cisco-nexus",
-        "forwarded",
-        "preserve_original_event"
+        "forwarded"
     ]
 }

--- a/packages/cisco/docs/README.md
+++ b/packages/cisco/docs/README.md
@@ -23,9 +23,9 @@ An example event for `asa` looks as following:
 {
     "@timestamp": "2018-10-10T12:34:56.000Z",
     "agent": {
-        "ephemeral_id": "f5535a1f-52da-44d4-a626-f85bbdc25e74",
+        "ephemeral_id": "a548620b-0623-4130-b586-fe233f00e6e5",
         "hostname": "docker-fleet-agent",
-        "id": "37c96a8c-c323-4db5-b898-9ba84c49e2ea",
+        "id": "3c803d12-46a2-48a4-a206-8fd3630cc2a9",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "7.14.0"
@@ -33,7 +33,6 @@ An example event for `asa` looks as following:
     "cisco": {
         "asa": {
             "destination_interface": "outside",
-            "message_id": "305011",
             "source_interface": "inside"
         }
     },
@@ -48,23 +47,24 @@ An example event for `asa` looks as following:
         "port": 8256
     },
     "ecs": {
-        "version": "1.9.0"
+        "version": "1.10.0"
     },
     "elastic_agent": {
-        "id": "732b7efe-6d7b-40fc-bbfe-799296be9d11",
+        "id": "3c803d12-46a2-48a4-a206-8fd3630cc2a9",
         "snapshot": true,
         "version": "7.14.0"
     },
     "event": {
         "action": "firewall-rule",
+        "agent_id_status": "verified",
         "category": [
             "network"
         ],
         "code": "305011",
         "dataset": "cisco.asa",
-        "ingested": "2021-06-03T09:22:20.519428820Z",
+        "ingested": "2021-07-19T08:54:36.436846422Z",
         "kind": "event",
-        "original": "%ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1772 to outside:100.66.98.44/8256",
+        "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1772 to outside:100.66.98.44/8256\n",
         "severity": 6,
         "timezone": "+00:00",
         "type": [
@@ -72,26 +72,8 @@ An example event for `asa` looks as following:
         ]
     },
     "host": {
-        "architecture": "x86_64",
-        "containerized": true,
         "hostname": "localhost",
-        "id": "f46ddd9d65ff20633d9c337909855778",
-        "ip": [
-            "172.19.0.7"
-        ],
-        "mac": [
-            "02:42:ac:13:00:07"
-        ],
-        "name": "docker-fleet-agent",
-        "os": {
-            "codename": "Core",
-            "family": "redhat",
-            "kernel": "5.10.25-linuxkit",
-            "name": "CentOS Linux",
-            "platform": "centos",
-            "type": "linux",
-            "version": "7 (Core)"
-        }
+        "name": "docker-fleet-agent"
     },
     "input": {
         "type": "udp"
@@ -99,7 +81,7 @@ An example event for `asa` looks as following:
     "log": {
         "level": "informational",
         "source": {
-            "address": "172.19.0.4:47315"
+            "address": "172.23.0.4:59451"
         }
     },
     "network": {
@@ -109,13 +91,13 @@ An example event for `asa` looks as following:
     "observer": {
         "egress": {
             "interface": {
-                "name": "inside"
+                "name": "outside"
             }
         },
         "hostname": "localhost",
         "ingress": {
             "interface": {
-                "name": "outside"
+                "name": "inside"
             }
         },
         "product": "asa",
@@ -141,8 +123,9 @@ An example event for `asa` looks as following:
         "port": 1772
     },
     "tags": [
+        "preserve_original_event",
         "cisco-asa",
-        "preserve_original_event"
+        "forwarded"
     ]
 }
 ```
@@ -336,16 +319,15 @@ An example event for `ftd` looks as following:
 {
     "@timestamp": "2019-08-16T09:39:03.000Z",
     "agent": {
-        "ephemeral_id": "f5535a1f-52da-44d4-a626-f85bbdc25e74",
+        "ephemeral_id": "915b9d78-907c-4615-90f8-e2997777f537",
         "hostname": "docker-fleet-agent",
-        "id": "37c96a8c-c323-4db5-b898-9ba84c49e2ea",
+        "id": "3c803d12-46a2-48a4-a206-8fd3630cc2a9",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "7.14.0"
     },
     "cisco": {
         "ftd": {
-            "message_id": "430005",
             "rule_name": "malware-and-file-policy",
             "security": {
                 "application_protocol": "HTTP",
@@ -403,23 +385,24 @@ An example event for `ftd` looks as following:
         "port": 80
     },
     "ecs": {
-        "version": "1.9.0"
+        "version": "1.10.0"
     },
     "elastic_agent": {
-        "id": "732b7efe-6d7b-40fc-bbfe-799296be9d11",
+        "id": "3c803d12-46a2-48a4-a206-8fd3630cc2a9",
         "snapshot": true,
         "version": "7.14.0"
     },
     "event": {
         "action": "malware-detected",
+        "agent_id_status": "verified",
         "category": [
             "malware"
         ],
         "code": "430005",
         "dataset": "cisco.ftd",
-        "ingested": "2021-06-03T09:24:01.526093450Z",
+        "ingested": "2021-07-19T08:56:32.448763106Z",
         "kind": "alert",
-        "original": "%FTD-1-430005: SrcIP: 10.0.1.20, DstIP: 213.211.198.62, SrcPort: 46004, DstPort: 80, Protocol: tcp, FileDirection: Download, FileAction: Malware Cloud Lookup, FileSHA256: 2546dcffc5ad854d4ddc64fbf056871cd5a00f2471cb7a5bfd4ac23b6e9eedad, SHA_Disposition: Unavailable, SperoDisposition: Spero detection not performed on file, ThreatName: Win.Ransomware.Eicar::95.sbx.tg, FileName: eicar_com.zip, FileType: ZIP, FileSize: 184, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-16T09:39:02Z, FilePolicy: malware-and-file-policy, FileStorageStatus: Not Stored (Disposition Was Pending), FileSandboxStatus: File Size Is Too Small, URI: http://www.eicar.org/download/eicar_com.zip",
+        "original": "2019-08-16T09:39:03Z firepower  %FTD-1-430005: SrcIP: 10.0.1.20, DstIP: 213.211.198.62, SrcPort: 46004, DstPort: 80, Protocol: tcp, FileDirection: Download, FileAction: Malware Cloud Lookup, FileSHA256: 2546dcffc5ad854d4ddc64fbf056871cd5a00f2471cb7a5bfd4ac23b6e9eedad, SHA_Disposition: Unavailable, SperoDisposition: Spero detection not performed on file, ThreatName: Win.Ransomware.Eicar::95.sbx.tg, FileName: eicar_com.zip, FileType: ZIP, FileSize: 184, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-16T09:39:02Z, FilePolicy: malware-and-file-policy, FileStorageStatus: Not Stored (Disposition Was Pending), FileSandboxStatus: File Size Is Too Small, URI: http://www.eicar.org/download/eicar_com.zip\n",
         "severity": 1,
         "start": "2019-08-16T09:39:02Z",
         "timezone": "+00:00",
@@ -435,26 +418,8 @@ An example event for `ftd` looks as following:
         "size": 184
     },
     "host": {
-        "architecture": "x86_64",
-        "containerized": true,
         "hostname": "firepower",
-        "id": "f46ddd9d65ff20633d9c337909855778",
-        "ip": [
-            "172.19.0.7"
-        ],
-        "mac": [
-            "02:42:ac:13:00:07"
-        ],
-        "name": "docker-fleet-agent",
-        "os": {
-            "codename": "Core",
-            "family": "redhat",
-            "kernel": "5.10.25-linuxkit",
-            "name": "CentOS Linux",
-            "platform": "centos",
-            "type": "linux",
-            "version": "7 (Core)"
-        }
+        "name": "docker-fleet-agent"
     },
     "input": {
         "type": "udp"
@@ -462,7 +427,7 @@ An example event for `ftd` looks as following:
     "log": {
         "level": "alert",
         "source": {
-            "address": "172.19.0.4:46787"
+            "address": "172.23.0.4:41328"
         }
     },
     "network": {
@@ -498,11 +463,16 @@ An example event for `ftd` looks as following:
         "port": 46004
     },
     "tags": [
+        "preserve_original_event",
         "cisco-ftd",
-        "preserve_original_event"
+        "forwarded"
     ],
     "url": {
-        "original": "http://www.eicar.org/download/eicar_com.zip"
+        "domain": "www.eicar.org",
+        "extension": "zip",
+        "original": "http://www.eicar.org/download/eicar_com.zip",
+        "path": "/download/eicar_com.zip",
+        "scheme": "http"
     },
     "user": {
         "id": "No Authentication Required",
@@ -713,11 +683,11 @@ An example event for `ios` looks as following:
 
 ```json
 {
-    "@timestamp": "2021-06-03T09:25:42.537Z",
+    "@timestamp": "2021-07-19T08:58:29.370Z",
     "agent": {
-        "ephemeral_id": "f5535a1f-52da-44d4-a626-f85bbdc25e74",
+        "ephemeral_id": "7e9d4c95-b972-479d-bc6c-2ac0d05f3eb1",
         "hostname": "docker-fleet-agent",
-        "id": "37c96a8c-c323-4db5-b898-9ba84c49e2ea",
+        "id": "3c803d12-46a2-48a4-a206-8fd3630cc2a9",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "7.14.0"
@@ -738,46 +708,29 @@ An example event for `ios` looks as following:
         "ip": "224.0.0.22"
     },
     "ecs": {
-        "version": "1.9.0"
+        "version": "1.10.0"
     },
     "elastic_agent": {
-        "id": "732b7efe-6d7b-40fc-bbfe-799296be9d11",
+        "id": "3c803d12-46a2-48a4-a206-8fd3630cc2a9",
         "snapshot": true,
         "version": "7.14.0"
     },
     "event": {
         "action": "deny",
+        "agent_id_status": "verified",
         "category": "network",
         "code": "IPACCESSLOGRP",
         "dataset": "cisco.ios",
-        "ingested": "2021-06-03T09:25:43.560570635Z",
+        "ingested": "2021-07-19T08:58:30.397370366Z",
         "original": "Feb  8 04:00:48 198.51.100.2 585917: Feb  8 04:00:47.272: %SEC-6-IPACCESSLOGRP: list 177 denied igmp 198.51.100.197 -\u003e 224.0.0.22, 1 packet\n",
         "provider": "firewall",
         "sequence": 585917,
         "severity": 6,
-        "type": "info"
+        "timezone": "+00:00",
+        "type": "denied"
     },
     "host": {
-        "architecture": "x86_64",
-        "containerized": true,
-        "hostname": "docker-fleet-agent",
-        "id": "f46ddd9d65ff20633d9c337909855778",
-        "ip": [
-            "172.19.0.7"
-        ],
-        "mac": [
-            "02:42:ac:13:00:07"
-        ],
-        "name": "docker-fleet-agent",
-        "os": {
-            "codename": "Core",
-            "family": "redhat",
-            "kernel": "5.10.25-linuxkit",
-            "name": "CentOS Linux",
-            "platform": "centos",
-            "type": "linux",
-            "version": "7 (Core)"
-        }
+        "name": "docker-fleet-agent"
     },
     "input": {
         "type": "udp"
@@ -807,8 +760,9 @@ An example event for `ios` looks as following:
         "packets": 1
     },
     "tags": [
+        "preserve_original_event",
         "cisco-ios",
-        "preserve_original_event"
+        "forwarded"
     ]
 }
 ```
@@ -921,11 +875,11 @@ An example event for `nexus` looks as following:
 
 ```json
 {
-    "@timestamp": "2021-06-03T09:31:40.532Z",
+    "@timestamp": "2021-07-19T09:05:27.398Z",
     "agent": {
-        "ephemeral_id": "f5535a1f-52da-44d4-a626-f85bbdc25e74",
+        "ephemeral_id": "9cae1736-608e-4d97-9238-c5acffac7d36",
         "hostname": "docker-fleet-agent",
-        "id": "37c96a8c-c323-4db5-b898-9ba84c49e2ea",
+        "id": "3c803d12-46a2-48a4-a206-8fd3630cc2a9",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "7.14.0"
@@ -936,17 +890,18 @@ An example event for `nexus` looks as following:
         "type": "logs"
     },
     "ecs": {
-        "version": "1.9.0"
+        "version": "1.10.0"
     },
     "elastic_agent": {
-        "id": "732b7efe-6d7b-40fc-bbfe-799296be9d11",
+        "id": "3c803d12-46a2-48a4-a206-8fd3630cc2a9",
         "snapshot": true,
         "version": "7.14.0"
     },
     "event": {
+        "agent_id_status": "verified",
         "code": "pam_aaa",
         "dataset": "cisco.nexus",
-        "ingested": "2021-06-03T09:31:41.553114054Z",
+        "ingested": "2021-07-19T09:05:28.421638917Z",
         "original": "2012 Dec 18 14:51:08 Nexus5010-B %AUTHPRIV-3-SYSTEM_MSG: pam_aaa:Authentication failed for user en from 2.2.2.1 - login\n",
         "timezone": "+00:00"
     },
@@ -958,7 +913,7 @@ An example event for `nexus` looks as following:
     },
     "log": {
         "source": {
-            "address": "172.19.0.4:46985"
+            "address": "172.23.0.4:37919"
         }
     },
     "observer": {
@@ -980,9 +935,9 @@ An example event for `nexus` looks as following:
         }
     },
     "tags": [
+        "preserve_original_event",
         "cisco-nexus",
-        "forwarded",
-        "preserve_original_event"
+        "forwarded"
     ]
 }
 ```
@@ -1829,9 +1784,9 @@ An example event for `meraki` looks as following:
 {
     "@timestamp": "2016-01-29T06:09:59.000Z",
     "agent": {
-        "ephemeral_id": "f5535a1f-52da-44d4-a626-f85bbdc25e74",
+        "ephemeral_id": "9b0d0418-f480-4f0b-8017-4cb9d88c01d7",
         "hostname": "docker-fleet-agent",
-        "id": "37c96a8c-c323-4db5-b898-9ba84c49e2ea",
+        "id": "3c803d12-46a2-48a4-a206-8fd3630cc2a9",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "7.14.0"
@@ -1848,18 +1803,19 @@ An example event for `meraki` looks as following:
         "port": 5293
     },
     "ecs": {
-        "version": "1.9.0"
+        "version": "1.10.0"
     },
     "elastic_agent": {
-        "id": "732b7efe-6d7b-40fc-bbfe-799296be9d11",
+        "id": "3c803d12-46a2-48a4-a206-8fd3630cc2a9",
         "snapshot": true,
         "version": "7.14.0"
     },
     "event": {
         "action": "deny\n",
+        "agent_id_status": "verified",
         "code": "security_event",
         "dataset": "cisco.meraki",
-        "ingested": "2021-06-03T09:28:46.590942659Z",
+        "ingested": "2021-07-19T09:02:10.469724425Z",
         "original": "modtempo 1454047799.olab nto_ security_event olaborissecurity_event tur url=https://example.org/odoco/ria.jpg?ritin=uredolor#tatemac src=10.15.44.253:5078 dst=10.193.124.51:5293 mac=01:00:5e:28:ae:7d name=psa sha256=umq disposition=ntium action=deny\n",
         "timezone": "+00:00"
     },
@@ -1871,7 +1827,7 @@ An example event for `meraki` looks as following:
     },
     "log": {
         "source": {
-            "address": "172.19.0.4:37952"
+            "address": "172.23.0.4:44394"
         }
     },
     "observer": {
@@ -1884,8 +1840,8 @@ An example event for `meraki` looks as following:
             "docker-fleet-agent"
         ],
         "ip": [
-            "10.15.44.253",
-            "10.193.124.51"
+            "10.193.124.51",
+            "10.15.44.253"
         ]
     },
     "rsa": {
@@ -1914,9 +1870,9 @@ An example event for `meraki` looks as following:
         "port": 5078
     },
     "tags": [
+        "preserve_original_event",
         "cisco-meraki",
-        "forwarded",
-        "preserve_original_event"
+        "forwarded"
     ],
     "url": {
         "original": "https://example.org/odoco/ria.jpg?ritin=uredolor#tatemac"

--- a/packages/cisco/manifest.yml
+++ b/packages/cisco/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco
 title: Cisco
-version: 0.10.0
+version: 0.10.1
 license: basic
 description: Cisco Integration
 type: integration


### PR DESCRIPTION
## What does this PR do?

Align the asa/ftd pipelines with Cisco package from Beats: https://github.com/elastic/beats/pull/26265

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).
