### PR TITLE
Update elastic-package to v0.9.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/elastic/elastic-package v0.9.3-0.20210719091614-7fabac93a939
+	github.com/elastic/elastic-package v0.9.3
 	github.com/elastic/package-registry v0.20.0
 	github.com/magefile/mage v1.11.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5m
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
-github.com/elastic/elastic-package v0.9.3-0.20210719091614-7fabac93a939 h1:8MXa49ZKaxyn1XnWrm9CkDnye0Mc6aaiUJzHlJ5Iylk=
-github.com/elastic/elastic-package v0.9.3-0.20210719091614-7fabac93a939/go.mod h1:5wXDv6wl9fgj/LawKdxUKWKzTuB9ZTRm4azxtJU/Cqs=
+github.com/elastic/elastic-package v0.9.3 h1:7hYu5gdPeLNLpdL/KkZl0seypyVlapSng6WwpqbvUUE=
+github.com/elastic/elastic-package v0.9.3/go.mod h1:5wXDv6wl9fgj/LawKdxUKWKzTuB9ZTRm4azxtJU/Cqs=
 github.com/elastic/go-elasticsearch/v7 v7.13.1 h1:PaM3V69wPlnwR+ne50rSKKn0RNDYnnOFQcuGEI0ce80=
 github.com/elastic/go-elasticsearch/v7 v7.13.1/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/go-licenser v0.3.1/go.mod h1:D8eNQk70FOCVBl3smCGQt/lv7meBeQno2eI1S5apiHQ=


### PR DESCRIPTION
This PR updates dependency on elastic-package to the release v0.9.3 (not anymore "master").