### PR TITLE
Re-adding pipeline changes removed by mistake

### DIFF
--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.1"
+  changes:
+    - description: Re-add pipelien changes for invalid json
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1051
 - version: "0.5.0"
   changes:
     - description: Add input groups

--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "0.5.1"
   changes:
-    - description: Re-add pipelien changes for invalid json
+    - description: Re-add pipeline changes for invalid json
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1051
+      link: https://github.com/elastic/integrations/pull/1353
 - version: "0.5.0"
   changes:
     - description: Add input groups

--- a/packages/azure/data_stream/platformlogs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/azure/data_stream/platformlogs/elasticsearch/ingest_pipeline/default.yml
@@ -23,6 +23,23 @@ processors:
   - json:
       field: event.original
       target_field: azure.platformlogs
+      on_failure:
+        - grok:
+            field: event.original
+            patterns:
+              - "resourceId\": \"%{DATA:azure.platformlogs.resourceId}\""
+            ignore_failure: true
+            ignore_missing: true
+        - grok:
+            field: event.original
+            patterns:
+              - "category\": \"%{DATA:azure.platformlogs.category}\""
+            ignore_failure: true
+            ignore_missing: true
+        - set:
+            field: error.message
+            value: 'invalid json log'
+            ignore_failure: true
   - date:
       field: azure.platformlogs.time
       target_field: '@timestamp'

--- a/packages/azure/data_stream/platformlogs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/azure/data_stream/platformlogs/elasticsearch/ingest_pipeline/default.yml
@@ -27,13 +27,19 @@ processors:
         - grok:
             field: event.original
             patterns:
-              - "resourceId\": \"%{DATA:azure.platformlogs.resourceId}\""
+              - "resourceId\": ?\"%{DATA:azure.platformlogs.resourceId}\""
             ignore_failure: true
             ignore_missing: true
         - grok:
             field: event.original
             patterns:
-              - "category\": \"%{DATA:azure.platformlogs.category}\""
+              - "category\": ?\"%{DATA:azure.platformlogs.category}\""
+            ignore_failure: true
+            ignore_missing: true
+        - grok:
+            field: event.original
+            patterns:
+              - "time\": ?\"%{DATA:azure.platformlogs.time}\""
             ignore_failure: true
             ignore_missing: true
         - set:

--- a/packages/azure/manifest.yml
+++ b/packages/azure/manifest.yml
@@ -1,6 +1,6 @@
 name: azure
 title: Azure Logs
-version: 0.5.0
+version: 0.5.1
 release: beta
 description: Azure Logs Integration
 type: integration


### PR DESCRIPTION
- add pipeline changes removed during module integration sync, offending PR https://github.com/elastic/integrations/pull/722

## What does this PR do?

- add pipeline changes removed during module integration sync

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

