### PR TITLE
Change categories in AWS package

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix categories for each policy template
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1334
+      link: https://github.com/elastic/integrations/pull/1357
 - version: "0.9.2"
   changes:
     - description: Add linked account information into billing metricset

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.9.3"
+  changes:
+    - description: Fix categories for each policy template
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1334
 - version: "0.9.2"
   changes:
     - description: Add linked account information into billing metricset

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,15 +1,13 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 0.9.2
+version: 0.9.3
 license: basic
 description: AWS Integration
 type: integration
 categories:
   - aws
   - cloud
-  - network
-  - security
 release: beta
 conditions:
   kibana.version: "^7.14.0"
@@ -209,6 +207,8 @@ policy_templates:
     data_streams:
       - elb_logs
       - elb_metrics
+    categories:
+      - network
     inputs:
       - type: aws-s3
         title: Collect logs from ELB service
@@ -257,6 +257,8 @@ policy_templates:
     description: Collect AWS NATGateway metrics
     data_streams:
       - natgateway
+    categories:
+      - network
     inputs:
       - type: aws/metrics
         title: Collect NATGateway metrics
@@ -366,6 +368,8 @@ policy_templates:
     description: Collect AWS Transit Gateway metrics
     data_streams:
       - transitgateway
+    categories:
+      - network
     inputs:
       - type: aws/metrics
         title: Collect Transit Gateway metrics
@@ -396,6 +400,9 @@ policy_templates:
     description: Collect AWS vpcflow logs
     data_streams:
       - vpcflow
+    categories:
+      - network
+      - security
     inputs:
       - type: aws-s3
         title: Collect VPC Flow logs

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -93,6 +93,8 @@ policy_templates:
     description: Collect logs from AWS Cloudtrail
     data_streams:
       - cloudtrail
+    categories:
+      - security
     inputs:
       - type: aws-s3
         title: Collect logs from Cloudtrail service
@@ -300,6 +302,7 @@ policy_templates:
       - s3access
     categories:
       - datastore
+      - security
     inputs:
       - type: aws-s3
         title: Collect S3 access logs


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR is to remove network and security categories at the package level for AWS and add them into each policy template.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Related issues

- Closes https://github.com/elastic/integrations/issues/1342