### PR TITLE
Osquery_manager: Update ECS mapping format based on the latest developers feedback

### DIFF
--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.1"
+  changes:
+    - description: Update ECS mapping format based on the latest developers feedback
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/1360
 - version: "0.4.0"
   changes:
     - description: ECS mapping configuration support for queries/streams

--- a/packages/osquery_manager/data_stream/result/agent/stream/stream.yml.hbs
+++ b/packages/osquery_manager/data_stream/result/agent/stream/stream.yml.hbs
@@ -12,6 +12,9 @@ version: {{version}}
 {{#if ecs_mapping}}
 ecs_mapping:
 {{#each ecs_mapping}}
-   {{@key}}: {{this}}
+   {{@key}}:
+      {{#each this}}
+         {{@key}}: {{this}}
+      {{/each}}
 {{/each}}
 {{/if}}

--- a/packages/osquery_manager/manifest.yml
+++ b/packages/osquery_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: osquery_manager
 title: Osquery Manager
-version: 0.4.0
+version: 0.4.1
 license: basic
 description: Centrally manage osquery deployments, run live queries, and schedule recurring queries
 type: integration


### PR DESCRIPTION
## What does this PR do?

Changes the format of ECS mapping configuration for the queries:
1. The mapping keys are the ECS key path
2. The mapping value is an object that allows to define the static ```value``` or the ```field``` which is the name of the osquery result column. 

Current format example:
```
                        "ecs_mapping": {
                                "user.custom.shoeSize": {
                                    "value": 45
                                },
                                "user.id": {
                                    "field": "uid"
                                },
                                "user.name": {
                                    "field": "username"
                                }
                        }
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).


## Screenshots

The fragment of the document showing and example of the ECS fields mapped:

<img width="326" alt="Screen Shot 2021-07-27 at 3 19 42 PM" src="https://user-images.githubusercontent.com/872351/127231388-3d2e91a6-a345-4ca5-ac14-2678bb49b99d.png">
