### PR TITLE
azure update to ECS 1.11.0

### DIFF
--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.6.2'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1372
 - version: "0.6.1"
   changes:
     - description: Escape special characters in docs

--- a/packages/azure/data_stream/activitylogs/_dev/test/pipeline/test-activitylogs-edgecases.log-expected.json
+++ b/packages/azure/data_stream/activitylogs/_dev/test/pipeline/test-activitylogs-edgecases.log-expected.json
@@ -6,7 +6,7 @@
             },
             "@timestamp": "2021-05-25T22:04:07.220Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "Information"

--- a/packages/azure/data_stream/activitylogs/_dev/test/pipeline/test-activitylogs-raw.log-expected.json
+++ b/packages/azure/data_stream/activitylogs/_dev/test/pipeline/test-activitylogs-raw.log-expected.json
@@ -33,7 +33,7 @@
             },
             "@timestamp": "2019-10-24T00:13:46.355Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/azure/data_stream/activitylogs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/azure/data_stream/activitylogs/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   - rename:
       field: azure
       target_field: azure-eventhub

--- a/packages/azure/data_stream/auditlogs/_dev/test/pipeline/test-auditlogs-raw.log-expected.json
+++ b/packages/azure/data_stream/auditlogs/_dev/test/pipeline/test-auditlogs-raw.log-expected.json
@@ -6,7 +6,7 @@
             },
             "@timestamp": "2019-10-18T15:30:51.027Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "Informational"

--- a/packages/azure/data_stream/auditlogs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/azure/data_stream/auditlogs/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   - rename:
       field: azure
       target_field: azure-eventhub

--- a/packages/azure/data_stream/platformlogs/_dev/test/pipeline/test-platformlogs-invalid-raw.log-expected.json
+++ b/packages/azure/data_stream/platformlogs/_dev/test/pipeline/test-platformlogs-invalid-raw.log-expected.json
@@ -6,7 +6,7 @@
             },
             "@timestamp": "2020-10-11T20:30:59.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "event": {
                 "action": "ApplicationGatewayAccess",

--- a/packages/azure/data_stream/platformlogs/_dev/test/pipeline/test-platformlogs-kube.log-expected.json
+++ b/packages/azure/data_stream/platformlogs/_dev/test/pipeline/test-platformlogs-kube.log-expected.json
@@ -6,7 +6,7 @@
             },
             "@timestamp": "2020-11-09T10:57:31.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "event": {
                 "action": "Microsoft.ContainerService/managedClusters/diagnosticLogs/Read",

--- a/packages/azure/data_stream/platformlogs/_dev/test/pipeline/test-platformlogs-raw.log-expected.json
+++ b/packages/azure/data_stream/platformlogs/_dev/test/pipeline/test-platformlogs-raw.log-expected.json
@@ -7,7 +7,7 @@
             },
             "@timestamp": "2020-11-03T09:06:42.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "event": {
                 "action": "Retreive ConsumerGroup",
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2020-11-03T09:06:42.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "event": {
                 "action": "Retreive ConsumerGroup",

--- a/packages/azure/data_stream/platformlogs/_dev/test/pipeline/test-platformlogs-remote-raw.log-expected.json
+++ b/packages/azure/data_stream/platformlogs/_dev/test/pipeline/test-platformlogs-remote-raw.log-expected.json
@@ -6,7 +6,7 @@
             },
             "@timestamp": "2020-11-09T10:57:31.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "event": {
                 "action": "Microsoft.ContainerService/managedClusters/diagnosticLogs/Read",

--- a/packages/azure/data_stream/platformlogs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/azure/data_stream/platformlogs/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   - rename:
       field: azure
       target_field: azure-eventhub

--- a/packages/azure/data_stream/signinlogs/_dev/test/pipeline/test-signinlogs-raw.log-expected.json
+++ b/packages/azure/data_stream/signinlogs/_dev/test/pipeline/test-signinlogs-raw.log-expected.json
@@ -43,7 +43,7 @@
             },
             "@timestamp": "2019-10-18T09:45:48.072Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -162,7 +162,7 @@
             },
             "@timestamp": "2019-10-18T09:45:48.072Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/azure/data_stream/signinlogs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/azure/data_stream/signinlogs/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   - rename:
       field: azure
       target_field: azure-eventhub

--- a/packages/azure/manifest.yml
+++ b/packages/azure/manifest.yml
@@ -1,6 +1,6 @@
 name: azure
 title: Azure Logs
-version: 0.6.1
+version: 0.6.2
 release: beta
 description: This Elastic integration collects logs from Azure
 type: integration


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967