### PR TITLE
barracuda update to ECS 1.11.0

### DIFF
--- a/packages/barracuda/changelog.yml
+++ b/packages/barracuda/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.5.1'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1373
 - version: "0.5.0"
   changes:
     - description: Update integration description

--- a/packages/barracuda/data_stream/spamfirewall/_dev/test/pipeline/test-generated.log-expected.json
+++ b/packages/barracuda/data_stream/spamfirewall/_dev/test/pipeline/test-generated.log-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "notify/smtp[avolupt]: 10.224.15.48 nto sse accept tur 3 illumqui 1090 1.2364 ivelitse ritin",
             "event": {
@@ -14,7 +14,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inbound/pass1: etdo[10.173.228.223] ntsunti 1455282753 1455282753 SCAN nseq itinvol psa umq 0 31 psaq SZ:cer SUBJ:reveri",
             "event": {
@@ -26,7 +26,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "outbound/smtp: 10.104.162.169 eosquir orsi nulapari allow vol 4 uidolor nibus mipsumq \u003c\u003cgnaali\u003e: enatus",
             "event": {
@@ -38,7 +38,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "notify/smtp[iatu]: 10.57.70.73 dolo meumfug deny roinBCS 2 com 1060 1.2548 byC tinculp",
             "event": {
@@ -50,7 +50,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "outbound/smtp: 10.236.42.236 tconsec nsequat taev block untutl 1 llu uptassi tamremap tur",
             "event": {
@@ -62,7 +62,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (enatuse.exe) queued as magn",
             "event": {
@@ -74,7 +74,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inbound/pass1[sit]: avol[10.162.151.94] laboreet 1461457525 1461457525 RECV aquaeabi giatq quid",
             "event": {
@@ -86,7 +86,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inbound/pass1: tempor[10.138.137.28] eip 1462692479 1462692479 SCAN lupta iusmodt doloreeu pori 7 8 ect SZ:reetdolo SUBJ:nrepreh",
             "event": {
@@ -98,7 +98,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "scan: ari[10.108.180.105] nsequat 1463927433 1463927433 block llam llamcorp ari eataevit 4 38 uovol dmi",
             "event": {
@@ -110,7 +110,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inbound/pass1: [10.206.159.177] ididu 1465162388 1465162388 RECV ciunt turQuisa 10 74 lit",
             "event": {
@@ -122,7 +122,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inbound/pass1[umdo]: sed[10.206.224.241] reetdolo 1466397342 1466397342 RECV olupta turveli 4 40 tatno",
             "event": {
@@ -134,7 +134,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inbound/pass1: aveniam[10.82.201.113] essequ 1467632296 1467632296 SCAN taevi ender snulapar aedic 5 13 iumto SZ:aboreetd SUBJ:sun",
             "event": {
@@ -146,7 +146,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (tem.exe) queued as ons",
             "event": {
@@ -158,7 +158,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "outbound/smtp: 10.110.109.5 ittenbyC aperi lor accept ipi 4 paqu eseru remeum #to#10.18.165.35",
             "event": {
@@ -170,7 +170,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "scan: dolore[10.195.109.134] eddoei 1471337159 1471337159 deny etM nimadmin ditautfu piscing 6 74 ostr rudexerc",
             "event": {
@@ -182,7 +182,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "scan[colabor]: iusmodt[10.21.92.218] lorumw 1472572113 1472572113 accept llitani inima tlabo suntexp 4 45 stiae SZ:nofdeF SUBJ:sunt",
             "event": {
@@ -194,7 +194,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (tat.exe) queued as tion",
             "event": {
@@ -206,7 +206,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (emp.exe) queued as aperia",
             "event": {
@@ -218,7 +218,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "web: Ret Policy Summary (Del:eritquii Kept:dexeac)",
             "event": {
@@ -230,7 +230,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "web: [10.45.25.68] LOGOUT (rehender)",
             "event": {
@@ -242,7 +242,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "web: Ret Policy Summary (Del:hil Kept:atquovo)",
             "event": {
@@ -254,7 +254,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "notify/smtp[tatn]: 10.18.109.121 ents pida allow idolor 1 emoeni 269 1.2857 utlabore ecillu",
             "event": {
@@ -266,7 +266,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "web: [10.19.194.101] global CHANGE orinrepr (conse)",
             "event": {
@@ -278,7 +278,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (lumqui.exe) queued as itinvo",
             "event": {
@@ -290,7 +290,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (usmodt.exe) queued as siar",
             "event": {
@@ -302,7 +302,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "notify/smtp[sci]: 10.116.193.182 snostrud nama allow data 1 ationul 2530 1.5361 commod adol",
             "event": {
@@ -314,7 +314,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inbound/pass1: hitect[10.198.6.166] modocon 1486156610 1486156610 SCAN que atevel nsecte itame 0 38 lit5929.test quamnih",
             "event": {
@@ -326,7 +326,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "outbound/smtp: 10.198.19.111 aquaeabi lita adeseru accept amc 4 amest corp modtemp \u003c\u003crehender\u003e: iae",
             "event": {
@@ -338,7 +338,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inbound/pass1: equat[10.77.137.72] ione 1488626519 1488626519 SCAN ihilmole eriamea amre rsita 8 56 uptat3156.www5.test tmo",
             "event": {
@@ -350,7 +350,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inbound/pass1: vitaedi[10.128.114.77] temqu 1489861473 1489861473 SCAN edol colab ommodico quatD 4 59 neav6028.internal.domain agnid",
             "event": {
@@ -362,7 +362,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "outbound/smtp: 10.181.80.139 hitecto ents liquide allow tenatu 1 boN eprehend aevit aboN",
             "event": {
@@ -374,7 +374,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inbound/pass1[ris]: uamqu[10.138.252.123] quioffi 1492331381 1492331381 RECV uptate ncidid quaturve",
             "event": {
@@ -386,7 +386,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (aera.exe) queued as ate",
             "event": {
@@ -398,7 +398,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inbound/pass1: [10.153.108.27] uir 1494801290 1494801290 RECV dol essecil citation",
             "event": {
@@ -410,7 +410,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "outbound/smtp: 10.120.167.239 gnido ratvolu olup deny nsecte 3 eveli eroi dtemp aliquide",
             "event": {
@@ -422,7 +422,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inbound/pass1[ris]: nisi[10.105.88.20] ecte 1497271198 1497271198 RECV tinvolu iurer iciadese",
             "event": {
@@ -434,7 +434,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "scan: olupta[10.98.92.244] idolor 1498506153 1498506153 deny uta llumdolo nre ercitat 7 38 riosamn SZ:ept SUBJ:iumtotam",
             "event": {
@@ -446,7 +446,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "scan[sperna]: sintocc[10.185.107.75] tDuisaut 1499741107 1499741107 allow tate imvenia spi stquido 8 62 ptas SZ:pta SUBJ:tetu",
             "event": {
@@ -458,7 +458,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (nevo.exe) queued as ide",
             "event": {
@@ -470,7 +470,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "notify/smtp[etcons]: 10.80.214.206 ate uiac accept officiad 4 quinesc 6218 1.5651 tur roi",
             "event": {
@@ -482,7 +482,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "notify/smtp[nof]: 10.48.34.226 ccaec ten allow isc 2 ntN 6179 1.2364 tateve itinvol",
             "event": {
@@ -494,7 +494,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (etconsec.exe) queued as ios",
             "event": {
@@ -506,7 +506,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inbound/pass1: tquov[10.211.93.62] mod 1505915878 1505915878 SCAN hilm ataevi com tnulapa 5 57 tiumt SZ:reetdolo SUBJ:norum",
             "event": {
@@ -518,7 +518,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (uidol.exe) queued as mporin",
             "event": {
@@ -530,7 +530,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "scan: qui[10.199.182.123] entor 1508385787 1508385787 accept Sedutp utp ema rsitv 0 69 ntiumt iquipe",
             "event": {
@@ -542,7 +542,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (tvolupt.exe) queued as eufugi",
             "event": {
@@ -554,7 +554,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "scan[pid]: illoin[10.130.38.118] uamni 1510855695 1510855695 block gnamal metMalo ntexplic archite 1 56 untu asi",
             "event": {
@@ -566,7 +566,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inbound/pass1: [10.153.152.219] eumiu 1512090649 1512090649 RECV orumSe boree intoc",
             "event": {
@@ -578,7 +578,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "web: Retention violating accounts: rnatur total",
             "event": {
@@ -590,7 +590,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (isisten.exe) queued as cusant",
             "event": {
@@ -602,7 +602,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (naal.exe) queued as borios",
             "event": {
@@ -614,7 +614,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "outbound/smtp: 10.167.227.44 tali lillum cusant deny ender 2 oles edic seq tutlab",
             "event": {
@@ -626,7 +626,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "notify/smtp[atevelit]: 10.56.136.27 aperia ccaeca deny ttenby 1 amc 5163 1.375 orumSe ratv",
             "event": {
@@ -638,7 +638,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "web: [10.194.90.130] FAILED_LOGIN (siut)",
             "event": {
@@ -650,7 +650,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inbound/pass1: [10.103.69.44] velitess 1520735329 1520735329 RECV naali uunturm temUte",
             "event": {
@@ -662,7 +662,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inbound/pass1: aveni[10.29.155.171] uptatema 1521970284 1521970284 SCAN oeni tdol sit tiaec 6 23 oremagna3521.mail.home asiar",
             "event": {
@@ -674,7 +674,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inbound/pass1: [10.145.193.93] nonp 1523205238 1523205238 RECV labo ulapar aboreetd",
             "event": {
@@ -686,7 +686,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inbound/pass1[ama]: uatur[10.143.79.226] exeacom 1524440192 1524440192 RECV roidents tem dol",
             "event": {
@@ -698,7 +698,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "web: [10.30.25.84] FAILED_LOGIN (utlab)",
             "event": {
@@ -710,7 +710,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inbound/pass1: [10.141.225.182] bor 1526910101 1526910101 RECV rauto ationev 8 57 uaUten",
             "event": {
@@ -722,7 +722,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (dun.exe) queued as reprehe",
             "event": {
@@ -734,7 +734,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "web: [10.90.9.88] global CHANGE umexerc (oremipsu)",
             "event": {
@@ -746,7 +746,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (amco.exe) queued as ssecillu",
             "event": {
@@ -758,7 +758,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (olo.exe) queued as psumqu",
             "event": {
@@ -770,7 +770,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "notify/smtp[rationev]: 10.226.20.199 tatem untutlab allow eveli 2 lillum 7809 1.2000 uisaute imide",
             "event": {
@@ -782,7 +782,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "web: [10.134.140.191] global CHANGE nte (mvel)",
             "event": {
@@ -794,7 +794,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "outbound/smtp[conse]: 10.252.40.172 nimadmin isiu licabo cancel etdolor 3 dic cola amcor",
             "event": {
@@ -806,7 +806,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "scan[xea]: ites[10.126.26.131] nisiut 1536789735 1536789735 accept teturad perspici itation sequatD 5 24 isciv rroqu",
             "event": {
@@ -818,7 +818,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "scan[rExc]: iusmo[10.187.210.173] reetd 1538024689 1538024689 accept ulpa sitam rad loi 2 15 Nequepor SZ:eirure SUBJ:deserun",
             "event": {
@@ -830,7 +830,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (orroq.exe) queued as vitaedic",
             "event": {
@@ -842,7 +842,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (orem.exe) queued as rcit",
             "event": {
@@ -854,7 +854,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "scan[untincul]: ssecil[10.180.147.129] atise 1541729552 1541729552 allow umetMalo oluptas emvele isnost 2 5 ido emqu",
             "event": {
@@ -866,7 +866,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "notify/smtp[exeaco]: 10.99.17.210 olorsit tore cancel illu 4 turadip 688 1.7484 boreetdo undeom",
             "event": {
@@ -878,7 +878,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "notify/smtp[uov]: 10.230.46.162 sBono loremqu accept quunt 3 siuta 1107 1.2607 dquia temporin",
             "event": {
@@ -890,7 +890,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "scan[nimveni]: idi[10.96.135.47] rum 1545434414 1545434414 accept eporroq ulla iqu oin 1 55 cingel modocon",
             "event": {
@@ -902,7 +902,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (atv.exe) queued as onu",
             "event": {
@@ -914,7 +914,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "scan: obeataev[10.139.127.232] nsec 1547904323 1547904323 cancel maperi agnaaliq tlaboree norumet 7 48 tin SZ:fugitse SUBJ:imad",
             "event": {
@@ -926,7 +926,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inbound/pass1: inv[10.163.209.70] atu 1549139277 1549139277 SCAN lloin remipsum tempor citatio 0 57 mveniamq SZ:taedict SUBJ:edquian",
             "event": {
@@ -938,7 +938,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (mipsamvo.exe) queued as eiusmod",
             "event": {
@@ -950,7 +950,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "scan[avolu]: Except[10.191.7.121] umetMal 1551609186 1551609186 accept sciun metcons itasper uae 2 21 uia iciad",
             "event": {
@@ -962,7 +962,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inbound/pass1: [10.157.196.101] gnaa 1552844140 1552844140 RECV mod doei cipitl",
             "event": {
@@ -974,7 +974,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "web: [10.171.72.5] global CHANGE eprehend (asnu)",
             "event": {
@@ -986,7 +986,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "scan: eritatis[10.209.184.60] mquisn 1555314049 1555314049 cancel uto emUte molestia quir 4 18 emip SZ:ver SUBJ:erc",
             "event": {
@@ -998,7 +998,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inbound/pass1[dolorsit]: archite[10.143.228.97] isqua 1556549003 1556549003 RECV uta emo itq",
             "event": {
@@ -1010,7 +1010,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (ntexpl.exe) queued as dunt",
             "event": {
@@ -1022,7 +1022,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "scan: plic[10.17.87.79] tetur 1559018911 1559018911 block amali ate idolor ratvolu 7 64 onse olorem",
             "event": {
@@ -1034,7 +1034,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "web: [10.163.18.29] FAILED_LOGIN (nim)",
             "event": {
@@ -1046,7 +1046,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "web: Retention violating accounts: erspi total",
             "event": {
@@ -1058,7 +1058,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (billoi.exe) queued as moles",
             "event": {
@@ -1070,7 +1070,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "scan: taedi[10.17.98.243] etconsec 1563958728 1563958728 cancel ill mporinc onsectet idolo 8 55 docon SZ:mdolore SUBJ:eosquira",
             "event": {
@@ -1082,7 +1082,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (apariatu.exe) queued as lorsita",
             "event": {
@@ -1094,7 +1094,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (ever.exe) queued as tali",
             "event": {
@@ -1106,7 +1106,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inbound/pass1[mipsumqu]: tatio[10.181.247.224] onnu 1567663591 1567663591 RECV olorema aquiof ende",
             "event": {
@@ -1118,7 +1118,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "scan[ugitse]: quiineav[10.235.116.121] ventore 1568898545 1568898545 deny obea emp agnaaliq est 0 73 aev SZ:inrepr SUBJ:mol",
             "event": {
@@ -1130,7 +1130,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "outbound/smtp: 10.178.30.158 llit tenimad sitametc allow onproide 2 cillumd riosa Ok: queued as tNe #to#10.1.6.115",
             "event": {
@@ -1142,7 +1142,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "notify/smtp[rautod]: 10.124.32.120 lapar ritati accept qui 3 mullam 4965 1.4254 meaque uid",
             "event": {
@@ -1154,7 +1154,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (ataevita.exe) queued as oremqu",
             "event": {
@@ -1166,7 +1166,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reports: REPORTS (velitsed.exe) queued as magnaali",
             "event": {
@@ -1178,7 +1178,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inbound/pass1: der[10.77.182.191] enbyCi 1575073317 1575073317 SCAN quameiu diduntu eiusmod itation 8 79 piciatis2460.api.host iusmodt",
             "event": {
@@ -1190,7 +1190,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "scan: iame[10.193.110.71] tiumd 1576308271 1576308271 accept loinve tanimid isnostru nofdeFi 3 5 saqu remips",
             "event": {

--- a/packages/barracuda/data_stream/spamfirewall/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/barracuda/data_stream/spamfirewall/elasticsearch/ingest_pipeline/default.yml
@@ -8,7 +8,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: '1.10.0'
+      value: '1.11.0'
   # User agent
   - user_agent:
       field: user_agent.original

--- a/packages/barracuda/data_stream/waf/_dev/test/pipeline/test-generated.log-expected.json
+++ b/packages/barracuda/data_stream/waf/_dev/test/pipeline/test-generated.log-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "PROCMON: Started monitoring",
             "event": {
@@ -14,7 +14,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "BYPASS: Mode set to BYPASS (nbyCic).",
             "event": {
@@ -26,7 +26,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "UPDATE: [ALERT:tvolup] New attack definition version 1.1000 is available",
             "event": {
@@ -38,7 +38,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM_WRAPPER: Rolling back the current database transaction. Configuration digest failed.",
             "event": {
@@ -50,7 +50,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM_WRAPPER: Initializing STM.",
             "event": {
@@ -62,7 +62,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "eventmgr: Forwarding log messages to syslog host #imadm, address=10.16.222.151",
             "event": {
@@ -74,7 +74,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "PROCMON: [ALERT:eritqui] One of the RAID arrays is degrading.",
             "event": {
@@ -86,7 +86,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "BYPASS: Mode change: ccusant,epteurs",
             "event": {
@@ -98,7 +98,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "UPDATE: [ALERT:modoco] New attack definition version 1.3971 is available",
             "event": {
@@ -110,7 +110,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM: LB-doloreeu elillumq CreateServer =loremeum",
             "event": {
@@ -122,7 +122,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM: WebLog-radi ula itsed: SapCtx=rad,SapId=olupta, ididu",
             "event": {
@@ -134,7 +134,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "UPDATE: [ALERT:xcepte] New attack definition version 1.4012 is available",
             "event": {
@@ -146,7 +146,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "PROCMON: Monitoring links: lo4933",
             "event": {
@@ -158,7 +158,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "PROCMON: [ALERT:doconse] One of the RAID arrays is degrading.",
             "event": {
@@ -170,7 +170,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "CONFIG_AGENT: odite atn It is recommended to configure cookie_encryption_key_expiry atleast 7 days ahead of current time., sectet",
             "event": {
@@ -182,7 +182,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM: LB-tet voluptas ActiveServerOutOfBandMonitorAttr =inv",
             "event": {
@@ -194,7 +194,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM_WRAPPER: [ALERT:obeata] Configuration size is pexeaco which exceeds the ercitati safe limit. Please check your configuration.",
             "event": {
@@ -206,7 +206,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "BYPASS: Mode change: urEx,labo",
             "event": {
@@ -218,7 +218,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "eventmgr: Event manager startup succeeded.",
             "event": {
@@ -230,7 +230,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM: LB-Maloru lapariat SetServerdmin=oinBCSed",
             "event": {
@@ -242,7 +242,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM_WRAPPER: Successfully stopped STM.",
             "event": {
@@ -254,7 +254,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "CONFIG_AGENT: luptate Initiating config_agent database commit phase.",
             "event": {
@@ -266,7 +266,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM: LB-isistena Malorum SetSapquelauda=enderit",
             "event": {
@@ -278,7 +278,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "eventmgr: Forwarding log messages to syslog host #equun, address=10.4.65.246",
             "event": {
@@ -290,7 +290,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "UPDATE: [ALERT:exer] New attack definition version 1.481 is available",
             "event": {
@@ -302,7 +302,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "eventmgr: Event manager startup succeeded.",
             "event": {
@@ -314,7 +314,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM_WRAPPER: Rolling back the current database transaction. Configuration digest failed.",
             "event": {
@@ -326,7 +326,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "CONFIG_AGENT: isnisiu aspernat Update succeeded",
             "event": {
@@ -338,7 +338,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "INSTALL: Loading the snapshot for mquel release.",
             "event": {
@@ -350,7 +350,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "INSTALL: Migrating configuration from ueporr to ptate",
             "event": {
@@ -362,7 +362,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "PROCMON: [ALERT:onsequ] enp0s7094: link is up",
             "event": {
@@ -374,7 +374,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "CONFIG_AGENT: iquip tDuisau It is recommended to configure cookie_encryption_key_expiry atleast 7 days ahead of current time., amali",
             "event": {
@@ -386,7 +386,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "eventmgr: Event manager startup succeeded.",
             "event": {
@@ -398,7 +398,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "PROCMON: Started monitoring",
             "event": {
@@ -410,7 +410,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM: LB-mveniam rvelill EnableServer =iame",
             "event": {
@@ -422,7 +422,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "PROCMON: number of stm worker threads iseuf",
             "event": {
@@ -434,7 +434,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM: WebLog-ipiscin idolore turExce: SapCtx=modoc,SapId=mdolors, borios",
             "event": {
@@ -446,7 +446,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM_WRAPPER: Successfully stopped STM.",
             "event": {
@@ -458,7 +458,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "eventmgr: Forwarding log messages to syslog host #ccusa, address=10.58.33.30",
             "event": {
@@ -470,7 +470,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "PROCMON: [ALERT:uiadolo] eth321: link is up",
             "event": {
@@ -482,7 +482,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "CONFIG_AGENT: rsi ciduntut Update succeeded",
             "event": {
@@ -494,7 +494,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "CONFIG_AGENT: radipis RPC Name =isa, RPC Result: aal",
             "event": {
@@ -506,7 +506,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "INSTALL: Loading the snapshot for ris release.",
             "event": {
@@ -518,7 +518,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "CONFIG_AGENT: aliqui rcitat Update succeeded",
             "event": {
@@ -530,7 +530,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "CONFIG_AGENT: aeconse Initiating config_agent database commit phase.",
             "event": {
@@ -542,7 +542,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "PROCMON: Started monitoring",
             "event": {
@@ -554,7 +554,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "CONFIG_AGENT: iaecon ipexea Update succeeded",
             "event": {
@@ -566,7 +566,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "INSTALL: Migrating configuration from nulapa to cillu",
             "event": {
@@ -578,7 +578,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "PROCMON: [ALERT:ectetura] Firmware storage exceeds didun",
             "event": {
@@ -590,7 +590,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "CONFIG_AGENT: rcit nul Received put-tree command",
             "event": {
@@ -602,7 +602,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "UPDATE: [ALERT:aliquaU] New attack definition version 1.1278 is available",
             "event": {
@@ -614,7 +614,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "UPDATE: [ALERT:amei] New attack definition version 1.7778 is available",
             "event": {
@@ -626,7 +626,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "UPDATE: [ALERT:gelitse] New attack definition version 1.3018 is available",
             "event": {
@@ -638,7 +638,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "INSTALL: Migrating configuration from iceroin to qui",
             "event": {
@@ -650,7 +650,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "INSTALL: Migrating configuration from pariatu to issusc",
             "event": {
@@ -662,7 +662,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM: FAILOVE-roinBCSe oreet Stateful Failover Module initialized.",
             "event": {
@@ -674,7 +674,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM_WRAPPER: Committing UI configuration.",
             "event": {
@@ -686,7 +686,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM_WRAPPER: Rolling back the current database transaction. Configuration digest failed.",
             "event": {
@@ -698,7 +698,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "INSTALL: Migrating configuration from ernat to Ute",
             "event": {
@@ -710,7 +710,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM_WRAPPER: Rolling back the current database transaction. Configuration digest failed.",
             "event": {
@@ -722,7 +722,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM_WRAPPER: Successfully initialized STM.",
             "event": {
@@ -734,7 +734,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM: RespPage-rinrepr rvelill CreateRP: Response Page mve created successfully",
             "event": {
@@ -746,7 +746,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM_WRAPPER: [ALERT:ineav] Configuration size is onp which exceeds the gnaaliqu safe limit. Please check your configuration.",
             "event": {
@@ -758,7 +758,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "BYPASS: Mode set to never bypass.",
             "event": {
@@ -770,7 +770,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "CONFIG_AGENT: quaea RPC Name =eetd, RPC Result: fdeFin",
             "event": {
@@ -782,7 +782,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "PROCMON: number of stm worker threads isrro",
             "event": {
@@ -794,7 +794,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "CONFIG_AGENT: tutlabo Initiating config_agent database commit phase.",
             "event": {
@@ -806,7 +806,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "INSTALL: Loading the snapshot for pli release.",
             "event": {
@@ -818,7 +818,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "CONFIG_AGENT: erit Initiating config_agent database commit phase.",
             "event": {
@@ -830,7 +830,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "INSTALL: Loading the snapshot for mod release.",
             "event": {
@@ -842,7 +842,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "INSTALL: Loading the snapshot for lamcolab release.",
             "event": {
@@ -854,7 +854,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "INSTALL: Migrating configuration from estlab to tis",
             "event": {
@@ -866,7 +866,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "PROCMON: [ALERT:uamqua] Firmware storage exceeds labo",
             "event": {
@@ -878,7 +878,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "INSTALL: Migrating configuration from tfugit to taspern",
             "event": {
@@ -890,7 +890,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "eventmgr: Forwarding log messages to syslog host #meiusm, address=10.48.248.158",
             "event": {
@@ -902,7 +902,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM_WRAPPER: Successfully initialized STM.",
             "event": {
@@ -914,7 +914,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "PROCMON: number of stm worker threads isonula",
             "event": {
@@ -926,7 +926,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM: FTPSVC-nimi ilmoles Ftp proxy initialized labor",
             "event": {
@@ -938,7 +938,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "PROCMON: [ALERT:atev] One of the RAID arrays is degrading.",
             "event": {
@@ -950,7 +950,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "CONFIG_AGENT: amaliq ept Received put-tree command",
             "event": {
@@ -962,7 +962,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "BYPASS: Mode set to BYPASS (ectetura).",
             "event": {
@@ -974,7 +974,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM: COOKIE-icab quiado scipit = quiavolu",
             "event": {
@@ -986,7 +986,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "BYPASS: Mode set to never bypass.",
             "event": {
@@ -998,7 +998,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM: CACHE-oconseq tsedd untin SapCtx susc, SapId amr, Return Code success",
             "event": {
@@ -1010,7 +1010,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM: aps-ddoeius tautfugi ParamProtectionClonePatterns: Old:cin, New:fugia, PatternsNode:olors",
             "event": {
@@ -1022,7 +1022,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "INSTALL: Loading the snapshot for admi release.",
             "event": {
@@ -1034,7 +1034,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "CONFIG_AGENT: aecons Initiating config_agent database commit phase.",
             "event": {
@@ -1046,7 +1046,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "PROCMON: Monitoring links: eth801",
             "event": {
@@ -1058,7 +1058,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "PROCMON: Started monitoring",
             "event": {
@@ -1070,7 +1070,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "UPDATE: [ALERT:ntoc] New attack definition version 1.7781 is available",
             "event": {
@@ -1082,7 +1082,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "INSTALL: Loading the snapshot for stru release.",
             "event": {
@@ -1094,7 +1094,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "PROCMON: Monitoring links: enp0s6182",
             "event": {
@@ -1106,7 +1106,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "PROCMON: number of stm worker threads isumwri",
             "event": {
@@ -1118,7 +1118,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "BYPASS: Mode set to never bypass.",
             "event": {
@@ -1130,7 +1130,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "BYPASS: Mode set to BYPASS (eniamqu).",
             "event": {
@@ -1142,7 +1142,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "UPDATE: [ALERT:tco] New attack definition version 1.6840 is available",
             "event": {
@@ -1154,7 +1154,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM_WRAPPER: Successfully initialized STM.",
             "event": {
@@ -1166,7 +1166,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM_WRAPPER: Initializing STM.",
             "event": {
@@ -1178,7 +1178,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "STM_WRAPPER: Successfully initialized STM.",
             "event": {
@@ -1190,7 +1190,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "PROCMON: Started monitoring",
             "event": {

--- a/packages/barracuda/data_stream/waf/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/barracuda/data_stream/waf/elasticsearch/ingest_pipeline/default.yml
@@ -8,7 +8,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: '1.10.0'
+      value: '1.11.0'
   # User agent
   - user_agent:
       field: user_agent.original

--- a/packages/barracuda/manifest.yml
+++ b/packages/barracuda/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: barracuda
 title: Barracuda
-version: 0.5.0
+version: 0.5.1
 description: This Elastic integration collects logs from Barracuda devices
 categories: ["network", "security"]
 release: experimental


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967