### PR TITLE
checkpoint update to ECS 1.11.0

### DIFF
--- a/packages/checkpoint/changelog.yml
+++ b/packages/checkpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.8.1'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1376
 - version: "0.8.0"
   changes:
     - description: Update integration description

--- a/packages/checkpoint/data_stream/firewall/_dev/test/pipeline/test-checkpoint-with-time.log-expected.json
+++ b/packages/checkpoint/data_stream/firewall/_dev/test/pipeline/test-checkpoint-with-time.log-expected.json
@@ -44,7 +44,7 @@
             },
             "@timestamp": "2020-07-13T13:29:14.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -131,7 +131,7 @@
             },
             "@timestamp": "2021-05-05T12:27:09.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/checkpoint/data_stream/firewall/_dev/test/pipeline/test-checkpoint.log-expected.json
+++ b/packages/checkpoint/data_stream/firewall/_dev/test/pipeline/test-checkpoint.log-expected.json
@@ -17,7 +17,7 @@
             },
             "@timestamp": "2020-03-29T13:19:20.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "event": {
                 "sequence": 1,
@@ -53,7 +53,7 @@
             },
             "@timestamp": "2020-03-29T13:19:21.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "event": {
                 "sequence": 2,
@@ -116,7 +116,7 @@
             },
             "@timestamp": "2020-03-29T13:19:22.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -208,7 +208,7 @@
             },
             "@timestamp": "2020-03-29T13:19:22.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -277,7 +277,7 @@
             },
             "@timestamp": "2020-03-29T13:19:22.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -316,7 +316,7 @@
             },
             "@timestamp": "2020-03-29T23:18:44.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "event": {
                 "sequence": 1,
@@ -399,7 +399,7 @@
             },
             "@timestamp": "2020-03-29T23:18:43.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -481,7 +481,7 @@
             },
             "@timestamp": "2020-03-29T23:18:53.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -519,7 +519,7 @@
             },
             "@timestamp": "2020-03-30T01:18:44.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "event": {
                 "sequence": 1,
@@ -602,7 +602,7 @@
             },
             "@timestamp": "2020-03-30T01:18:46.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -671,7 +671,7 @@
             },
             "@timestamp": "2020-03-30T01:18:46.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -710,7 +710,7 @@
             },
             "@timestamp": "2020-03-30T01:18:46.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "event": {
                 "sequence": 5,
@@ -773,7 +773,7 @@
             },
             "@timestamp": "2020-03-30T06:12:45.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -812,7 +812,7 @@
             },
             "@timestamp": "2020-03-30T06:12:51.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "event": {
                 "severity": 1,
@@ -846,7 +846,7 @@
             },
             "@timestamp": "2020-03-30T06:12:51.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "event": {
                 "severity": 1,
@@ -910,7 +910,7 @@
             },
             "@timestamp": "2020-03-30T06:13:21.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -984,7 +984,7 @@
             },
             "@timestamp": "2020-03-30T06:13:42.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1048,7 +1048,7 @@
             },
             "@timestamp": "2020-03-30T07:18:59.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1117,7 +1117,7 @@
             },
             "@timestamp": "2020-03-30T07:19:22.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1186,7 +1186,7 @@
             },
             "@timestamp": "2020-03-30T07:20:33.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1255,7 +1255,7 @@
             },
             "@timestamp": "2020-03-30T07:20:35.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/checkpoint/data_stream/firewall/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/checkpoint/data_stream/firewall/elasticsearch/ingest_pipeline/default.yml
@@ -3,7 +3,7 @@ description: Pipeline for parsing checkpoint firewall logs
 processors:
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   - set:
       field: event.ingested
       value: "{{_ingest.timestamp}}"

--- a/packages/checkpoint/manifest.yml
+++ b/packages/checkpoint/manifest.yml
@@ -1,6 +1,6 @@
 name: checkpoint
 title: Check Point
-version: 0.8.0
+version: 0.8.1
 release: experimental
 description: This Elastic integration collects logs from Check Point products
 type: integration


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967