### PR TITLE
crowdstrike update to ECS 1.11.0

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.7.1'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1378
 - version: "0.7.0"
   changes:
     - description: Update integration description

--- a/packages/crowdstrike/data_stream/falcon/_dev/test/pipeline/test-falcon-audit-events.log-expected.json
+++ b/packages/crowdstrike/data_stream/falcon/_dev/test/pipeline/test-falcon-audit-events.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2020-02-27T19:12:14.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -59,7 +59,7 @@
         {
             "@timestamp": "2020-02-27T19:12:52.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -123,7 +123,7 @@
             "event.action": "stream_started",
             "@timestamp": "2020-02-12T21:29:10.710Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -199,7 +199,7 @@
             "event.action": "two_factor_authenticate",
             "@timestamp": "2020-02-12T21:39:37.147Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -254,7 +254,7 @@
             "event.action": "two_factor_authenticate",
             "@timestamp": "2020-02-12T22:14:37.554Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -301,7 +301,7 @@
         {
             "@timestamp": "2020-02-12T22:24:08.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -373,7 +373,7 @@
             "event.action": "request_reset_password",
             "@timestamp": "2020-02-13T13:41:52.140Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -434,7 +434,7 @@
             "event.action": "two_factor_authenticate",
             "@timestamp": "2020-02-13T13:42:21.730Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -489,7 +489,7 @@
             "event.action": "change_password",
             "@timestamp": "2020-02-13T13:45:20.236Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -550,7 +550,7 @@
             "event.action": "user_authenticate",
             "@timestamp": "2020-02-13T13:46:12.362Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -605,7 +605,7 @@
             "event.action": "two_factor_authenticate",
             "@timestamp": "2020-02-13T13:50:14.754Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -660,7 +660,7 @@
             "event.action": "self_accept_eula",
             "@timestamp": "2020-02-13T13:50:20.289Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -707,7 +707,7 @@
         {
             "@timestamp": "2020-02-13T14:14:22.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/crowdstrike/data_stream/falcon/_dev/test/pipeline/test-falcon-events.log-expected.json
+++ b/packages/crowdstrike/data_stream/falcon/_dev/test/pipeline/test-falcon-events.log-expected.json
@@ -31,7 +31,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -138,7 +138,7 @@
             },
             "@timestamp": "2020-03-04T04:17:56.766Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "event": {
                 "ingested": "2021-07-01T08:21:45.615786500Z",
@@ -178,7 +178,7 @@
         {
             "@timestamp": "2020-06-26T15:55:52.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/crowdstrike/data_stream/falcon/_dev/test/pipeline/test-falcon-sample.log-expected.json
+++ b/packages/crowdstrike/data_stream/falcon/_dev/test/pipeline/test-falcon-sample.log-expected.json
@@ -29,7 +29,7 @@
             },
             "@timestamp": "2020-07-20T12:41:46.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -106,7 +106,7 @@
             },
             "@timestamp": "2020-07-17T17:02:08.414Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "event": {
                 "ingested": "2021-07-01T08:21:45.763830600Z",
@@ -155,7 +155,7 @@
             "event.action": "saml2_assert",
             "@timestamp": "2020-07-20T12:26:10.093Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -224,7 +224,7 @@
         {
             "@timestamp": "2020-07-20T12:41:25.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -280,7 +280,7 @@
         {
             "@timestamp": "2020-07-17T17:14:53.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -336,7 +336,7 @@
         {
             "@timestamp": "2020-07-17T17:28:19.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -436,7 +436,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/crowdstrike/data_stream/falcon/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/crowdstrike/data_stream/falcon/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   - rename:
       field: message
       target_field: event.original

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: 0.7.0
+version: 0.7.1
 description: This Elastic integration collects logs from CrowdStrike products
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967