### PR TITLE
cyberark update to ECS 1.11.0

### DIFF
--- a/packages/cyberark/changelog.yml
+++ b/packages/cyberark/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.3.1'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1379
 - version: "0.3.0"
   changes:
     - description: Set "event.module" and "event.dataset"

--- a/packages/cyberark/data_stream/corepas/_dev/test/pipeline/test-generated.log-expected.json
+++ b/packages/cyberark/data_stream/corepas/_dev/test/pipeline/test-generated.log-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016-01-29 06:09:59.732538723 +0000 UTC eacommod1428.lan %CYBERARK: MessageID=\"188\";exercita 1.1332\",ProductAccount=\"itv\",ProductProcess=\"odoco\",EventId=\"ria\",EventClass=\"min\",EventSeverity=\"low\",EventMessage=\"allow\",ActingUserName=\"utl\",ActingAddress=\"10.208.15.216\",ActionSourceUser=\"tation\",ActionTargetUser=\"quasiarc\",ActionObject=\"liqua\",ActionSafe=\"ciade\",ActionLocation=\"turadipi\",ActionCategory=\"aeca\",ActionRequestId=\"idi\",ActionReason=\"pexe\",ActionExtraDetails=\"nes\"",
             "event": {
@@ -14,7 +14,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%CYBERARK: MessageID=\"168\";Version=1.259;Message=block;Issuer=dolore;Station=10.92.136.230;File=ritquiin;Safe=umqui;Location=reeufugi;Category=mdolo;RequestId=mqui;Reason=nci;Severity=very-high;SourceUser=litesse;TargetUser=orev;GatewayStation=10.175.75.18;TicketID=deF;PolicyID=sist;UserName=nnumqu;LogonDomain=iatnu3810.mail.localdomain;Address=volup208.invalid;CPMStatus=eosquir;Port=5191;Database=umdo;DeviceType=itessequ;ExtraDetails=vol;",
             "event": {
@@ -26,7 +26,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "nibus 2016-02-26 20:15:08.252538723 +0000 UTC mipsumq3879.internal.localdomain %CYBERARK: MessageID=\"26\";Version=1.7269;Message=accept;Issuer=incid;Station=10.51.132.10;File=utper;Safe=squame;Location=ntex;Category=eius;RequestId=luptat;Reason=emape;Severity=low;SourceUser=incidi;TargetUser=nse;GatewayStation=10.46.185.46;TicketID=temvel;PolicyID=iatu;UserName=serror;LogonDomain=anti4454.api.example;Address=tetu5280.www5.invalid;CPMStatus=tionulam;Port=2548;Database=byC;DeviceType=tinculp;ExtraDetails=tur;",
             "event": {
@@ -38,7 +38,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016-03-12 03:17:42.512538723 +0000 UTC minim7868.www5.localdomain %CYBERARK: MessageID=\"184\";Version=1.6713;Message=deny;Issuer=psumquia;Station=10.53.192.140;File=con;Safe=uia;Location=quiavo;Category=issusci;RequestId=mol;Reason=taspe;Severity=high;SourceUser=psumq;TargetUser=atcup;GatewayStation=10.155.236.240;TicketID=tatno;PolicyID=dquiac;UserName=ptass;LogonDomain=uam6303.api.lan;Address=llu4762.mail.localdomain;CPMStatus=scivel;Port=5695;Database=aperi;DeviceType=iveli;ExtraDetails=llumd;",
             "event": {
@@ -50,7 +50,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%CYBERARK: MessageID=\"161\";emaper 1.2638\",ProductAccount=\"eos\",ProductProcess=\"enimad\",EventId=\"rmagni\",EventClass=\"sit\",EventSeverity=\"medium\",EventMessage=\"cancel\",ActingUserName=\"oremips\",ActingAddress=\"10.81.199.122\",ActionSourceUser=\"aquaeabi\",ActionTargetUser=\"giatq\",ActionObject=\"quid\",ActionSafe=\"fug\",ActionLocation=\"uatDuis\",ActionCategory=\"ude\",ActionRequestId=\"maveniam\",ActionReason=\"uian\",ActionExtraDetails=\"tempo\"",
             "event": {
@@ -62,7 +62,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "eetd 2016-04-09 17:22:51.032538723 +0000 UTC eip1448.internal.local %CYBERARK: MessageID=\"139\";Version=1.3491;Message=deny;Issuer=tcupida;Station=10.139.186.201;File=ect;Safe=reetdolo;Location=nrepreh;Category=obeataev;RequestId=lor;Reason=uidexea;Severity=medium;SourceUser=natura;TargetUser=aboris;GatewayStation=10.172.14.142;TicketID=ssitaspe;PolicyID=gitsedqu;UserName=uam;LogonDomain=temq1198.internal.example;Address=aquaeab2275.www5.domain;CPMStatus=ehend;Port=4091;Database=isiu;DeviceType=nimadmi;ExtraDetails=iatisu;",
             "event": {
@@ -74,7 +74,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%CYBERARK: MessageID=\"106\";Version=1.6875;Message=accept;Issuer=ipis;Station=10.47.76.251;File=eataevit;Safe=uptatev;Location=uovol;Category=dmi;RequestId=olab;Reason=mquisnos;Severity=medium;SourceUser=ore;TargetUser=etconsec;GatewayStation=10.104.111.129;TicketID=mUt;PolicyID=usmodte;UserName=ele;LogonDomain=tenbyCic5882.api.home;Address=amquisno3338.www5.lan;CPMStatus=nonnu;Port=776;Database=riat;DeviceType=luptatem;ExtraDetails=umdolor;",
             "event": {
@@ -86,7 +86,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inB 2016-05-08 07:27:59.552538723 +0000 UTC deomni124.www.example %CYBERARK: MessageID=\"74\";tae 1.1382\",ProductAccount=\"animi\",ProductProcess=\"oluptate\",EventId=\"ofdeF\",EventClass=\"tion\",EventSeverity=\"very-high\",EventMessage=\"deny\",ActingUserName=\"quiratio\",ActingAddress=\"10.116.120.216\",ActionSourceUser=\"qua\",ActionTargetUser=\"umdo\",ActionObject=\"sed\",ActionSafe=\"apariat\",ActionLocation=\"mol\",ActionCategory=\"pteursi\",ActionRequestId=\"onse\",ActionReason=\"rumet\",ActionExtraDetails=\"oll\"",
             "event": {
@@ -98,7 +98,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Ciceroi 2016-05-22 14:30:33.812538723 +0000 UTC aveniam1436.www.test %CYBERARK: MessageID=\"144\";Version=1.5529;Message=cancel;Issuer=taevi;Station=10.62.54.220;File=ehenderi;Safe=pidatat;Location=gni;Category=tquiinea;RequestId=mquaera;Reason=dun;Severity=medium;SourceUser=Duisau;TargetUser=psum;GatewayStation=10.57.40.29;TicketID=undeo;PolicyID=loremip;UserName=rnatura;LogonDomain=isqu7224.localdomain;Address=idolores3839.localdomain;CPMStatus=metcon;Port=2424;Database=emeumfug;DeviceType=upta;ExtraDetails=omn;",
             "event": {
@@ -110,7 +110,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ons 2016-06-05 21:33:08.072538723 +0000 UTC tessec3539.home %CYBERARK: MessageID=\"240\";nsect 1.6476\",ProductAccount=\"tnon\",ProductProcess=\"ionul\",EventId=\"nibus\",EventClass=\"edquiano\",EventSeverity=\"medium\",EventMessage=\"cancel\",ActingUserName=\"ema\",ActingAddress=\"10.74.237.180\",ActionSourceUser=\"nsequu\",ActionTargetUser=\"cup\",ActionObject=\"boNemoen\",ActionSafe=\"uid\",ActionLocation=\"rors\",ActionCategory=\"onofd\",ActionRequestId=\"taed\",ActionReason=\"lup\",ActionExtraDetails=\"remeumf\"",
             "event": {
@@ -122,7 +122,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016-06-20 04:35:42.332538723 +0000 UTC sectetur3333.mail.example %CYBERARK: MessageID=\"61\";edqui 1.7780\",ProductAccount=\"lor\",ProductProcess=\"fugit\",EventId=\"ido\",EventClass=\"paqu\",EventSeverity=\"high\",EventMessage=\"allow\",ActingUserName=\"remeum\",ActingAddress=\"10.18.165.35\",ActionSourceUser=\"admi\",ActionTargetUser=\"modocons\",ActionObject=\"elaudant\",ActionSafe=\"tinvol\",ActionLocation=\"dolore\",ActionCategory=\"abor\",ActionRequestId=\"iqui\",ActionReason=\"etc\",ActionExtraDetails=\"etM\"",
             "event": {
@@ -134,7 +134,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016-07-04 11:38:16.592538723 +0000 UTC xercitat4824.local %CYBERARK: MessageID=\"90\";ostr 1.4979\",ProductAccount=\"onproide\",ProductProcess=\"luptat\",EventId=\"itaut\",EventClass=\"imaven\",EventSeverity=\"high\",EventMessage=\"deny\",ActingUserName=\"tema\",ActingAddress=\"10.74.253.127\",ActionSourceUser=\"tfug\",ActionTargetUser=\"icab\",ActionObject=\"mwr\",ActionSafe=\"fugi\",ActionLocation=\"inculpaq\",ActionCategory=\"agna\",ActionRequestId=\"tionemu\",ActionReason=\"eomnisis\",ActionExtraDetails=\"mqui\"",
             "event": {
@@ -146,7 +146,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "errorsi 2016-07-18 18:40:50.852538723 +0000 UTC des5377.lan %CYBERARK: MessageID=\"385\";Version=1.1697;Message=block;Issuer=ono;Station=10.189.109.245;File=emaperi;Safe=tame;Location=\"tinvol\";Category=tectobe;RequestId=colabor;Reason=iusmodt;Severity=medium;GatewayStation=10.92.8.15;TicketID=agnaali;PolicyID=llitani;UserName=inima;LogonDomain=tlabo6088.www.localdomain;Address=Lor5841.internal.example;CPMStatus=sunt;Port=\"3075\";Database=uines;DeviceType=nsec;ExtraDetails=onse",
             "event": {
@@ -158,7 +158,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 2 01:43:25 tat %CYBERARK: MessageID=\"190\";tion 1.1761\",ProductAccount=\"upt\",ProductProcess=\"uiineavo\",EventId=\"tisetq\",EventClass=\"irati\",EventSeverity=\"low\",EventMessage=\"accept\",ActingUserName=\"giatquov\",ActingAddress=\"10.21.78.128\",ActionSourceUser=\"riat\",ActionTargetUser=\"taut\",ActionObject=\"oreseos\",ActionSafe=\"uames\",ActionLocation=\"tati\",ActionCategory=\"utaliqu\",ActionRequestId=\"oriosamn\",ActionReason=\"deFinibu\",ActionExtraDetails=\"iadese\"",
             "event": {
@@ -170,7 +170,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%CYBERARK: MessageID=\"256\";eporroqu 1.4200\",ProductAccount=\"hil\",ProductProcess=\"atquovo\",EventId=\"suntinc\",EventClass=\"xeac\",EventSeverity=\"medium\",EventMessage=\"deny\",ActingUserName=\"tatn\",ActingAddress=\"10.18.109.121\",ActionSourceUser=\"ents\",ActionTargetUser=\"pida\",ActionObject=\"nse\",ActionSafe=\"sinto\",ActionLocation=\"emoeni\",ActionCategory=\"oenimips\",ActionRequestId=\"utlabore\",ActionReason=\"ecillu\",ActionExtraDetails=\"quip\"",
             "event": {
@@ -182,7 +182,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%CYBERARK: MessageID=\"105\";Version=1.3727;Message=cancel;Issuer=iunt;Station=10.63.37.192;File=tio;Safe=orinrepr;Location=conse;Category=rumetM;RequestId=equi;Reason=agnaali;Severity=medium;SourceUser=sitvolup;TargetUser=reetd;GatewayStation=10.225.115.13;TicketID=maccusa;PolicyID=uptat;UserName=equep;LogonDomain=iavolu5352.localhost;Address=rpo79.mail.example;CPMStatus=siarchi;Port=2289;Database=aliqu;DeviceType=olupta;ExtraDetails=mipsumd;",
             "event": {
@@ -194,7 +194,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "remi 2016-09-13 22:51:07.892538723 +0000 UTC saute7154.internal.lan %CYBERARK: MessageID=\"105\";Version=1.3219;Message=deny;Issuer=run;Station=10.47.202.102;File=quirat;Safe=llu;Location=licab;Category=eirure;RequestId=conseq;Reason=oidentsu;Severity=medium;SourceUser=aaliquaU;TargetUser=ntor;GatewayStation=10.95.64.124;TicketID=psaquae;PolicyID=ationemu;UserName=ice;LogonDomain=estiae3750.api.corp;Address=tionof7613.domain;CPMStatus=lapari;Port=2335;Database=ite;DeviceType=ationul;ExtraDetails=iquipex;",
             "event": {
@@ -206,7 +206,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "adol 2016-09-28 05:53:42.152538723 +0000 UTC doloremi7402.www.test %CYBERARK: MessageID=\"376\";Version=1.6371;Message=block;Issuer=itquiin;Station=10.106.239.55;File=taevit;Safe=rinrepre;Location=etconse;Category=tincu;RequestId=ari;Reason=exercit;Severity=low;GatewayStation=10.244.114.61;TicketID=oluptate;PolicyID=onseq;UserName=serunt;LogonDomain=aquaeabi7735.internal.lan;Address=acc7692.home;CPMStatus=amest;Port=\"4147\";Database=itame;DeviceType=intoc;ExtraDetails=oluptas;",
             "event": {
@@ -218,7 +218,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016-10-12 12:56:16.412538723 +0000 UTC luptasn2126.mail.home %CYBERARK: MessageID=\"24\";Version=1.821;Message=allow;Issuer=ione;Station=10.125.160.129;File=suntexp;Safe=duntut;Location=magni;Category=pisciv;RequestId=iquidex;Reason=radipisc;Severity=low;SourceUser=nti;TargetUser=abi;GatewayStation=10.53.168.235;TicketID=fugitse;PolicyID=veniamq;UserName=one;LogonDomain=etMalor4236.www5.host;Address=quatD4191.local;CPMStatus=tenima;Port=5685;Database=sperna;DeviceType=eabilloi;ExtraDetails=estia;",
             "event": {
@@ -230,7 +230,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "orem 2016-10-26 19:58:50.672538723 +0000 UTC beata6448.mail.test %CYBERARK: MessageID=\"197\";Version=1.1123;Message=allow;Issuer=tasuntex;Station=10.227.177.121;File=boN;Safe=eprehend;Location=aevit;Category=aboN;RequestId=ihilmo;Reason=radi;Severity=low;SourceUser=uames;TargetUser=iduntu;GatewayStation=10.33.245.220;TicketID=giatnu;PolicyID=ulapa;UserName=liqui;LogonDomain=quioffi1359.internal.lan;Address=eturadi6608.mail.host;CPMStatus=aera;Port=3366;Database=rvel;DeviceType=uid;ExtraDetails=onsecte;",
             "event": {
@@ -242,7 +242,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 10 03:01:24 edo %CYBERARK: MessageID=\"411\";Version=1.5071;Message=allow;Issuer=econs;Station=\"10.98.182.220\";File=\"untex\";Safe=\"quiratio\";Location=\"boree\";Category=\"eco\";RequestId=Utenimad;Reason=orpor;Severity=\"low\";GatewayStation=\"10.167.85.181\";TicketID=emvel;PolicyID=\"tmollita\";UserName=fde;LogonDomain=\"nsecte3304.mail.corp\";Address=\"eroi176.example\";CPMStatus=\"non\";Port=\"3341\";Database=equat;DeviceType=derit;ExtraDetails=\"Command=dexea;ConnectionComponentId=atcu;DstHost=labor;ProcessId=6501;ProcessName=laboree.exe;Protocol=tcp;PSMID=intocc;RDPOffset=liqu;SessionID=eporr;SrcHost=xeacomm6855.api.corp;User=utlabor;VIDOffset=rau;\"",
             "event": {
@@ -254,7 +254,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 24 10:03:59 aeabi %CYBERARK: MessageID=\"111\";eiu 1.4456\",ProductAccount=\"iciadese\",ProductProcess=\"quidolor\",EventId=\"tessec\",EventClass=\"olupta\",EventSeverity=\"high\",EventMessage=\"block\",ActingUserName=\"icabo\",ActingAddress=\"10.89.208.95\",ActionSourceUser=\"eleum\",ActionTargetUser=\"sintoc\",ActionObject=\"volupt\",ActionSafe=\"siste\",ActionLocation=\"uiinea\",ActionCategory=\"Utenima\",ActionRequestId=\"volupta\",ActionReason=\"rcitati\",ActionExtraDetails=\"eni\"",
             "event": {
@@ -266,7 +266,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Ute 2016-12-08 17:06:33.452538723 +0000 UTC sperna5368.mail.invalid %CYBERARK: MessageID=\"81\";Version=1.509;Message=accept;Issuer=tDuisaut;Station=10.214.191.180;File=imvenia;Safe=spi;Location=stquido;Category=ommodico;RequestId=ptas;Reason=pta;Severity=medium;SourceUser=ptatemq;TargetUser=luptatev;GatewayStation=10.72.148.32;TicketID=ipsumd;PolicyID=ntocc;UserName=uteirure;LogonDomain=nevo4284.internal.local;Address=reetdolo6852.www.test;CPMStatus=nnum;Port=5428;Database=uamest;DeviceType=tco;ExtraDetails=uae;",
             "event": {
@@ -278,7 +278,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%CYBERARK: MessageID=\"168\";Version=1.3599;Message=block;Issuer=ipsumd;Station=10.136.190.236;File=evolu;Safe=ersp;Location=tquov;Category=diconseq;RequestId=inven;Reason=osquira;Severity=low;SourceUser=ataevi;TargetUser=com;GatewayStation=10.252.124.150;TicketID=trud;PolicyID=eriti;UserName=litessec;LogonDomain=itas981.mail.domain;Address=mporin6932.api.localdomain;CPMStatus=roid;Port=6604;Database=tasn;DeviceType=Nemoenim;ExtraDetails=squirati;",
             "event": {
@@ -290,7 +290,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "nbyCic 2017-01-06 07:11:41.972538723 +0000 UTC utlabor6305.internal.corp %CYBERARK: MessageID=\"90\";Version=1.5649;Message=accept;Issuer=iquipe;Station=10.192.34.76;File=modtemp;Safe=quovol;Location=nve;Category=remag;RequestId=uredol;Reason=ccaecat;Severity=medium;SourceUser=onsequ;TargetUser=temqu;GatewayStation=10.213.144.249;TicketID=udexerci;PolicyID=naal;UserName=lore;LogonDomain=tnonpro7635.localdomain;Address=illoin2914.mail.lan;CPMStatus=uamni;Port=6895;Database=gnamal;DeviceType=metMalo;ExtraDetails=ntexplic;",
             "event": {
@@ -302,7 +302,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%CYBERARK: MessageID=\"376\";Version=1.2217;Message=accept;Issuer=untu;Station=10.154.4.197;File=con;Safe=nisist;Location=usmodte;Category=msequi;RequestId=tau;Reason=exercita;Severity=low;GatewayStation=10.216.84.30;TicketID=orumSe;PolicyID=boree;UserName=intoc;LogonDomain=rQuisau5300.www5.example;Address=evit5780.www.corp;CPMStatus=onev;Port=\"725\";Database=oditem;DeviceType=gitsedqu;ExtraDetails=borios;",
             "event": {
@@ -314,7 +314,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017-02-03 21:16:50.492538723 +0000 UTC temUt631.www5.example %CYBERARK: MessageID=\"3\";npr 1.4414\",ProductAccount=\"niamqui\",ProductProcess=\"boNem\",EventId=\"ess\",EventClass=\"ipisci\",EventSeverity=\"medium\",EventMessage=\"deny\",ActingUserName=\"tqu\",ActingAddress=\"10.143.193.199\",ActionSourceUser=\"quam\",ActionTargetUser=\"quid\",ActionObject=\"fugiat\",ActionSafe=\"atisun\",ActionLocation=\"esci\",ActionCategory=\"epre\",ActionRequestId=\"tobeata\",ActionReason=\"eroinBCS\",ActionExtraDetails=\"inci\"",
             "event": {
@@ -326,7 +326,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "February 18 04:19:24 rnatur %CYBERARK: MessageID=\"140\";Version=1.5632;Message=deny;Issuer=essequam;Station=10.193.83.81;File=isisten;Safe=cusant;Location=atemq;Category=rinre;RequestId=naal;Reason=borios;Severity=high;SourceUser=isnostr;TargetUser=umqu;GatewayStation=10.65.175.9;TicketID=inesci;PolicyID=isnisi;UserName=ritatise;LogonDomain=uamei2389.internal.example;Address=uisa5736.internal.local;CPMStatus=cusant;Port=302;Database=ender;DeviceType=riamea;ExtraDetails=entorev;",
             "event": {
@@ -338,7 +338,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%CYBERARK: MessageID=\"87\";tutlab 1.792\",ProductAccount=\"tatn\",ProductProcess=\"dolorsit\",EventId=\"sau\",EventClass=\"aperia\",EventSeverity=\"very-high\",EventMessage=\"accept\",ActingUserName=\"umdolo\",ActingAddress=\"10.205.72.243\",ActionSourceUser=\"stenatu\",ActionTargetUser=\"isiuta\",ActionObject=\"orsitam\",ActionSafe=\"siutaliq\",ActionLocation=\"dutp\",ActionCategory=\"psaquaea\",ActionRequestId=\"taevita\",ActionReason=\"ameiusm\",ActionExtraDetails=\"proide\"",
             "event": {
@@ -350,7 +350,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017-03-18 18:24:33.272538723 +0000 UTC velitess7586.mail.example %CYBERARK: MessageID=\"45\";nre 1.7231\",ProductAccount=\"sit\",ProductProcess=\"olab\",EventId=\"eumiure\",EventClass=\"ersp\",EventSeverity=\"medium\",EventMessage=\"allow\",ActingUserName=\"mquisno\",ActingAddress=\"10.107.9.163\",ActionSourceUser=\"uptate\",ActionTargetUser=\"mac\",ActionObject=\"iumdol\",ActionSafe=\"tpersp\",ActionLocation=\"stla\",ActionCategory=\"uptatema\",ActionRequestId=\"oeni\",ActionReason=\"tdol\",ActionExtraDetails=\"sit\"",
             "event": {
@@ -362,7 +362,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 2 01:27:07 psum %CYBERARK: MessageID=\"132\";tasnulap 1.7220\",ProductAccount=\"umSe\",ProductProcess=\"xeacomm\",EventId=\"cinge\",EventClass=\"itla\",EventSeverity=\"high\",EventMessage=\"deny\",ActingUserName=\"asiarc\",ActingAddress=\"10.80.101.72\",ActionSourceUser=\"uptate\",ActionTargetUser=\"quidexea\",ActionObject=\"ect\",ActionSafe=\"modocons\",ActionLocation=\"gitsed\",ActionCategory=\"fugia\",ActionRequestId=\"oditautf\",ActionReason=\"quatu\",ActionExtraDetails=\"veli\"",
             "event": {
@@ -374,7 +374,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 16 08:29:41 labo %CYBERARK: MessageID=\"200\";Version=1.267;Message=accept;Issuer=aboreetd;Station=10.235.136.109;File=lorin;Safe=pitl;Location=por;Category=quidexea;RequestId=nimid;Reason=runtmol;Severity=very-high;SourceUser=odi;TargetUser=ptass;GatewayStation=10.39.10.155;TicketID=dol;PolicyID=proiden;UserName=urExcept;LogonDomain=miurerep1152.internal.domain;Address=utlab3706.api.host;CPMStatus=dantium;Port=246;Database=teirured;DeviceType=onemulla;ExtraDetails=dolorem;",
             "event": {
@@ -386,7 +386,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 30 15:32:16 ationev %CYBERARK: MessageID=\"233\";umdolor 1.4389\",ProductAccount=\"itation\",ProductProcess=\"paquioff\",EventId=\"nci\",EventClass=\"isau\",EventSeverity=\"low\",EventMessage=\"cancel\",ActingUserName=\"ibusBon\",ActingAddress=\"10.96.224.19\",ActionSourceUser=\"nsequat\",ActionTargetUser=\"doloreme\",ActionObject=\"dun\",ActionSafe=\"reprehe\",ActionLocation=\"tincu\",ActionCategory=\"suntin\",ActionRequestId=\"itse\",ActionReason=\"umexerc\",ActionExtraDetails=\"oremipsu\"",
             "event": {
@@ -398,7 +398,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017-05-14 22:34:50.312538723 +0000 UTC ntsunt4826.mail.corp %CYBERARK: MessageID=\"170\";olo 1.237\",ProductAccount=\"aec\",ProductProcess=\"fdeF\",EventId=\"iquidexe\",EventClass=\"diconse\",EventSeverity=\"medium\",EventMessage=\"cancel\",ActingUserName=\"reseo\",ActingAddress=\"10.71.238.250\",ActionSourceUser=\"consequa\",ActionTargetUser=\"moenimi\",ActionObject=\"olupt\",ActionSafe=\"oconsequ\",ActionLocation=\"edquiac\",ActionCategory=\"urerepr\",ActionRequestId=\"eseru\",ActionReason=\"quamest\",ActionExtraDetails=\"mac\"",
             "event": {
@@ -410,7 +410,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%CYBERARK: MessageID=\"294\";Version=1.3804;Message=deny;Issuer=rationev;Station=10.226.20.199;File=tatem;Safe=untutlab;Location=amcor;Category=ica;RequestId=lillum;Reason=remips;Severity=low;SourceUser=taedicta;TargetUser=ritt;GatewayStation=10.226.101.180;TicketID=itesseq;PolicyID=dictasun;UserName=veniamqu;LogonDomain=rum5798.home;Address=mvel1188.internal.localdomain;CPMStatus=tetur;Port=2694;Database=conse;DeviceType=ipi;ExtraDetails=imveniam;",
             "event": {
@@ -422,7 +422,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 12 12:39:58 licabo %CYBERARK: MessageID=\"13\";Version=1.1493;Message=cancel;Issuer=utaliqu;Station=10.86.22.67;File=nvolupt;Safe=oremi;Location=elites;Category=nbyCi;RequestId=tevel;Reason=usc;Severity=high;SourceUser=equinesc;TargetUser=cab;GatewayStation=10.134.65.15;TicketID=equepor;PolicyID=ncidid;UserName=quaUten;LogonDomain=nisiut3624.api.example;Address=perspici5680.domain;CPMStatus=iconseq;Port=2039;Database=isciv;DeviceType=rroqu;ExtraDetails=nofd;",
             "event": {
@@ -434,7 +434,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%CYBERARK: MessageID=\"358\";ilmol 1.5112\",ProductAccount=\"tten\",ProductProcess=\"ueipsa\",EventId=\"tae\",EventClass=\"autodit\",EventSeverity=\"very-high\",EventMessage=\"accept\",ActingUserName=\"cidunt\",ActingAddress=\"10.70.147.120\",ActionSourceUser=\"exeaco\",ActionTargetUser=\"emqu\",ActionObject=\"nderi\",ActionSafe=\"acommod\",ActionLocation=\"itsedd\",ActionCategory=\"leumiur\",ActionRequestId=\"eratvol\",ActionReason=\"quidol\",ActionExtraDetails=\"eaqu\"",
             "event": {
@@ -446,7 +446,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "luptatem 2017-07-11 02:45:07.352538723 +0000 UTC uaeratv3432.invalid %CYBERARK: MessageID=\"160\";Version=1.6255;Message=cancel;Issuer=dqu;Station=10.178.242.100;File=dutpers;Safe=erun;Location=orisn;Category=reetd;RequestId=prehen;Reason=ntutlabo;Severity=medium;SourceUser=rad;TargetUser=loi;GatewayStation=10.24.111.229;TicketID=volupt;PolicyID=rem;UserName=idid;LogonDomain=tesse1089.www.host;Address=ptateve6909.www5.lan;CPMStatus=toccaec;Port=7645;Database=tenatuse;DeviceType=psaqua;ExtraDetails=ullamcor;",
             "event": {
@@ -458,7 +458,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017-07-25 09:47:41.612538723 +0000 UTC cupi1867.www5.test %CYBERARK: MessageID=\"67\";orroq 1.6677\",ProductAccount=\"ritati\",ProductProcess=\"orisni\",EventId=\"ons\",EventClass=\"remagn\",EventSeverity=\"very-high\",EventMessage=\"deny\",ActingUserName=\"mmodoc\",ActingAddress=\"10.211.179.168\",ActionSourceUser=\"atu\",ActionTargetUser=\"untincul\",ActionObject=\"ssecil\",ActionSafe=\"commodi\",ActionLocation=\"emporain\",ActionCategory=\"ntiumto\",ActionRequestId=\"umetMalo\",ActionReason=\"oluptas\",ActionExtraDetails=\"emvele\"",
             "event": {
@@ -470,7 +470,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Sedut 2017-08-08 16:50:15.872538723 +0000 UTC yCiceroi2786.www.test %CYBERARK: MessageID=\"141\";iquamqua 1.4890\",ProductAccount=\"dolore\",ProductProcess=\"nsequat\",EventId=\"olorsi\",EventClass=\"aliq\",EventSeverity=\"low\",EventMessage=\"cancel\",ActingUserName=\"mven\",ActingAddress=\"10.30.243.163\",ActionSourceUser=\"oremag\",ActionTargetUser=\"illu\",ActionObject=\"ruredo\",ActionSafe=\"mac\",ActionLocation=\"temUt\",ActionCategory=\"ptassita\",ActionRequestId=\"its\",ActionReason=\"lore\",ActionExtraDetails=\"idol\"",
             "event": {
@@ -482,7 +482,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017-08-22 23:52:50.132538723 +0000 UTC urmag7650.api.invalid %CYBERARK: MessageID=\"26\";Version=1.1844;Message=cancel;Issuer=amvo;Station=10.6.79.159;File=ommodo;Safe=uptat;Location=idex;Category=ptateve;RequestId=cons;Reason=olorese;Severity=high;SourceUser=ore;TargetUser=quid;GatewayStation=10.212.214.4;TicketID=ddoeius;PolicyID=ugiatn;UserName=midestl;LogonDomain=dictasun3878.internal.localhost;Address=modocon5089.mail.example;CPMStatus=lupta;Port=5112;Database=urExce;DeviceType=asi;ExtraDetails=ectiono;",
             "event": {
@@ -494,7 +494,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "onu 2017-09-06 06:55:24.392538723 +0000 UTC liquaUte6729.api.localhost %CYBERARK: MessageID=\"150\";Version=1.3546;Message=deny;Issuer=atDu;Station=10.237.170.202;File=maperi;Safe=agnaaliq;Location=tlaboree;Category=norumet;RequestId=dtempo;Reason=tin;Severity=low;SourceUser=mve;TargetUser=liquide;GatewayStation=10.70.147.46;TicketID=inv;PolicyID=rroq;UserName=rcit;LogonDomain=aecatcup2241.www5.test;Address=tempor1282.www5.localhost;CPMStatus=incidid;Port=7699;Database=taedict;DeviceType=edquian;ExtraDetails=loremeu;",
             "event": {
@@ -506,7 +506,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "dmi 2017-09-20 13:57:58.652538723 +0000 UTC untexpl2847.www5.local %CYBERARK: MessageID=\"292\";Version=1.4282;Message=allow;Issuer=emoe;Station=10.179.50.138;File=ehende;Safe=eaqueip;Location=eum;Category=lamc;RequestId=umetMal;Reason=asper;Severity=high;SourceUser=metcons;TargetUser=itasper;GatewayStation=10.228.118.81;TicketID=temquiav;PolicyID=obeata;UserName=tatemU;LogonDomain=mad5185.www5.localhost;Address=mipsum2964.invalid;CPMStatus=doei;Port=6825;Database=toditaut;DeviceType=voluptat;ExtraDetails=ugit;",
             "event": {
@@ -518,7 +518,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "October 4 21:00:32 asnu %CYBERARK: MessageID=\"38\";Version=1.3806;Message=cancel;Issuer=henderit;Station=10.49.71.118;File=ationul;Safe=mquisn;Location=queips;Category=midest;RequestId=dex;Reason=ccae;Severity=medium;SourceUser=eavolup;TargetUser=emip;GatewayStation=10.234.165.130;TicketID=ntexplic;PolicyID=uto;UserName=iuntNequ;LogonDomain=esseq7889.www.invalid;Address=veniamq1236.invalid;CPMStatus=emo;Port=1458;Database=veniamqu;DeviceType=licaboN;ExtraDetails=atquo;",
             "event": {
@@ -530,7 +530,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "udan 2017-10-19 04:03:07.172538723 +0000 UTC yCic5749.www.localhost %CYBERARK: MessageID=\"119\";itanim 1.4024\",ProductAccount=\"olorema\",ProductProcess=\"mollita\",EventId=\"tatem\",EventClass=\"iae\",EventSeverity=\"low\",EventMessage=\"allow\",ActingUserName=\"emip\",ActingAddress=\"10.199.5.49\",ActionSourceUser=\"stquid\",ActionTargetUser=\"turadipi\",ActionObject=\"usmodi\",ActionSafe=\"ree\",ActionLocation=\"saquaea\",ActionCategory=\"ation\",ActionRequestId=\"luptas\",ActionReason=\"minim\",ActionExtraDetails=\"ataevi\"",
             "event": {
@@ -542,7 +542,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%CYBERARK: MessageID=\"156\";plic 1.7053\",ProductAccount=\"utlabo\",ProductProcess=\"tetur\",EventId=\"tionula\",EventClass=\"ritqu\",EventSeverity=\"very-high\",EventMessage=\"allow\",ActingUserName=\"uamei\",ActingAddress=\"10.193.219.34\",ActionSourceUser=\"onse\",ActionTargetUser=\"olorem\",ActionObject=\"turvel\",ActionSafe=\"eratv\",ActionLocation=\"ipsa\",ActionCategory=\"asuntexp\",ActionRequestId=\"adminim\",ActionReason=\"orisni\",ActionExtraDetails=\"nse\"",
             "event": {
@@ -554,7 +554,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 16 18:08:15 nderi %CYBERARK: MessageID=\"202\";Version=1.7083;Message=allow;Issuer=animid;Station=10.120.167.217;File=atuse;Safe=ueipsa;Location=scipitl;Category=eumi;RequestId=quasiarc;Reason=olli;Severity=low;SourceUser=tetura;TargetUser=rsp;GatewayStation=10.174.185.109;TicketID=roquisqu;PolicyID=edolorin;UserName=dolorem;LogonDomain=tem6815.home;Address=taliqui5348.mail.localdomain;CPMStatus=loremag;Port=6816;Database=tsuntinc;DeviceType=inrepreh;ExtraDetails=quovo;",
             "event": {
@@ -566,7 +566,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%CYBERARK: MessageID=\"133\";Version=1.1432;Message=cancel;Issuer=atev;Station=10.117.137.159;File=acommodi;Safe=essecill;Location=billoi;Category=moles;RequestId=dipiscin;Reason=olup;Severity=high;SourceUser=undeomni;TargetUser=accusa;GatewayStation=10.141.213.219;TicketID=itat;PolicyID=stlaboru;UserName=ate;LogonDomain=mporainc2064.home;Address=atnulapa3548.www.domain;CPMStatus=radipisc;Port=5347;Database=nibus;DeviceType=vitaed;ExtraDetails=ser;",
             "event": {
@@ -578,7 +578,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017-12-15 08:13:24.212538723 +0000 UTC ill6772.www.invalid %CYBERARK: MessageID=\"104\";Version=1.4043;Message=cancel;Issuer=rem;Station=10.166.90.130;File=mdolore;Safe=eosquira;Location=pta;Category=snos;RequestId=orsi;Reason=tetura;Severity=very-high;SourceUser=lorsita;TargetUser=eavol;GatewayStation=10.94.224.229;TicketID=lupta;PolicyID=npr;UserName=etconsec;LogonDomain=caboNem1043.internal.home;Address=litesseq6785.host;CPMStatus=tob;Port=7390;Database=oditempo;DeviceType=doeiu;ExtraDetails=deF;",
             "event": {
@@ -590,7 +590,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "rcitat 2017-12-29 15:15:58.472538723 +0000 UTC dolorema2984.www.home %CYBERARK: MessageID=\"316\";Version=1.2456;Message=deny;Issuer=tiumto;Station=10.38.28.151;File=nrepreh;Safe=ratv;Location=alorum;Category=mquisn;RequestId=atq;Reason=erspi;Severity=low;SourceUser=ugiatquo;TargetUser=incidid;GatewayStation=10.201.81.46;TicketID=sBonor;PolicyID=fugits;UserName=mipsumqu;LogonDomain=tatio6513.www.invalid;Address=onnu2272.mail.corp;CPMStatus=atatnon;Port=6064;Database=abor;DeviceType=magnid;ExtraDetails=adol;",
             "event": {
@@ -602,7 +602,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "January 12 22:18:32 niam %CYBERARK: MessageID=\"266\";Version=1.2721;Message=deny;Issuer=rerepre;Station=10.214.245.95;File=quiineav;Safe=billoinv;Location=sci;Category=col;RequestId=obea;Reason=emp;Severity=medium;SourceUser=luptas;TargetUser=uptatem;GatewayStation=10.255.28.56;TicketID=inrepr;PolicyID=mol;UserName=umdolors;LogonDomain=dolori6232.api.invalid;Address=llit958.www.domain;CPMStatus=tat;Port=2957;Database=odt;DeviceType=cillumd;ExtraDetails=riosa;",
             "event": {
@@ -614,7 +614,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "January 27 05:21:06 lapar %CYBERARK: MessageID=\"311\";ritati 1.3219\",ProductAccount=\"qui\",ProductProcess=\"otamr\",EventId=\"nim\",EventClass=\"ame\",EventSeverity=\"very-high\",EventMessage=\"cancel\",ActingUserName=\"mip\",ActingAddress=\"10.45.35.180\",ActionSourceUser=\"mvolupta\",ActionTargetUser=\"Utenima\",ActionObject=\"iqua\",ActionSafe=\"luptat\",ActionLocation=\"deriti\",ActionCategory=\"sintocc\",ActionRequestId=\"cididu\",ActionReason=\"uteir\",ActionExtraDetails=\"boree\"",
             "event": {
@@ -626,7 +626,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "February 10 12:23:41 diduntu %CYBERARK: MessageID=\"285\";eiusmod 1.7546\",ProductAccount=\"ess\",ProductProcess=\"uide\",EventId=\"scivel\",EventClass=\"henderi\",EventSeverity=\"low\",EventMessage=\"accept\",ActingUserName=\"enim\",ActingAddress=\"10.141.200.133\",ActionSourceUser=\"ersp\",ActionTargetUser=\"iame\",ActionObject=\"orroquis\",ActionSafe=\"aquio\",ActionLocation=\"riatu\",ActionCategory=\"loinve\",ActionRequestId=\"tanimid\",ActionReason=\"isnostru\",ActionExtraDetails=\"nofdeFi\"",
             "event": {
@@ -638,7 +638,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%CYBERARK: MessageID=\"155\";ulap 1.3765\",ProductAccount=\"illoi\",ProductProcess=\"reetdolo\",EventId=\"rationev\",EventClass=\"ehender\",EventSeverity=\"medium\",EventMessage=\"accept\",ActingUserName=\"ugi\",ActingAddress=\"10.83.238.145\",ActionSourceUser=\"ptatems\",ActionTargetUser=\"runtmo\",ActionObject=\"ore\",ActionSafe=\"isund\",ActionLocation=\"exerci\",ActionCategory=\"tas\",ActionRequestId=\"oraincid\",ActionReason=\"quaer\",ActionExtraDetails=\"eetdo\"",
             "event": {
@@ -650,7 +650,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018-03-11 02:28:49.772538723 +0000 UTC aali6869.api.localdomain %CYBERARK: MessageID=\"48\";Version=1.3147;Message=block;Issuer=sedquiac;Station=10.39.143.155;File=ipsaqu;Safe=nisiut;Location=rumwri;Category=velill;RequestId=ore;Reason=tation;Severity=very-high;SourceUser=porincid;TargetUser=tperspic;GatewayStation=10.41.89.217;TicketID=ict;PolicyID=squirati;UserName=tem;LogonDomain=mestq2106.api.host;Address=llamc6724.www.lan;CPMStatus=tesseci;Port=4020;Database=radipis;DeviceType=cive;ExtraDetails=nse;",
             "event": {
@@ -662,7 +662,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "isnisiu 2018-03-25 09:31:24.032538723 +0000 UTC suntincu2940.www5.domain %CYBERARK: MessageID=\"378\";Version=1.6382;Message=accept;Issuer=minim;Station=10.5.5.1;File=reseosq;Safe=gna;Location=isiutali;Category=lumqu;RequestId=onulamco;Reason=ons;Severity=low;SourceUser=uptat;TargetUser=unt;GatewayStation=10.153.123.20;TicketID=tla;PolicyID=mquiad;UserName=CSe;LogonDomain=lors7553.api.local;Address=reseosqu1629.mail.lan;CPMStatus=utemvel;Port=5325;Database=atu;DeviceType=iusm;ExtraDetails=roi;",
             "event": {
@@ -674,7 +674,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018-04-08 16:33:58.292538723 +0000 UTC rere5274.mail.domain %CYBERARK: MessageID=\"269\";Version=1.3193;Message=deny;Issuer=iamea;Station=10.210.61.109;File=tiumto;Safe=cor;Location=odoco;Category=oin;RequestId=itseddoe;Reason=elites;Severity=low;SourceUser=uamei;TargetUser=eursinto;GatewayStation=10.168.132.175;TicketID=licaboNe;PolicyID=tautfug;UserName=giatquov;LogonDomain=olu5333.www.domain;Address=orumSe4514.www.corp;CPMStatus=umquam;Port=80;Database=ici;DeviceType=nisiuta;ExtraDetails=iquaUt;",
             "event": {
@@ -686,7 +686,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%CYBERARK: MessageID=\"176\";atnula 1.5038\",ProductAccount=\"lmo\",ProductProcess=\"iquidex\",EventId=\"olup\",EventClass=\"remipsu\",EventSeverity=\"low\",EventMessage=\"accept\",ActingUserName=\"quiac\",ActingAddress=\"10.123.154.17\",ActionSourceUser=\"etdol\",ActionTargetUser=\"dolorsi\",ActionObject=\"nturmag\",ActionSafe=\"tura\",ActionLocation=\"osquirat\",ActionCategory=\"equat\",ActionRequestId=\"aliquid\",ActionReason=\"usantiu\",ActionExtraDetails=\"idunt\"",
             "event": {
@@ -698,7 +698,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%CYBERARK: MessageID=\"4\";min 1.136\",ProductAccount=\"xplic\",ProductProcess=\"eseruntm\",EventId=\"lpaquiof\",EventClass=\"oloreeu\",EventSeverity=\"very-high\",EventMessage=\"deny\",ActingUserName=\"etquasia\",ActingAddress=\"10.169.123.103\",ActionSourceUser=\"riatur\",ActionTargetUser=\"oeni\",ActionObject=\"dol\",ActionSafe=\"dol\",ActionLocation=\"atur\",ActionCategory=\"issu\",ActionRequestId=\"identsu\",ActionReason=\"piscivel\",ActionExtraDetails=\"hend\"",
             "event": {
@@ -710,7 +710,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%CYBERARK: MessageID=\"276\";aer 1.7744\",ProductAccount=\"iati\",ProductProcess=\"minim\",EventId=\"scipi\",EventClass=\"tur\",EventSeverity=\"very-high\",EventMessage=\"cancel\",ActingUserName=\"Nemoenim\",ActingAddress=\"10.126.205.76\",ActionSourceUser=\"etur\",ActionTargetUser=\"rsitvol\",ActionObject=\"utali\",ActionSafe=\"sed\",ActionLocation=\"xeac\",ActionCategory=\"umdolors\",ActionRequestId=\"lumdo\",ActionReason=\"acom\",ActionExtraDetails=\"eFini\"",
             "event": {
@@ -722,7 +722,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 4 20:44:15 uovol %CYBERARK: MessageID=\"38\";Version=1.3184;Message=accept;Issuer=eufug;Station=10.164.66.154;File=est;Safe=civelits;Location=ici;Category=snulap;RequestId=enimadm;Reason=stenatu;Severity=very-high;SourceUser=sitvo;TargetUser=ine;GatewayStation=10.169.101.161;TicketID=itessequ;PolicyID=iusmodit;UserName=orissu;LogonDomain=fic5107.home;Address=mmodoco2581.www5.host;CPMStatus=isiutali;Port=3575;Database=stquidol;DeviceType=Nemoenim;ExtraDetails=imadmini;",
             "event": {
@@ -734,7 +734,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "amvo 2018-06-19 03:46:49.592538723 +0000 UTC tnul6235.www5.lan %CYBERARK: MessageID=\"79\";isau 1.1480\",ProductAccount=\"ihilmole\",ProductProcess=\"saquaea\",EventId=\"ons\",EventClass=\"orsitam\",EventSeverity=\"medium\",EventMessage=\"block\",ActingUserName=\"metco\",ActingAddress=\"10.70.83.200\",ActionSourceUser=\"riame\",ActionTargetUser=\"riat\",ActionObject=\"sseq\",ActionSafe=\"eriam\",ActionLocation=\"pernat\",ActionCategory=\"udan\",ActionRequestId=\"archi\",ActionReason=\"iutaliq\",ActionExtraDetails=\"urQuis\"",
             "event": {
@@ -746,7 +746,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 3 10:49:23 orum %CYBERARK: MessageID=\"53\";Version=1.4887;Message=block;Issuer=madminim;Station=10.207.97.192;File=quio;Safe=eom;Location=teni;Category=ipiscive;RequestId=dant;Reason=etdolor;Severity=high;SourceUser=paria;TargetUser=mmod;GatewayStation=10.134.55.11;TicketID=amqu;PolicyID=lorsitam;UserName=tanimid;LogonDomain=onpr47.api.home;Address=oremqu7663.local;CPMStatus=llumq;Port=5816;Database=tetura;DeviceType=rumet;ExtraDetails=uptasnul;",
             "event": {
@@ -758,7 +758,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018-07-17 17:51:58.112538723 +0000 UTC nde2358.mail.corp %CYBERARK: MessageID=\"75\";Version=1.3601;Message=cancel;Issuer=texplica;Station=10.52.150.104;File=esse;Safe=veniam;Location=edquian;Category=sus;RequestId=imavenia;Reason=expli;Severity=low;SourceUser=orum;TargetUser=oinBCSed;GatewayStation=10.31.187.19;TicketID=ilm;PolicyID=mvel;UserName=eritq;LogonDomain=rehen4859.api.host;Address=eve234.www5.local;CPMStatus=nula;Port=2783;Database=lit;DeviceType=santi;ExtraDetails=ritati;",
             "event": {
@@ -770,7 +770,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "dip 2018-08-01 00:54:32.372538723 +0000 UTC idolo5292.local %CYBERARK: MessageID=\"89\";Version=1.3175;Message=allow;Issuer=runtm;Station=10.41.232.147;File=psumd;Safe=oloree;Location=seos;Category=rios;RequestId=labo;Reason=lpaquiof;Severity=high;SourceUser=mcorpo;TargetUser=ntexpl;GatewayStation=10.61.175.217;TicketID=enbyCi;PolicyID=reetdo;UserName=tat;LogonDomain=eufugia4481.corp;Address=fficia2304.www5.home;CPMStatus=vel;Port=2396;Database=rere;DeviceType=pta;ExtraDetails=nonn;",
             "event": {
@@ -782,7 +782,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 15 07:57:06 volup %CYBERARK: MessageID=\"261\";ptate 1.3830\",ProductAccount=\"uisnos\",ProductProcess=\"quamqua\",EventId=\"ntut\",EventClass=\"mag\",EventSeverity=\"very-high\",EventMessage=\"deny\",ActingUserName=\"mini\",ActingAddress=\"10.150.30.95\",ActionSourceUser=\"tur\",ActionTargetUser=\"atnonpr\",ActionObject=\"ita\",ActionSafe=\"amquaer\",ActionLocation=\"aqui\",ActionCategory=\"enby\",ActionRequestId=\"lpa\",ActionReason=\"isn\",ActionExtraDetails=\"smod\"",
             "event": {
@@ -794,7 +794,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 29 14:59:40 siuta %CYBERARK: MessageID=\"66\";atev 1.6626\",ProductAccount=\"CSe\",ProductProcess=\"exerci\",EventId=\"inesciu\",EventClass=\"quid\",EventSeverity=\"high\",EventMessage=\"deny\",ActingUserName=\"onse\",ActingAddress=\"10.98.71.45\",ActionSourceUser=\"destla\",ActionTargetUser=\"fugitse\",ActionObject=\"minimve\",ActionSafe=\"serrorsi\",ActionLocation=\"tametco\",ActionCategory=\"mquisnos\",ActionRequestId=\"lore\",ActionReason=\"isci\",ActionExtraDetails=\"Dui\"",
             "event": {
@@ -806,7 +806,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "lup 2018-09-12 22:02:15.152538723 +0000 UTC iumtotam1010.www5.corp %CYBERARK: MessageID=\"168\";userror 1.5986\",ProductAccount=\"nonn\",ProductProcess=\"hite\",EventId=\"ianonnum\",EventClass=\"nofdeFi\",EventSeverity=\"medium\",EventMessage=\"deny\",ActingUserName=\"remq\",ActingAddress=\"10.252.251.143\",ActionSourceUser=\"velill\",ActionTargetUser=\"rspic\",ActionObject=\"orinrepr\",ActionSafe=\"ror\",ActionLocation=\"onsecte\",ActionCategory=\"doei\",ActionRequestId=\"nvolupta\",ActionReason=\"tev\",ActionExtraDetails=\"nre\"",
             "event": {
@@ -818,7 +818,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%CYBERARK: MessageID=\"274\";lumdolor 1.4706\",ProductAccount=\"eserun\",ProductProcess=\"rvelill\",EventId=\"lupta\",EventClass=\"byC\",EventSeverity=\"high\",EventMessage=\"accept\",ActingUserName=\"uta\",ActingAddress=\"10.197.203.167\",ActionSourceUser=\"ulapa\",ActionTargetUser=\"iumdo\",ActionObject=\"iusmodit\",ActionSafe=\"aturv\",ActionLocation=\"ectetura\",ActionCategory=\"obeataev\",ActionRequestId=\"umf\",ActionReason=\"olesti\",ActionExtraDetails=\"smo\"",
             "event": {
@@ -830,7 +830,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "tDuis 2018-10-11 12:07:23.672538723 +0000 UTC iqu1643.www.host %CYBERARK: MessageID=\"96\";inim 1.6806\",ProductAccount=\"ibusBo\",ProductProcess=\"untincu\",EventId=\"tten\",EventClass=\"etur\",EventSeverity=\"low\",EventMessage=\"accept\",ActingUserName=\"enima\",ActingAddress=\"10.187.170.23\",ActionSourceUser=\"sequ\",ActionTargetUser=\"sectetu\",ActionObject=\"evi\",ActionSafe=\"tionula\",ActionLocation=\"accus\",ActionCategory=\"uatu\",ActionRequestId=\"mquis\",ActionReason=\"lab\",ActionExtraDetails=\"uido\"",
             "event": {
@@ -842,7 +842,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018-10-25 19:09:57.932538723 +0000 UTC nimadmin5577.corp %CYBERARK: MessageID=\"61\";Version=1.3824;Message=allow;Issuer=tinculpa;Station=10.123.62.215;File=rumSecti;Safe=riamea;Location=eca;Category=oluptate;RequestId=Duisa;Reason=consequa;Severity=low;SourceUser=iaecon;TargetUser=aevitaed;GatewayStation=10.250.248.215;TicketID=remap;PolicyID=deri;UserName=quaeratv;LogonDomain=involu1450.www.localhost;Address=udexerc2708.api.test;CPMStatus=odic;Port=505;Database=lica;DeviceType=secil;ExtraDetails=uisnos;",
             "event": {
@@ -854,7 +854,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "scipit 2018-11-09 02:12:32.192538723 +0000 UTC lloinve551.internal.local %CYBERARK: MessageID=\"372\";Version=1.3759;Message=block;Issuer=isiutali;Station=10.146.57.23;File=evit;Safe=tno;Location=iss;Category=taspe;RequestId=lum;Reason=xerc;Severity=high;GatewayStation=10.147.154.118;TicketID=nvol;PolicyID=enimadmi;UserName=tateveli;LogonDomain=osa3211.www5.example;Address=temvele5776.www.test;CPMStatus=inimve;Port=\"864\";Database=cin;DeviceType=tmo;ExtraDetails=onofdeF;",
             "event": {
@@ -866,7 +866,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "its 2018-11-23 09:15:06.452538723 +0000 UTC uptasnul2751.www5.corp %CYBERARK: MessageID=\"232\";ostrudex 1.4542\",ProductAccount=\"niamqui\",ProductProcess=\"usmodite\",EventId=\"tlabo\",EventClass=\"tatemse\",EventSeverity=\"very-high\",EventMessage=\"cancel\",ActingUserName=\"uamestqu\",ActingAddress=\"10.193.33.201\",ActionSourceUser=\"hender\",ActionTargetUser=\"ptatemU\",ActionObject=\"seq\",ActionSafe=\"rumSe\",ActionLocation=\"tatnonp\",ActionCategory=\"ommo\",ActionRequestId=\"adeser\",ActionReason=\"uasiarc\",ActionExtraDetails=\"doeiu\"",
             "event": {
@@ -878,7 +878,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018-12-07 16:17:40.712538723 +0000 UTC atuserro6791.internal.host %CYBERARK: MessageID=\"24\";upta 1.313\",ProductAccount=\"onnumqua\",ProductProcess=\"quioff\",EventId=\"iuntN\",EventClass=\"ipis\",EventSeverity=\"low\",EventMessage=\"block\",ActingUserName=\"nesci\",ActingAddress=\"10.154.172.82\",ActionSourceUser=\"lorsi\",ActionTargetUser=\"tetura\",ActionObject=\"eeufug\",ActionSafe=\"edutper\",ActionLocation=\"tevelite\",ActionCategory=\"tocca\",ActionRequestId=\"orsitvol\",ActionReason=\"ntor\",ActionExtraDetails=\"oinBCSed\"",
             "event": {
@@ -890,7 +890,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%CYBERARK: MessageID=\"79\";obeatae 1.1886\",ProductAccount=\"midestl\",ProductProcess=\"quatu\",EventId=\"avolu\",EventClass=\"teturad\",EventSeverity=\"very-high\",EventMessage=\"allow\",ActingUserName=\"expl\",ActingAddress=\"10.47.63.70\",ActionSourceUser=\"lup\",ActionTargetUser=\"tpers\",ActionObject=\"orsitv\",ActionSafe=\"temseq\",ActionLocation=\"uisaute\",ActionCategory=\"uun\",ActionRequestId=\"end\",ActionReason=\"odocons\",ActionExtraDetails=\"olu\"",
             "event": {
@@ -902,7 +902,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "January 5 06:22:49 amn %CYBERARK: MessageID=\"312\";itessequ 1.5170\",ProductAccount=\"fdeFinib\",ProductProcess=\"uip\",EventId=\"ectobea\",EventClass=\"dat\",EventSeverity=\"very-high\",EventMessage=\"block\",ActingUserName=\"turQuis\",ActingAddress=\"10.178.160.245\",ActionSourceUser=\"deomnisi\",ActionTargetUser=\"olupta\",ActionObject=\"oll\",ActionSafe=\"laboree\",ActionLocation=\"udantiu\",ActionCategory=\"itametco\",ActionRequestId=\"iav\",ActionReason=\"odico\",ActionExtraDetails=\"rsint\"",
             "event": {
@@ -914,7 +914,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "January 19 13:25:23 quiav %CYBERARK: MessageID=\"77\";Version=1.6648;Message=block;Issuer=Nem;Station=10.85.13.237;File=oluptat;Safe=enimad;Location=tis;Category=qua;RequestId=con;Reason=tore;Severity=high;SourceUser=quelaud;TargetUser=luptat;GatewayStation=10.89.154.115;TicketID=oeiusmo;PolicyID=nimv;UserName=emeu;LogonDomain=tatemac5192.www5.test;Address=teursint1321.www5.example;CPMStatus=lamcolab;Port=7024;Database=nturmag;DeviceType=uredol;ExtraDetails=maliqua;",
             "event": {
@@ -926,7 +926,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019-02-02 20:27:57.752538723 +0000 UTC omnisi5530.mail.example %CYBERARK: MessageID=\"308\";Version=1.3387;Message=allow;Issuer=itame;Station=10.222.32.183;File=yCiceroi;Safe=nostrum;Location=orroquis;Category=eumi;RequestId=tvo;Reason=aea;Severity=low;SourceUser=mmo;TargetUser=eve;GatewayStation=10.65.207.234;TicketID=ciad;PolicyID=ugiatqu;UserName=eruntmo;LogonDomain=nimve2787.mail.test;Address=boreet2051.internal.localdomain;CPMStatus=iavo;Port=1644;Database=udexerc;DeviceType=ovolupta;ExtraDetails=volup;",
             "event": {
@@ -938,7 +938,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "rro 2019-02-17 03:30:32.012538723 +0000 UTC tuser6944.local %CYBERARK: MessageID=\"54\";iarchite 1.1612\",ProductAccount=\"oinven\",ProductProcess=\"natu\",EventId=\"edqu\",EventClass=\"tationu\",EventSeverity=\"high\",EventMessage=\"cancel\",ActingUserName=\"olore\",ActingAddress=\"10.16.181.60\",ActionSourceUser=\"ameaquei\",ActionTargetUser=\"gnama\",ActionObject=\"esciun\",ActionSafe=\"tesse\",ActionLocation=\"olupta\",ActionCategory=\"isno\",ActionRequestId=\"oluptas\",ActionReason=\"nderiti\",ActionExtraDetails=\"uatu\"",
             "event": {
@@ -950,7 +950,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "orem 2019-03-03 10:33:06.272538723 +0000 UTC giatqu1484.internal.corp %CYBERARK: MessageID=\"208\";oreseosq 1.2275\",ProductAccount=\"uianon\",ProductProcess=\"nul\",EventId=\"onse\",EventClass=\"sitam\",EventSeverity=\"very-high\",EventMessage=\"deny\",ActingUserName=\"illoin\",ActingAddress=\"10.91.213.82\",ActionSourceUser=\"uid\",ActionTargetUser=\"amnis\",ActionObject=\"rvelil\",ActionSafe=\"adese\",ActionLocation=\"olorsi\",ActionCategory=\"caboNemo\",ActionRequestId=\"uptas\",ActionReason=\"temaccus\",ActionExtraDetails=\"ons\"",
             "event": {
@@ -962,7 +962,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019-03-17 17:35:40.532538723 +0000 UTC oreeu3666.invalid %CYBERARK: MessageID=\"48\";tis 1.6724\",ProductAccount=\"eprehe\",ProductProcess=\"tinvolup\",EventId=\"iaeconse\",EventClass=\"uisa\",EventSeverity=\"medium\",EventMessage=\"allow\",ActingUserName=\"tdolo\",ActingAddress=\"10.204.214.98\",ActionSourceUser=\"iumt\",ActionTargetUser=\"porissus\",ActionObject=\"imip\",ActionSafe=\"tsunt\",ActionLocation=\"rnat\",ActionCategory=\"oremi\",ActionRequestId=\"ectobeat\",ActionReason=\"ecte\",ActionExtraDetails=\"abo\"",
             "event": {
@@ -974,7 +974,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%CYBERARK: MessageID=\"219\";snos 1.5910\",ProductAccount=\"moenimip\",ProductProcess=\"uames\",EventId=\"tium\",EventClass=\"ianonn\",EventSeverity=\"very-high\",EventMessage=\"accept\",ActingUserName=\"etc\",ActingAddress=\"10.223.178.192\",ActionSourceUser=\"atquovol\",ActionTargetUser=\"evel\",ActionObject=\"edol\",ActionSafe=\"sequuntu\",ActionLocation=\"quameius\",ActionCategory=\"litse\",ActionRequestId=\"san\",ActionReason=\"apari\",ActionExtraDetails=\"iarchit\"",
             "event": {
@@ -986,7 +986,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019-04-15 07:40:49.052538723 +0000 UTC nsequat6724.www.invalid %CYBERARK: MessageID=\"183\";Version=1.801;Message=cancel;Issuer=ati;Station=10.26.137.126;File=dolor;Safe=Mal;Location=ametcons;Category=tconse;RequestId=eumf;Reason=roquisq;Severity=medium;SourceUser=doconse;TargetUser=audant;GatewayStation=10.26.33.181;TicketID=remeum;PolicyID=mmod;UserName=taevit;LogonDomain=ama6820.mail.example;Address=umto3015.mail.lan;CPMStatus=sitv;Port=4667;Database=com;DeviceType=rep;ExtraDetails=mveni;",
             "event": {
@@ -998,7 +998,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 29 14:43:23 num %CYBERARK: MessageID=\"41\";Version=1.10;Message=accept;Issuer=quaerat;Station=10.148.195.208;File=amnih;Safe=tper;Location=pisciv;Category=tconsect;RequestId=pariat;Reason=iutal;Severity=low;SourceUser=ctobeat;TargetUser=isi;GatewayStation=10.142.161.116;TicketID=eca;PolicyID=ctionofd;UserName=mpori;LogonDomain=olupt966.www5.corp;Address=etquasia1800.www.host;CPMStatus=nimip;Port=7612;Database=squamest;DeviceType=quisn;ExtraDetails=pteu;",
             "event": {
@@ -1010,7 +1010,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "velillum 2019-05-13 21:45:57.572538723 +0000 UTC ntNequ7639.internal.localdomain %CYBERARK: MessageID=\"270\";Version=1.1026;Message=block;Issuer=itinvo;Station=10.107.24.54;File=emipsumq;Safe=culpaq;Location=quamq;Category=usan;RequestId=tdolo;Reason=ident;Severity=medium;SourceUser=itaedi;TargetUser=hend;GatewayStation=10.10.174.253;TicketID=esciun;PolicyID=tasnul;UserName=uptasn;LogonDomain=lit4112.www.localhost;Address=quisquam2153.mail.host;CPMStatus=dit;Port=2717;Database=lup;DeviceType=aeca;ExtraDetails=isau;",
             "event": {
@@ -1022,7 +1022,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 28 04:48:31 boreetd %CYBERARK: MessageID=\"309\";tNe 1.2566\",ProductAccount=\"eeufug\",ProductProcess=\"ntin\",EventId=\"iades\",EventClass=\"radipis\",EventSeverity=\"very-high\",EventMessage=\"deny\",ActingUserName=\"luptate\",ActingAddress=\"10.87.92.17\",ActionSourceUser=\"utlabore\",ActionTargetUser=\"tamr\",ActionObject=\"serr\",ActionSafe=\"usci\",ActionLocation=\"unturmag\",ActionCategory=\"dexeaco\",ActionRequestId=\"lupta\",ActionReason=\"ura\",ActionExtraDetails=\"oreeufug\"",
             "event": {
@@ -1034,7 +1034,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 11 11:51:06 dolo %CYBERARK: MessageID=\"295\";Version=1.5649;Message=deny;Issuer=Finibus;Station=10.161.51.135;File=porin;Safe=metMal;Location=ciati;Category=ecillum;RequestId=olor;Reason=amei;Severity=medium;SourceUser=quid;TargetUser=accus;GatewayStation=10.231.51.136;TicketID=ctobeat;PolicyID=upta;UserName=asper;LogonDomain=dictasun3408.internal.invalid;Address=secte1774.localhost;CPMStatus=iqui;Port=5200;Database=litani;DeviceType=emp;ExtraDetails=arch;",
             "event": {
@@ -1046,7 +1046,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 25 18:53:40 dipisciv %CYBERARK: MessageID=\"148\";uam 1.2575\",ProductAccount=\"llum\",ProductProcess=\"mwr\",EventId=\"cia\",EventClass=\"idolo\",EventSeverity=\"low\",EventMessage=\"allow\",ActingUserName=\"mquido\",ActingAddress=\"10.51.17.32\",ActionSourceUser=\"ree\",ActionTargetUser=\"itten\",ActionObject=\"quipexea\",ActionSafe=\"orsitv\",ActionLocation=\"dunt\",ActionCategory=\"int\",ActionRequestId=\"ionevo\",ActionReason=\"llitani\",ActionExtraDetails=\"uscipit\"",
             "event": {
@@ -1058,7 +1058,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "etco 2019-07-10 01:56:14.612538723 +0000 UTC iuntN4077.www.invalid %CYBERARK: MessageID=\"260\";isnostru 1.270\",ProductAccount=\"mmodicon\",ProductProcess=\"eetdo\",EventId=\"mquisno\",EventClass=\"atvolup\",EventSeverity=\"medium\",EventMessage=\"deny\",ActingUserName=\"ollita\",ActingAddress=\"10.108.123.148\",ActionSourceUser=\"cto\",ActionTargetUser=\"cusa\",ActionObject=\"nderi\",ActionSafe=\"tem\",ActionLocation=\"tcu\",ActionCategory=\"eumiu\",ActionRequestId=\"nim\",ActionReason=\"pteurs\",ActionExtraDetails=\"ercitati\"",
             "event": {
@@ -1070,7 +1070,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 24 08:58:48 eturadip %CYBERARK: MessageID=\"8\";Version=1.425;Message=accept;Issuer=rsitamet;Station=10.114.0.148;File=utod;Safe=olesti;Location=edquia;Category=ihi;RequestId=undeomn;Reason=ape;Severity=medium;SourceUser=amco;TargetUser=ons;GatewayStation=10.198.187.144;TicketID=atquo;PolicyID=borio;UserName=equatD;LogonDomain=uidol6868.mail.localdomain;Address=uido2773.www5.test;CPMStatus=acons;Port=3820;Database=periam;DeviceType=ain;ExtraDetails=umiurer;",
             "event": {
@@ -1082,7 +1082,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "onorume 2019-08-07 16:01:23.132538723 +0000 UTC abill5290.lan %CYBERARK: MessageID=\"89\";mini 1.7224\",ProductAccount=\"loru\",ProductProcess=\"iadeser\",EventId=\"litess\",EventClass=\"qui\",EventSeverity=\"low\",EventMessage=\"allow\",ActingUserName=\"equa\",ActingAddress=\"10.61.140.120\",ActionSourceUser=\"olorsit\",ActionTargetUser=\"naaliq\",ActionObject=\"plica\",ActionSafe=\"asiarc\",ActionLocation=\"lor\",ActionCategory=\"nvolupt\",ActionRequestId=\"dquia\",ActionReason=\"ora\",ActionExtraDetails=\"umfugiat\"",
             "event": {
@@ -1094,7 +1094,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%CYBERARK: MessageID=\"36\";Version=1.6988;Message=deny;Issuer=ite;Station=10.93.24.151;File=Duis;Safe=lupt;Location=quatur;Category=dminim;RequestId=ptatevel;Reason=aperiame;Severity=very-high;SourceUser=eirured;TargetUser=sequamn;GatewayStation=10.149.238.108;TicketID=ciatisun;PolicyID=duntutl;UserName=nven;LogonDomain=ptat4878.lan;Address=quame1852.www.test;CPMStatus=deomni;Port=4512;Database=fugi;DeviceType=nse;ExtraDetails=nesciu;",
             "event": {
@@ -1106,7 +1106,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "September 5 06:06:31 inrepreh %CYBERARK: MessageID=\"39\";rit 1.6107\",ProductAccount=\"cipitla\",ProductProcess=\"tlab\",EventId=\"vel\",EventClass=\"ionevo\",EventSeverity=\"high\",EventMessage=\"accept\",ActingUserName=\"uinesc\",ActingAddress=\"10.101.45.225\",ActionSourceUser=\"utla\",ActionTargetUser=\"emi\",ActionObject=\"uaerat\",ActionSafe=\"iduntu\",ActionLocation=\"samvol\",ActionCategory=\"equa\",ActionRequestId=\"apari\",ActionReason=\"tsunt\",ActionExtraDetails=\"caecat\"",
             "event": {
@@ -1118,7 +1118,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "qui 2019-09-19 13:09:05.912538723 +0000 UTC caboN3124.mail.home %CYBERARK: MessageID=\"8\";catcupid 1.3167\",ProductAccount=\"quela\",ProductProcess=\"uamquaer\",EventId=\"texplica\",EventClass=\"enimi\",EventSeverity=\"low\",EventMessage=\"cancel\",ActingUserName=\"ore\",ActingAddress=\"10.2.204.161\",ActionSourceUser=\"iquamqu\",ActionTargetUser=\"eumfugia\",ActionObject=\"reeufugi\",ActionSafe=\"sequines\",ActionLocation=\"minimve\",ActionCategory=\"texplica\",ActionRequestId=\"entorev\",ActionReason=\"quuntur\",ActionExtraDetails=\"olup\"",
             "event": {
@@ -1130,7 +1130,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "les 2019-10-03 20:11:40.172538723 +0000 UTC norumet2571.internal.example %CYBERARK: MessageID=\"89\";temp 1.6971\",ProductAccount=\"aliqu\",ProductProcess=\"sequine\",EventId=\"utaliqui\",EventClass=\"isciv\",EventSeverity=\"very-high\",EventMessage=\"cancel\",ActingUserName=\"ptatemse\",ActingAddress=\"10.33.112.100\",ActionSourceUser=\"catcup\",ActionTargetUser=\"enimad\",ActionObject=\"magnaali\",ActionSafe=\"velillum\",ActionLocation=\"ionev\",ActionCategory=\"vitaedi\",ActionRequestId=\"rna\",ActionReason=\"cons\",ActionExtraDetails=\"Except\"",
             "event": {
@@ -1142,7 +1142,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%CYBERARK: MessageID=\"95\";Version=1.3175;Message=block;Issuer=neavol;Station=10.94.152.238;File=rporiss;Safe=billoinv;Location=etconse;Category=nesciu;RequestId=mali;Reason=roinBCSe;Severity=very-high;SourceUser=uames;TargetUser=tla;GatewayStation=10.151.110.250;TicketID=psa;PolicyID=nreprehe;UserName=pidatatn;LogonDomain=isno4595.local;Address=lla5407.lan;CPMStatus=upt;Port=4762;Database=itaedict;DeviceType=eroi;ExtraDetails=onemull;",
             "event": {
@@ -1154,7 +1154,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "mporain 2019-11-01 10:16:48.692538723 +0000 UTC eratvo7756.localdomain %CYBERARK: MessageID=\"179\";Version=1.4965;Message=allow;Issuer=alorumwr;Station=10.146.61.5;File=tvolu;Safe=imve;Location=ollitan;Category=temseq;RequestId=vol;Reason=loremips;Severity=high;SourceUser=eturadi;TargetUser=umS;GatewayStation=10.77.9.17;TicketID=henderi;PolicyID=taevitae;UserName=tevel;LogonDomain=tatemse5403.home;Address=iquipexe4708.api.localhost;CPMStatus=quuntur;Port=5473;Database=amremap;DeviceType=oremagna;ExtraDetails=aqu;",
             "event": {
@@ -1166,7 +1166,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%CYBERARK: MessageID=\"83\";tvolu 1.2244\",ProductAccount=\"ore\",ProductProcess=\"lors\",EventId=\"saute\",EventClass=\"ecillumd\",EventSeverity=\"high\",EventMessage=\"allow\",ActingUserName=\"sequatu\",ActingAddress=\"10.128.102.130\",ActionSourceUser=\"mdoloree\",ActionTargetUser=\"que\",ActionObject=\"inBCSed\",ActionSafe=\"cteturad\",ActionLocation=\"umq\",ActionCategory=\"ita\",ActionRequestId=\"ipsaquae\",ActionReason=\"olu\",ActionExtraDetails=\"exerci\"",
             "event": {
@@ -1178,7 +1178,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019-11-30 00:21:57.212538723 +0000 UTC moen6809.internal.example %CYBERARK: MessageID=\"150\";Version=1.7701;Message=cancel;Issuer=reseo;Station=10.31.86.83;File=pariat;Safe=icaboNe;Location=boreetd;Category=uir;RequestId=rumex;Reason=ectobea;Severity=medium;SourceUser=tamrem;TargetUser=doloremi;GatewayStation=10.200.162.248;TicketID=uptate;PolicyID=giatquo;UserName=onnu;LogonDomain=reprehe650.www.corp;Address=oremip4070.www5.invalid;CPMStatus=turad;Port=1704;Database=billo;DeviceType=doloremi;ExtraDetails=ectetura;",
             "event": {
@@ -1190,7 +1190,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%CYBERARK: MessageID=\"166\";cul 1.3325\",ProductAccount=\"atatn\",ProductProcess=\"ipisc\",EventId=\"iatnulap\",EventClass=\"roi\",EventSeverity=\"high\",EventMessage=\"allow\",ActingUserName=\"volup\",ActingAddress=\"10.103.215.159\",ActionSourceUser=\"ddoeiusm\",ActionTargetUser=\"apa\",ActionObject=\"archite\",ActionSafe=\"tur\",ActionLocation=\"ddo\",ActionCategory=\"emp\",ActionRequestId=\"inBC\",ActionReason=\"did\",ActionExtraDetails=\"atcupi\"",
             "event": {

--- a/packages/cyberark/data_stream/corepas/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cyberark/data_stream/corepas/elasticsearch/ingest_pipeline/default.yml
@@ -8,7 +8,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   # User agent
   - user_agent:
       field: user_agent.original

--- a/packages/cyberark/manifest.yml
+++ b/packages/cyberark/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cyberark
 title: Cyber-Ark - Deprecated
-version: 0.3.0
+version: 0.3.1
 description: "Cyber-Ark Integration - Deprecated: Use 'CyberArk Privileged Access Security' instead."
 categories: ["security"]
 release: experimental


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967