### PR TITLE
cyberarkpas update to ECS 1.11.0

### DIFF
--- a/packages/cyberarkpas/changelog.yml
+++ b/packages/cyberarkpas/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '1.2.2'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1380
 - version: "1.2.1"
   changes:
     - description: Escape special characters in docs

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-105-add-file-category.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-105-add-file-category.log-expected.json
@@ -31,7 +31,7 @@
                 "path": "Root\\Operating System-WinDesktopLocal-Address-adriansr"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -105,7 +105,7 @@
                 "path": "Root\\PSMPApp_localhost.localdomain.LiveSessions"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -176,7 +176,7 @@
                 "path": "Root\\PSMServer.LiveSessions"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -246,7 +246,7 @@
                 "path": "Root\\PSM-ASR-CYBERARK-WI"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -317,7 +317,7 @@
                 "path": "Root\\PSM-ASR-CYBERARK-WI.LiveSessions"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -388,7 +388,7 @@
                 "path": "Root\\PSMPApp_VAGRANT.LiveSessions"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-106-update-file-category.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-106-update-file-category.log-expected.json
@@ -31,7 +31,7 @@
                 "path": "Root\\Operating System-WinDesktopLocal-Address-adriansr"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -105,7 +105,7 @@
                 "path": "Root\\PSMServer.LiveSessions"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -175,7 +175,7 @@
                 "path": "Root\\PSM-ASR-CYBERARK-WI.LiveSessions"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -246,7 +246,7 @@
                 "path": "root\\87012dcc-8290-11eb-949e-080027efd402.session"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -317,7 +317,7 @@
                 "path": "Root\\PSM-ASR-CYBERARK-WI.LiveSessions"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -386,7 +386,7 @@
                 "path": "Root\\PSMPApp_SSH.LiveSessions"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-107-delete-file-category.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-107-delete-file-category.log-expected.json
@@ -31,7 +31,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-124-rename-file.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-124-rename-file.log-expected.json
@@ -31,7 +31,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-PSMConnect"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-125-rename-file-cont.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-125-rename-file-cont.log-expected.json
@@ -31,7 +31,7 @@
                 "path": "Operating System-UnixSSH-34.71.250.247-PSMConnect"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-126-unlock-file.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-126-unlock-file.log-expected.json
@@ -24,7 +24,7 @@
                 "path": "Root\\PVConfiguration.xml"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-130-cpm-disable-password.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-130-cpm-disable-password.log-expected.json
@@ -24,7 +24,7 @@
                 "path": "Root\\Operating System-WinDomain-35.192.121.42-ELASTICbart"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-178-get-user-s-details.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-178-get-user-s-details.log-expected.json
@@ -21,7 +21,7 @@
             },
             "@timestamp": "2021-03-11T18:45:23.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-180-add-user.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-180-add-user.log-expected.json
@@ -33,7 +33,7 @@
             },
             "@timestamp": "2021-03-10T09:11:20.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -115,7 +115,7 @@
             },
             "@timestamp": "2021-03-10T09:11:20.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -197,7 +197,7 @@
             },
             "@timestamp": "2021-03-10T09:11:35.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -279,7 +279,7 @@
             },
             "@timestamp": "2021-03-10T17:59:19.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -361,7 +361,7 @@
             },
             "@timestamp": "2021-03-10T17:59:27.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -442,7 +442,7 @@
             },
             "@timestamp": "2021-03-10T22:19:06.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -523,7 +523,7 @@
             },
             "@timestamp": "2021-03-10T22:19:15.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -605,7 +605,7 @@
             },
             "@timestamp": "2021-03-11T16:59:36.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -688,7 +688,7 @@
             },
             "@timestamp": "2021-03-11T16:59:36.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -768,7 +768,7 @@
             },
             "@timestamp": "2021-03-14T12:57:16.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -848,7 +848,7 @@
             },
             "@timestamp": "2021-03-14T12:57:16.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -928,7 +928,7 @@
             },
             "@timestamp": "2021-03-14T12:57:21.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-181-update-safe.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-181-update-safe.log-expected.json
@@ -33,7 +33,7 @@
             },
             "@timestamp": "2021-03-10T18:15:44.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-185-add-safe.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-185-add-safe.log-expected.json
@@ -33,7 +33,7 @@
             },
             "@timestamp": "2021-03-10T09:11:20.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -99,7 +99,7 @@
             },
             "@timestamp": "2021-03-11T17:38:13.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-187-add-folder.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-187-add-folder.log-expected.json
@@ -36,7 +36,7 @@
                 "path": "Root\\Scripts\\"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -94,7 +94,7 @@
                 "path": "Root\\2\\"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-19-full-gateway-connection.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-19-full-gateway-connection.log-expected.json
@@ -34,7 +34,7 @@
             },
             "@timestamp": "2021-03-08T18:07:51.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -129,7 +129,7 @@
             },
             "@timestamp": "2021-03-09T08:32:51.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -224,7 +224,7 @@
             },
             "@timestamp": "2021-03-09T10:14:58.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -307,7 +307,7 @@
             },
             "@timestamp": "2021-03-10T08:31:50.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -389,7 +389,7 @@
             },
             "@timestamp": "2021-03-10T22:37:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -484,7 +484,7 @@
             },
             "@timestamp": "2021-03-11T17:38:05.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -580,7 +580,7 @@
             },
             "@timestamp": "2021-03-11T17:48:22.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -675,7 +675,7 @@
             },
             "@timestamp": "2021-03-11T18:02:57.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -780,7 +780,7 @@
             },
             "@timestamp": "2021-03-14T13:49:35.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-20-partial-gateway-connection.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-20-partial-gateway-connection.log-expected.json
@@ -21,7 +21,7 @@
             },
             "@timestamp": "2021-03-25T09:20:07.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-202-old-backup-files-deletion-start.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-202-old-backup-files-deletion-start.log-expected.json
@@ -21,7 +21,7 @@
             },
             "@timestamp": "2021-03-09T10:17:54.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-203-old-backup-files-deletion-end.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-203-old-backup-files-deletion-end.log-expected.json
@@ -21,7 +21,7 @@
             },
             "@timestamp": "2021-03-09T10:17:54.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-22-cpm-verify-password.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-22-cpm-verify-password.log-expected.json
@@ -29,7 +29,7 @@
                 "path": "Root\\Operating System-LINUX-SSH-radiussrv.cyberark.local-test12"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -143,7 +143,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-23-action-on-closed-safe.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-23-action-on-closed-safe.log-expected.json
@@ -33,7 +33,7 @@
             },
             "@timestamp": "2021-03-10T09:11:20.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -88,7 +88,7 @@
             },
             "@timestamp": "2021-03-14T12:07:27.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -153,7 +153,7 @@
             },
             "@timestamp": "2021-03-14T12:57:16.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-24-cpm-change-password.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-24-cpm-change-password.log-expected.json
@@ -22,7 +22,7 @@
                 "path": "Root\\Operating System-LINUX-SSH-radiussrv.cyberark.local-test12"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -119,7 +119,7 @@
                 "path": "Root\\Operating System-WindowsDesktopLocalAccountsRotationalPolicy-10.0.1.20-x_accountA"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -223,7 +223,7 @@
                 "path": "Root\\Operating System-WindowsDesktopLocalAccountsRotationalPolicy-10.0.1.20-x_accountB"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -327,7 +327,7 @@
                 "path": "Root\\Operating System-WindowsDesktopLocalAccountsRotationalPolicy-10.0.1.20-x_accountA"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-259-add-update-group.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-259-add-update-group.log-expected.json
@@ -33,7 +33,7 @@
             },
             "@timestamp": "2021-03-10T09:11:21.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -99,7 +99,7 @@
             },
             "@timestamp": "2021-03-10T09:11:21.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -165,7 +165,7 @@
             },
             "@timestamp": "2021-03-10T09:11:35.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -231,7 +231,7 @@
             },
             "@timestamp": "2021-03-10T17:59:29.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-265-add-group-member.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-265-add-group-member.log-expected.json
@@ -33,7 +33,7 @@
             },
             "@timestamp": "2021-03-10T09:11:22.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -100,7 +100,7 @@
             },
             "@timestamp": "2021-03-10T09:11:22.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -167,7 +167,7 @@
             },
             "@timestamp": "2021-03-10T09:11:35.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -234,7 +234,7 @@
             },
             "@timestamp": "2021-03-10T17:58:01.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -301,7 +301,7 @@
             },
             "@timestamp": "2021-03-10T17:59:29.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -368,7 +368,7 @@
             },
             "@timestamp": "2021-03-10T17:59:30.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -434,7 +434,7 @@
             },
             "@timestamp": "2021-03-10T22:17:15.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -500,7 +500,7 @@
             },
             "@timestamp": "2021-03-10T22:19:16.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -566,7 +566,7 @@
             },
             "@timestamp": "2021-03-10T22:19:16.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -633,7 +633,7 @@
             },
             "@timestamp": "2021-03-11T16:59:38.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -701,7 +701,7 @@
             },
             "@timestamp": "2021-03-11T16:59:38.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -766,7 +766,7 @@
             },
             "@timestamp": "2021-03-14T12:57:17.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -831,7 +831,7 @@
             },
             "@timestamp": "2021-03-14T12:57:17.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -896,7 +896,7 @@
             },
             "@timestamp": "2021-03-14T12:57:21.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-266-remove-group-member.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-266-remove-group-member.log-expected.json
@@ -33,7 +33,7 @@
             },
             "@timestamp": "2021-03-10T17:59:48.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -99,7 +99,7 @@
             },
             "@timestamp": "2021-03-10T22:19:23.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-273-remove-owner.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-273-remove-owner.log-expected.json
@@ -33,7 +33,7 @@
             },
             "@timestamp": "2021-03-10T17:59:33.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-278-add-rule.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-278-add-rule.log-expected.json
@@ -24,7 +24,7 @@
                 "path": "Root\\2"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-288-auto-clear-users-history-start.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-288-auto-clear-users-history-start.log-expected.json
@@ -21,7 +21,7 @@
             },
             "@timestamp": "2021-03-05T11:00:06.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -62,7 +62,7 @@
             },
             "@timestamp": "2021-03-08T03:00:20.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-289-auto-clear-users-history-end.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-289-auto-clear-users-history-end.log-expected.json
@@ -21,7 +21,7 @@
             },
             "@timestamp": "2021-03-05T11:00:06.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -62,7 +62,7 @@
             },
             "@timestamp": "2021-03-08T03:00:20.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-290-auto-clear-safes-history-start.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-290-auto-clear-safes-history-start.log-expected.json
@@ -21,7 +21,7 @@
             },
             "@timestamp": "2021-03-09T09:00:47.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-291-auto-clear-safes-history-end.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-291-auto-clear-safes-history-end.log-expected.json
@@ -21,7 +21,7 @@
             },
             "@timestamp": "2021-03-09T09:00:47.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-294-store-password.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-294-store-password.log-expected.json
@@ -24,7 +24,7 @@
                 "path": "Root\\Groups\\WindowsGroup"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -99,7 +99,7 @@
                 "path": "Root\\Operating System-WinDesktopLocal-Address-adriansr"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -159,7 +159,7 @@
                 "path": "Root\\Operating System-WindowsDesktopLocalAccountsRotationalPolicy-10.0.1.20-x_accountA"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -238,7 +238,7 @@
                 "path": "Root\\Groups\\WindowsGroup"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -318,7 +318,7 @@
                 "path": "Root\\PSMServer"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -387,7 +387,7 @@
                 "path": "Root\\PSM-ASR-CYBERARK-WI"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -445,7 +445,7 @@
                 "path": "Root\\Operating System-WindowsDesktopLocalAccountsRotationalPolicy-10.0.1.20-x_accountB"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -524,7 +524,7 @@
                 "path": "Root\\Groups\\WindowsGroup"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -593,7 +593,7 @@
                 "path": "Root\\Operating System-WindowsDesktopLocalAccountsRotationalPolicy-10.0.1.20-x_accountA"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -680,7 +680,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-295-retrieve-password.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-295-retrieve-password.log-expected.json
@@ -28,7 +28,7 @@
                 "path": "Root\\Operating System-LINUX-SSH-radiussrv.cyberark.local-admin2"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -114,7 +114,7 @@
                 "path": "Root\\Operating System-WIN-SERVER-LOCAL-dbserver.cyberark.local-Administrator2"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -220,7 +220,7 @@
                 "path": "Root\\testobject"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -314,7 +314,7 @@
                 "path": "Root\\Operating System-WindowsDesktopLocalAccountsRotationalPolicy-10.0.1.20-x_accountA"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -413,7 +413,7 @@
                 "path": "Root\\Groups\\WindowsGroup"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -506,7 +506,7 @@
                 "path": "Root\\Operating System-WindowsDesktopLocalAccountsRotationalPolicy-10.0.1.20-x_accountA"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -611,7 +611,7 @@
                 "path": "Root\\PSMAdmin"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -706,7 +706,7 @@
                 "path": "Root\\PSMServer"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -798,7 +798,7 @@
                 "path": "Root\\Operating System-WindowsDesktopLocalAccountsRotationalPolicy-10.0.1.20-x_accountB"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -897,7 +897,7 @@
                 "path": "Root\\Groups\\WindowsGroup"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -993,7 +993,7 @@
                 "path": "Root\\PSMAdmin"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1089,7 +1089,7 @@
                 "path": "Root\\PSMServer"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1180,7 +1180,7 @@
                 "path": "Root\\Operating System-UnixSSH-centos8-PSMApp_VAGRANT"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-300-psm-connect.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-300-psm-connect.log-expected.json
@@ -31,7 +31,7 @@
                 "path": "Root\\Operating System-LINUX-SSH-radiussrv.cyberark.local-admin2"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -146,7 +146,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -264,7 +264,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -382,7 +382,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -500,7 +500,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -618,7 +618,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -736,7 +736,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -866,7 +866,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1002,7 +1002,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1138,7 +1138,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1272,7 +1272,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1406,7 +1406,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1540,7 +1540,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1670,7 +1670,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1800,7 +1800,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1939,7 +1939,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2078,7 +2078,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-302-psm-disconnect.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-302-psm-disconnect.log-expected.json
@@ -31,7 +31,7 @@
                 "path": "Root\\Operating System-LINUX-SSH-radiussrv.cyberark.local-admin2"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -148,7 +148,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -268,7 +268,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -388,7 +388,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -508,7 +508,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -628,7 +628,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -748,7 +748,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -880,7 +880,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1018,7 +1018,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1156,7 +1156,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1292,7 +1292,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1428,7 +1428,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1564,7 +1564,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1696,7 +1696,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1828,7 +1828,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1969,7 +1969,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-304-psm-upload-recording.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-304-psm-upload-recording.log-expected.json
@@ -24,7 +24,7 @@
                 "path": "Root\\a4636750-50a2-492e-984c-e08743d8a883.SSH.txt"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-308-use-password.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-308-use-password.log-expected.json
@@ -28,7 +28,7 @@
                 "path": "Root\\Operating System-WIN-SERVER-LOCAL-dbserver.cyberark.local-Administrator2"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -139,7 +139,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -247,7 +247,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -355,7 +355,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -463,7 +463,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -571,7 +571,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -679,7 +679,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -799,7 +799,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -924,7 +924,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1047,7 +1047,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1175,7 +1175,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-309-undefined-user-logon.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-309-undefined-user-logon.log-expected.json
@@ -28,7 +28,7 @@
             },
             "@timestamp": "2021-03-08T18:31:52.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -103,7 +103,7 @@
             },
             "@timestamp": "2021-03-08T18:32:03.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -183,7 +183,7 @@
             },
             "@timestamp": "2021-03-11T16:43:26.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -269,7 +269,7 @@
             },
             "@timestamp": "2021-03-11T17:46:28.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -366,7 +366,7 @@
             },
             "@timestamp": "2021-03-14T13:28:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-31-cpm-reconcile-password.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-31-cpm-reconcile-password.log-expected.json
@@ -22,7 +22,7 @@
                 "path": "Root\\Operating System-WIN-SERVER-LOCAL-dbserver.cyberark.local-Administrator2"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-310-monitor-dr-replication-start.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-310-monitor-dr-replication-start.log-expected.json
@@ -21,7 +21,7 @@
             },
             "@timestamp": "2021-03-04T19:10:01.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -62,7 +62,7 @@
             },
             "@timestamp": "2021-03-08T02:48:07.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-311-monitor-dr-replication-end.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-311-monitor-dr-replication-end.log-expected.json
@@ -21,7 +21,7 @@
             },
             "@timestamp": "2021-03-04T19:10:01.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -62,7 +62,7 @@
             },
             "@timestamp": "2021-03-08T02:48:07.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-316-reset-user-password-detailed-information.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-316-reset-user-password-detailed-information.log-expected.json
@@ -33,7 +33,7 @@
             },
             "@timestamp": "2021-03-10T18:16:45.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-317-reset-user-password.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-317-reset-user-password.log-expected.json
@@ -33,7 +33,7 @@
             },
             "@timestamp": "2021-03-10T18:16:45.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-32-add-owner.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-32-add-owner.log-expected.json
@@ -33,7 +33,7 @@
             },
             "@timestamp": "2021-03-10T09:11:20.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -118,7 +118,7 @@
             },
             "@timestamp": "2021-03-10T09:11:20.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -202,7 +202,7 @@
             },
             "@timestamp": "2021-03-10T09:11:20.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -287,7 +287,7 @@
             },
             "@timestamp": "2021-03-10T09:11:20.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -372,7 +372,7 @@
             },
             "@timestamp": "2021-03-10T09:11:20.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -457,7 +457,7 @@
             },
             "@timestamp": "2021-03-10T09:11:20.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -542,7 +542,7 @@
             },
             "@timestamp": "2021-03-10T09:11:20.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -627,7 +627,7 @@
             },
             "@timestamp": "2021-03-10T09:11:20.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -712,7 +712,7 @@
             },
             "@timestamp": "2021-03-10T09:11:22.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -797,7 +797,7 @@
             },
             "@timestamp": "2021-03-10T09:11:23.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -882,7 +882,7 @@
             },
             "@timestamp": "2021-03-10T09:11:23.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -967,7 +967,7 @@
             },
             "@timestamp": "2021-03-10T09:11:23.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1052,7 +1052,7 @@
             },
             "@timestamp": "2021-03-10T09:11:36.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1137,7 +1137,7 @@
             },
             "@timestamp": "2021-03-10T09:11:37.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1222,7 +1222,7 @@
             },
             "@timestamp": "2021-03-10T09:11:38.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1307,7 +1307,7 @@
             },
             "@timestamp": "2021-03-10T17:59:32.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-326-cpm-auto-detection-start.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-326-cpm-auto-detection-start.log-expected.json
@@ -24,7 +24,7 @@
                 "path": " "
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-327-cpm-auto-detection-end.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-327-cpm-auto-detection-end.log-expected.json
@@ -24,7 +24,7 @@
                 "path": " "
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-33-update-owner.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-33-update-owner.log-expected.json
@@ -33,7 +33,7 @@
             },
             "@timestamp": "2021-03-10T18:16:49.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -118,7 +118,7 @@
             },
             "@timestamp": "2021-03-10T18:16:50.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -203,7 +203,7 @@
             },
             "@timestamp": "2021-03-10T18:16:51.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -288,7 +288,7 @@
             },
             "@timestamp": "2021-03-10T18:16:51.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -373,7 +373,7 @@
             },
             "@timestamp": "2021-03-10T18:16:53.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -457,7 +457,7 @@
             },
             "@timestamp": "2021-03-10T22:19:18.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -542,7 +542,7 @@
             },
             "@timestamp": "2021-03-11T17:38:14.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-355-monitor-license-expiration-date-start.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-355-monitor-license-expiration-date-start.log-expected.json
@@ -21,7 +21,7 @@
             },
             "@timestamp": "2021-03-09T10:17:54.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-356-monitor-license-expiration-date-end.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-356-monitor-license-expiration-date-end.log-expected.json
@@ -21,7 +21,7 @@
             },
             "@timestamp": "2021-03-09T10:17:54.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-357-monitor-fw-rules-start.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-357-monitor-fw-rules-start.log-expected.json
@@ -21,7 +21,7 @@
             },
             "@timestamp": "2021-03-04T19:10:01.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -62,7 +62,7 @@
             },
             "@timestamp": "2021-03-08T02:32:56.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-358-monitor-fw-rules-end.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-358-monitor-fw-rules-end.log-expected.json
@@ -21,7 +21,7 @@
             },
             "@timestamp": "2021-03-04T19:10:01.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -62,7 +62,7 @@
             },
             "@timestamp": "2021-03-08T02:32:56.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-359-sql-command.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-359-sql-command.log-expected.json
@@ -37,7 +37,7 @@
                 "path": "Root\\Database-Oracle-oracle.cybr.com-HR"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -156,7 +156,7 @@
                 "path": "Root\\Database-Oracle-oracle.cybr.com-HR"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -275,7 +275,7 @@
                 "path": "Root\\Database-Oracle-oracle.cybr.com-HR"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -394,7 +394,7 @@
                 "path": "Root\\Database-Oracle-oracle.cybr.com-HR"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -513,7 +513,7 @@
                 "path": "Root\\Database-Oracle-oracle.cybr.com-HR"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -632,7 +632,7 @@
                 "path": "Root\\Database-Oracle-oracle.cybr.com-HR"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -751,7 +751,7 @@
                 "path": "Root\\Database-Oracle-oracle.cybr.com-HR"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -870,7 +870,7 @@
                 "path": "Root\\Database-Oracle-oracle.cybr.com-HR"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -989,7 +989,7 @@
                 "path": "Root\\Database-Oracle-oracle.cybr.com-HR"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1108,7 +1108,7 @@
                 "path": "Root\\Database-Oracle-oracle.cybr.com-HR"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-361-keystroke-logging.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-361-keystroke-logging.log-expected.json
@@ -31,7 +31,7 @@
                 "path": "Root\\Operating System-LINUX-SSH-radiussrv.cyberark.local-admin2"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -160,7 +160,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -298,7 +298,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -434,7 +434,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -570,7 +570,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -706,7 +706,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -847,7 +847,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-38-cpm-verify-password-failed.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-38-cpm-verify-password-failed.log-expected.json
@@ -48,7 +48,7 @@
                 "path": "Root\\Operating System-WinDomain-35.192.121.42-ELASTICbart"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -169,7 +169,7 @@
                 "path": "Root\\Operating System-WinDomain-35.192.121.42-ELASTICbart"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -291,7 +291,7 @@
                 "path": "Root\\Operating System-WinDomain-34.66.114.180-ELASTICbart"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -412,7 +412,7 @@
                 "path": "Root\\Operating System-WinDomain-34.66.114.180-ELASTICbart"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -534,7 +534,7 @@
                 "path": "Root\\Operating System-WinDomain-34.66.114.180-ELASTICbart"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -645,7 +645,7 @@
                 "path": "Root\\Database-MySQL-10.0.1.20-root"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -753,7 +753,7 @@
                 "path": "Root\\Database-MySQL-10.0.1.20-root"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -863,7 +863,7 @@
                 "path": "Root\\Database-MySQL-10.0.1.20-root"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -973,7 +973,7 @@
                 "path": "Root\\Database-MySQL-10.0.1.20-root"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1083,7 +1083,7 @@
                 "path": "Root\\Database-MySQL-10.0.1.20-root"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1194,7 +1194,7 @@
                 "path": "Root\\Database-MySQL-10.0.1.20-root"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1307,7 +1307,7 @@
                 "path": "Root\\Database-MySQL-10.0.1.20-root"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1417,7 +1417,7 @@
                 "path": "Root\\Database-MySQL-10.0.1.20-root"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1540,7 +1540,7 @@
                 "path": "Root\\Operating System-WinDomain-34.66.114.180-ELASTICbart"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1662,7 +1662,7 @@
                 "path": "Root\\Operating System-WinDomain-34.66.114.180-ELASTICbart"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-385-blservice-audit-record.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-385-blservice-audit-record.log-expected.json
@@ -28,7 +28,7 @@
             },
             "@timestamp": "2021-03-11T16:31:13.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -92,7 +92,7 @@
             },
             "@timestamp": "2021-03-11T16:31:23.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -156,7 +156,7 @@
             },
             "@timestamp": "2021-03-11T19:40:52.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -220,7 +220,7 @@
             },
             "@timestamp": "2021-03-14T12:04:35.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -284,7 +284,7 @@
             },
             "@timestamp": "2021-03-14T12:04:53.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-4-user-authentication.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-4-user-authentication.log-expected.json
@@ -33,7 +33,7 @@
             },
             "@timestamp": "2021-03-10T18:42:36.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -106,7 +106,7 @@
             },
             "@timestamp": "2021-03-11T18:03:43.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-411-window-title.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-411-window-title.log-expected.json
@@ -35,7 +35,7 @@
                 "path": "Root\\Operating System-WIN-SERVER-LOCAL-dbserver.cyberark.local-Administrator2"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-412-keystroke-logging.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-412-keystroke-logging.log-expected.json
@@ -37,7 +37,7 @@
                 "path": "Root\\Database-MSSql-epmsvr01.cybr.com-sa"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-414-cpm-verify-ssh-key.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-414-cpm-verify-ssh-key.log-expected.json
@@ -34,7 +34,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-rhel7.cybr.com-firecall1"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-427-store-ssh-key.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-427-store-ssh-key.log-expected.json
@@ -31,7 +31,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-428-retrieve-ssh-key.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-428-retrieve-ssh-key.log-expected.json
@@ -46,7 +46,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -163,7 +163,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -283,7 +283,7 @@
                 "path": "Root\\Operating System-UnixSSHKeys-34.123.103.115-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-449-create-discovery-succeeded.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-449-create-discovery-succeeded.log-expected.json
@@ -21,7 +21,7 @@
             },
             "@timestamp": "2021-03-14T12:06:35.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-459-general-audit.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-459-general-audit.log-expected.json
@@ -24,7 +24,7 @@
                 "path": "Root\\Operating System-WindowsDesktopLocalAccountsRotationalPolicy-10.0.1.20-x_accountB"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -106,7 +106,7 @@
                 "path": "Root\\Operating System-WindowsDesktopLocalAccountsRotationalPolicy-10.0.1.20-x_accountA"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -188,7 +188,7 @@
                 "path": "Root\\Operating System-WindowsDesktopLocalAccountsRotationalPolicy-10.0.1.20-x_accountB"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-467-the-component-public-key-for-jwt-authentication-was-updated.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-467-the-component-public-key-for-jwt-authentication-was-updated.log-expected.json
@@ -21,7 +21,7 @@
             },
             "@timestamp": "2021-03-10T18:14:35.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-479-security-warning-the-signature-hash-algorithm-of-the-vault-certificate-is-sha1.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-479-security-warning-the-signature-hash-algorithm-of-the-vault-certificate-is-sha1.log-expected.json
@@ -21,7 +21,7 @@
             },
             "@timestamp": "2021-03-04T19:10:01.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -63,7 +63,7 @@
             },
             "@timestamp": "2021-03-08T07:46:54.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-482-update-existing-add-account-bulk-operation-succeeded.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-482-update-existing-add-account-bulk-operation-succeeded.log-expected.json
@@ -21,7 +21,7 @@
             },
             "@timestamp": "2021-03-10T08:31:49.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-50-store-file.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-50-store-file.log-expected.json
@@ -24,7 +24,7 @@
                 "path": "Root\\YWRtaW5pc3RyYXRvcg=="
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -94,7 +94,7 @@
                 "path": "Root\\syntaxparser-conf.json.1.1"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -152,7 +152,7 @@
                 "path": "Root\\PVConfiguration.xml"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -221,7 +221,7 @@
                 "path": "ROOT\\PVConfiguration.xml"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -291,7 +291,7 @@
                 "path": "root\\87012dcc-8290-11eb-949e-080027efd402.SSH.txt"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -357,7 +357,7 @@
                 "path": "Root\\PVConfiguration.xml"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-51-retrieve-file.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-51-retrieve-file.log-expected.json
@@ -24,7 +24,7 @@
                 "path": "Root\\Policies\\Policy-GenericWebApp.ini"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -82,7 +82,7 @@
                 "path": "Root\\main_appprovider.conf.Win64.11.04"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-52-delete-file.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-52-delete-file.log-expected.json
@@ -31,7 +31,7 @@
                 "path": "Root\\Operating System-WinDesktopLocal-Address-adriansr"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -106,7 +106,7 @@
                 "path": "Root\\Operating System-WinServerLocal-components-adriansr"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -175,7 +175,7 @@
                 "path": "Root\\Test_4"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -244,7 +244,7 @@
                 "path": "Root\\c89ca3ba9c76f820fdc58e86f2c854f99d232fcd"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -303,7 +303,7 @@
                 "path": "Root\\PSMPApp_VAGRANT.LiveSessions"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -378,7 +378,7 @@
                 "path": "Root\\Operating System-WinDomain-35.192.121.42-PSMConnect"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -454,7 +454,7 @@
                 "path": "Root\\PSM-ASR-CYBERARK-WI"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -528,7 +528,7 @@
                 "path": "Root\\PSMAdmin"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -602,7 +602,7 @@
                 "path": "Root\\Database-Oracle-10.128.0.7-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -680,7 +680,7 @@
                 "path": "Root\\Database-MySQL-10.128.0.7-adrian"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-57-cpm-change-password-failed.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-57-cpm-change-password-failed.log-expected.json
@@ -28,7 +28,7 @@
                 "path": "Root\\Operating System-UnixSSH-rhel7.cybr.com-firecall2"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-59-clear-safe-history.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-59-clear-safe-history.log-expected.json
@@ -21,7 +21,7 @@
             },
             "@timestamp": "2021-03-04T19:25:02.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -63,7 +63,7 @@
             },
             "@timestamp": "2021-03-08T03:10:31.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -122,7 +122,7 @@
             },
             "@timestamp": "2021-03-09T09:00:47.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-60-cpm-reconcile-password-failed.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-60-cpm-reconcile-password-failed.log-expected.json
@@ -42,7 +42,7 @@
                 "path": "Root\\Operating System-WinDomain-35.192.121.42-ELASTICbart"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -162,7 +162,7 @@
                 "path": "Root\\Operating System-WinDomain-35.192.121.42-ELASTICbart"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -281,7 +281,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -400,7 +400,7 @@
                 "path": "Root\\Operating System-WinDomain-35.192.121.42-ELASTICbart"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -521,7 +521,7 @@
                 "path": "Root\\Operating System-WinDomain-35.192.121.42-ELASTICbart"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -640,7 +640,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -760,7 +760,7 @@
                 "path": "Root\\Operating System-WinDomain-35.192.121.42-ELASTICbart"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -880,7 +880,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -998,7 +998,7 @@
                 "path": "Root\\Operating System-UnixSSH-34.123.103.115-testark"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-62-create-file-version.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-62-create-file-version.log-expected.json
@@ -36,7 +36,7 @@
                 "path": "Root\\PSMPApp_localhost.localdomain.LiveSessions"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -106,7 +106,7 @@
                 "path": "Root\\SessionControl"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -176,7 +176,7 @@
                 "path": "Root\\PSMServer.LiveSessions"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -245,7 +245,7 @@
                 "path": "Root\\PSM-ASR-CYBERARK-WI.LiveSessions"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -303,7 +303,7 @@
                 "path": "Root\\ec7c3e3bd11069dd20a491a6b11bbe293bf4780b"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -374,7 +374,7 @@
                 "path": "Root\\PSMPApp_VAGRANT.LiveSessions"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -440,7 +440,7 @@
                 "path": "Root\\Windows discovery from ELASTIC.local_PasswordManager_UID1.log"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -509,7 +509,7 @@
                 "path": "Root\\PSMPApp_SSH.LiveSessions"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-7-logon.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-7-logon.log-expected.json
@@ -22,7 +22,7 @@
             },
             "@timestamp": "2021-03-16T15:01:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -88,7 +88,7 @@
             },
             "@timestamp": "2021-03-04T19:10:05.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -155,7 +155,7 @@
             },
             "@timestamp": "2021-03-04T19:10:20.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -222,7 +222,7 @@
             },
             "@timestamp": "2021-03-04T19:11:20.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -289,7 +289,7 @@
             },
             "@timestamp": "2021-03-04T19:11:23.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -356,7 +356,7 @@
             },
             "@timestamp": "2021-03-05T10:18:50.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -430,7 +430,7 @@
             },
             "@timestamp": "2021-03-08T18:07:51.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -518,7 +518,7 @@
             },
             "@timestamp": "2021-03-09T08:32:51.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -606,7 +606,7 @@
             },
             "@timestamp": "2021-03-09T10:14:58.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -687,7 +687,7 @@
             },
             "@timestamp": "2021-03-10T09:11:48.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -766,7 +766,7 @@
             },
             "@timestamp": "2021-03-10T09:11:48.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -845,7 +845,7 @@
             },
             "@timestamp": "2021-03-10T09:11:49.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-8-logoff.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-8-logoff.log-expected.json
@@ -21,7 +21,7 @@
             },
             "@timestamp": "2021-03-08T18:19:15.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -88,7 +88,7 @@
             },
             "@timestamp": "2021-03-08T18:59:23.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -155,7 +155,7 @@
             },
             "@timestamp": "2021-03-10T08:28:28.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -222,7 +222,7 @@
             },
             "@timestamp": "2021-03-10T08:28:29.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -289,7 +289,7 @@
             },
             "@timestamp": "2021-03-10T08:28:30.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -356,7 +356,7 @@
             },
             "@timestamp": "2021-03-10T08:28:30.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -435,7 +435,7 @@
             },
             "@timestamp": "2021-03-10T09:11:33.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -514,7 +514,7 @@
             },
             "@timestamp": "2021-03-10T09:12:20.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -593,7 +593,7 @@
             },
             "@timestamp": "2021-03-10T09:12:27.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -671,7 +671,7 @@
             },
             "@timestamp": "2021-03-10T22:17:27.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -757,7 +757,7 @@
             },
             "@timestamp": "2021-03-11T17:38:13.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -846,7 +846,7 @@
             },
             "@timestamp": "2021-03-11T17:48:28.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -928,7 +928,7 @@
             },
             "@timestamp": "2021-03-11T17:49:06.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1005,7 +1005,7 @@
             },
             "@timestamp": "2021-03-14T12:57:20.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1101,7 +1101,7 @@
             },
             "@timestamp": "2021-03-14T13:49:36.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-88-set-password.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-88-set-password.log-expected.json
@@ -21,7 +21,7 @@
             },
             "@timestamp": "2021-03-04T19:16:19.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -74,7 +74,7 @@
             },
             "@timestamp": "2021-03-04T19:16:19.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -115,7 +115,7 @@
             },
             "@timestamp": "2021-03-08T02:54:46.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -173,7 +173,7 @@
             },
             "@timestamp": "2021-03-10T08:29:19.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -226,7 +226,7 @@
             },
             "@timestamp": "2021-03-10T08:29:28.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -291,7 +291,7 @@
             },
             "@timestamp": "2021-03-10T09:11:52.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -356,7 +356,7 @@
             },
             "@timestamp": "2021-03-10T09:11:52.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -421,7 +421,7 @@
             },
             "@timestamp": "2021-03-10T09:11:55.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -486,7 +486,7 @@
             },
             "@timestamp": "2021-03-10T18:46:47.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -551,7 +551,7 @@
             },
             "@timestamp": "2021-03-10T18:46:47.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -615,7 +615,7 @@
             },
             "@timestamp": "2021-03-10T22:20:12.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -679,7 +679,7 @@
             },
             "@timestamp": "2021-03-10T22:20:12.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -744,7 +744,7 @@
             },
             "@timestamp": "2021-03-11T16:59:54.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -810,7 +810,7 @@
             },
             "@timestamp": "2021-03-11T16:59:55.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -875,7 +875,7 @@
             },
             "@timestamp": "2021-03-11T20:10:33.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -938,7 +938,7 @@
             },
             "@timestamp": "2021-03-14T12:57:25.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1001,7 +1001,7 @@
             },
             "@timestamp": "2021-03-14T12:57:25.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1064,7 +1064,7 @@
             },
             "@timestamp": "2021-03-14T12:57:25.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-98-open-file-write-only.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-98-open-file-write-only.log-expected.json
@@ -24,7 +24,7 @@
                 "path": "Root\\YWRtaW5pc3RyYXRvcg=="
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -94,7 +94,7 @@
                 "path": "ROOT\\PVConfiguration.xml"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -163,7 +163,7 @@
                 "path": "ROOT\\PVConfiguration.xml"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -228,7 +228,7 @@
                 "path": "Root\\PVConfiguration.xml"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-99-open-file.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-99-open-file.log-expected.json
@@ -24,7 +24,7 @@
                 "path": "Root\\EPMConfiguration.xml"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-legacysyslog.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-legacysyslog.log-expected.json
@@ -19,7 +19,7 @@
                 "path": "Root\\Policies\\Policy-BusinessWebsite.ini"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-rfc5424syslog.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-rfc5424syslog.log-expected.json
@@ -21,7 +21,7 @@
             },
             "@timestamp": "2021-03-04T17:27:14.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -88,7 +88,7 @@
             },
             "@timestamp": "2021-03-04T17:27:21.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -158,7 +158,7 @@
                 "path": "Root\\Policies\\Policy-GenericWebApp.ini"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -213,7 +213,7 @@
             },
             "@timestamp": "2021-03-04T17:27:33.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/cyberarkpas/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cyberarkpas/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -10,7 +10,7 @@ processors:
       value: '{{{_ingest.timestamp}}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
 
   #
   # Set event.original from message, unless reindexing.

--- a/packages/cyberarkpas/manifest.yml
+++ b/packages/cyberarkpas/manifest.yml
@@ -1,6 +1,6 @@
 name: cyberarkpas
 title: CyberArk Privileged Access Security
-version: 1.2.1
+version: 1.2.2
 release: beta
 description: This Elastic integration collects logs from CyberArk
 type: integration


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967