### PR TITLE
cylance update to ECS 1.11.0

### DIFF
--- a/packages/cylance/changelog.yml
+++ b/packages/cylance/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.4.1'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1381
 - version: "0.4.0"
   changes:
     - description: Update integration description

--- a/packages/cylance/data_stream/protect/_dev/test/pipeline/test-generated.log-expected.json
+++ b/packages/cylance/data_stream/protect/_dev/test/pipeline/test-generated.log-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "29-January-2016 06:09:59 high boNemoe4402.www.invalid dolore \u003c\u003csequa\u003eabo 2016-1-29T6:09:59.squira nostrud4819.mail.test CylancePROTECT mqui nci [billoi] Event Type: AuditLog, Event Name: ZoneAdd, Message: Policy Assigned:orev; Devices: pisciv , User: uii umexe (estlabo)",
             "event": {
@@ -14,7 +14,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016-2-12T1:12:33.olupt volup208.invalid CylancePROTECT eosquir orsi [nulapari] Event Type: AuditLog, Event Name: LoginSuccess, Message: Devices: vol, User: luptat isiutal (moenimi)",
             "event": {
@@ -26,7 +26,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "26-Feb-2016 8:15:08 very-high anonnu410.internal.home aqu \u003c\u003cutper\u003esquame 26T20:15:08.ntex eius6159.www5.localhost CylancePROTECT Event Name:Alert, Device Message: Device: aer User: ),lupt (tia oloremqu Zone Names: temvel Device Id: iatu",
             "event": {
@@ -38,7 +38,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016-3-12T3:17:42.ceroinBC ratvolup497.www.corp CylancePROTECT ionofde con [uia] Event Type: AuditLog, Event Name: SystemSecurity, Message: ommodic, User: mipsu consec (taliquip)",
             "event": {
@@ -50,7 +50,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016-3-26T10:20:16.gelit tatno5625.api.local CylancePROTECT taev roidents [oluptas] Event Type: AuditLog, Event Name: Alert, Message: Source: taliqu; SHA256: ommod; Reason: failure, User: tur aperi (iveli)",
             "event": {
@@ -62,7 +62,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "uatDuis 2016-4-9T5:22:51.ude maveniam1399.mail.lan CylancePROTECT siutaliq exercit [tempor] Event Type: omnis, Event Name: SystemSecurity, Device Name: eip, Agent Version: lupta, IP Address: (10.124.61.119), MAC Address: (01:00:5e:dc:bb:8b), Logged On Users: (occ), OS: ect Zone Names: reetdolo",
             "event": {
@@ -74,7 +74,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "24-Apr-2016 12:25:25 low lor340.mail.local natura \u003c\u003caboris\u003eima 24T00:25:25.tanimi nimadmin6499.local CylancePROTECT Event Name:Device Policy Assigned, Device Message: Device: dexe User: ),urerep (aquaeab liqu Zone Names: lorem Device Id: emq",
             "event": {
@@ -86,7 +86,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ari 2016-5-8T7:27:59.equun suntinc4934.www5.test CylancePROTECT ipis gelits [tatevel] Event Type: AuditLog, Event Name: ThreatUpdated, Message: Policy: uptatev; SHA256: uovol, User: )dmi (olab mquisnos",
             "event": {
@@ -98,7 +98,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "22-May-2016 14:30:33 medium tvol457.internal.local inim \u003c\u003cema\u003eroinBCSe 2016-5-22T2:30:33.onse tae1382.mail.localhost CylancePROTECT oluptate ofdeF tion Event Type: orsitame, Event Name: threat_quarantined, Threat Class: lit, Threat Subclass: iam, SHA256: qua, MD5: umdo",
             "event": {
@@ -110,7 +110,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016-6-5T9:33:08.eniam reetdolo2451.www.example CylancePROTECT rumet oll [erc] Event Type: ScriptControl, Event Name: SystemSecurity, Device Name: llam, File Path: aspern, Interpreter: itlabori, Interpreter Version: 1.2344, Zone Names: ollit, User Name: usan",
             "event": {
@@ -122,7 +122,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "olo 2016-6-20T4:35:42.uaera sitas4259.mail.corp CylancePROTECT atquovo iumto aboreetd Event Type: AuditLog, Event Name: ZoneAddDevice, Message: Zone: dun; Policy: enim; Value: saute, User: vel quu (undeo)",
             "event": {
@@ -134,7 +134,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016-7-4T11:38:16.isqu uis7612.www5.domain CylancePROTECT llumquid tation [ips] Event Type: emeumfug, Event Name: Registration, emporinc",
             "event": {
@@ -146,7 +146,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "cup 2016-7-18T6:40:50.boNemoen uid7309.api.domain CylancePROTECT uradi aborumSe luptat Event Type: AuditLog, Event Name: SyslogSettingsSave, Message: Policy: antiumto, User: strude ctetura (usmod)",
             "event": {
@@ -158,7 +158,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2-Aug-2016 1:43:25 high fugit7668.www5.invalid lupt \u003c\u003cxea\u003equa 2T01:43:25.luptatev admi3749.api.lan CylancePROTECT Event Name:DeviceRemove, Device Message: Device: tinvol; Zones Removed: dolore; Zones Added: abor, User: iqui etc (etM), Zone Names:nimadmin Device Id: ditautfu",
             "event": {
@@ -170,7 +170,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016-8-16T8:45:59.ostr rudexerc703.internal.host CylancePROTECT itaut imaven [liqua] Event Type: ScriptControl, Event Name: fullaccess, Device Name: onproide, File Path: Nemoen, Interpreter: tfug, Interpreter Version: 1.5383 (ccu), Zone Names: urE, User Name: isaute",
             "event": {
@@ -182,7 +182,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "eomnisis 2016-8-30T3:48:33.mqui civeli370.www5.local CylancePROTECT sunt stl tdolorem Event Type: AuditLog, Event Name: Alert, Message: The Device: picia was auto assigned to the Zone: IP Address: Fake Devices, User: mUtenima emaperi ()tame",
             "event": {
@@ -194,7 +194,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "September 2016/09/13 22:51:07 ivelits712.api.example CylancePROTECT Event Type: AppControl, etdolo inv [agnaali] Event Type: AppControl, Event Name: threat_found, Device Name: sequatur, IP Address: (10.199.98.186), Action: cancel, Action Type: nihi, File Path: Lor, SHA256: itecto, Zone Names: erc",
             "event": {
@@ -206,7 +206,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "olupt 2016-9-28T5:53:42.modoco estqu1709.internal.example CylancePROTECT ostrume molest [upt] Event Type: Threat, Event Name: LoginSuccess, Device Name: uasia, IP Address: (10.64.70.5), File Name: ici, Path: giatquov, Drive Type: eritquii, SHA256: dexeac, MD5: iscinge, Status: atvol, Cylance Score: 145.898000, Found Date: uames, File Type: tati, Is Running: utaliqu, Auto Run: oriosamn, Detected By: deFinibu, Zone Names: iadese, Is Malware: imidest, Is Unique To Cylance: emagnama, Threat Classification: eprehend",
             "event": {
@@ -218,7 +218,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016-10-12T12:56:16.suntinc xeac7155.www.localdomain CylancePROTECT taliq intoccae [ents] Event Type: pida, Event Name: Alert, Device Name: idolor, Agent Version: emeumfu, IP Address: (10.143.239.210), MAC Address: (01:00:5e:93:1c:9f), Logged On Users: (oinBCSe), OS: mnisist Zone Names: sedd",
             "event": {
@@ -230,7 +230,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ipitla 2016-10-26T7:58:50.quae maccusa5126.api.domain CylancePROTECT idex xerci [aqu] Event Type: ExploitAttempt, Event Name: Alert, Device Name: olorema, IP Address: (10.32.143.134), Action: accept, Process ID: 2289, Process Name: aliqu.exe, User Name: olupta, Violation Type: mipsumd, Zone Names: eFinib",
             "event": {
@@ -242,7 +242,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10-Nov-2016 3:01:24 low eav3687.internal.local siar \u003c\u003corev\u003eiamquis 10T03:01:24.quirat llu4718.localhost CylancePROTECT Event Name:DeviceEdit, Device Name:conseq, External Device Type:oidentsu, External Device Vendor ID:atiset, External Device Name:atu, External Device Product ID:umexerci, External Device Serial Number:ern, Zone Names:psaquae",
             "event": {
@@ -254,7 +254,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Nov 24 10:03:59 doloremi7402.www.test CylancePROTECT Event Type:stquidol, Event Name:DeviceRemove, Device Message: Device: leumiu; Policy Changed: namali to 'taevit', User: rinrepre etconse (tincu), Zone Names:ari, Device Id: exercit",
             "event": {
@@ -266,7 +266,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "8-December-2016 17:06:33 very-high occae1180.internal.localhost aquaeabi \u003c\u003clita\u003eadeseru 2016-12-8T5:06:33.emoe eaq908.api.home CylancePROTECT itame intoc [oluptas] Event Type: tNequepo, Event Name: ZoneAddDevice, Device Name: luptasn, Zone Names:equat",
             "event": {
@@ -278,7 +278,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ihilmole 2016-12-23T12:09:07.eriamea amre146.mail.host CylancePROTECT pisciv iquidex radipisc Event Type: AuditLog, Event Name: ZoneAddDevice, Message: Policy: nti; SHA256: abi; Category: sectetur, User: )uioffi (oru temqu",
             "event": {
@@ -290,7 +290,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ommodico 2017-1-6T7:11:41.quatD mcolab379.internal.home CylancePROTECT tsedqu agnid [proide] Event Type: ScriptControl, Event Name: DeviceRemove, Device Name: tper, File Path: olor, Interpreter: Neque, Interpreter Version: 1.4129 (xerc), Zone Names: iutali, User Name: fdeFi",
             "event": {
@@ -302,7 +302,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan 20 2:14:16 tasuntex5037.www.corp CylancePROTECT Event Type:boN, Event Name:threat_quarantined, Device Name:ectio, Agent Version:dutper, IP Address: (10.237.205.140), MAC Address: (01:00:5e:3f:c4:6c), Logged On Users: (uames), OS:iduntu, Zone Names:veniam",
             "event": {
@@ -314,7 +314,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "3-Feb-2017 9:16:50 very-high reme622.mail.example isnisiu \u003c\u003cbore\u003etsu 3T21:16:50.tcons sciun4694.api.lan CylancePROTECT Event Name:LoginSuccess, Device Message: Device: nsect User: ),idata (rumwritt magnid Zone Names: enderit Device Id: untex",
             "event": {
@@ -326,7 +326,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "paquioff 2017-2-18T4:19:24.mquisnos maven3758.www.invalid CylancePROTECT labor didunt uptatema Event Type: ExploitAttempt, Event Name: DeviceEdit, Device Name: udan, IP Address: (10.74.104.215), Action: cancel, Process ID: 7410, Process Name: mveleu.exe, User Name: nofdeFin, Violation Type: sequam, Zone Names: temvel",
             "event": {
@@ -338,7 +338,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "4-Mar-2017 11:21:59 medium tvolu3997.mail.home eiu \u003c\u003cntiumdo\u003eautfu 4T11:21:59.gnaaliq mni7200.mail.localdomain CylancePROTECT Event Name:pechange, Device Name:idolor, Zone Names:uisau, Device Id: eleum",
             "event": {
@@ -350,7 +350,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Mar 18 6:24:33 ate4627.localdomain CylancePROTECT Event Type:officiad, Event Name:Device Policy Assigned, Message: The Device:quinescwas auto assigned to Zone:madmi, User:tur",
             "event": {
@@ -362,7 +362,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2-April-2017 01:27:07 very-high orem6702.invalid tev \u003c\u003csaute\u003entocca 2017-4-2T1:27:07.ostru ntoccae1705.internal.invalid CylancePROTECT temquiav equatu [upta] Event Type: ScriptControl, Event Name: Alert, Device Name: sBon, File Path: orro, Interpreter: tae, Interpreter Version: 1.3212, Zone Names: tlab, User Name: aperiame",
             "event": {
@@ -374,7 +374,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "16-Apr-2017 8:29:41 high tobea2364.internal.localhost itinvol \u003c\u003ceavolup\u003efugiatn 16T08:29:41.docon etconsec6708.internal.invalid CylancePROTECT Event Name:PolicyAdd, Device Name:ersp, External Device Type:tquov, External Device Vendor ID:diconseq, External Device Name:inven, External Device Product ID:osquira, External Device Serial Number:tes, Zone Names:mquame",
             "event": {
@@ -386,7 +386,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017-4-30T3:32:16.squirati Sedutp7428.internal.home CylancePROTECT utlabor itessequ [porro] Event Type: AuditLog, Event Name: PolicyAdd, Message: Zone: iquipe; Policy: itempor; Value: quin, User: upida tvolupt (eufugi)",
             "event": {
@@ -398,7 +398,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "uamni 2017-5-14T10:34:50.ctet ati4639.www5.home CylancePROTECT archite loreme [untu] Event Type: AuditLog, Event Name: Alert, Message: Device: ven; User: con nisist (usmodte)",
             "event": {
@@ -410,7 +410,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017-5-29T5:37:24.eturadi torever662.www5.home CylancePROTECT quam sumdolor [meaqueip] Event Type: AuditLog, Event Name: PolicyAdd, Message: The Device: pexe was auto assigned to the Zone: IP Address: 10.70.168.240, User: amcol adeser ()oin",
             "event": {
@@ -422,7 +422,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "12-June-2017 12:39:58 medium meius3932.internal.example ccaeca \u003c\u003cumdolo\u003euptate 2017-6-12T12:39:58.amc cusant1701.api.localdomain CylancePROTECT siutaliq dutp psaquaea Event Type: taevita, Event Name: DeviceRemove, Device Name: siut, Agent Version: tconsect, IP Address: (10.190.175.158), MAC Address: (01:00:5e:45:8b:97), Logged On Users: (ditemp), OS: edqui",
             "event": {
@@ -434,7 +434,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "26-June-2017 19:42:33 very-high rnatu2805.www.home enderi \u003c\u003cmquisno\u003eodoconse 2017-6-26T7:42:33.quamqua eacommod1930.internal.lan CylancePROTECT tpersp stla uptatema Event Type: AuditLog, Event Name: fullaccess, Message: Device: uradi; SHA256: tot; Category: llamco, User: )nea (psum tasnulap",
             "event": {
@@ -446,7 +446,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017-7-11T2:45:07.oremipsu emeumfug4387.internal.lan CylancePROTECT uidol litani [utodita] Event Type: AuditLog, Event Name: Alert, Message: Device: untincul; SHA256: iduntu, User: )ccaeca (niamq lapariat",
             "event": {
@@ -458,7 +458,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "uat 2017-7-25T9:47:41.tiaec rumwrit764.www5.local CylancePROTECT edquiac urerepr [eseru] Event Type: DeviceControl, Event Name: DeviceRemove, Device Name: etMal, External Device Type: qua, External Device Vendor ID: rsita, External Device Name: ate, External Device Product ID: ipsamvo, External Device Serial Number: onula, Zone Names: miu",
             "event": {
@@ -470,7 +470,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Aug 8 4:50:15 mex2054.mail.corp CylancePROTECT Event Type:luptat, Event Name:SyslogSettingsSave, Message: Provider:ica, Source IP:10.13.66.97, User: dicta taedicta (ritt)#015",
             "event": {
@@ -482,7 +482,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017-8-22T11:52:50.dictasun veniamqu7284.mail.invalid CylancePROTECT nte mvel nof Event Type: AuditLog, Event Name: DeviceEdit, Message: The Device: tetur was auto assigned to the Zone: IP Address: Fake Devices, User: ()xce",
             "event": {
@@ -494,7 +494,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "6-September-2017 06:55:24 high isiu5733.api.domain etdolor \u003c\u003clupta\u003exeaco 2017-9-6T6:55:24.nvolupt oremi1485.api.localhost CylancePROTECT iosa boNemoe [onsequ] Event Type: AuditLog, Event Name: threat_quarantined, Message: SHA256: amvolupt; Reason: success, User: atisund xea (ites)",
             "event": {
@@ -506,7 +506,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "eri 2017-9-20T1:57:58.quunt olori416.api.test CylancePROTECT elit cidunt plica Event Type: ExploitAttempt, Event Name: Alert, Device Name: exeaco, IP Address: (10.31.190.145), Action: cancel, Process ID: 5530, Process Name: accusant.exe, User Name: onse, Violation Type: admin, Zone Names: stenatu",
             "event": {
@@ -518,7 +518,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "4-Oct-2017 9:00:32 high nvol6269.internal.local tla \u003c\u003citem\u003enimid 4T21:00:32.dat periam126.api.host CylancePROTECT Event Name:threat_found, Threat Class:rExc, Threat Subclass:iusmo, SHA256:tame, MD5:naaliq",
             "event": {
@@ -530,7 +530,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "19-October-2017 04:03:07 medium toccaec7645.www5.home psaqua \u003c\u003cullamcor\u003eitationu 2017-10-19T4:03:07.proident maliquam2147.internal.home CylancePROTECT lores ritati orisni Event Type: DeviceControl, Event Name: PolicyAdd, Device Name: estl, External Device Type: sitam, External Device Vendor ID: orem, External Device Name: rcit, External Device Product ID: llamco, External Device Serial Number: atu, Zone Names: untincul",
             "event": {
@@ -542,7 +542,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "iuntNe 2017-11-2T11:05:41.atise tate6578.api.localdomain CylancePROTECT emvele isnost [olorem] Event Type: Threat, Event Name: PolicyAdd, Device Name: yCiceroi, IP Address: (10.252.165.146), File Name: iquamqua, Path: sit, Drive Type: rumSect, SHA256: ita, MD5: vitaed, Status: exeaco, Cylance Score: 51.523000, Found Date: mven, File Type: olorsit, Is Running: tore, Auto Run: elits, Detected By: consequa, Zone Names: turadip, Is Malware: tatevel, Is Unique To Cylance: boreetdo, Threat Classification: undeom",
             "event": {
@@ -554,7 +554,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017-11-16T6:08:15.uov itlab6956.mail.local CylancePROTECT loremqu tetur amvo Event Type: siuta, Event Name: threat_changed, Device Name: ommodo, Agent Version: uptat, IP Address: (10.105.46.101, tatione), MAC Address: (01:00:5e:de:32:2c, ori), Logged On Users: (tconsect), OS: rum",
             "event": {
@@ -566,7 +566,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017-12-1T1:10:49.ugiatn midestl1919.host CylancePROTECT cingel modocon [ipsu] Event Type: ntNeq, Event Name: Device Policy Assigned, Device Name: aUt, Agent Version: boNem, IP Address: (10.124.88.222), MAC Address: (01:00:5e:f9:78:c2), Logged On Users: (onu), OS: liquaUte",
             "event": {
@@ -578,7 +578,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ria 2017-12-15T8:13:24.atDu nsec923.internal.local CylancePROTECT agnaaliq tlaboree norumet Event Type: ExploitAttempt, Event Name: DeviceEdit, Device Name: mod, IP Address: (10.28.120.149), Action: deny, Process ID: 3916, Process Name: tinvolup.exe, User Name: tsed, Violation Type: inv, Zone Names: rroq",
             "event": {
@@ -590,7 +590,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017-12-29T3:15:58.mipsamvo eiusmod3517.internal.invalid CylancePROTECT oreveri ehende [eaqueip] Event Type: AuditLog, Event Name: ZoneAddDevice, Message: Device: olup; SHA256: labor, User: )dol (sciun metcons",
             "event": {
@@ -602,7 +602,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "12-January-2018 22:18:32 high asnu3806.api.lan tamet \u003c\u003cperspici\u003eationul 2018/01/12T22:18:32.mquisn queips4947.mail.example CylancePROTECT molestia quir eavolup Event Type: AppControl, Event Name: Registration, Device Name: labore, IP Address: (10.165.16.231), Action: accept, Action Type: uto, File Path: iuntNequ, SHA256: esseq, Zone Names: aincidun",
             "event": {
@@ -614,7 +614,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "27-January-2018 05:21:06 low oloreseo5039.test derit \u003c\u003corese\u003edolor 2018-1-27T5:21:06.econs ntexpl3889.www.home CylancePROTECT yCic nder [mdolore] Event Type: Cic, Event Name: DeviceRemove, Device Name: saqu, Agent Version: iscive, IP Address: (10.156.34.19), MAC Address: (01:00:5e:54:ab:3f), Logged On Users: (imveni), OS: ariaturE Zone Names: stquid",
             "event": {
@@ -626,7 +626,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ree 2018-2-10T12:23:41.saquaea ation6657.www.home CylancePROTECT iatqu lorsi repreh Event Type: AuditLog, Event Name: Registration, Message: sitamet, User: utlabo tetur (tionula)",
             "event": {
@@ -638,7 +638,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "24-Feb-2018 7:26:15 very-high idolor3916.www5.home tas \u003c\u003cautfugi\u003etasun 24T19:26:15.duntutla ntium4450.www5.localdomain CylancePROTECT Event Name:DeviceRemove, Device Name:vol, Agent Version:oremquel, IP Address: (10.22.94.10), MAC Address: (01:00:5e:ee:e8:77), Logged On Users: (ssusci), OS:animid, Zone Names:mpo",
             "event": {
@@ -650,7 +650,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "llam 2018-3-11T2:28:49.cti aparia1179.www.localdomain CylancePROTECT rever ore offici Event Type: AuditLog, Event Name: DeviceEdit, Message: Devices: metco, User: acom ceroinB (nim)",
             "event": {
@@ -662,7 +662,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "25-March-2018 09:31:24 medium taliqui5348.mail.localdomain loremag \u003c\u003ctcu\u003eiatqu 2018-3-25T9:31:24.inBCSedu erspi5757.local CylancePROTECT suntex iacons [occaec] Event Type: DeviceControl, Event Name: LoginSuccess, Device Name: uov, External Device Type: quaeab, External Device Vendor ID: fici, External Device Name: imve, External Device Product ID: quide, External Device Serial Number: quaU, Zone Names: undeomni",
             "event": {
@@ -674,7 +674,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "liquid 2018-4-8T4:33:58.enim Finibus1411.www5.corp CylancePROTECT xea taed umdolo Event Type: AuditLog, Event Name: fullaccess, Message: Policy Assigned:rroqu; Devices: dquiaco , User: nibus vitaed (ser)",
             "event": {
@@ -686,7 +686,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Apr 22 11:36:32 upt7879.www5.example CylancePROTECT Event Type:idolo, Event Name:threat_found, Device Message: Device: edolo; Zones Removed: ugiatquo; Zones Added: ntium, User: uptate lloinven (econs), Zone Names:lmolesti Device Id: apariatu",
             "event": {
@@ -698,7 +698,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 2018/05/07 06:39:06 erspi4926.www5.test CylancePROTECT Event Type: AppControl, incidid quin [autemv] Event Type: AppControl, Event Name: PolicyAdd, Device Name: fugits, IP Address: (10.153.34.43), Action: allow, Action Type: acommo, File Path: isi, SHA256: culpaq, Zone Names: saute",
             "event": {
@@ -710,7 +710,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018-5-21T1:41:41.abor magnid3343.home CylancePROTECT tesseq niam [pernat] Event Type: DeviceControl, Event Name: threat_found, Device Name: gitse, External Device Type: ugitse, External Device Vendor ID: quiineav, External Device Name: billoinv, External Device Product ID: sci, External Device Serial Number: col, Zone Names: obea",
             "event": {
@@ -722,7 +722,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "4-Jun-2018 8:44:15 high uptatem4483.localhost inrepr \u003c\u003cmol\u003eumdolors 4T20:44:15.dolori asperna7623.www.home CylancePROTECT Event Name:ThreatUpdated, Message: Device:dexewas auto assigned to Zone:tat, User:onproide",
             "event": {
@@ -734,7 +734,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "riosa 2018-6-19T3:46:49.tNe pisc3553.internal.home CylancePROTECT rautod olest eataev Event Type: ExploitAttempt, Event Name: DeviceEdit, Device Name: ritati, IP Address: (10.43.110.203), Action: allow, Process ID: 1359, Process Name: nim.exe, User Name: ame, Violation Type: amvolu, Zone Names: mip",
             "event": {
@@ -746,7 +746,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "3-July-2018 10:49:23 medium iame4937.local tiumd \u003c\u003cntmoll\u003emexer 2018/07/03T10:49:23.estla uipexe7153.api.corp CylancePROTECT saqu remips illoi Event Type: AppControl, Event Name: ZoneAdd, Device Name: abori, IP Address: (10.127.20.244), Action: block, Action Type: uelauda, File Path: ema, SHA256: odi, Zone Names: ptatems",
             "event": {
@@ -758,7 +758,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "nde 2018-7-17T5:51:58.abillo undeom845.www5.example CylancePROTECT quaer eetdo [tlab] Event Type: ScriptControl, Event Name: LoginSuccess, Device Name: liq, File Path: seddoeiu, Interpreter: nse, Interpreter Version: 1.3421, Zone Names: quira, User Name: tassita",
             "event": {
@@ -770,7 +770,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Aug 1 12:54:32 atis6201.internal.invalid CylancePROTECT Event Type:nisiut, Event Name:threat_changed, Message: Device:quirawas auto assigned to Zone:rror, User:tatema",
             "event": {
@@ -782,7 +782,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "15-August-2018 07:57:06 low tperspic7591.www.lan ict \u003c\u003csquirati\u003etem 2018-8-15T7:57:06.mestq ura675.mail.localdomain CylancePROTECT eleumiu uei Nequepo Event Type: DeviceControl, Event Name: DeviceRemove, Device Name: seddo, External Device Type: uam, External Device Vendor ID: orumSec, External Device Name: nisiuta, External Device Product ID: stiaecon, External Device Serial Number: dol, Zone Names: sumquiad",
             "event": {
@@ -794,7 +794,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "29-August-2018 14:59:40 high oeni179.api.localhost gna \u003c\u003cisiutali\u003elumqu 2018-8-29T2:59:40.onulamco ons5050.mail.test CylancePROTECT unt tass [tiumdol] Event Type: Threat, Event Name: threat_quarantined, Device Name: mquiad, IP Address: (10.48.209.115), File Name: psa, Path: nculpaq, Drive Type: reseosqu, SHA256: sequat, MD5: lor, Status: ccaec, Cylance Score: 75.498000, Found Date: ommo, File Type: iame, Is Running: laudanti, Auto Run: umiurer, Detected By: rere, Zone Names: cta, Is Malware: aevi, Is Unique To Cylance: uameiusm, Threat Classification: adm",
             "event": {
@@ -806,7 +806,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "12-September-2018 22:02:15 medium mnihilm1903.internal.host ditautf \u003c\u003citametc\u003eori 2018-9-12T10:02:15.uamqu olori4584.mail.domain CylancePROTECT sunt autfugit emUte Event Type: AuditLog, Event Name: ThreatUpdated, Message: Zone: nturmag; Policy: tura; Value: osquirat, User: equat aliquid (usantiu)",
             "event": {
@@ -818,7 +818,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "27-Sep-2018 5:04:49 very-high trudex4443.www5.localhost lor \u003c\u003cxplic\u003eeseruntm 27T05:04:49.lpaquiof oloreeu7597.mail.home CylancePROTECT Event Name:PolicyAdd, Device Name:nula, Agent Version:quiacons, IP Address: (10.7.99.47), MAC Address: (01:00:5e:e8:41:ae), Logged On Users: (evolupta), OS:teturadi, Zone Names:ditau",
             "event": {
@@ -830,7 +830,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "hend 2018-10-11T12:07:23.eacommo ueip5847.api.test CylancePROTECT umd sciveli [dolorem] Event Type: sed, Event Name: Device Updated, Threat Class: Nemoenim, Threat Subclass: usm, SHA256: labori, MD5: porai",
             "event": {
@@ -842,7 +842,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ostr 2018-10-25T7:09:57.sec uid3520.www.home CylancePROTECT eFini ectob [mrema] Event Type: ScriptControl, Event Name: SystemSecurity, Device Name: prehend, File Path: eufug, Interpreter: roquisq, Interpreter Version: 1.989 (est), Zone Names: civelits, User Name: ici",
             "event": {
@@ -854,7 +854,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Nov 9 2:12:32 miurerep3693.mail.localhost CylancePROTECT Event Type:iduntu, Event Name:SyslogSettingsSave, Device Name:inibusB, Zone Names:nostrud",
             "event": {
@@ -866,7 +866,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Nov 23 9:15:06 esse3795.www.host CylancePROTECT Event Type:pariatur, Event Name:SyslogSettingsSave, Message: The Device:imaveniawas auto assigned to Zone:expli, User:ugiat",
             "event": {
@@ -878,7 +878,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "bore 2018-12-7T4:17:40.ptate teir7585.www5.localdomain CylancePROTECT quu xeac [llitanim] Event Type: AuditLog, Event Name: SystemSecurity, Message: Devices: oreverit, User: scip Finibus (Utenimad)",
             "event": {
@@ -890,7 +890,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Dec 21 11:20:14 hen1901.example CylancePROTECT Event Type:ali, Event Name:SyslogSettingsSave, Device Name:quunt, External Device Type:itasp, External Device Vendor ID:qui, External Device Name:equeporr, External Device Product ID:met, External Device Serial Number:volup, Zone Names:ptate, Device Id: entsu, Policy Name: conse",
             "event": {
@@ -902,7 +902,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan 5 6:22:49 mag4267.www.test CylancePROTECT Event Type:atura, Event Name:Alert, Device Message: Device: oreeu User: ),nvo (iamqui tassita Zone Names: colabori Device Id: imidestl",
             "event": {
@@ -914,7 +914,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019-1-19T1:25:23.minimve serrorsi1096.www5.localdomain CylancePROTECT lamco cit [siar] Event Type: AuditLog, Event Name: ZoneAddDevice, Message: The Device: reetdo was auto assigned to the Zone: IP Address: Fake Devices, User: ()ever",
             "event": {
@@ -926,7 +926,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "quiav 2019-2-2T8:27:57.mse prehen4807.mail.invalid CylancePROTECT liqua ariatur [labo] Event Type: DeviceControl, Event Name: SystemSecurity, Device Name: remq, External Device Type: unt, External Device Vendor ID: tla, External Device Name: arch, External Device Product ID: lite, External Device Serial Number: ugia, Zone Names: meum",
             "event": {
@@ -938,7 +938,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Feb 17 3:30:32 nvolupta126.www.domain CylancePROTECT Event Type:quas, Event Name:threat_found, Device Name:orp, File Path:ender, Interpreter:dico, Interpreter Version:1.5848, Zone Names:Utenima, User Name: olore",
             "event": {
@@ -950,7 +950,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "3-March-2019 10:33:06 medium radip4253.www.corp gna \u003c\u003cici\u003equamnih 2019-3-3T10:33:06.asnulap yCiceroi5998.mail.home CylancePROTECT inc tect uiad Event Type: DeviceControl, Event Name: DeviceRemove, Device Name: roinBCSe, External Device Type: maperiam, External Device Vendor ID: mSec, External Device Name: smoditem, External Device Product ID: tatisetq, External Device Serial Number: uidolo, Zone Names: umdolore",
             "event": {
@@ -962,7 +962,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019-3-17T5:35:40.abori sit1400.www.lan CylancePROTECT ames amni [tatio] Event Type: AuditLog, Event Name: ZoneAdd, Message: Zone: ntsunti; Policy: borios; Value: ani, User: uid idatat (onev)",
             "event": {
@@ -974,7 +974,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "iosamni 2019-4-1T12:38:14.idu sis3986.internal.lan CylancePROTECT tsedquia its umdolor Event Type: isiu, Event Name: Device Policy Assigned, Device Name: mmodi, Agent Version: snostr, IP Address: (10.232.90.3), MAC Address: (01:00:5e:e6:a6:a2), Logged On Users: (midestl), OS: nci",
             "event": {
@@ -986,7 +986,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "hilmole 2019-4-15T7:40:49.sequ sectetu7182.localdomain CylancePROTECT dolor lorumwri [amnihil] Event Type: orissus, Event Name: Device Updated, uido",
             "event": {
@@ -998,7 +998,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019-4-29T2:43:23.itse officiad4982.www5.domain CylancePROTECT lumqui quiavolu [upta] Event Type: AuditLog, Event Name: ZoneAdd, Message: Device: umtota; User: etdolore magnaa (sumquiad)",
             "event": {
@@ -1010,7 +1010,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019-5-13T9:45:57.Duisa consequa1486.internal.localdomain CylancePROTECT aevitaed byCic [leumiur] Event Type: ptatemse, Event Name: pechange, Threat Class: quaeratv, Threat Subclass: involu, SHA256: tobeata, MD5: nesciun",
             "event": {
@@ -1022,7 +1022,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "onorumet 2019-5-28T4:48:31.ptatema eavolup6981.www5.example CylancePROTECT psaquaea rchit psumq Event Type: DeviceControl, Event Name: threat_changed, Device Name: lum, External Device Type: xerc, External Device Vendor ID: ctetura, External Device Name: msequ, External Device Product ID: nvol, External Device Serial Number: enimadmi, Zone Names: tateveli",
             "event": {
@@ -1034,7 +1034,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019-6-11T11:51:06.oremip its6443.mail.example CylancePROTECT natuserr ostrudex [nse] Event Type: miurere, Event Name: fullaccess, Device Name: tlabo, Agent Version: tatemse, IP Address: (10.139.80.71), MAC Address: (01:00:5e:bc:c1:21), Logged On Users: (orem), OS: eniamqui",
             "event": {
@@ -1046,7 +1046,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "25-June-2019 18:53:40 high tnulapa7580.www.domain adeser \u003c\u003cuasiarc\u003edoeiu 2019-6-25T6:53:40.onsectet dentsunt6061.www5.home CylancePROTECT tobeata imven onnumqua Event Type: quioff, Event Name: SyslogSettingsSave, Device Names: (upt), Policy Name: atatnonp, User: nvol dtemp (mquis)",
             "event": {
@@ -1058,7 +1058,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10-July-2019 01:56:14 medium midest133.www5.example tocca \u003c\u003corsitvol\u003entor 2019-7-10T1:56:14.oinBCSed oid218.api.invalid CylancePROTECT roquisqu ariat midestl Event Type: AuditLog, Event Name: SyslogSettingsSave, Message: mcorpori, User: mqu pteursi (orsitam)",
             "event": {
@@ -1070,7 +1070,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "totamre 2019-7-24T8:58:48.rpo velites4233.internal.home CylancePROTECT uisaute uun end Event Type: odocons, Event Name: Alert, Threat Class: asp, Threat Subclass: dexercit, SHA256: amn, MD5: itessequ",
             "event": {
@@ -1082,7 +1082,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "7-August-2019 16:01:23 low sumd3215.test aUtenima \u003c\u003cturQuis\u003etaevi 2019-8-7T4:01:23.uames tconsec7604.corp CylancePROTECT laboree udantiu [itametco] Event Type: Threat, Event Name: Alert, Device Name: stiaecon, IP Address: (10.223.246.244), File Name: itl, Path: ttenb, Drive Type: olor, SHA256: quiav, MD5: gna, Status: Nem, Cylance Score: 105.845000, Found Date: lors, File Type: oluptat, Is Running: enimad, Auto Run: tis, Detected By: qua, Zone Names: con, Is Malware: tore, Is Unique To Cylance: sequatD, Threat Classification: ercitati",
             "event": {
@@ -1094,7 +1094,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "21-Aug-2019 11:03:57 high oeiusmo5035.api.local tconse \u003c\u003crem\u003etseddoei 21T23:03:57.teursint etMa3452.www5.test CylancePROTECT Event Name:threat_found, Device Name:nturmag, File Path:uredol, Interpreter:maliqua, Interpreter Version:1.4613, Zone Names:mquia, User Name: omnisi, Device Id: etMalor, Policy Name: mco",
             "event": {
@@ -1106,7 +1106,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "5-September-2019 06:06:31 high taspe1205.mail.domain cti \u003c\u003commodoc\u003ense 2019-9-5T6:06:31.mveniam tuser2694.internal.invalid CylancePROTECT tlaboru aeabillo [ciad] Event Type: ugiatqu, Event Name: threat_found, Device Names: (turveli), Policy Name: isciv, User: natus boreet (luptasnu)",
             "event": {
@@ -1118,7 +1118,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "edqu 2019-9-19T1:09:05.tationu gnaaliq5240.api.test CylancePROTECT nula ameaquei [gnama] Event Type: esciun, Event Name: pechange, Threat Class: ratvo, Threat Subclass: ntutl, SHA256: volupt, MD5: ine",
             "event": {
@@ -1130,7 +1130,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "3-Oct-2019 8:11:40 low ditaut33.mail.localhost iumdo \u003c\u003coreeu\u003emea 3T20:11:40.ssec illum2625.test CylancePROTECT Event Name:LoginSuccess, Threat Class:iaeconse, Threat Subclass:uisa, SHA256:nimadmin, MD5:tdolo",
             "event": {
@@ -1142,7 +1142,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "18-October-2019 03:14:14 high porissus1225.www5.corp ddoe \u003c\u003cuptateve\u003eured 2019-10-18T3:14:14.ctetu oreeu6419.www.corp CylancePROTECT cul iinea snos Event Type: AuditLog, Event Name: PolicyAdd, Message: Device: moenimip; User: uames tium (ianonn)",
             "event": {
@@ -1154,7 +1154,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019-11-1T10:16:48.tiset sci333.mail.home CylancePROTECT doloreeu lors eumfu Event Type: docons, Event Name: PolicyAdd, Device Names: (eumf), Policy Name: roquisq, User: uasi maveniam (uis)",
             "event": {
@@ -1166,7 +1166,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "imi 2019-11-15T5:19:22.animi edutpers6452.api.host CylancePROTECT ntiumt sumquia vento Event Type: sitv, Event Name: LoginSuccess, Threat Class: com, Threat Subclass: rep, SHA256: mveni, MD5: aquae",
             "event": {
@@ -1178,7 +1178,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "30-November-2019 00:21:57 low iaturE3103.api.domain aturve \u003c\u003cptateve\u003eiatu 2019/11/30T00:21:57.use nulamc5617.mail.host CylancePROTECT teturad ese [eddoei] Event Type: AppControl, Event Name: SystemSecurity, Device Name: ntu, IP Address: (10.134.137.205), Action: deny, Action Type: duntut, File Path: emporin, SHA256: oreseosq, Zone Names: etquasia",
             "event": {
@@ -1190,7 +1190,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019-12-14T7:24:31.cinge tatem4713.internal.host CylancePROTECT elites pariat [nimip] Event Type: AuditLog, Event Name: threat_found, Message: Zone: usci; Policy: unturmag; Value: dexeaco, User: lupta ura (oreeufug)",
             "event": {

--- a/packages/cylance/data_stream/protect/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cylance/data_stream/protect/elasticsearch/ingest_pipeline/default.yml
@@ -8,7 +8,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   # User agent
   - user_agent:
       field: user_agent.original

--- a/packages/cylance/manifest.yml
+++ b/packages/cylance/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cylance
 title: CylanceProtect
-version: 0.4.0
+version: 0.4.1
 description: This Elastic integration collects logs from CylanceProtect
 categories: ["security"]
 release: experimental


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967