### PR TITLE
google_workspace update to ECS 1.11.0

### DIFF
--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.7.2'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1386
 - version: "0.7.1"
   changes:
     - description: Escape special characters in docs

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-application.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-application.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -86,7 +86,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -169,7 +169,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -252,7 +252,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -335,7 +335,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -418,7 +418,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -498,7 +498,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -578,7 +578,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -659,7 +659,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-calendar.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-calendar.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -85,7 +85,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -167,7 +167,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -249,7 +249,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -331,7 +331,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -413,7 +413,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -495,7 +495,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -577,7 +577,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -660,7 +660,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -742,7 +742,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -824,7 +824,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -907,7 +907,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -995,7 +995,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-chat.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-chat.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -85,7 +85,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -167,7 +167,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -250,7 +250,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-chromeos.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-chromeos.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -86,7 +86,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -166,7 +166,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -249,7 +249,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -331,7 +331,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -413,7 +413,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -494,7 +494,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -574,7 +574,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -655,7 +655,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -737,7 +737,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -819,7 +819,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -901,7 +901,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -983,7 +983,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1065,7 +1065,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1147,7 +1147,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1228,7 +1228,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1309,7 +1309,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1394,7 +1394,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1474,7 +1474,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1556,7 +1556,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1638,7 +1638,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-contacts.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-contacts.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-delegatedadmin.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-delegatedadmin.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -85,7 +85,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -167,7 +167,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -249,7 +249,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -331,7 +331,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -413,7 +413,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -493,7 +493,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -575,7 +575,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-docs.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-docs.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -85,7 +85,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -164,7 +164,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-domain.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-domain.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -85,7 +85,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -167,7 +167,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -249,7 +249,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -331,7 +331,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -413,7 +413,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -495,7 +495,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -577,7 +577,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -659,7 +659,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -739,7 +739,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -821,7 +821,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -903,7 +903,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -985,7 +985,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1067,7 +1067,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1149,7 +1149,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1231,7 +1231,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1314,7 +1314,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1397,7 +1397,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1480,7 +1480,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1562,7 +1562,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1644,7 +1644,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1726,7 +1726,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1808,7 +1808,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1890,7 +1890,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1973,7 +1973,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2056,7 +2056,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2138,7 +2138,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2221,7 +2221,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2304,7 +2304,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2386,7 +2386,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2469,7 +2469,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2551,7 +2551,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2631,7 +2631,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2712,7 +2712,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2792,7 +2792,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2874,7 +2874,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2956,7 +2956,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3038,7 +3038,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3120,7 +3120,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3202,7 +3202,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3284,7 +3284,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3366,7 +3366,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3448,7 +3448,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3530,7 +3530,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3612,7 +3612,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3695,7 +3695,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3778,7 +3778,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3861,7 +3861,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3941,7 +3941,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4018,7 +4018,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4100,7 +4100,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4182,7 +4182,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4264,7 +4264,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4346,7 +4346,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4428,7 +4428,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4510,7 +4510,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4593,7 +4593,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4676,7 +4676,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4758,7 +4758,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4840,7 +4840,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4923,7 +4923,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5005,7 +5005,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5088,7 +5088,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5170,7 +5170,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5252,7 +5252,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5334,7 +5334,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5417,7 +5417,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5499,7 +5499,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5581,7 +5581,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5663,7 +5663,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5743,7 +5743,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5825,7 +5825,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5907,7 +5907,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5989,7 +5989,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -6071,7 +6071,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -6151,7 +6151,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -6231,7 +6231,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -6313,7 +6313,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -6395,7 +6395,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -6477,7 +6477,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -6559,7 +6559,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -6641,7 +6641,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -6723,7 +6723,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -6806,7 +6806,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -6883,7 +6883,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-gmail.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-gmail.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -87,7 +87,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -171,7 +171,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -250,7 +250,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -333,7 +333,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -416,7 +416,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -499,7 +499,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -582,7 +582,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -666,7 +666,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-groups.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-groups.log-expected.json
@@ -33,7 +33,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -125,7 +125,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -217,7 +217,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -280,7 +280,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -388,7 +388,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -481,7 +481,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -574,7 +574,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -667,7 +667,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -760,7 +760,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -823,7 +823,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -906,7 +906,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1014,7 +1014,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1107,7 +1107,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1170,7 +1170,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-licenses.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-licenses.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -83,7 +83,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -163,7 +163,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -243,7 +243,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -323,7 +323,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -403,7 +403,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -483,7 +483,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -563,7 +563,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-mobile.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-mobile.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -88,7 +88,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -173,7 +173,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -255,7 +255,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -337,7 +337,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -419,7 +419,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -501,7 +501,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -583,7 +583,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -665,7 +665,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -747,7 +747,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -829,7 +829,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -911,7 +911,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -994,7 +994,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1076,7 +1076,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1159,7 +1159,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1242,7 +1242,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1325,7 +1325,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1408,7 +1408,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1491,7 +1491,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1573,7 +1573,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1655,7 +1655,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1737,7 +1737,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1819,7 +1819,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1901,7 +1901,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1983,7 +1983,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2060,7 +2060,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2137,7 +2137,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2214,7 +2214,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2291,7 +2291,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2374,7 +2374,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2457,7 +2457,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-org.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-org.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -85,7 +85,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -167,7 +167,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -249,7 +249,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -331,7 +331,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -413,7 +413,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -495,7 +495,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -577,7 +577,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -659,7 +659,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -741,7 +741,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -823,7 +823,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -905,7 +905,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -987,7 +987,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1069,7 +1069,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1149,7 +1149,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1229,7 +1229,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1311,7 +1311,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-security.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-security.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -86,7 +86,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -171,7 +171,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -256,7 +256,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -339,7 +339,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -421,7 +421,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -503,7 +503,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -587,7 +587,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -670,7 +670,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -753,7 +753,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -836,7 +836,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -919,7 +919,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1002,7 +1002,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1082,7 +1082,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1162,7 +1162,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1244,7 +1244,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1326,7 +1326,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1438,7 +1438,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1501,7 +1501,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1584,7 +1584,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1695,7 +1695,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1758,7 +1758,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1841,7 +1841,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1922,7 +1922,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-sites.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-sites.log-expected.json
@@ -36,7 +36,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -117,7 +117,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -165,7 +165,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -248,7 +248,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -331,7 +331,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-user.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-user.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -92,7 +92,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -181,7 +181,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -264,7 +264,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -347,7 +347,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -436,7 +436,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -525,7 +525,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -614,7 +614,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -703,7 +703,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -786,7 +786,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -867,7 +867,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -949,7 +949,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1038,7 +1038,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1127,7 +1127,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1216,7 +1216,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1305,7 +1305,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1394,7 +1394,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1483,7 +1483,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1572,7 +1572,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1661,7 +1661,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1750,7 +1750,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1839,7 +1839,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1928,7 +1928,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2017,7 +2017,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2106,7 +2106,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2195,7 +2195,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2284,7 +2284,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2373,7 +2373,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2462,7 +2462,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2551,7 +2551,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2640,7 +2640,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2729,7 +2729,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2818,7 +2818,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2907,7 +2907,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2996,7 +2996,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3085,7 +3085,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3174,7 +3174,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3263,7 +3263,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3352,7 +3352,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3441,7 +3441,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3530,7 +3530,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3619,7 +3619,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3708,7 +3708,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3785,7 +3785,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3874,7 +3874,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3963,7 +3963,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4052,7 +4052,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4141,7 +4141,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4224,7 +4224,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4313,7 +4313,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4402,7 +4402,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4491,7 +4491,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4574,7 +4574,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4657,7 +4657,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4746,7 +4746,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4835,7 +4835,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4924,7 +4924,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5013,7 +5013,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5096,7 +5096,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5185,7 +5185,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5274,7 +5274,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5363,7 +5363,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5452,7 +5452,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5529,7 +5529,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5610,7 +5610,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5691,7 +5691,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5772,7 +5772,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5861,7 +5861,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5950,7 +5950,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -6039,7 +6039,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -6128,7 +6128,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -6217,7 +6217,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -6306,7 +6306,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -6388,7 +6388,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/google_workspace/data_stream/admin/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/admin/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
       value: "{{ _ingest.timestamp }}"
   - set:
       field: ecs.version
-      value: '1.10.0'
+      value: '1.11.0'
   - append:
       field: event.category
       value: iam

--- a/packages/google_workspace/data_stream/drive/_dev/test/pipeline/test-drive.log-expected.json
+++ b/packages/google_workspace/data_stream/drive/_dev/test/pipeline/test-drive.log-expected.json
@@ -38,7 +38,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -137,7 +137,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -236,7 +236,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -335,7 +335,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -434,7 +434,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -533,7 +533,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -630,7 +630,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -727,7 +727,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -824,7 +824,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -921,7 +921,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1018,7 +1018,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1119,7 +1119,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1216,7 +1216,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1313,7 +1313,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1413,7 +1413,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1511,7 +1511,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1608,7 +1608,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1705,7 +1705,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1802,7 +1802,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1899,7 +1899,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1996,7 +1996,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2094,7 +2094,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2197,7 +2197,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2301,7 +2301,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2405,7 +2405,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2509,7 +2509,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2613,7 +2613,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2712,7 +2712,7 @@
                 "type": "file"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/google_workspace/data_stream/drive/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/drive/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
       value: "{{ _ingest.timestamp }}"
   - set:
       field: ecs.version
-      value: '1.10.0'
+      value: '1.11.0'
   - append:
       field: event.category
       value: file

--- a/packages/google_workspace/data_stream/groups/_dev/test/pipeline/test-groups.log-expected.json
+++ b/packages/google_workspace/data_stream/groups/_dev/test/pipeline/test-groups.log-expected.json
@@ -33,7 +33,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -132,7 +132,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -224,7 +224,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -323,7 +323,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -415,7 +415,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -507,7 +507,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -602,7 +602,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -693,7 +693,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -784,7 +784,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -879,7 +879,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -973,7 +973,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1068,7 +1068,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1162,7 +1162,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1257,7 +1257,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1352,7 +1352,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1447,7 +1447,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1542,7 +1542,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1638,7 +1638,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1737,7 +1737,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1837,7 +1837,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1937,7 +1937,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2036,7 +2036,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2135,7 +2135,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2234,7 +2234,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2333,7 +2333,7 @@
             ],
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/google_workspace/data_stream/groups/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/groups/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
       value: "{{ _ingest.timestamp }}"
   - set:
       field: ecs.version
-      value: '1.10.0'
+      value: '1.11.0'
   - append: 
       field: event.category
       value: iam

--- a/packages/google_workspace/data_stream/login/_dev/test/pipeline/test-login.log-expected.json
+++ b/packages/google_workspace/data_stream/login/_dev/test/pipeline/test-login.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -89,7 +89,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -176,7 +176,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -263,7 +263,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -350,7 +350,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -436,7 +436,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -522,7 +522,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -608,7 +608,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -696,7 +696,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -773,7 +773,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -857,7 +857,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -940,7 +940,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1023,7 +1023,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1104,7 +1104,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/google_workspace/data_stream/login/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/login/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
       value: "{{ _ingest.timestamp }}"
   - set:
       field: ecs.version
-      value: '1.10.0'
+      value: '1.11.0'
   - append:
       field: event.category
       value: authentication

--- a/packages/google_workspace/data_stream/saml/_dev/test/pipeline/test-saml.log-expected.json
+++ b/packages/google_workspace/data_stream/saml/_dev/test/pipeline/test-saml.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -90,7 +90,7 @@
         {
             "@timestamp": "2020-10-02T15:00:01.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/google_workspace/data_stream/saml/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/saml/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
       value: "{{ _ingest.timestamp }}"
   - set:
       field: ecs.version
-      value: '1.10.0'
+      value: '1.11.0'
   - append:
       field: event.type
       value: start

--- a/packages/google_workspace/data_stream/user_accounts/_dev/test/pipeline/test-user-accounts.log-expected.json
+++ b/packages/google_workspace/data_stream/user_accounts/_dev/test/pipeline/test-user-accounts.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -81,7 +81,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -159,7 +159,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -237,7 +237,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -315,7 +315,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -393,7 +393,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -471,7 +471,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -549,7 +549,7 @@
         {
             "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/google_workspace/data_stream/user_accounts/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/user_accounts/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
       value: "{{ _ingest.timestamp }}"
   - set:
       field: ecs.version
-      value: '1.10.0'
+      value: '1.11.0'
   - append:
       field: event.type
       value: change

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: 0.7.1
+version: 0.7.2
 release: experimental
 description: This Elastic integration collects logs from Google Workspace APIs
 type: integration


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967