### PR TITLE
haproxy update to ECS 1.11.0

### DIFF
--- a/packages/haproxy/changelog.yml
+++ b/packages/haproxy/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.5.2'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1387
 - version: "0.5.1"
   changes:
     - description: Escape special characters in docs

--- a/packages/haproxy/data_stream/log/_dev/test/pipeline/test-default.log-expected.json
+++ b/packages/haproxy/data_stream/log/_dev/test/pipeline/test-default.log-expected.json
@@ -7,7 +7,7 @@
             },
             "@timestamp": "2021-09-20T15:42:59.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/haproxy/data_stream/log/_dev/test/pipeline/test-haproxy.log-expected.json
+++ b/packages/haproxy/data_stream/log/_dev/test/pipeline/test-haproxy.log-expected.json
@@ -33,7 +33,7 @@
             ],
             "@timestamp": "2018-07-30T09:03:52.726Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -115,7 +115,7 @@
             ],
             "@timestamp": "2021-05-22T02:22:22.222Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "haproxy": {
                 "server_name": "node2",

--- a/packages/haproxy/data_stream/log/_dev/test/pipeline/test-httplog-no-headers.log-expected.json
+++ b/packages/haproxy/data_stream/log/_dev/test/pipeline/test-httplog-no-headers.log-expected.json
@@ -20,7 +20,7 @@
             ],
             "@timestamp": "2018-12-10T12:01:46.395Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -97,7 +97,7 @@
             ],
             "@timestamp": "2018-12-10T15:46:49.497Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -174,7 +174,7 @@
             ],
             "@timestamp": "2018-12-10T15:48:56.017Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/haproxy/data_stream/log/_dev/test/pipeline/test-tcplog.log-expected.json
+++ b/packages/haproxy/data_stream/log/_dev/test/pipeline/test-tcplog.log-expected.json
@@ -8,7 +8,7 @@
             },
             "@timestamp": "2018-09-20T15:44:23.285Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/haproxy/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/haproxy/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -7,7 +7,7 @@ processors:
       value: "{{ _ingest.timestamp }}"
   - set:
       field: ecs.version
-      value: '1.10.0'
+      value: '1.11.0'
   - rename:
       field: message
       target_field: event.original

--- a/packages/haproxy/manifest.yml
+++ b/packages/haproxy/manifest.yml
@@ -1,6 +1,6 @@
 name: haproxy
 title: HAProxy
-version: 0.5.1
+version: 0.5.2
 description: This Elastic integration collects logs and metrics from HAProxy instances
 type: integration
 icons:


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967