### PR TITLE
iis update to ECS 1.11.0

### DIFF
--- a/packages/iis/changelog.yml
+++ b/packages/iis/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.6.1'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1388
 - version: "0.6.0"
   changes:
     - description: Update integration description

--- a/packages/iis/data_stream/access/_dev/test/pipeline/test-iis-access-72.log-expected.json
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/test-iis-access-72.log-expected.json
@@ -28,7 +28,7 @@
             },
             "@timestamp": "2018-12-31T12:02:53.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -100,7 +100,7 @@
             },
             "@timestamp": "2018-12-31T12:02:53.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -170,7 +170,7 @@
             },
             "@timestamp": "2018-12-31T12:02:53.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -240,7 +240,7 @@
             },
             "@timestamp": "2018-12-31T12:02:53.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -312,7 +312,7 @@
             },
             "@timestamp": "2018-12-31T12:02:53.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/iis/data_stream/access/_dev/test/pipeline/test-iis-access-75.log-expected.json
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/test-iis-access-75.log-expected.json
@@ -26,7 +26,7 @@
             },
             "@timestamp": "2018-08-28T18:24:25.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -96,7 +96,7 @@
             },
             "@timestamp": "2019-03-06T18:43:17.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -153,7 +153,7 @@
             },
             "@timestamp": "2019-03-06T18:43:17.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -210,7 +210,7 @@
             },
             "@timestamp": "2019-03-06T18:43:17.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/iis/data_stream/access/_dev/test/pipeline/test-iis-access.log-expected.json
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/test-iis-access.log-expected.json
@@ -45,7 +45,7 @@
             },
             "@timestamp": "2018-01-01T08:09:10.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -116,7 +116,7 @@
             },
             "@timestamp": "2018-01-01T09:10:11.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -209,7 +209,7 @@
             },
             "@timestamp": "2018-01-01T10:11:12.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -287,7 +287,7 @@
             },
             "@timestamp": "2018-12-31T12:52:33.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -356,7 +356,7 @@
             },
             "@timestamp": "2018-12-31T12:52:33.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/iis/data_stream/access/_dev/test/pipeline/test-ipv6zone.log-expected.json
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/test-ipv6zone.log-expected.json
@@ -30,7 +30,7 @@
             },
             "@timestamp": "2018-01-01T10:11:12.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/iis/data_stream/access/_dev/test/pipeline/test-x-forward-for-extended.log-expected.json
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/test-x-forward-for-extended.log-expected.json
@@ -34,7 +34,7 @@
             },
             "@timestamp": "2020-10-04T22:00:34.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -120,7 +120,7 @@
             },
             "@timestamp": "2020-10-05T21:40:30.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -202,7 +202,7 @@
             },
             "@timestamp": "2020-10-05T21:48:33.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -290,7 +290,7 @@
             },
             "@timestamp": "2020-10-05T21:48:33.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -378,7 +378,7 @@
             },
             "@timestamp": "2020-10-08T22:00:22.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -466,7 +466,7 @@
             },
             "@timestamp": "2020-10-08T22:00:22.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/iis/data_stream/access/_dev/test/pipeline/test-x-forward-for.log-expected.json
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/test-x-forward-for.log-expected.json
@@ -29,7 +29,7 @@
             },
             "@timestamp": "2020-10-07T23:00:17.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -103,7 +103,7 @@
             },
             "@timestamp": "2020-10-07T23:00:17.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -177,7 +177,7 @@
             },
             "@timestamp": "2020-10-07T23:00:17.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -252,7 +252,7 @@
             },
             "@timestamp": "2020-10-07T23:00:17.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -327,7 +327,7 @@
             },
             "@timestamp": "2020-10-07T23:00:17.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -401,7 +401,7 @@
             },
             "@timestamp": "2020-10-07T23:06:42.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -475,7 +475,7 @@
             },
             "@timestamp": "2020-10-07T23:06:42.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -549,7 +549,7 @@
             },
             "@timestamp": "2020-10-07T23:06:42.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -623,7 +623,7 @@
             },
             "@timestamp": "2020-10-07T23:07:02.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/iis/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/iis/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -7,7 +7,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   - rename:
       field: message
       target_field: event.original

--- a/packages/iis/data_stream/error/_dev/test/pipeline/test-iis-error-72.log-expected.json
+++ b/packages/iis/data_stream/error/_dev/test/pipeline/test-iis-error-72.log-expected.json
@@ -26,7 +26,7 @@
             },
             "@timestamp": "2018-01-01T08:09:10.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -101,7 +101,7 @@
             },
             "@timestamp": "2018-01-01T09:10:11.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -175,7 +175,7 @@
             },
             "@timestamp": "2018-01-01T10:11:12.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -214,7 +214,7 @@
             },
             "@timestamp": "2018-01-01T11:12:13.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/iis/data_stream/error/_dev/test/pipeline/test-iis-error.log-expected.json
+++ b/packages/iis/data_stream/error/_dev/test/pipeline/test-iis-error.log-expected.json
@@ -35,7 +35,7 @@
             },
             "@timestamp": "2018-05-05T05:05:55.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -101,7 +101,7 @@
             },
             "@timestamp": "2018-05-05T05:05:55.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -165,7 +165,7 @@
             },
             "@timestamp": "2018-05-05T05:05:55.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -229,7 +229,7 @@
             },
             "@timestamp": "2018-05-05T05:05:55.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -295,7 +295,7 @@
             },
             "@timestamp": "2018-05-05T05:05:55.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -359,7 +359,7 @@
             },
             "@timestamp": "2018-05-05T05:05:55.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -424,7 +424,7 @@
             },
             "@timestamp": "2018-05-05T05:05:55.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -489,7 +489,7 @@
             },
             "@timestamp": "2018-05-05T05:05:55.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/iis/data_stream/error/_dev/test/pipeline/test-ipv6-zone-id.log-expected.json
+++ b/packages/iis/data_stream/error/_dev/test/pipeline/test-ipv6-zone-id.log-expected.json
@@ -8,7 +8,7 @@
             },
             "@timestamp": "2018-12-30T14:22:07.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/iis/data_stream/error/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/iis/data_stream/error/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   - rename:
       field: message
       target_field: event.original

--- a/packages/iis/manifest.yml
+++ b/packages/iis/manifest.yml
@@ -1,6 +1,6 @@
 name: iis
 title: IIS
-version: 0.6.0
+version: 0.6.1
 description: This Elastic integration collects metrics from IIS instances
 type: integration
 icons:


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967