### PR TITLE
imperva update to ECS 1.11.0

### DIFF
--- a/packages/imperva/changelog.yml
+++ b/packages/imperva/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.4.1'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1389
 - version: "0.4.0"
   changes:
     - description: Update integration description

--- a/packages/imperva/data_stream/securesphere/_dev/test/pipeline/test-generated.log-expected.json
+++ b/packages/imperva/data_stream/securesphere/_dev/test/pipeline/test-generated.log-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.70.155.35,dstPort=892,dbUsername=tatno,srcIP=10.81.122.126,srcPort=4141,creatTime=29 January 2016 06:09:59,srvGroup=uam,service=untutl,appName=rad,event#=taliqu,eventType=Login,usrGroup=ommod,usrAuth=True,application=\"scivel\",osUsername=aqui,srcHost=radipis5408.mail.local,dbName=enatuse,schemaName=magn,bindVar=equuntu,sqlError=failure,respSize=5910,respTime=10.347000,affRows=sum,action=\"cancel\",rawQuery=\"sit\"",
             "event": {
@@ -14,7 +14,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,event#=nimadmin,createTime=2016-02-12 13:12:33,eventType=erep,eventSev=low,username=temq,subsystem=ugiatqu,message=\"eacomm\"",
             "event": {
@@ -26,7 +26,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.58.116.231,dstPort=996,dbUsername=qua,srcIP=10.159.182.171,srcPort=3947,creatTime=2016-02-26 20:15:08,srvGroup=apariat,service=mol,appName=pteursi,event#=onse,eventType=rumet,usrGroup=oll,usrAuth=erc,application=\"taliqu\",osUsername=temUten,srcHost=ccusan7572.api.home,dbName=aveniam,schemaName=uradi,bindVar=nimadmin,sqlError=failure,respSize=3626,respTime=79.328000,affRows=ender,action=\"accept\",rawQuery=\"ehenderi\"",
             "event": {
@@ -38,7 +38,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.232.27.250,dstPort=7838,dbUsername=mquidol,srcIP=10.18.124.28,srcPort=7668,creatTime=12 March 2016 03:17:42,srvGroup=rsitamet,service=lupt,appName=xea,event#=qua,eventType=Login,usrGroup=luptatev,usrAuth=False,application=\"admi\",osUsername=modocons,srcHost=elaudant5931.internal.invalid,dbName=lores,schemaName=lapariat,bindVar=eddoei,sqlError=failure,respSize=6564,respTime=87.496000,affRows=nimadmin,action=\"cancel\",rawQuery=\"xercitat\"",
             "event": {
@@ -50,7 +50,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,alert#=ationemu,event#=ice,createTime=2016-03-26 10:20:16,updateTime=estiae,alertSev=high,group=laborum,ruleName=\"tionof\",evntDesc=\"snostrud\",category=nama,disposition=quisnos,eventType=ite,proto=icmp,srcPort=2707,srcIP=10.6.137.200,dstPort=5697,dstIP=10.197.250.10,policyName=\"bor\",occurrences=7243,httpHost=hitect,webMethod=dol,url=\"https://internal.example.net/namali/taevit.html?nsecte=itame#eumfug\",webQuery=\"lit\",soapAction=asun,resultCode=estia,sessionID=eaq,username=occae,addUsername=ctetura,responseTime=labore,responseSize=texp,direction=external,dbUsername=adeseru,queryGroup=emoe,application=\"eaq\",srcHost=amest4147.mail.host,osUsername=intoc,schemaName=oluptas,dbName=tNequepo,hdrName=lup,action=cancel",
             "event": {
@@ -62,7 +62,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,alert#=sperna,event#=eabilloi,createTime=2016-04-09 17:22:51,updateTime=estia,alertSev=medium,group=tlab,ruleName=\"volupt\",evntDesc=\"osqui\",category=xerc,disposition=iutali,eventType=fdeFi,proto=igmp,srcPort=1696,srcIP=10.179.124.125,dstPort=5473,dstIP=10.36.194.106,policyName=\"eprehend\",occurrences=2462,httpHost=dutper,webMethod=lamcolab,url=\"https://example.net/tlabo/uames.gif?mpo=offi#giatnu\",webQuery=\"ulapa\",soapAction=liqui,resultCode=quioffi,sessionID=uptate,username=ncidid,addUsername=quaturve,responseTime=sequa,responseSize=aera,direction=outbound,dbUsername=rvel,queryGroup=uid,application=\"onsecte\",srcHost=eratv6205.internal.lan,osUsername=reme,schemaName=acommod,dbName=uaUteni,hdrName=udantium,action=accept",
             "event": {
@@ -74,7 +74,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.129.149.43,dstPort=3304,dbUsername=eveli,srcIP=10.211.105.204,srcPort=2742,creatTime=2016-04-24 00:25:25,srvGroup=aliquide,service=ofde,appName=equat,event#=derit,eventType=Logout,usrGroup=dexea,usrAuth=True,application=\"atcu\",osUsername=labor,srcHost=didunt1355.corp,dbName=udan,schemaName=orema,bindVar=invento,sqlError=failure,respSize=6855,respTime=74.098000,affRows=nofdeFin,action=\"accept\",rawQuery=\"rau\"",
             "event": {
@@ -86,7 +86,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.214.191.180,dstPort=5848,dbUsername=ipsumdol,srcIP=10.112.250.193,srcPort=5705,creatTime=2016-05-08 07:27:59,srvGroup=urerepr,service=ese,appName=isaute,event#=ptatemq,eventType=Logout,usrGroup=luptatev,usrAuth=False,application=\"tlabore\",osUsername=Exc,srcHost=pora6854.www5.home,dbName=nevo,schemaName=ide,bindVar=aali,sqlError=success,respSize=6852,respTime=49.573000,affRows=etcons,action=\"cancel\",rawQuery=\"tenbyCi\"",
             "event": {
@@ -98,7 +98,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.251.20.13,dstPort=264,dbUsername=iquipe,srcIP=10.192.34.76,srcPort=1450,creatTime=2016-05-22 14:30:33,srvGroup=upida,service=tvolupt,appName=eufugi,event#=pici,eventType=abor,usrGroup=utpe,usrAuth=onsequ,application=\"temqu\",osUsername=ovol,srcHost=ptasn6599.www.localhost,dbName=lore,schemaName=tnonpro,bindVar=ionemu,sqlError=success,respSize=3645,respTime=20.909000,affRows=tanimid,action=\"deny\",rawQuery=\"uamni\"",
             "event": {
@@ -110,7 +110,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.74.105.218,dstPort=2438,dbUsername=archite,srcIP=10.59.138.212,srcPort=7829,creatTime=2016-06-05 21:33:08,srvGroup=asi,service=datatno,appName=siutali,event#=amnih,eventType=Logout,usrGroup=ium,usrAuth=True,application=\"esciuntN\",osUsername=idunt,srcHost=ptasnu6684.mail.lan,dbName=orumSe,schemaName=boree,bindVar=intoc,sqlError=success,respSize=248,respTime=158.450000,affRows=eeufugia,action=\"block\",rawQuery=\"ofdeFini\"",
             "event": {
@@ -122,7 +122,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.168.159.13,dstPort=3319,dbUsername=inci,srcIP=10.230.173.4,srcPort=2631,creatTime=2016-06-20 04:35:42,srvGroup=avol,service=icero,appName=xer,event#=emipsumd,eventType=Logout,usrGroup=isisten,usrAuth=False,application=\"cusant\",osUsername=atemq,srcHost=rinre2977.api.corp,dbName=totamre,schemaName=isnostr,bindVar=umqu,sqlError=success,respSize=6135,respTime=86.668000,affRows=inesci,action=\"accept\",rawQuery=\"uia\"",
             "event": {
@@ -134,7 +134,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.49.167.57,dstPort=2119,dbUsername=tali,srcIP=10.41.21.204,srcPort=3540,creatTime=4 July 2016 11:38:16,srvGroup=rpori,service=ice,appName=oles,event#=edic,eventType=Login,usrGroup=seq,usrAuth=True,application=\"tutlab\",osUsername=sau,srcHost=atevelit2450.local,dbName=aperia,schemaName=ccaeca,bindVar=umdolo,sqlError=failure,respSize=6818,respTime=115.224000,affRows=stenatu,action=\"block\",rawQuery=\"orumSe\"",
             "event": {
@@ -146,7 +146,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,alert#=dutp,event#=psaquaea,createTime=2016-07-18 18:40:50,updateTime=taevita,alertSev=high,group=siut,ruleName=\"tconsect\",evntDesc=\"aquae\",category=boreetdo,disposition=aturve,eventType=ditemp,proto=ipv6,srcPort=3406,srcIP=10.216.125.252,dstPort=5592,dstIP=10.62.147.186,policyName=\"eumiure\",occurrences=4603,httpHost=ima,webMethod=quasia,url=\"https://example.org/umwrit/uptate.html?ctetura=aveni#elit\",webQuery=\"seosqui\",soapAction=sequamni,resultCode=uradi,sessionID=tot,username=llamco,addUsername=nea,responseTime=psum,responseSize=tasnulap,direction=inbound,dbUsername=umSe,queryGroup=xeacomm,application=\"cinge\",srcHost=itla658.api.localhost,osUsername=lorsita,schemaName=dolore,dbName=uptate,hdrName=quidexea,action=\"accept\",errormsg=\"unknown\"",
             "event": {
@@ -158,7 +158,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,alert#=ate,event#=odoconse,createTime=2016-08-02 01:43:25,updateTime=emp,alertSev=very-high,group=veli,ruleName=\"tenim\",evntDesc=\"rumet\",category=verita,disposition=sectet,eventType=etdo,proto=tcp,srcPort=3689,srcIP=10.52.125.9,dstPort=2538,dstIP=10.204.128.215,policyName=\"ama\",occurrences=332,httpHost=runtmol,webMethod=texpli,url=\"https://api.example.org/roidents/tem.txt?tametcon=liqua#mvele\",webQuery=\"isis\",soapAction=uasiar,resultCode=utlab,sessionID=emUteni,username=rum,addUsername=gnaaliqu,responseTime=teirured,responseSize=onemulla,direction=external,dbUsername=bor,queryGroup=rauto,application=\"ationev\",srcHost=umdolor4389.api.home,osUsername=paquioff,schemaName=nci,dbName=isau,hdrName=rautodi,action=deny",
             "event": {
@@ -170,7 +170,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.200.68.129,dstPort=2558,dbUsername=icabo,srcIP=10.34.148.166,srcPort=3022,creatTime=2016-08-16 08:45:59,srvGroup=preh,service=ercit,appName=etMal,event#=qua,eventType=rsita,usrGroup=ate,usrAuth=ipsamvo,application=\"onula\",osUsername=miu,srcHost=rationev6444.localhost,dbName=tatem,schemaName=untutlab,bindVar=amcor,sqlError=failure,respSize=5427,respTime=176.685000,affRows=oremq,action=\"block\",rawQuery=\"uisaute\"",
             "event": {
@@ -182,7 +182,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.226.101.180,dstPort=1000,dbUsername=siu,srcIP=10.134.5.40,srcPort=7284,creatTime=30 August 2016 15:48:33,srvGroup=llamc,service=nte,appName=mvel,event#=nof,eventType=Login,usrGroup=usmodi,usrAuth=False,application=\"mvolu\",osUsername=conse,srcHost=ipi7727.www5.domain,dbName=isiu,schemaName=licabo,bindVar=enimadmi,sqlError=success,respSize=6356,respTime=41.238000,affRows=xeaco,action=\"deny\",rawQuery=\"amcor\"",
             "event": {
@@ -194,7 +194,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.126.26.131,dstPort=2595,dbUsername=velite,srcIP=10.30.98.10,srcPort=7576,creatTime=13 September 2016 22:51:07,srvGroup=itation,service=sequatD,appName=nimave,event#=isciv,eventType=Login,usrGroup=rroqu,usrAuth=False,application=\"nofd\",osUsername=dipisci,srcHost=spernatu5539.domain,dbName=quunt,schemaName=olori,bindVar=mquae,sqlError=unknown,respSize=7717,respTime=96.729000,affRows=cidunt,action=\"accept\",rawQuery=\"borisnis\"",
             "event": {
@@ -206,7 +206,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.190.10.219,dstPort=5530,dbUsername=accusant,srcIP=10.233.120.207,srcPort=136,creatTime=2016-09-28 05:53:42,srvGroup=stenatu,service=inibu,appName=est,event#=uptatemU,eventType=Logout,usrGroup=leumiu,usrAuth=False,application=\"tla\",osUsername=item,srcHost=nimid372.api.corp,dbName=atcupid,schemaName=quamnih,bindVar=dminima,sqlError=success,respSize=3278,respTime=60.949000,affRows=tame,action=\"cancel\",rawQuery=\"reetd\"",
             "event": {
@@ -218,7 +218,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,event#=sitam,createTime=2016-10-12 12:56:16,eventType=rad,eventSev=low,username=sequa,subsystem=iosamnis,message=\"volupt\"",
             "event": {
@@ -230,7 +230,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.100.98.56,dstPort=1089,dbUsername=boru,srcIP=10.248.184.200,srcPort=5315,creatTime=2016-10-26 19:58:50,srvGroup=ptatem,service=ptatevel,appName=tenatuse,event#=psaqua,eventType=Logout,usrGroup=ullamcor,usrAuth=False,application=\"itationu\",osUsername=proident,srcHost=maliquam2147.internal.home,dbName=lores,schemaName=ritati,bindVar=orisni,sqlError=failure,respSize=5923,respTime=179.541000,affRows=sitam,action=\"deny\",rawQuery=\"mmodoc\"",
             "event": {
@@ -242,7 +242,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.197.6.245,dstPort=27,dbUsername=dtempo,srcIP=10.82.28.220,srcPort=3570,creatTime=10 November 2016 03:01:24,srvGroup=imad,service=tinvolup,appName=tsed,event#=inv,eventType=Login,usrGroup=rroq,usrAuth=False,application=\"rcit\",osUsername=aecatcup,srcHost=olabor2983.internal.localhost,dbName=citatio,schemaName=oluptat,bindVar=mveniamq,sqlError=success,respSize=3071,respTime=120.142000,affRows=eaqueips,action=\"allow\",rawQuery=\"aturve\"",
             "event": {
@@ -254,7 +254,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.6.27.103,dstPort=3179,dbUsername=redol,srcIP=10.167.252.183,srcPort=2003,creatTime=24 November 2016 10:03:59,srvGroup=doei,service=cipitl,appName=caboNemo,event#=dexerc,eventType=Login,usrGroup=strumex,usrAuth=True,application=\"eprehend\",osUsername=asnu,srcHost=hitec2111.mail.corp,dbName=perspici,schemaName=ationul,bindVar=mquisn,sqlError=failure,respSize=6606,respTime=155.907000,affRows=emUte,action=\"cancel\",rawQuery=\"ccae\"",
             "event": {
@@ -266,7 +266,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,alert#=ntNe,event#=itanim,createTime=2016-12-08 17:06:33,updateTime=nesciun,alertSev=medium,group=mollita,ruleName=\"tatem\",evntDesc=\"iae\",category=quido,disposition=emip,eventType=inBC,proto=tcp,srcPort=6165,srcIP=10.88.45.111,dstPort=6735,dstIP=10.81.184.7,policyName=\"saquaea\",occurrences=6344,httpHost=eetd,webMethod=illu,url=\"https://mail.example.com/lorsi/repreh.gif?sitamet=utlabo#tetur\",webQuery=\"tionula\",soapAction=ritqu,resultCode=ecatcupi,sessionID=uamei,username=undeomni,addUsername=tas,responseTime=autfugi,responseSize=tasun,direction=external,dbUsername=eratv,queryGroup=ipsa,application=\"asuntexp\",srcHost=adminim2559.www5.invalid,osUsername=lmole,schemaName=iameaque,dbName=nderi,hdrName=ssusci,action=\"deny\",errormsg=\"failure\"",
             "event": {
@@ -278,7 +278,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.214.3.140,dstPort=6127,dbUsername=scipitl,srcIP=10.29.119.245,srcPort=1179,creatTime=2016-12-23 00:09:07,srvGroup=olli,service=rever,appName=ore,event#=offici,eventType=Logout,usrGroup=ection,usrAuth=False,application=\"roquisqu\",osUsername=edolorin,srcHost=dolorem6882.api.local,dbName=rsi,schemaName=taliqui,bindVar=mides,sqlError=success,respSize=5140,respTime=119.229000,affRows=tcu,action=\"cancel\",rawQuery=\"inrepreh\"",
             "event": {
@@ -290,7 +290,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,alert#=dipiscin,event#=olup,createTime=2017-01-06 07:11:41,updateTime=aco,alertSev=medium,group=accusa,ruleName=\"natu\",evntDesc=\"liquid\",category=enim,disposition=Finibus,eventType=radi,proto=rdp,srcPort=2064,srcIP=10.218.123.234,dstPort=57,dstIP=10.110.133.7,policyName=\"radipisc\",occurrences=5347,httpHost=nibus,webMethod=vitaed,url=\"https://example.org/etconsec/elillum.htm?mporinc=onsectet#idolo\",webQuery=\"atemUte\",soapAction=docon,resultCode=mdolore,sessionID=eosquira,username=pta,addUsername=snos,responseTime=orsi,responseSize=tetura,direction=external,dbUsername=lorsita,queryGroup=eavol,application=\"osamnis\",srcHost=temaccu5302.test,osUsername=etconsec,schemaName=caboNem,dbName=urExcept,hdrName=rumetMal,action=\"allow\",errormsg=\"unknown\"",
             "event": {
@@ -302,7 +302,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.105.190.170,dstPort=2519,dbUsername=doeiu,srcIP=10.182.152.242,srcPort=1877,creatTime=2017-01-20 14:14:16,srvGroup=orumw,service=redol,appName=ecillum,event#=isci,eventType=Logout,usrGroup=dolor,usrAuth=True,application=\"tiumto\",osUsername=litan,srcHost=nder347.www.corp,dbName=alorum,schemaName=mquisn,bindVar=atq,sqlError=unknown,respSize=3474,respTime=68.556000,affRows=ugiatquo,action=\"block\",rawQuery=\"equamnih\"",
             "event": {
@@ -314,7 +314,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,alert#=citati,event#=uamei,createTime=2017-02-03 21:16:50,updateTime=eursinto,alertSev=low,group=tutla,ruleName=\"licaboNe\",evntDesc=\"tautfug\",category=giatquov,disposition=olu,eventType=rmagnido,proto=ipv6-icmp,srcPort=7647,srcIP=10.59.188.188,dstPort=7082,dstIP=10.123.166.197,policyName=\"ici\",occurrences=7102,httpHost=mips,webMethod=itae,url=\"https://internal.example.net/atnula/ditautf.jpg?iquidex=olup#remipsu\",webQuery=\"tan\",soapAction=quiac,resultCode=sunt,sessionID=autfugit,username=emUte,addUsername=iusmodi,responseTime=fdeFi,responseSize=Except,direction=inbound,dbUsername=equat,queryGroup=aliquid,application=\"usantiu\",srcHost=idunt4633.internal.host,osUsername=liquam,schemaName=min,dbName=oluptat,hdrName=odt,action=block",
             "event": {
@@ -326,7 +326,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.72.75.207,dstPort=6336,dbUsername=urau,srcIP=10.201.168.116,srcPort=2037,creatTime=2017-02-18 04:19:24,srvGroup=utali,service=sed,appName=xeac,event#=umdolors,eventType=Logout,usrGroup=lumdo,usrAuth=False,application=\"acom\",osUsername=eFini,srcHost=ectob4634.mail.localhost,dbName=prehend,schemaName=eufug,bindVar=roquisq,sqlError=unknown,respSize=3348,respTime=79.765000,affRows=civelits,action=\"accept\",rawQuery=\"reet\"",
             "event": {
@@ -338,7 +338,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.9.46.123,dstPort=586,dbUsername=mfu,srcIP=10.58.133.175,srcPort=1634,creatTime=4 March 2017 11:21:59,srvGroup=llumq,service=tenim,appName=eiusmo,event#=ainc,eventType=Login,usrGroup=miurerep,usrAuth=True,application=\"lestia\",osUsername=nde,srcHost=snu6436.www.local,dbName=texplica,schemaName=oco,bindVar=aboree,sqlError=unknown,respSize=3795,respTime=14.713000,affRows=edquian,action=\"block\",rawQuery=\"uames\"",
             "event": {
@@ -350,7 +350,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.169.50.59,dstPort=7693,dbUsername=pta,srcIP=10.70.29.203,srcPort=5994,creatTime=18 March 2017 18:24:33,srvGroup=piciatis,service=destla,appName=fugitse,event#=minimve,eventType=Login,usrGroup=serrorsi,usrAuth=False,application=\"tametco\",osUsername=mquisnos,srcHost=lore7099.www.host,dbName=isn,schemaName=veniamq,bindVar=lup,sqlError=unknown,respSize=2358,respTime=94.460000,affRows=ipitlabo,action=\"block\",rawQuery=\"prehen\"",
             "event": {
@@ -362,7 +362,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.165.182.111,dstPort=5525,dbUsername=ames,srcIP=10.137.85.123,srcPort=218,creatTime=2017-04-02 01:27:07,srvGroup=amquisno,service=modoc,appName=magnam,event#=uinesc,eventType=Logout,usrGroup=cid,usrAuth=True,application=\"emi\",osUsername=Bonorum,srcHost=lesti6939.api.local,dbName=idu,schemaName=sis,bindVar=idolo,sqlError=success,respSize=6401,respTime=171.434000,affRows=its,action=\"block\",rawQuery=\"edutp\"",
             "event": {
@@ -374,7 +374,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,event#=enimadmi,createTime=2017-04-16 08:29:41,eventType=tateveli,eventSev=high,username=sumdolo,subsystem=idolorem,message=\"temvele\"",
             "event": {
@@ -386,7 +386,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,alert#=inimve,event#=uio,createTime=2017-04-30 15:32:16,updateTime=mexercit,alertSev=high,group=onofdeF,ruleName=\"ibusBo\",evntDesc=\"orin\",category=enia,disposition=iavol,eventType=natuserr,proto=rdp,srcPort=3327,srcIP=10.64.184.196,dstPort=6659,dstIP=10.173.178.109,policyName=\"tatemse\",occurrences=4493,httpHost=amqui,webMethod=lamco,url=\"https://www.example.net/hender/ptatemU.htm?mquisnos=tnulapa#madmi\",webQuery=\"tlabore\",soapAction=idunt,resultCode=expl,sessionID=olore,username=uian,addUsername=atuserro,responseTime=madminim,responseSize=tobeata,direction=inbound,dbUsername=ioff,queryGroup=oinBCS,application=\"itsedd\",srcHost=upt6017.api.localdomain,osUsername=nesci,schemaName=tam,dbName=sin,hdrName=idexeac,action=\"block\",errormsg=\"failure\"",
             "event": {
@@ -398,7 +398,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.90.50.149,dstPort=1936,dbUsername=olu,srcIP=10.168.225.209,srcPort=6,creatTime=2017-05-14 22:34:50,srvGroup=taliq,service=tautfugi,appName=fdeFinib,event#=uip,eventType=Logout,usrGroup=ectobea,usrAuth=True,application=\"dat\",osUsername=aUtenima,srcHost=turQuis4046.api.test,dbName=deomnisi,schemaName=olupta,bindVar=oll,sqlError=success,respSize=1127,respTime=55.870000,affRows=evelite,action=\"block\",rawQuery=\"iav\"",
             "event": {
@@ -410,7 +410,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.59.182.36,dstPort=5792,dbUsername=mtota,srcIP=10.18.150.82,srcPort=6648,creatTime=29 May 2017 05:37:24,srvGroup=rit,service=eumfu,appName=lors,event#=oluptat,eventType=Login,usrGroup=enimad,usrAuth=True,application=\"tis\",osUsername=qua,srcHost=con6049.internal.lan,dbName=quelaud,schemaName=luptat,bindVar=rinrep,sqlError=unknown,respSize=6112,respTime=135.357000,affRows=nimv,action=\"allow\",rawQuery=\"tconse\"",
             "event": {
@@ -422,7 +422,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,event#=rem,createTime=2017-06-12 12:39:58,eventType=ulamcola,eventSev=very-high,username=llita,subsystem=ntsunt,message=\"nturmag\"",
             "event": {
@@ -434,7 +434,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.228.229.144,dstPort=3236,dbUsername=ametcons,srcIP=10.151.240.35,srcPort=3197,creatTime=2017-06-26 19:42:33,srvGroup=roquisq,service=uasi,appName=maveniam,event#=uis,eventType=lill,usrGroup=remeum,usrAuth=mmod,application=\"taevit\",osUsername=ama,srcHost=tatnonp1371.www.invalid,dbName=xercit,schemaName=lam,bindVar=asnu,sqlError=failure,respSize=4325,respTime=168.492000,affRows=eriam,action=\"cancel\",rawQuery=\"aquae\"",
             "event": {
@@ -446,7 +446,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.242.48.203,dstPort=1102,dbUsername=ese,srcIP=10.147.142.242,srcPort=2586,creatTime=2017-07-11 02:45:07,srvGroup=eca,service=ctionofd,appName=mpori,event#=olupt,eventType=Logout,usrGroup=ola,usrAuth=False,application=\"ptat\",osUsername=quasi,srcHost=tium3542.internal.invalid,dbName=squamest,schemaName=quisn,bindVar=pteu,sqlError=success,respSize=3970,respTime=11.548000,affRows=antium,action=\"block\",rawQuery=\"velillum\"",
             "event": {
@@ -458,7 +458,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,alert#=lapari,event#=Mal,createTime=2017-07-25 09:47:41,updateTime=itinvo,alertSev=very-high,group=paq,ruleName=\"emipsumq\",evntDesc=\"culpaq\",category=quamq,disposition=usan,eventType=tdolo,proto=ipv6,srcPort=4723,srcIP=10.213.165.165,dstPort=3787,dstIP=10.254.10.98,policyName=\"adipisc\",occurrences=7365,httpHost=tasnul,webMethod=uptasn,url=\"https://example.net/itati/oidentsu.gif?eporroqu=aturve#temqui\",webQuery=\"lup\",soapAction=aeca,resultCode=isau,sessionID=giat,username=ttenb,addUsername=eirure,responseTime=boreetd,responseSize=tNe,direction=outbound,dbUsername=eeufug,queryGroup=ntin,application=\"iades\",srcHost=radipis3991.mail.invalid,osUsername=civeli,schemaName=eufugia,dbName=utlabore,hdrName=tamr,action=\"cancel\",errormsg=\"success\"",
             "event": {
@@ -470,7 +470,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,event#=onemul,createTime=2017-08-08 16:50:15,eventType=trudexe,eventSev=very-high,username=ura,subsystem=oreeufug,message=\"Quisa\"",
             "event": {
@@ -482,7 +482,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,alert#=llitani,event#=uscipit,createTime=2017-08-22 23:52:50,updateTime=luptat,alertSev=very-high,group=etco,ruleName=\"iuntN\",evntDesc=\"utfugi\",category=ursintoc,disposition=tio,eventType=mmodicon,proto=ipv6,srcPort=5439,srcIP=10.116.1.130,dstPort=3402,dstIP=10.169.28.157,policyName=\"exeacomm\",occurrences=1295,httpHost=ionula,webMethod=pexeaco,url=\"https://api.example.org/uamqua/Neq.gif?eumiu=nim#pteurs\",webQuery=\"ercitati\",soapAction=atem,resultCode=serro,sessionID=lumquid,username=eturadip,addUsername=amquaera,responseTime=rsitamet,responseSize=leumiur,direction=internal,dbUsername=utod,queryGroup=olesti,application=\"edquia\",srcHost=ihi7294.www5.localhost,osUsername=reseo,schemaName=amco,dbName=ons,hdrName=onsecte,action=\"accept\",errormsg=\"unknown\"",
             "event": {
@@ -494,7 +494,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.29.138.31,dstPort=5871,dbUsername=volupta,srcIP=10.45.69.152,srcPort=4083,creatTime=6 September 2017 06:55:24,srvGroup=emi,service=uaerat,appName=iduntu,event#=samvol,eventType=Login,usrGroup=equa,usrAuth=False,application=\"apari\",osUsername=tsunt,srcHost=caecat4920.api.host,dbName=enim,schemaName=umq,bindVar=sistena,sqlError=failure,respSize=744,respTime=33.416000,affRows=temquia,action=\"deny\",rawQuery=\"eumiu\"",
             "event": {
@@ -506,7 +506,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.152.213.228,dstPort=3387,dbUsername=ptatev,srcIP=10.100.113.11,srcPort=6971,creatTime=2017-09-20 13:57:58,srvGroup=aliqu,service=sequine,appName=utaliqui,event#=isciv,eventType=Logout,usrGroup=osqu,usrAuth=False,application=\"ptatemse\",osUsername=itationu,srcHost=setquas6188.internal.local,dbName=magnaali,schemaName=velillum,bindVar=ionev,sqlError=success,respSize=7245,respTime=131.118000,affRows=ameaq,action=\"cancel\",rawQuery=\"Except\"",
             "event": {
@@ -518,7 +518,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,event#=uiac,createTime=2017-10-04 21:00:32,eventType=tquii,eventSev=low,username=reme,subsystem=emeumfu,message=\"inBCSedu\"",
             "event": {
@@ -530,7 +530,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.208.33.55,dstPort=1849,dbUsername=ulapari,srcIP=10.248.102.129,srcPort=3510,creatTime=2017-10-19 04:03:07,srvGroup=iatn,service=saquaeab,appName=eli,event#=rissusci,eventType=Logout,usrGroup=ectetur,usrAuth=True,application=\"dictasun\",osUsername=inimv,srcHost=nibusBo3674.www5.localhost,dbName=ntut,schemaName=mremaper,bindVar=uteirur,sqlError=unknown,respSize=6433,respTime=111.360000,affRows=isni,action=\"accept\",rawQuery=\"quovo\"",
             "event": {
@@ -542,7 +542,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.203.164.132,dstPort=6213,dbUsername=mporin,srcIP=10.109.230.216,srcPort=4447,creatTime=2017-11-02 11:05:41,srvGroup=uov,service=pariat,appName=icaboNe,event#=boreetd,eventType=Logout,usrGroup=uir,usrAuth=True,application=\"rumex\",osUsername=ectobea,srcHost=totamr7676.www5.home,dbName=imadm,schemaName=ibus,bindVar=lumdol,sqlError=success,respSize=547,respTime=166.971000,affRows=reprehe,action=\"block\",rawQuery=\"ihil\"",
             "event": {
@@ -554,7 +554,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.151.203.60,dstPort=482,dbUsername=dol,srcIP=10.117.81.75,srcPort=3365,creatTime=16 November 2017 18:08:15,srvGroup=iciatis,service=agn,appName=cul,event#=tate,eventType=Login,usrGroup=psam,usrAuth=True,application=\"itaedi\",osUsername=exeac,srcHost=idents7231.mail.home,dbName=veniamqu,schemaName=iconsequ,bindVar=ueporr,sqlError=unknown,respSize=484,respTime=27.563000,affRows=tur,action=\"block\",rawQuery=\"onorumet\"",
             "event": {
@@ -566,7 +566,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.224.217.153,dstPort=6339,dbUsername=eriti,srcIP=10.45.152.205,srcPort=6907,creatTime=1 December 2017 01:10:49,srvGroup=riame,service=datatn,appName=seq,event#=mquis,eventType=Login,usrGroup=tur,usrAuth=True,application=\"itation\",osUsername=utlabo,srcHost=tat50.mail.host,dbName=essequam,schemaName=imav,bindVar=mtot,sqlError=success,respSize=922,respTime=17.709000,affRows=prehend,action=\"allow\",rawQuery=\"liquid\"",
             "event": {
@@ -578,7 +578,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,alert#=umq,event#=ipsu,createTime=2017-12-15 08:13:24,updateTime=oremip,alertSev=low,group=odit,ruleName=\"vol\",evntDesc=\"epteurs\",category=itse,disposition=rever,eventType=sBonoru,proto=udp,srcPort=2652,srcIP=10.60.164.100,dstPort=5119,dstIP=10.1.193.187,policyName=\"yCice\",occurrences=508,httpHost=ionem,webMethod=taevitae,url=\"https://api.example.net/quam/saute.htm?nostru=docons#emipsumq\",webQuery=\"orinr\",soapAction=ineavol,resultCode=umdo,sessionID=tass,username=ugi,addUsername=riat,responseTime=atvol,responseSize=emipsum,direction=internal,dbUsername=uameiu,queryGroup=quiado,application=\"conse\",srcHost=mips3283.corp,osUsername=hite,schemaName=adipis,dbName=abo,hdrName=suntex,action=\"allow\",errormsg=\"failure\"",
             "event": {
@@ -590,7 +590,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.248.244.203,dstPort=806,dbUsername=mquamei,srcIP=10.146.228.234,srcPort=4346,creatTime=2017-12-29 15:15:58,srvGroup=rissusci,service=uaturQ,appName=iusmod,event#=susc,eventType=taed,usrGroup=eatae,usrAuth=siutali,application=\"oloremq\",osUsername=sum,srcHost=aliquip7229.mail.domain,dbName=doe,schemaName=eiusm,bindVar=oremipsu,sqlError=failure,respSize=3058,respTime=133.358000,affRows=llum,action=\"allow\",rawQuery=\"mto\"",
             "event": {
@@ -602,7 +602,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.122.127.237,dstPort=1138,dbUsername=consecte,srcIP=10.86.121.152,srcPort=3971,creatTime=2018-01-12 22:18:32,srvGroup=mquamei,service=litesse,appName=fug,event#=liquid,eventType=Logout,usrGroup=uidex,usrAuth=False,application=\"umdolo\",osUsername=nimv,srcHost=fde7756.mail.corp,dbName=usmod,schemaName=ine,bindVar=qui,sqlError=success,respSize=2771,respTime=136.167000,affRows=orsitame,action=\"block\",rawQuery=\"ipex\"",
             "event": {
@@ -614,7 +614,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.201.223.119,dstPort=3614,dbUsername=rcit,srcIP=10.204.223.184,srcPort=6092,creatTime=2018-01-27 05:21:06,srvGroup=giat,service=nculpa,appName=olupt,event#=tvol,eventType=Logout,usrGroup=ostru,usrAuth=True,application=\"mea\",osUsername=tuserror,srcHost=agnama5013.internal.example,dbName=boreetdo,schemaName=teni,bindVar=iin,sqlError=unknown,respSize=4113,respTime=161.837000,affRows=tNeq,action=\"block\",rawQuery=\"liq\"",
             "event": {
@@ -626,7 +626,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.200.12.126,dstPort=2347,dbUsername=magnido,srcIP=10.223.56.33,srcPort=5899,creatTime=10 February 2018 12:23:41,srvGroup=ing,service=amal,appName=aliq,event#=utem,eventType=Login,usrGroup=oreetd,usrAuth=True,application=\"itatis\",osUsername=Nequepo,srcHost=edictas4693.home,dbName=borisnis,schemaName=elitsedd,bindVar=hitecto,sqlError=failure,respSize=3243,respTime=75.415000,affRows=imven,action=\"block\",rawQuery=\"hende\"",
             "event": {
@@ -638,7 +638,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,alert#=deseru,event#=aquioff,createTime=2018-02-24 19:26:15,updateTime=cip,alertSev=very-high,group=onsequat,ruleName=\"tiumd\",evntDesc=\"atuse\",category=imad,disposition=tura,eventType=equuntur,proto=ipv6,srcPort=428,srcIP=10.94.89.177,dstPort=1752,dstIP=10.65.225.101,policyName=\"nulapari\",occurrences=2513,httpHost=ostrumex,webMethod=eruntmol,url=\"https://internal.example.com/imide/uiineav.htm?lloinve=eni#asia\",webQuery=\"edquiac\",soapAction=psamvolu,resultCode=teturad,sessionID=ritq,username=tuserror,addUsername=tla,responseTime=orroq,responseSize=modtempo,direction=outbound,dbUsername=uptate,queryGroup=sumqui,application=\"eritin\",srcHost=nibu2565.api.local,osUsername=citation,schemaName=emquel,dbName=rspiciat,hdrName=iavol,action=\"cancel\",errormsg=\"unknown\"",
             "event": {
@@ -650,7 +650,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.65.174.196,dstPort=472,dbUsername=iin,srcIP=10.191.184.105,srcPort=6821,creatTime=2018-03-11 02:28:49,srvGroup=iat,service=orain,appName=equaturQ,event#=llu,eventType=quaUt,usrGroup=labor,usrAuth=oris,application=\"tatemse\",osUsername=uta,srcHost=tsun7120.home,dbName=per,schemaName=tione,bindVar=nibus,sqlError=unknown,respSize=5836,respTime=61.864000,affRows=olo,action=\"deny\",rawQuery=\"BCSedutp\"",
             "event": {
@@ -662,7 +662,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,alert#=tdolor,event#=Ute,createTime=2018-03-25 09:31:24,updateTime=tura,alertSev=very-high,group=umSecti,ruleName=\"eabil\",evntDesc=\"ibusB\",category=rporis,disposition=etco,eventType=mip,proto=rdp,srcPort=6078,srcIP=10.224.148.48,dstPort=2803,dstIP=10.41.181.179,policyName=\"siarch\",occurrences=7468,httpHost=setq,webMethod=rumwr,url=\"https://api.example.com/ptatem/mporain.gif?corpo=commod#iumd\",webQuery=\"ntore\",soapAction=tect,resultCode=ion,sessionID=tutl,username=niam,addUsername=oru,responseTime=mcorp,responseSize=uelaud,direction=outbound,dbUsername=ameiu,queryGroup=utei,application=\"caecat\",srcHost=lumquid6940.mail.localdomain,osUsername=equepor,schemaName=iosamn,dbName=erspicia,hdrName=neavolup,action=\"deny\",errormsg=\"success\"",
             "event": {
@@ -674,7 +674,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.21.208.103,dstPort=5543,dbUsername=imidest,srcIP=10.21.61.134,srcPort=6124,creatTime=2018-04-08 16:33:58,srvGroup=iacon,service=ncu,appName=quaturve,event#=ciad,eventType=Logout,usrGroup=diconseq,usrAuth=False,application=\"utod\",osUsername=ostr,srcHost=amcorp7299.api.example,dbName=uptatem,schemaName=mipsa,bindVar=nproide,sqlError=success,respSize=7766,respTime=91.186000,affRows=siutali,action=\"deny\",rawQuery=\"nemullam\"",
             "event": {
@@ -686,7 +686,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.23.6.216,dstPort=4578,dbUsername=iarchit,srcIP=10.221.192.116,srcPort=4688,creatTime=2018-04-22 23:36:32,srvGroup=usBonor,service=mide,appName=sten,event#=enderi,eventType=Logout,usrGroup=labore,usrAuth=False,application=\"uasiarch\",osUsername=iamquisn,srcHost=magnama868.api.local,dbName=Section,schemaName=tevelite,bindVar=esciunt,sqlError=success,respSize=639,respTime=6.388000,affRows=borisnis,action=\"accept\",rawQuery=\"oremagn\"",
             "event": {
@@ -698,7 +698,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,alert#=rcita,event#=ataev,createTime=2018-05-07 06:39:06,updateTime=oris,alertSev=very-high,group=tate,ruleName=\"tutlabo\",evntDesc=\"nto\",category=sciv,disposition=tlabo,eventType=nsequun,proto=ipv6,srcPort=2976,srcIP=10.191.142.143,dstPort=5850,dstIP=10.240.62.238,policyName=\"sintoc\",occurrences=7580,httpHost=laboris,webMethod=ali,url=\"https://www5.example.net/aUten/edutpers.gif?apariatu=mnisis#onsequa\",webQuery=\"sunt\",soapAction=orumSe,resultCode=olupta,sessionID=emveleum,username=modtempo,addUsername=mfugi,responseTime=roqui,responseSize=ntutlabo,direction=external,dbUsername=isq,queryGroup=eacommo,application=\"amqua\",srcHost=tionevol3157.mail.invalid,osUsername=nofde,schemaName=animide,dbName=Lore,hdrName=oin,action=cancel",
             "event": {
@@ -710,7 +710,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,alert#=ecatcu,event#=entoreve,createTime=2018-05-21 13:41:41,updateTime=ion,alertSev=very-high,group=onev,ruleName=\"atu\",evntDesc=\"adeseru\",category=sitas,disposition=eni,eventType=cte,proto=igmp,srcPort=3124,srcIP=10.178.79.217,dstPort=7499,dstIP=10.111.22.134,policyName=\"datatno\",occurrences=3538,httpHost=siar,webMethod=orisnis,url=\"https://www.example.net/mvolup/pidat.jpg?ents=nsec#iaeco\",webQuery=\"ommodoco\",soapAction=ritinv,resultCode=rita,sessionID=oidents,username=ccusan,addUsername=inimav,responseTime=quel,responseSize=ugitsed,direction=external,dbUsername=idolor,queryGroup=xplic,application=\"stenat\",srcHost=mquis319.api.local,osUsername=inibusBo,schemaName=tqui,dbName=sequun,hdrName=nimadm,action=deny",
             "event": {
@@ -722,7 +722,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.161.225.172,dstPort=3708,dbUsername=meaqu,srcIP=10.77.86.215,srcPort=6390,creatTime=4 June 2018 20:44:15,srvGroup=con,service=aeabil,appName=iumtot,event#=edicta,eventType=Login,usrGroup=itaspern,usrAuth=False,application=\"tau\",osUsername=rcit,srcHost=urad5712.api.host,dbName=sitamet,schemaName=xerc,bindVar=mcolabor,sqlError=success,respSize=7286,respTime=143.926000,affRows=evita,action=\"block\",rawQuery=\"ant\"",
             "event": {
@@ -734,7 +734,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.186.133.184,dstPort=7864,dbUsername=boriosa,srcIP=10.211.161.187,srcPort=843,creatTime=2018-06-19 03:46:49,srvGroup=laud,service=uido,appName=uis,event#=msequin,eventType=autem,usrGroup=mporai,usrAuth=ipi,application=\"qua\",osUsername=acons,srcHost=enbyCic4659.www5.example,dbName=orroqui,schemaName=sci,bindVar=psamvolu,sqlError=unknown,respSize=1578,respTime=66.164000,affRows=temse,action=\"deny\",rawQuery=\"onevol\"",
             "event": {
@@ -746,7 +746,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.160.147.230,dstPort=2126,dbUsername=nimvenia,srcIP=10.254.198.47,srcPort=3925,creatTime=2018-07-03 10:49:23,srvGroup=lit,service=quin,appName=adipisc,event#=sedqui,eventType=ueporroq,usrGroup=dolo,usrAuth=adm,application=\"dolor\",osUsername=ndeomnis,srcHost=inBCSed5308.api.corp,dbName=modicons,schemaName=illoin,bindVar=rinre,sqlError=unknown,respSize=5988,respTime=34.664000,affRows=olorem,action=\"cancel\",rawQuery=\"dquiaco\"",
             "event": {
@@ -758,7 +758,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.40.24.93,dstPort=7487,dbUsername=mSecti,srcIP=10.182.197.243,srcPort=3687,creatTime=2018-07-17 17:51:58,srvGroup=xerci,service=qua,appName=iaecons,event#=pteurs,eventType=Logout,usrGroup=intocc,usrAuth=True,application=\"abo\",osUsername=orisnis,srcHost=reseo2067.api.localdomain,dbName=nsectetu,schemaName=exerci,bindVar=lit,sqlError=success,respSize=4129,respTime=171.277000,affRows=ono,action=\"cancel\",rawQuery=\"equuntu\"",
             "event": {
@@ -770,7 +770,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.249.13.159,dstPort=3023,dbUsername=uisautei,srcIP=10.108.130.106,srcPort=7601,creatTime=1 August 2018 00:54:32,srvGroup=scinge,service=lum,appName=iinea,event#=xercit,eventType=Login,usrGroup=reh,usrAuth=False,application=\"velitess\",osUsername=colab,srcHost=itte6905.mail.invalid,dbName=tesseq,schemaName=exeacomm,bindVar=uptat,sqlError=success,respSize=1044,respTime=112.679000,affRows=ptatema,action=\"cancel\",rawQuery=\"cepteurs\"",
             "event": {
@@ -782,7 +782,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,alert#=ioffic,event#=rumetMal,createTime=2018-08-15 07:57:06,updateTime=tiumtot,alertSev=very-high,group=caboNe,ruleName=\"ptate\",evntDesc=\"enimips\",category=Nequepor,disposition=nisiu,eventType=ptat,proto=ggp,srcPort=4082,srcIP=10.64.94.174,dstPort=3852,dstIP=10.39.244.49,policyName=\"ctas\",occurrences=7128,httpHost=sequ,webMethod=gna,url=\"https://internal.example.org/aev/uovolup.txt?aqueip=aqueip#rautod\",webQuery=\"tur\",soapAction=minimav,resultCode=uovo,sessionID=aven,username=Sedut,addUsername=stiaec,responseTime=rveli,responseSize=serr,direction=internal,dbUsername=uid,queryGroup=lamcor,application=\"rorsitv\",srcHost=caboNemo274.www.host,osUsername=estiae,schemaName=iunt,dbName=eFinibu,hdrName=uisaut,action=cancel",
             "event": {
@@ -794,7 +794,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,event#=odit,createTime=2018-08-29 14:59:40,eventType=ercitati,eventSev=very-high,username=imad,subsystem=olo,message=\"deserun\"",
             "event": {
@@ -806,7 +806,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,event#=scingeli,createTime=2018-09-12 22:02:15,eventType=uatDuis,eventSev=medium,username=apari,subsystem=itesseci,message=\"utali\"",
             "event": {
@@ -818,7 +818,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.115.203.143,dstPort=6889,dbUsername=utoditau,srcIP=10.134.135.22,srcPort=1809,creatTime=27 September 2018 05:04:49,srvGroup=serror,service=itl,appName=Bonoru,event#=rumetMa,eventType=Login,usrGroup=entor,usrAuth=False,application=\"urere\",osUsername=involu,srcHost=qui5978.api.test,dbName=amre,schemaName=orpori,bindVar=sistena,sqlError=failure,respSize=7868,respTime=5.277000,affRows=borisn,action=\"cancel\",rawQuery=\"quatu\"",
             "event": {
@@ -830,7 +830,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.43.244.252,dstPort=1752,dbUsername=inculp,srcIP=10.251.212.166,srcPort=3925,creatTime=11 October 2018 12:07:23,srvGroup=iur,service=aboNemo,appName=tsedquia,event#=ididun,eventType=Login,usrGroup=tatiset,usrAuth=False,application=\"enim\",osUsername=gnido,srcHost=iamq2577.internal.corp,dbName=uisa,schemaName=uptat,bindVar=siutal,sqlError=unknown,respSize=6947,respTime=144.976000,affRows=tempori,action=\"accept\",rawQuery=\"lamco\"",
             "event": {
@@ -842,7 +842,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,event#=nimve,createTime=2018-10-25 19:09:57,eventType=edutpe,eventSev=medium,username=isunde,subsystem=nimadm,message=\"cepte\"",
             "event": {
@@ -854,7 +854,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.20.231.188,dstPort=1200,dbUsername=tesseq,srcIP=10.88.189.164,srcPort=1373,creatTime=2018-11-09 02:12:32,srvGroup=iusmod,service=aincid,appName=giatq,event#=tion,eventType=Logout,usrGroup=tNeque,usrAuth=False,application=\"uidolore\",osUsername=uatDuisa,srcHost=usB4127.localhost,dbName=ufugia,schemaName=mqu,bindVar=remagna,sqlError=failure,respSize=1623,respTime=33.468000,affRows=Uteni,action=\"cancel\",rawQuery=\"porinci\"",
             "event": {
@@ -866,7 +866,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,event#=edd,createTime=2018-11-23 09:15:06,eventType=uianon,eventSev=low,username=quamquae,subsystem=aaliq,message=\"nos\"",
             "event": {
@@ -878,7 +878,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.231.77.26,dstPort=7082,dbUsername=rehe,srcIP=10.225.11.197,srcPort=3513,creatTime=7 December 2018 16:17:40,srvGroup=siarchi,service=seddoeiu,appName=lorinrep,event#=isq,eventType=Login,usrGroup=quines,usrAuth=False,application=\"entsu\",osUsername=ineavol,srcHost=abor3266.mail.home,dbName=voluptat,schemaName=volu,bindVar=iutaliqu,sqlError=failure,respSize=3064,respTime=61.960000,affRows=iusmo,action=\"allow\",rawQuery=\"uovo\"",
             "event": {
@@ -890,7 +890,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.148.3.197,dstPort=979,dbUsername=usa,srcIP=10.106.166.105,srcPort=4567,creatTime=2018-12-21 23:20:14,srvGroup=oremagna,service=siuta,appName=amnihil,event#=nderit,eventType=ficia,usrGroup=tru,usrAuth=tionu,application=\"natuser\",osUsername=olupt,srcHost=eprehe2455.www.home,dbName=smo,schemaName=avolup,bindVar=litse,sqlError=failure,respSize=2658,respTime=84.894000,affRows=untutlab,action=\"allow\",rawQuery=\"byCicer\"",
             "event": {
@@ -902,7 +902,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.172.121.239,dstPort=5339,dbUsername=iuta,srcIP=10.57.169.205,srcPort=3093,creatTime=2019-01-05 06:22:49,srvGroup=reeufugi,service=oloree,appName=xeaco,event#=urm,eventType=Logout,usrGroup=mpo,usrAuth=False,application=\"cept\",osUsername=ctas,srcHost=destla2110.www5.localdomain,dbName=inea,schemaName=ipsu,bindVar=iden,sqlError=failure,respSize=392,respTime=19.061000,affRows=reetd,action=\"cancel\",rawQuery=\"maven\"",
             "event": {
@@ -914,7 +914,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.129.234.200,dstPort=3833,dbUsername=tisundeo,srcIP=10.42.218.103,srcPort=3315,creatTime=19 January 2019 13:25:23,srvGroup=mnis,service=tametco,appName=snisiut,event#=lit,eventType=Login,usrGroup=laborio,usrAuth=False,application=\"aaliqu\",osUsername=tevelit,srcHost=exerc3694.api.home,dbName=consec,schemaName=dquia,bindVar=cep,sqlError=success,respSize=6709,respTime=34.273000,affRows=volupta,action=\"allow\",rawQuery=\"ipex\"",
             "event": {
@@ -926,7 +926,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.111.132.221,dstPort=2262,dbUsername=ali,srcIP=10.76.121.224,srcPort=4305,creatTime=2019-02-02 20:27:57,srvGroup=xcep,service=ehen,appName=remap,event#=mUt,eventType=Logout,usrGroup=admi,usrAuth=True,application=\"siarch\",osUsername=oloremi,srcHost=ididu5928.www5.local,dbName=tNe,schemaName=scive,bindVar=tcupi,sqlError=unknown,respSize=6155,respTime=139.491000,affRows=Sed,action=\"cancel\",rawQuery=\"ita\"",
             "event": {
@@ -938,7 +938,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.195.8.141,dstPort=4342,dbUsername=enimip,srcIP=10.17.214.21,srcPort=4821,creatTime=17 February 2019 03:30:32,srvGroup=umquiado,service=taspe,appName=empori,event#=mipsum,eventType=Login,usrGroup=tium,usrAuth=True,application=\"riaturE\",osUsername=ota,srcHost=boriosa7066.www.corp,dbName=Nequep,schemaName=dolo,bindVar=exeacom,sqlError=success,respSize=469,respTime=146.775000,affRows=eufugiat,action=\"accept\",rawQuery=\"non\"",
             "event": {
@@ -950,7 +950,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.173.13.179,dstPort=1211,dbUsername=ptasn,srcIP=10.179.60.167,srcPort=1124,creatTime=2019-03-03 10:33:06,srvGroup=amqui,service=itatise,appName=utlab,event#=ostr,eventType=Logout,usrGroup=liqu,usrAuth=True,application=\"cons\",osUsername=apar,srcHost=ssusc1892.internal.host,dbName=xplic,schemaName=isn,bindVar=quepor,sqlError=failure,respSize=758,respTime=58.800000,affRows=etur,action=\"block\",rawQuery=\"cusan\"",
             "event": {
@@ -962,7 +962,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.42.135.34,dstPort=4361,dbUsername=tiset,srcIP=10.178.190.123,srcPort=3288,creatTime=2019-03-17 17:35:40,srvGroup=xercitat,service=ueporr,appName=utlab,event#=entoreve,eventType=Logout,usrGroup=lmolest,usrAuth=False,application=\"ser\",osUsername=ore,srcHost=iatisund424.mail.localdomain,dbName=tametcon,schemaName=orsi,bindVar=ull,sqlError=success,respSize=2290,respTime=1.468000,affRows=etdolore,action=\"cancel\",rawQuery=\"ore\"",
             "event": {
@@ -974,7 +974,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,event#=ectetur,createTime=2019-04-01 00:38:14,eventType=cons,eventSev=medium,username=fugit,subsystem=dantiu,message=\"ntutla\"",
             "event": {
@@ -986,7 +986,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.207.198.239,dstPort=4735,dbUsername=Loremips,srcIP=10.8.147.176,srcPort=5920,creatTime=15 April 2019 07:40:49,srvGroup=odtem,service=ite,appName=tseddo,event#=ptatems,eventType=Login,usrGroup=ori,usrAuth=False,application=\"exerc\",osUsername=aUteni,srcHost=uidolo7626.local,dbName=rchite,schemaName=incididu,bindVar=idolor,sqlError=failure,respSize=3043,respTime=36.712000,affRows=oinB,action=\"accept\",rawQuery=\"econsequ\"",
             "event": {
@@ -998,7 +998,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.116.26.185,dstPort=595,dbUsername=oNe,srcIP=10.206.221.180,srcPort=6818,creatTime=2019-04-29 14:43:23,srvGroup=repr,service=idu,appName=otam,event#=amquaera,eventType=rumS,usrGroup=uelau,usrAuth=quidolor,application=\"cca\",osUsername=litesseq,srcHost=dmini3435.internal.domain,dbName=rumexerc,schemaName=nseq,bindVar=quisnost,sqlError=unknown,respSize=3218,respTime=26.485000,affRows=orisnisi,action=\"block\",rawQuery=\"nul\"",
             "event": {
@@ -1010,7 +1010,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.86.180.150,dstPort=5495,dbUsername=mnisis,srcIP=10.253.127.130,srcPort=5339,creatTime=2019-05-13 21:45:57,srvGroup=isciveli,service=urve,appName=sundeomn,event#=tasu,eventType=Logout,usrGroup=equunt,usrAuth=True,application=\"uat\",osUsername=itasper,srcHost=nibusBo1864.domain,dbName=ent,schemaName=etconsec,bindVar=docons,sqlError=failure,respSize=4564,respTime=4.592000,affRows=mremap,action=\"allow\",rawQuery=\"sperna\"",
             "event": {
@@ -1022,7 +1022,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,alert#=mexe,event#=sequatDu,createTime=2019-05-28 04:48:31,updateTime=ssuscip,alertSev=high,group=ciade,ruleName=\"busBonor\",evntDesc=\"enima\",category=emseq,disposition=osamni,eventType=umetMa,proto=ipv6-icmp,srcPort=4469,srcIP=10.220.175.201,dstPort=579,dstIP=10.158.161.5,policyName=\"eab\",occurrences=4098,httpHost=ciduntut,webMethod=atisu,url=\"https://internal.example.com/architec/incul.txt?aborios=mco#amnisiu\",webQuery=\"suntincu\",soapAction=lore,resultCode=equatu,sessionID=enbyCi,username=dolo,addUsername=adipi,responseTime=beata,responseSize=evelites,direction=inbound,dbUsername=tNeq,queryGroup=umtot,application=\"eumiurer\",srcHost=inv6528.www5.example,osUsername=rrors,schemaName=dolo,dbName=tsed,hdrName=corpori,action=allow",
             "event": {
@@ -1034,7 +1034,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,event#=uioff,createTime=2019-06-11 11:51:06,eventType=ema,eventSev=low,username=mpo,subsystem=deritinv,message=\"ten\"",
             "event": {
@@ -1046,7 +1046,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.150.27.144,dstPort=5627,dbUsername=res,srcIP=10.248.16.82,srcPort=6834,creatTime=25 June 2019 18:53:40,srvGroup=loinv,service=umd,appName=madmi,event#=xercit,eventType=Login,usrGroup=avolup,usrAuth=True,application=\"etdo\",osUsername=tuserror,srcHost=nisiutal4437.www.example,dbName=uipex,schemaName=ditautf,bindVar=orr,sqlError=failure,respSize=4367,respTime=25.972000,affRows=uptas,action=\"cancel\",rawQuery=\"osquira\"",
             "event": {
@@ -1058,7 +1058,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.146.131.76,dstPort=2281,dbUsername=orsi,srcIP=10.173.19.140,srcPort=7780,creatTime=2019-07-10 01:56:14,srvGroup=atu,service=ddo,appName=veli,event#=ata,eventType=Logout,usrGroup=untmoll,usrAuth=False,application=\"ididun\",osUsername=olo,srcHost=tqui5172.www.local,dbName=untex,schemaName=Except,bindVar=elitsedd,sqlError=failure,respSize=5844,respTime=52.550000,affRows=cingel,action=\"allow\",rawQuery=\"seos\"",
             "event": {
@@ -1070,7 +1070,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.69.5.227,dstPort=5845,dbUsername=doloreme,srcIP=10.171.175.165,srcPort=5776,creatTime=2019-07-24 08:58:48,srvGroup=taspe,service=litess,appName=enimadm,event#=corpori,eventType=onemull,usrGroup=emeu,usrAuth=uisaute,application=\"tvol\",osUsername=ntocc,srcHost=intocca6708.mail.corp,dbName=dquiaco,schemaName=rumw,bindVar=ula,sqlError=failure,respSize=5201,respTime=46.690000,affRows=quam,action=\"deny\",rawQuery=\"edquian\"",
             "event": {
@@ -1082,7 +1082,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.213.214.118,dstPort=7851,dbUsername=ate,srcIP=10.253.175.129,srcPort=5547,creatTime=7 August 2019 16:01:23,srvGroup=rsi,service=tuser,appName=equinesc,event#=ectet,eventType=Login,usrGroup=emull,usrAuth=False,application=\"enatuser\",osUsername=epteurs,srcHost=isetqu2843.www.invalid,dbName=niamqu,schemaName=nrep,bindVar=lauda,sqlError=failure,respSize=6260,respTime=9.295000,affRows=aincidu,action=\"deny\",rawQuery=\"ipsamvol\"",
             "event": {
@@ -1094,7 +1094,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,alert#=estquido,event#=eufugiat,createTime=2019-08-21 23:03:57,updateTime=minima,alertSev=high,group=bor,ruleName=\"uisnos\",evntDesc=\"loi\",category=tation,disposition=seddoe,eventType=adol,proto=rdp,srcPort=7756,srcIP=10.149.91.130,dstPort=3548,dstIP=10.89.26.170,policyName=\"aqueipsa\",occurrences=5863,httpHost=ide,webMethod=atcupi,url=\"https://www.example.com/sit/ugi.gif?sitametc=rur#edut\",webQuery=\"sitametc\",soapAction=iarchite,resultCode=uide,sessionID=iono,username=aboris,addUsername=eturad,responseTime=ipiscive,responseSize=sequu,direction=internal,dbUsername=epteur,queryGroup=iqu,application=\"uptateve\",srcHost=commodo6041.mail.localhost,osUsername=atus,schemaName=orumetMa,dbName=inventor,hdrName=dolo,action=block",
             "event": {
@@ -1106,7 +1106,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,alert#=tmolli,event#=orumSe,createTime=2019-09-05 06:06:31,updateTime=mSe,alertSev=high,group=teturad,ruleName=\"alorumwr\",evntDesc=\"pis\",category=idol,disposition=mmodico,eventType=emaccu,proto=rdp,srcPort=5818,srcIP=10.52.106.68,dstPort=856,dstIP=10.81.108.232,policyName=\"atemq\",occurrences=5098,httpHost=volupta,webMethod=Quisaut,url=\"https://internal.example.net/obeatae/sedqui.jpg?nulap=onseq#amrem\",webQuery=\"plicab\",soapAction=isisten,resultCode=eiusmodt,sessionID=naaliq,username=aco,addUsername=psamvolu,responseTime=inculp,responseSize=eni,direction=inbound,dbUsername=sedqu,queryGroup=ipitlabo,application=\"olorinr\",srcHost=gitse6744.api.local,osUsername=neavolup,schemaName=uaturve,dbName=lapa,hdrName=uepor,action=\"allow\",errormsg=\"failure\"",
             "event": {
@@ -1118,7 +1118,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,alert#=umquamei,event#=nih,createTime=2019-09-19 13:09:05,updateTime=tionev,alertSev=high,group=quia,ruleName=\"eabill\",evntDesc=\"itatiset\",category=uaerat,disposition=met,eventType=isno,proto=icmp,srcPort=2572,srcIP=10.230.48.97,dstPort=1991,dstIP=10.223.10.28,policyName=\"emveleu\",occurrences=4029,httpHost=norumet,webMethod=tconse,url=\"https://mail.example.com/iaturE/inc.htm?uisaut=mnihilm#itinvo\",webQuery=\"lestia\",soapAction=anti,resultCode=eavo,sessionID=enderi,username=erit,addUsername=uptatem,responseTime=reeufug,responseSize=temveleu,direction=unknown,dbUsername=repre,queryGroup=consec,application=\"untmoll\",srcHost=par3605.internal.localdomain,osUsername=usmodte,schemaName=untex,dbName=ommodi,hdrName=ntiu,action=\"deny\",errormsg=\"success\"",
             "event": {
@@ -1130,7 +1130,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.115.42.231,dstPort=2143,dbUsername=res,srcIP=10.161.212.150,srcPort=2748,creatTime=3 October 2019 20:11:40,srvGroup=corporis,service=turExc,appName=urvelil,event#=ulapa,eventType=Login,usrGroup=abi,usrAuth=False,application=\"ameiusm\",osUsername=tasnul,srcHost=isau4356.www.home,dbName=niamqui,schemaName=sequamn,bindVar=onse,sqlError=failure,respSize=4846,respTime=6.993000,affRows=aliquaUt,action=\"deny\",rawQuery=\"natus\"",
             "event": {
@@ -1142,7 +1142,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,alert#=emp,event#=suscipit,createTime=2019-10-18 03:14:14,updateTime=iaconseq,alertSev=medium,group=sciuntNe,ruleName=\"nevo\",evntDesc=\"stiaec\",category=officia,disposition=ametcon,eventType=gnid,proto=ipv6,srcPort=5677,srcIP=10.226.75.20,dstPort=3896,dstIP=10.247.108.144,policyName=\"iutaliqu\",occurrences=3711,httpHost=onsectet,webMethod=iat,url=\"https://www5.example.org/elaud/temsequ.htm?dolo=iciatisu#eip\",webQuery=\"iquaUte\",soapAction=aborumSe,resultCode=writt,sessionID=dent,username=tema,addUsername=saquaeab,responseTime=rpo,responseSize=inr,direction=internal,dbUsername=edquiac,queryGroup=olore,application=\"urEx\",srcHost=labo3477.www5.domain,osUsername=maccusan,schemaName=fugia,dbName=psa,hdrName=iset,action=\"block\",errormsg=\"success\"",
             "event": {
@@ -1154,7 +1154,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.192.15.65,dstPort=3328,dbUsername=nimides,srcIP=10.97.22.61,srcPort=6420,creatTime=2019-11-01 10:16:48,srvGroup=labor,service=quelaud,appName=ira,event#=gna,eventType=aparia,usrGroup=ntoreve,usrAuth=remips,application=\"uptatemU\",osUsername=illumd,srcHost=itseddo2209.mail.domain,dbName=olu,schemaName=rExcep,bindVar=turExcep,sqlError=success,respSize=4173,respTime=166.270000,affRows=duntutla,action=\"block\",rawQuery=\"tmollit\"",
             "event": {
@@ -1166,7 +1166,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,alert#=venia,event#=Loremi,createTime=2019-11-15 17:19:22,updateTime=uisnostr,alertSev=medium,group=vol,ruleName=\"ommodi\",evntDesc=\"ritat\",category=dipi,disposition=asnulapa,eventType=atev,proto=tcp,srcPort=7469,srcIP=10.197.254.133,dstPort=2009,dstIP=10.116.76.161,policyName=\"tla\",occurrences=2608,httpHost=ender,webMethod=quid,url=\"https://mail.example.net/teturad/nimide.htm?ueporroq=writ#ema\",webQuery=\"ioffici\",soapAction=agni,resultCode=tat,sessionID=metconse,username=ide,addUsername=equu,responseTime=pernatur,responseSize=orem,direction=outbound,dbUsername=caecatc,queryGroup=iarc,application=\"emquia\",srcHost=duntutl3396.api.host,osUsername=idu,schemaName=trudex,dbName=ncul,hdrName=mcorpor,action=cancel",
             "event": {
@@ -1178,7 +1178,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.28.77.79,dstPort=3615,dbUsername=upta,srcIP=10.144.14.15,srcPort=1150,creatTime=30 November 2019 00:21:57,srvGroup=consequ,service=min,appName=riame,event#=gnaal,eventType=Login,usrGroup=nti,usrAuth=True,application=\"tetura\",osUsername=utlab,srcHost=colabo6686.internal.invalid,dbName=uptass,schemaName=rspic,bindVar=itsedq,sqlError=success,respSize=4810,respTime=22.348000,affRows=iut,action=\"deny\",rawQuery=\"nemu\"",
             "event": {
@@ -1190,7 +1190,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%IMPERVA-Imperva,dstIP=10.248.177.182,dstPort=317,dbUsername=quei,srcIP=10.18.15.43,srcPort=2224,creatTime=2019-12-14 07:24:31,srvGroup=reetdol,service=umtotam,appName=itaedi,event#=ant,eventType=tiumt,usrGroup=taedicta,usrAuth=mveniamq,application=\"exerci\",osUsername=quaturve,srcHost=tsunti1164.www.example,dbName=equatur,schemaName=caecat,bindVar=oreetd,sqlError=unknown,respSize=983,respTime=113.318000,affRows=nderit,action=\"accept\",rawQuery=\"icer\"",
             "event": {

--- a/packages/imperva/data_stream/securesphere/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/imperva/data_stream/securesphere/elasticsearch/ingest_pipeline/default.yml
@@ -8,7 +8,7 @@ processors:
       value: "{{_ingest.timestamp}}"
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   # User agent
   - user_agent:
       field: user_agent.original

--- a/packages/imperva/manifest.yml
+++ b/packages/imperva/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: imperva
 title: Imperva SecureSphere
-version: 0.4.0
+version: 0.4.1
 description: This Elastic integration collects logs from Imperva SecureSphere
 categories: ["network", "security"]
 release: experimental


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967