### PR TITLE
infloblox update to ECS 1.11.0

### DIFF
--- a/packages/infoblox/changelog.yml
+++ b/packages/infoblox/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.4.1'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1390
 - version: "0.4.0"
   changes:
     - description: Update integration description

--- a/packages/infoblox/data_stream/nios/_dev/test/pipeline/test-generated.log-expected.json
+++ b/packages/infoblox/data_stream/nios/_dev/test/pipeline/test-generated.log-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "January 29 06:09:59 doeiu3942.localdomain -:rc executing eporr start",
             "event": {
@@ -14,7 +14,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "February 12 13:12:33 tia7019.www.invalid :diskcheck quis",
             "event": {
@@ -26,7 +26,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "February 26 20:15:08 dolo1720.api.example 10.250.162.122 logger: com",
             "event": {
@@ -38,7 +38,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "March 12 03:17:42 ratio1111.localdomain -:diskcheck atio",
             "event": {
@@ -50,7 +50,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "March 26 10:20:16 tconsec5932.mail.domain shutdown[uam]: shutting down for system reboot",
             "event": {
@@ -62,7 +62,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 9 17:22:51 llu4762.mail.localdomain snmptrapd[scivel]: NET-SNMP version 1.5695 aperi",
             "event": {
@@ -74,7 +74,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 24 00:25:25 estqui6557.www.localhost -:syslog-ng equuntu",
             "event": {
@@ -86,7 +86,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 08 07:27:59 mcolabor1656.www5.corp netauto_discovery[giatq]: quid:fug(uatDuis)10.68.114.91/veri: SNMP Credentials: Failed to authenticate",
             "event": {
@@ -98,7 +98,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 22 14:30:33 exercit4665.internal.domain -:scheduled_ftp_backups Scheduled backup to the eetd was successful - Backup file eip",
             "event": {
@@ -110,7 +110,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 5 21:33:08 iutal13.api.localdomain python[eacomm]: Utenimad: nibusBon.ehend [ueipsaqu]: Populated uidolore niamqu222.localdomain DnsView=tevelit",
             "event": {
@@ -122,7 +122,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 20 04:35:42 boree6686.www5.host ntpd[iinea]: ipit",
             "event": {
@@ -134,7 +134,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 4 11:38:16 itlabori2344.mail.invalid -:openvpn-member OpenVPN 1.4105 [icmp] [aper] essequ",
             "event": {
@@ -146,7 +146,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 18 18:40:50 tessec3539.home nsect: rc6 ntutl",
             "event": {
@@ -158,7 +158,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 2 01:43:25 siuta2896.www.localhost -:ntpd ntpd exiting on signal 2946",
             "event": {
@@ -170,7 +170,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 16 08:45:59 strude910.internal.local pidof[ittenbyC]: can't read sid from aperi",
             "event": {
@@ -182,7 +182,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 30 15:48:33 lores1409.www.home :sSMTP etc",
             "event": {
@@ -194,7 +194,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "September 13 22:51:07 nimadmin1493.www5.example rc3[lpa]: entsu",
             "event": {
@@ -206,7 +206,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "September 28 05:53:42 mqui4683.www.localhost tasuntex: kernel sunt",
             "event": {
@@ -218,7 +218,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "October 12 12:56:16 incidi2966.www.test controld[olupt]: Distribution Complete",
             "event": {
@@ -230,7 +230,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "October 26 19:58:50 ugiatnu5252.internal.localdomain -:syslog erc",
             "event": {
@@ -242,7 +242,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 10 03:01:24 aperia4409.www5.invalid :controld Distribution Started",
             "event": {
@@ -254,7 +254,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 24 10:03:59 emagnama4259.example 10.206.136.206 dhcpd: Average suntinc dynamic DNS update latency: success micro seconds",
             "event": {
@@ -266,7 +266,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "December 8 17:06:33 isno2228.home nnu: smart_check_io dolo",
             "event": {
@@ -278,7 +278,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "December 23 00:09:07 amvolup7700.www5.corp 10.19.194.101 rsyncd: rsync on orinrepr from conse2991.internal.lan (10.116.104.101)",
             "event": {
@@ -290,7 +290,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "January 6 07:11:41 tat7551.internal.local rc6[itinvo]: mdolore",
             "event": {
@@ -302,7 +302,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "January 20 14:14:16 siarchi2289.mail.lan debug_mount[olupta]: mount mipsumd",
             "event": {
@@ -314,7 +314,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "February 3 21:16:50 remi2114.local ionevo: ntpd ntpd exiting on signal 3219",
             "event": {
@@ -326,7 +326,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "February 18 04:19:24 dolor2707.api.localhost httpd[commod]: 2017-2-18 4:19:24.adol [doloremi]: Login_Denied - - to=luptasn ip=10.153.111.103 info=itquiin",
             "event": {
@@ -338,7 +338,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "March 4 11:21:59 que651.www5.host init[etconse]: tincu",
             "event": {
@@ -350,7 +350,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Mar 18 18:24:33 asun1250.api.localdomain DIS[oluptate]: onseq:serunt: Deviceaquaeabi/10.171.157.74login failurefailure",
             "event": {
@@ -362,7 +362,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 2 01:27:07 ento4488.www5.localhost :rc6 eriamea",
             "event": {
@@ -374,7 +374,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 16 08:29:41 pisciv7108.lan 10.140.136.44 named: client 10.31.14.36#2285/key dhcp_updater_default: signer \"vitaedi\" approved",
             "event": {
@@ -386,7 +386,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 30 15:32:16 veniamq1608.www.localdomain colab: diskcheck ommodico",
             "event": {
@@ -398,7 +398,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 14 22:34:50 tin183.api.corp netauto_discovery[sperna]: eabilloi:estia(tper)10.163.5.243/osqui: SNMP Credentials: Failed to authenticate",
             "event": {
@@ -410,7 +410,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 29 05:37:24 fdeFi1123.api.domain INFOBLOX-Grid[etdol]: Started distribution on member with IP address 10.177.36.38",
             "event": {
@@ -422,7 +422,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 12 12:39:58 aevit37.www5.test ati: kernel Linux version 1.6668 (gel) (lorsitam) mpo",
             "event": {
@@ -434,7 +434,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 26 19:42:33 aliquam1364.api.corp -:syslog eratv",
             "event": {
@@ -446,7 +446,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 11 02:45:07 uir1374.mail.domain -:smart_check_io quiratio",
             "event": {
@@ -458,7 +458,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 25 09:47:41 nse2256.www.localdomain equat: db_jnld Resolved conflict for replicated delete of TXT \"derit\" in zone \"dexea\"",
             "event": {
@@ -470,7 +470,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 8 16:50:15 lapar1024.www5.local intocc: sSMTP Unable to locate liqu2936.api.localdomain.",
             "event": {
@@ -482,7 +482,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 22 23:52:50 tDuisaut3296.www.invalid scheduled_ftp_backups[imvenia]: Scheduled backup to the spi was successful - Backup file stquido",
             "event": {
@@ -494,7 +494,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "September 6 06:55:24 upta3300.www.home 10.233.48.103 diskcheck: leumiur",
             "event": {
@@ -506,7 +506,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "September 20 13:57:58 vita2681.www5.local tobea: controld Distribution Complete",
             "event": {
@@ -518,7 +518,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "October 4 21:00:32 ersp3536.www5.lan 10.93.90.240 rsyncd: sent 1792 bytes received 7387 bytes total size tes",
             "event": {
@@ -530,7 +530,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Oct 19 04:03:07 tnulapa7592.www.local DIS[eriti]: litessec: itas: Attempting discover-now for 10.251.106.205 on mporin, using session ID",
             "event": {
@@ -542,7 +542,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 2 11:05:41 roid6604.www.test -:syslog Nemoenim",
             "event": {
@@ -554,7 +554,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 16 18:08:15 nihil657.domain validate_dhcpd[rsitv]: iciade",
             "event": {
@@ -566,7 +566,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "December 1 01:10:49 ven660.api.lan amnih: watchdog cancel, pid = 3981",
             "event": {
@@ -578,7 +578,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "December 15 08:13:24 atatn7364.internal.localdomain debug_mount[ofdeFin]: mount essequam",
             "event": {
@@ -590,7 +590,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "December 29 15:15:58 umqu301.internal.home init[inesci]: isnisi",
             "event": {
@@ -602,7 +602,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "January 12 22:18:32 riamea1540.www.host -:ntpd_initres ntpd exiting on signal 15",
             "event": {
@@ -614,7 +614,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "January 27 05:21:06 siut5663.local piscinge: rcsysinit fsck from 1.271",
             "event": {
@@ -626,7 +626,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "February 10 12:23:41 cinge7339.api.corp -:diskcheck vitaedi",
             "event": {
@@ -638,7 +638,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "February 24 19:26:15 dolore7072.www5.localhost ect: logger modocons",
             "event": {
@@ -650,7 +650,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "March 11 02:28:49 odoconse228.mail.localdomain -:syslog-ng veli",
             "event": {
@@ -662,7 +662,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "March 25 09:31:24 labo267.internal.localhost httpd[etdo]: 2018-3-25 9:31:24.par [lorin]: Login_Denied - - to=pitl ip=10.204.128.215 info=ama",
             "event": {
@@ -674,7 +674,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Apr 8 16:33:58 roidents6540.internal.corp -:debug tametcon",
             "event": {
@@ -686,7 +686,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 22 23:36:32 miurerep1152.internal.domain pidof[utlab]: can't read sid from emUteni",
             "event": {
@@ -698,7 +698,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 07 06:39:06 inimve2352.lan :captured_dns_uploader mco",
             "event": {
@@ -710,7 +710,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 21 13:41:41 amcorp1275.www5.host netauto_core[liqua]: netautoctl:olo",
             "event": {
@@ -722,7 +722,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jun 04 20:44:15 fdeF593.internal.lan DIS[niamq]: lapariat: remagn: Attempting discover-now for 10.238.140.186 on tiaec, using session ID",
             "event": {
@@ -734,7 +734,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 19 03:46:49 upt4986.mail.corp ntpdate[idunt]: luptat",
             "event": {
@@ -746,7 +746,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 3 10:49:23 lillum7809.mail.local taedicta: logger ritt",
             "event": {
@@ -758,7 +758,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 17 17:51:58 tetur2694.mail.local ipi: openvpn-member OpenVPN 1.7727 [ipv6-icmp] [uaeab] itinv",
             "event": {
@@ -770,7 +770,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 1 00:54:32 utaliqu6138.mail.localhost nvolupt: pidof can't read sid from oremi",
             "event": {
@@ -782,7 +782,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 15 07:57:06 atcupi2332.mail.localdomain -:INFOBLOX-Grid Upgrade to ore",
             "event": {
@@ -794,7 +794,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 29 14:59:40 luptatem6874.mail.test purge_scheduled_tasks[dat]: Scheduled tasks have been purged",
             "event": {
@@ -806,7 +806,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "September 12 22:02:15 tame4953.mail.localhost prehen: restarting ntutlabo",
             "event": {
@@ -818,7 +818,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "September 27 05:04:49 sequa1715.www5.domain sshd[eirure]: Accepted password for root from 10.210.113.252 port 4184 udp",
             "event": {
@@ -830,7 +830,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "October 11 12:07:23 tconsec5315.internal.example :kernel Linux version 1.341 (fugi) (labo) nostrud",
             "event": {
@@ -842,7 +842,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "October 25 19:09:57 cupi1867.www5.test :rcsysinit orroq",
             "event": {
@@ -854,7 +854,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 9 02:12:32 rcit2043.api.home 10.107.45.175 smart_check_io: ssecil",
             "event": {
@@ -866,7 +866,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 23 09:15:06 mes4801.internal.test 10.243.121.97 python: cancel: FQDN='illu4875.api.host', View='tatevel'",
             "event": {
@@ -878,7 +878,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "December 7 16:17:40 its7867.internal.invalid 10.44.115.94 debug_mount: mount isn",
             "event": {
@@ -890,7 +890,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Dec 21 23:20:14 equ4808.www.localhost DIS[siuta]: urmagn:dquia: Devicetemporin/10.46.166.75login failuresuccess",
             "event": {
@@ -902,7 +902,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan 05 06:22:49 idi7668.www5.test rum: captured_dns_uploader eataevi",
             "event": {
@@ -914,7 +914,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "January 19 13:25:23 iqu4614.www5.example 10.60.211.199 init: modocon",
             "event": {
@@ -926,7 +926,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "February 2 20:27:57 agnaaliq1829.mail.test :ntpd_initres ntpd exiting on signal 15",
             "event": {
@@ -938,7 +938,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "February 17 03:30:32 col3570.www.invalid tinvolup: sSMTP Sent mail for tsed (inv) uid=rroq username=rcit outbytes=2807",
             "event": {
@@ -950,7 +950,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "March 3 10:33:06 mipsamvo4282.api.home reetdo: init oreveri",
             "event": {
@@ -962,7 +962,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "March 17 17:35:40 Except6889.www.corp -:rc3 umetMal",
             "event": {
@@ -974,7 +974,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Apr 1 00:38:14 umq1309.api.test uae: debug mve",
             "event": {
@@ -986,7 +986,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 15 07:40:49 tatem4180.www.home 10.102.166.19 python: deny: FQDN='eritatis6343.api.local', View='mquisn'",
             "event": {
@@ -998,7 +998,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 29 14:43:23 quir7168.api.localdomain labore: syslog uela",
             "event": {
@@ -1010,7 +1010,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 13 21:45:57 iuntNequ7202.api.domain -:controld Distribution Complete",
             "event": {
@@ -1022,7 +1022,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 28 04:48:31 veniamq1236.invalid emo: radiusd itq",
             "event": {
@@ -1034,7 +1034,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 11 11:51:06 nderiti409.api.domain -:syslog Cic",
             "event": {
@@ -1046,7 +1046,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 25 18:53:40 tatem6156.www.local :dhcpd received shutdown -/-/ success",
             "event": {
@@ -1058,7 +1058,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 10 01:56:14 uamnihil6127.api.domain 10.29.119.245 python: accept: 'olli3116.internal.example' in view 'rsp'.",
             "event": {
@@ -1070,7 +1070,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jul 24 08:58:48 roquisqu1205.api.domain netauto_core[nim]: utaliqu: Attempting CLI on devicersiwith interface not in table, ip10.118.155.14",
             "event": {
@@ -1082,7 +1082,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 7 16:01:23 suntex5169.www.example phonehome[esci]: uov",
             "event": {
@@ -1094,7 +1094,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 21 23:03:57 fici5161.www5.example olup: debug_mount mount aco",
             "event": {
@@ -1106,7 +1106,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "September 5 06:06:31 orsi7617.www5.corp lorsita: shutdown shutting down for system reboot",
             "event": {
@@ -1118,7 +1118,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "September 19 13:09:05 osamnis4912.mail.host npr: radiusd etconsec",
             "event": {
@@ -1130,7 +1130,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Oct 03 20:11:40 urExcept6809.www5.corp captured_dns_uploader[atcupida]: tessequa",
             "event": {
@@ -1142,7 +1142,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Oct 18 03:14:14 icab3519.localdomain dhcpdv6[plicaboN]: Encapsulated Renew message from 2001:db8::b1f51444:f88dd359 port 2496 from client DUID acommo, transaction ID isi",
             "event": {
@@ -1154,7 +1154,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 1 10:16:48 abor4353.www5.host ame: python tesseq",
             "event": {
@@ -1166,7 +1166,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 15 17:19:22 olorem290.api.lan sshd[culpaqui]: deny: logout() unknown",
             "event": {
@@ -1178,7 +1178,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 30 00:21:57 ventore3612.www.home purge_scheduled_tasks[emp]: Scheduled tasks have been purged",
             "event": {
@@ -1190,7 +1190,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Dec 14 07:24:31 uptatem4483.localhost tacacs_acct[inrepr]: mol: Server 10.111.52.69 port 6073: asperna",
             "event": {

--- a/packages/infoblox/data_stream/nios/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/infoblox/data_stream/nios/elasticsearch/ingest_pipeline/default.yml
@@ -8,7 +8,7 @@ processors:
       value: "{{_ingest.timestamp}}"
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   # User agent
   - user_agent:
       field: user_agent.original

--- a/packages/infoblox/manifest.yml
+++ b/packages/infoblox/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: infoblox
 title: Infoblox NIOS
-version: 0.4.0
+version: 0.4.1
 description: This Elastic integration collects logs from Infoblox NIOS
 categories: ["network"]
 release: experimental


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967