### PR TITLE
juniper update to ECS 1.11.0

### DIFF
--- a/packages/juniper/changelog.yml
+++ b/packages/juniper/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.8.2'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1392
 - version: "0.8.1"
   changes:
     - description: Escape special characters in docs

--- a/packages/juniper/data_stream/junos/_dev/test/pipeline/test-generated.log-expected.json
+++ b/packages/juniper/data_stream/junos/_dev/test/pipeline/test-generated.log-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan 29 06:09:59 ceroinBC.exe[6713]: RPD_SCHED_TASK_LONGRUNTIME: : exe ran for 7309(5049)",
             "event": {
@@ -14,7 +14,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Feb 12 13:12:33 DCD_FILTER_LIB_ERROR message repeated [7608]: llu: Filter library initialization failed",
             "event": {
@@ -26,7 +26,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Feb 26 20:15:08 MIB2D_TRAP_SEND_FAILURE: restart [6747]: sum: uaerat: cancel: success",
             "event": {
@@ -38,7 +38,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Mar 12 03:17:42 seq olorema6148.www.localdomain: fug5500.www.domain IFP trace\u003e node: dqu",
             "event": {
@@ -50,7 +50,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Mar 26 10:20:16 ssb SNMPD_CONTEXT_ERROR: [7400]: emq: isiu: success in 6237 context 5367",
             "event": {
@@ -62,7 +62,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Apr 9 17:22:51 RPD_KRT_IFL_CELL_RELAY_MODE_UNSPECIFIED: restart [7618]: ionul: ifl : nibus, unknown",
             "event": {
@@ -74,7 +74,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Apr 24 00:25:25 CHASSISD_SNMP_TRAP10 message repeated [1284]: ume: SNMP trap: failure: ono",
             "event": {
@@ -86,7 +86,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 8 07:27:59 sunt prehen6218.www.localhost: onse.exe[254]: RPD_KRT_IFL_CELL_RELAY_MODE_INVALID: : ifl : inibusBo, failure",
             "event": {
@@ -98,7 +98,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 22 14:30:33 iamquis quirat6972.www5.lan: isc.exe[3237]: SNMPD_USER_ERROR: : conseq: unknown in 6404 user 'atiset' 4068",
             "event": {
@@ -110,7 +110,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jun 5 21:33:08 fpc9 RPD_TASK_REINIT: [4621]: lita: Reinitializing",
             "event": {
@@ -122,7 +122,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jun 20 04:35:42 fpc4 LOGIN_FAILED: [2227]: oinBC: Login failed for user quameius from host ipsumdol4488.api.localdomain",
             "event": {
@@ -134,7 +134,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jul 4 11:38:16 NASD_PPP_SEND_PARTIAL: restart [3994]: aper: Unable to send all of message: santiumd",
             "event": {
@@ -146,7 +146,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jul 18 18:40:50 UI_COMMIT_AT_FAILED message repeated [7440]: temqu: success, minimav",
             "event": {
@@ -158,7 +158,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Aug 2 01:43:25 rnatur ofdeFin7811.lan: emipsumd.exe[5020]: BOOTPD_NEW_CONF: : New configuration installed",
             "event": {
@@ -170,7 +170,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Aug 16 08:45:59 RPD_RIP_JOIN_MULTICAST message repeated [60]: onemulla: Unable to join multicast group enp0s4292: unknown",
             "event": {
@@ -182,7 +182,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Aug 30 15:48:33 FSAD_TERMINATED_CONNECTION: restart [6703]: xea: Open file ites` closed due to unknown",
             "event": {
@@ -194,7 +194,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Sep 13 22:51:07 RPD_KRT_IFL_GENERATION message repeated [5539]: eri: ifl lo2169 generation mismatch -- unknown",
             "event": {
@@ -206,7 +206,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Sep 28 05:53:42 cfeb UI_COMMIT_ROLLBACK_FAILED: [3453]: avolu: Automatic rollback failed",
             "event": {
@@ -218,7 +218,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Oct 12 12:56:16 mquisn.exe[3993]: RMOPD_usage : failure: midest",
             "event": {
@@ -230,7 +230,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Oct 26 19:58:50 undeomni.exe[4938]: RPD_ISIS_LSPCKSUM: : IS-IS 715 LSP checksum error, interface enp0s1965, LSP id tasun, sequence 3203, checksum eratv, lifetime ipsa",
             "event": {
@@ -242,7 +242,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Nov 10 03:01:24 kmd: restart ",
             "event": {
@@ -254,7 +254,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Nov 24 10:03:59 ever.exe[6463]: LOGIN_FAILED: : Login failed for user atq from host erspi4926.www5.test",
             "event": {
@@ -266,7 +266,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Dec 8 17:06:33 CHASSISD_MBUS_ERROR message repeated [72]: iadese: nisiu imad: management bus failed sanity test",
             "event": {
@@ -278,7 +278,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Dec 23 00:09:07 niamquis.exe[1471]: TFTPD_NAK_ERR : nak error ptatems, 357",
             "event": {
@@ -290,7 +290,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan 6 07:11:41 UI_DUPLICATE_UID: restart [3350]: atqu: Users naturau have the same UID olorsita",
             "event": {
@@ -302,7 +302,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan 20 14:14:16 piscivel.exe[4753]: TFTPD_CREATE_ERR: : check_space unknown",
             "event": {
@@ -314,7 +314,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Feb 3 21:16:50 fpc4 RPD_START: [1269]: riat: Start 181 version version built 7425",
             "event": {
@@ -326,7 +326,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Feb 18 04:19:24 fpc2 COSMAN: : uptasnul: delete class_to_ifl table 2069, ifl 3693",
             "event": {
@@ -338,7 +338,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Mar 4 11:21:59 orum oinBCSed3073.www.lan: ilm.exe[3193]: SNMPD_TRAP_QUEUE_MAX_ATTEMPTS: : fugiatqu: after 4003 attempts, deleting 4568 traps queued to exercita",
             "event": {
@@ -350,7 +350,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Mar 18 18:24:33 TFTPD_BIND_ERR: restart [1431]: ntut: bind: failure",
             "event": {
@@ -362,7 +362,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Apr 2 01:27:07 lite ugia517.api.host: doei.exe[7073]: RPD_LDP_SESSIONDOWN: : LDP session 10.88.126.165 is down, failure",
             "event": {
@@ -374,7 +374,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Apr 16 08:29:41 fpc6 SNMPD_CONTEXT_ERROR: [180]: eturadip: ent: unknown in 5848 context 316",
             "event": {
@@ -386,7 +386,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Apr 30 15:32:16 NASD_CHAP_INVALID_CHAP_IDENTIFIER message repeated [796]: iumdo: lo2721: received aturv expected CHAP ID: ectetura",
             "event": {
@@ -398,7 +398,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 14 22:34:50 UI_LOAD_EVENT message repeated [6342]: seq: User 'moll' is performing a 'allow'",
             "event": {
@@ -410,7 +410,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 29 05:37:24 fdeFin.exe[4053]: SNMP_TRAP_TRACE_ROUTE_TEST_FAILED : traceRouteCtlOwnerIndex = 1450, traceRouteCtlTestName = edic",
             "event": {
@@ -422,7 +422,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jun 12 12:39:58 SNMPD_RTSLIB_ASYNC_EVENT: restart [508]: uae: oremip: sequence mismatch failure",
             "event": {
@@ -434,7 +434,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jun 26 19:42:33 tesse olupta2743.internal.localdomain: ine.exe[3181]: BOOTPD_TIMEOUT: : Timeout success unreasonable",
             "event": {
@@ -446,7 +446,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jul 11 02:45:07 NASD_RADIUS_MESSAGE_UNEXPECTED message repeated [33]: abore: Unknown response from RADIUS server: unknown",
             "event": {
@@ -458,7 +458,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jul 25 09:47:41 PWC_LOCKFILE_BAD_FORMAT: restart [3426]: illum: PID lock file has bad format: eprehe",
             "event": {
@@ -470,7 +470,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Aug 8 16:50:15 snostr.exe[1613]: RPD_KRT_AFUNSUPRT : tec: received itaspe message with unsupported address family 4176",
             "event": {
@@ -482,7 +482,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Aug 22 23:52:50 oreeufug.exe[6086]: PWC_PROCESS_FORCED_HOLD : Process plicaboN forcing hold down of child 619 until signal",
             "event": {
@@ -494,7 +494,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Sep 6 06:55:24 MIB2D_IFL_IFINDEX_FAILURE message repeated [4115]: tiu: SNMP index assigned to wri changed from 3902 to unknown",
             "event": {
@@ -506,7 +506,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Sep 20 13:57:58 mwr cia5990.api.localdomain: pitlabo.exe[3498]: UI_DBASE_MISMATCH_MAJOR: : Database header major version number mismatch for file 'ende': expecting 6053, got 4884",
             "event": {
@@ -518,7 +518,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Oct 4 21:00:32 iuntN utfugi851.www5.invalid: nul.exe[1005]: SNMPD_VIEW_INSTALL_DEFAULT: : eetdo: success installing default 1243 view 5146",
             "event": {
@@ -530,7 +530,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Oct 19 04:03:07 DCD_PARSE_STATE_EMERGENCY message repeated [2498]: uptatem: An unhandled state was encountered during interface parsing",
             "event": {
@@ -542,7 +542,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Nov 2 11:05:41 loremagn acons3820.internal.home: ain.exe[7192]: LOGIN_PAM_MAX_RETRIES: : Too many retries while authenticating user iquipex",
             "event": {
@@ -554,7 +554,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Nov 16 18:08:15 onorume.exe[3290]: BOOTPD_NO_BOOTSTRING : No boot string found for type veleu",
             "event": {
@@ -566,7 +566,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Dec 1 01:10:49 eirured sequamn5243.mail.home: sshd: sshd: SSHD_LOGIN_FAILED: Login failed for user 'ciatisun' from host '10.252.209.246'.",
             "event": {
@@ -578,7 +578,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Dec 15 08:13:24 COS: restart : Received FC-\u003eQ map, caecat",
             "event": {
@@ -590,7 +590,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Dec 29 15:15:58 cgatool message repeated : nvolupta: generated address is success",
             "event": {
@@ -602,7 +602,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan 12 22:18:32 CHASSISD_SNMP_TRAP6 message repeated [4667]: idolor: SNMP trap generated: success (les)",
             "event": {
@@ -614,7 +614,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan 27 05:21:06 ssb FLOW_REASSEMBLE_SUCCEED: : Packet merged source 10.102.228.136 destination 10.151.136.250 ipid upt succeed",
             "event": {
@@ -626,7 +626,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Feb 10 12:23:41 DFWD_PARSE_FILTER_EMERGENCY message repeated [2037]: serrorsi: tsedquia encountered errors while parsing filter index file",
             "event": {
@@ -638,7 +638,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Feb 24 19:26:15 remips laboreet5949.mail.test: tesse.exe[4358]: RPD_LDP_SESSIONDOWN: : LDP session 10.148.255.126 is down, unknown",
             "event": {
@@ -650,7 +650,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Mar 11 02:28:49 fpc2 NASD_CHAP_REPLAY_ATTACK_DETECTED: [mipsumqu]: turad: eth680.6195: received doloremi unknown.iciatis",
             "event": {
@@ -662,7 +662,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Mar 25 09:31:24 rema mcol7795.domain: mquis lsys_ssam_handler: : processing lsys root-logical-system tur",
             "event": {
@@ -674,7 +674,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Apr 8 16:33:58 UI_LOST_CONN message repeated [7847]: loreeuf: Lost connection to daemon orainci",
             "event": {
@@ -686,7 +686,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Apr 22 23:36:32 PWC_PROCESS_HOLD: restart [1791]: itse: Process lapari holding down child 2702 until signal",
             "event": {
@@ -698,7 +698,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 7 06:39:06 undeo ficiade4365.mail.domain: norum.exe[4443]: LIBSERVICED_SOCKET_BIND: : dantium: unable to bind socket ors: failure",
             "event": {
@@ -710,7 +710,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 21 13:41:41 liq eleumiu2852.lan: mfugiat.exe[3946]: LOGIN_FAILED: : Login failed for user olu from host mSect5899.domain",
             "event": {
@@ -722,7 +722,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jun 4 20:44:15 idolo.exe[6535]: MIB2D_IFL_IFINDEX_FAILURE: : SNMP index assigned to deseru changed from 6460 to unknown",
             "event": {
@@ -734,7 +734,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jun 19 03:46:49 modtempo.exe[5276]: CHASSISD_RELEASE_MASTERSHIP: : Release mastership notification",
             "event": {
@@ -746,7 +746,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jul 3 10:49:23 fpc4 PWC_PROCESS_HOLD: [3450]: dexea: Process aturExc holding down child 7343 until signal",
             "event": {
@@ -758,7 +758,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jul 17 17:51:58 ame.exe[226]: SERVICED_RTSOCK_SEQUENCE : boreet: routing socket sequence error, unknown",
             "event": {
@@ -770,7 +770,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Aug 1 00:54:32 consect6919.mail.localdomain iset.exe[940]: idpinfo: urere",
             "event": {
@@ -782,7 +782,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Aug 15 07:57:06 RPD_KRT_NOIFD: restart [4822]: oreeufug: No device 5020 for interface lo4593",
             "event": {
@@ -794,7 +794,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Aug 29 14:59:40 eprehen oinB3432.api.invalid: citatio.exe[5029]: craftd: , unknown",
             "event": {
@@ -806,7 +806,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Sep 12 22:02:15 ACCT_CU_RTSLIB_error message repeated [7583]: eetd: liquide getting class usage statistics for interface enp0s2674: success",
             "event": {
@@ -818,7 +818,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Sep 27 05:04:49 userro oree nimadmi7341.www.home RT_FLOW - kmd [",
             "event": {
@@ -830,7 +830,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Oct 11 12:07:23 LOGIN_PAM_NONLOCAL_USER: restart [686]: rauto: User rese authenticated but has no local login ID",
             "event": {
@@ -842,7 +842,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Oct 25 19:09:57 doconse.exe[6184]: RPD_KRT_NOIFD : No device 5991 for interface enp0s7694",
             "event": {
@@ -854,7 +854,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Nov 9 02:12:32 quidolor1064.www.domain: uspinfo: : flow_print_session_summary_output received rcita",
             "event": {
@@ -866,7 +866,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Nov 23 09:15:06 RPD_TASK_REINIT: restart [1810]: mfugi: Reinitializing",
             "event": {
@@ -878,7 +878,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Dec 7 16:17:40 inibusBo.exe[2509]: ECCD_TRACE_FILE_OPEN_FAILED : allow: failure",
             "event": {
@@ -890,7 +890,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Dec 21 23:20:14 ECCD_TRACE_FILE_OPEN_FAILED message repeated [2815]: rudexer: accept: unknown",
             "event": {
@@ -902,7 +902,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan 5 06:22:49 eseosqu oeius641.api.home: laud.exe[913]: LOGIN_FAILED: : Login failed for user turQ from host tod6376.mail.host",
             "event": {
@@ -914,7 +914,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan 19 13:25:23 ine.exe[1578]: FSAD_CONNTIMEDOUT : Connection timed out to the client (oreve2538.www.localdomain, 10.44.24.103) having request type reprehen",
             "event": {
@@ -926,7 +926,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Feb 2 20:27:57 UI_SCHEMA_SEQUENCE_ERROR: restart [734]: rinre: Schema sequence number mismatch",
             "event": {
@@ -938,7 +938,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Feb 17 03:30:32 LIBJNX_EXEC_PIPE: restart [946]: olors: Unable to create pipes for command 'deny': unknown",
             "event": {
@@ -950,7 +950,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Mar 3 10:33:06 UI_DBASE_MISMATCH_EXTENT: restart [4686]: isnost: Database header extent mismatch for file 'lumdolor': expecting 559, got 7339",
             "event": {
@@ -962,7 +962,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Mar 17 17:35:40 NASD_usage message repeated [7744]: eumfu: unknown: quidex",
             "event": {
@@ -974,7 +974,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Apr 1 00:38:14 /kmd: ",
             "event": {
@@ -986,7 +986,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Apr 15 07:40:49 sshd message repeated : very-high: can't get client address: unknown",
             "event": {
@@ -998,7 +998,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Apr 29 14:43:23 fpc4 RPD_LDP_NBRUP: [4279]: stlaboru: LDP neighbor 10.248.68.242 (eth1282) is success",
             "event": {
@@ -1010,7 +1010,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 13 21:45:57 uun iduntutl4723.example: uel.exe[5770]: SNMPD_TRAP_QUEUE_DRAINED: : metco: traps queued to vel sent successfully",
             "event": {
@@ -1022,7 +1022,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 28 04:48:31 fpc8 ECCD_PCI_WRITE_FAILED: [4837]: radip: cancel: success",
             "event": {
@@ -1034,7 +1034,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jun 11 11:51:06 TFTPD_RECVCOMPLETE_INFO message repeated [7501]: piciatis: Received 3501 blocks of 5877 size for file 'tatisetq'",
             "event": {
@@ -1046,7 +1046,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jun 25 18:53:40 usp_trace_ipc_reconnect message repeated illum.exe:USP trace client cannot reconnect to server",
             "event": {
@@ -1058,7 +1058,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jul 10 01:56:14 amnis atevelit2799.internal.host: tatiset.exe IFP trace\u003e BCHIP: : cannot write ucode mask reg",
             "event": {
@@ -1070,7 +1070,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jul 24 08:58:48 RPD_MPLS_LSP_DOWN message repeated [5094]: moditemp: MPLS LSP eth2042 unknown",
             "event": {
@@ -1082,7 +1082,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Aug 7 16:01:23 CHASSISD_PARSE_INIT: restart [4153]: uatDuisa: Parsing configuration file 'usB'",
             "event": {
@@ -1094,7 +1094,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Aug 21 23:03:57 RMOPD_ROUTING_INSTANCE_NO_INFO: restart [6922]: upidatat: No information for routing instance non: failure",
             "event": {
@@ -1106,7 +1106,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Sep 5 06:06:31 Utenimad.exe[4305]: CHASSISD_TERM_SIGNAL: : Received SIGTERM request, success",
             "event": {
@@ -1118,7 +1118,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Sep 19 13:09:05 tseddo.exe[484]: RPD_OSPF_NBRUP : OSPF neighbor 10.49.190.163 (lo50) aUteni due to failure",
             "event": {
@@ -1130,7 +1130,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Oct 3 20:11:40 cfeb NASD_usage: [6968]: litseddo: failure: metconse",
             "event": {
@@ -1142,7 +1142,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Oct 18 03:14:14 RPD_LDP_NBRDOWN message repeated [4598]: emu: LDP neighbor 10.101.99.109 (eth4282) is success",
             "event": {
@@ -1154,7 +1154,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Nov 1 10:16:48 RPD_RDISC_NOMULTI message repeated [4764]: con: Ignoring interface 594 on lo7449 -- unknown",
             "event": {
@@ -1166,7 +1166,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Nov 15 17:19:22 BOOTPD_NEW_CONF: restart [1768]: isquames: New configuration installed",
             "event": {
@@ -1178,7 +1178,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Nov 30 00:21:57 SNMP_TRAP_LINK_DOWN message repeated [7368]: ngelit: ifIndex 4197, ifAdminStatus ons, ifOperStatus unknown, ifName lo3193",
             "event": {
@@ -1190,7 +1190,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Dec 14 07:24:31 MIB2D_ATM_ERROR message repeated [4927]: udexerci: voluptat: failure",
             "event": {

--- a/packages/juniper/data_stream/junos/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/juniper/data_stream/junos/elasticsearch/ingest_pipeline/default.yml
@@ -8,7 +8,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   # User agent
   - user_agent:
       field: user_agent.original

--- a/packages/juniper/data_stream/netscreen/_dev/test/pipeline/test-generated.log-expected.json
+++ b/packages/juniper/data_stream/netscreen/_dev/test/pipeline/test-generated.log-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "modtempo: NetScreen device_id=olab system-low-00628(rci): audit log queue Event Alarm Log is overwritten (2016-1-29 06:09:59)",
             "event": {
@@ -14,7 +14,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "luptat: NetScreen device_id=isiutal [moenimi]system-low-00620(gnaali): RTSYNC: Timer to purge the DRP backup routes is stopped. (2016-2-12 13:12:33)",
             "event": {
@@ -26,7 +26,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "deomni: NetScreen device_id=tquovol [ntsuntin]system-medium-00062(tatno): Track IP IP address 10.159.227.210 succeeded. (ofdeF)",
             "event": {
@@ -38,7 +38,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "untutlab: NetScreen device_id=tem [ons]system-medium-00004: DNS lookup time has been changed to start at ationu:ali with an interval of nsect",
             "event": {
@@ -50,7 +50,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "eve: NetScreen device_id=tatiset [eprehen]system-medium-00034(piscing): Ethernet driver ran out of rx bd (port 1044)",
             "event": {
@@ -62,7 +62,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "eomnisis: NetScreen device_id=mqui [civeli]system-high-00026: SCS: SCS has been tasuntex for enp0s5377 .",
             "event": {
@@ -74,7 +74,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "rehender: NetScreen device_id=eporroqu [uat]system-high-00026(atquovo): SSH: Maximum number of PKA keys (suntinc) has been bound to user 'xeac' Key not bound. (Key ID nidolo)",
             "event": {
@@ -86,7 +86,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "intoccae: NetScreen device_id=ents [pida]system-low-00535(idolor): PKCS #7 data cannot be decapsulated",
             "event": {
@@ -98,7 +98,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "numqu: NetScreen device_id=qui [No Name]system-medium-00520: Active Server Switchover: New requests for equi server will try agnaali from now on. (2016-5-22 14:30:33)",
             "event": {
@@ -110,7 +110,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ipitla: NetScreen device_id=quae [maccusa]system-high-00072(rQuisau): NSRP: Unit idex of VSD group xerci aqu",
             "event": {
@@ -122,7 +122,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "atu: NetScreen device_id=umexerci [ern]system-low-00084(iadese): RTSYNC: NSRP route synchronization is nsectet",
             "event": {
@@ -134,7 +134,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "dol: NetScreen device_id=leumiu [namali]system-medium-00527(atevel): MAC address 01:00:5e:11:0a:26 has detected an IP conflict and has declined address 10.90.127.74",
             "event": {
@@ -146,7 +146,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "acc: NetScreen device_id=amc [atur]system-low-00050(corp): Track IP enabled (2016-7-18 18:40:50)",
             "event": {
@@ -158,7 +158,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "tper: NetScreen device_id=olor [Neque]system-medium-00524(xerc): SNMP request from an unknown SNMP community public at 10.61.30.190:2509 has been received. (2016-8-2 01:43:25)",
             "event": {
@@ -170,7 +170,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "etdol: NetScreen device_id=uela [boN]system-medium-00521: Can't connect to E-mail server 10.210.240.175",
             "event": {
@@ -182,7 +182,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ati: NetScreen device_id=tlabo [uames]system-medium-00553(mpo): SCAN-MGR: Set maximum content size to offi.",
             "event": {
@@ -194,7 +194,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "umwr: NetScreen device_id=oluptate [issus]system-high-00005(uaUteni): SYN flood udantium has been changed to pre",
             "event": {
@@ -206,7 +206,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "tate: NetScreen device_id=imvenia [spi]system-high-00038(etdo): OSPF routing instance in vrouter urerepr is ese",
             "event": {
@@ -218,7 +218,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "smo: NetScreen device_id=etcons [iusmodi]system-medium-00012: ate Service group uiac has epte member idolo from host 10.170.139.87",
             "event": {
@@ -230,7 +230,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ersp: NetScreen device_id=tquov [diconseq]system-high-00551(mod): Rapid Deployment cannot start because gateway has undergone configuration changes. (2016-10-26 19:58:50)",
             "event": {
@@ -242,7 +242,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "mquame: NetScreen device_id=nihilmol [xercita]system-medium-00071(tiumt): The local device reetdolo in the Virtual Security Device group norum changed state",
             "event": {
@@ -254,7 +254,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "isnisi: NetScreen device_id=ritatise [uamei]system-medium-00057(quatur): uisa: static multicast route src=10.198.41.214, grp=cusant input ifp = lo2786 output ifp = eth3657 added",
             "event": {
@@ -266,7 +266,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "isis: NetScreen device_id=uasiar [utlab]system-high-00075(loremqu): The local device dantium in the Virtual Security Device group lor velillu",
             "event": {
@@ -278,7 +278,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "bor: NetScreen device_id=rauto [ationev]system-low-00039(mdol): BGP instance name created for vr itation",
             "event": {
@@ -290,7 +290,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "iaeco: NetScreen device_id=equaturv [siu]system-high-00262(veniamqu): Admin user rum has been rejected via the quaea server at 10.11.251.51",
             "event": {
@@ -302,7 +302,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "orroq: NetScreen device_id=vitaedic [orin]system-high-00038(ons): OSPF routing instance in vrouter remagn ecillu",
             "event": {
@@ -314,7 +314,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "enderit: NetScreen device_id=taut [tanimi]system-medium-00515(commodi): emporain Admin User \"ntiumto\" logged in for umetMalo(https) management (port 2206) from 10.80.237.27:2883",
             "event": {
@@ -326,7 +326,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ori: NetScreen device_id=tconsect [rum]system-high-00073(eporroq): NSRP: Unit ulla of VSD group iqu oin",
             "event": {
@@ -338,7 +338,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "mipsum: NetScreen device_id=lmo [aliquamq]system-medium-00030: X509 certificate for ScreenOS image authentication is invalid",
             "event": {
@@ -350,7 +350,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "orroqu: NetScreen device_id=elitsed [labore]system-medium-00034(erc): PPPoE Settings changed",
             "event": {
@@ -362,7 +362,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ntNe: NetScreen device_id=itanim [nesciun]system-medium-00612: Switch event: the status of ethernet port mollita changed to link down , duplex full , speed 10 M. (2017-4-2 01:27:07)",
             "event": {
@@ -374,7 +374,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "quide: NetScreen device_id=quaU [undeomni]system-medium-00077(acomm): NSRP: local unit= iutali of VSD group itat stlaboru",
             "event": {
@@ -386,7 +386,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "emq: NetScreen device_id=plicaboN [amc]system-high-00536(acommo): IKE 10.10.77.119: Dropped packet because remote gateway OK is not used in any VPN tunnel configurations",
             "event": {
@@ -398,7 +398,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "scivel: NetScreen device_id=henderi [iusmodt]system-medium-00536(tquas): IKE 10.200.22.41: Received incorrect ID payload: IP address lorinr instead of IP address ercita",
             "event": {
@@ -410,7 +410,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "equu: NetScreen device_id=sintoc [atae]system-medium-00203(tem): mestq lsa flood on interface eth82 has dropped a packet.",
             "event": {
@@ -422,7 +422,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "iqui: NetScreen device_id=tesseci [tat]system-high-00011(cive): The virtual router nse has been made unsharable",
             "event": {
@@ -434,7 +434,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "rroqui: NetScreen device_id=ursin [utemvel]system-medium-00002: ADMIN AUTH: Privilege requested for unknown user atu. Possible HA syncronization problem.",
             "event": {
@@ -446,7 +446,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "orumSe: NetScreen device_id=dolor [isiut]system-high-00206(emagn): OSPF instance with router-id emulla received a Hello packet flood from neighbor (IP address 10.219.1.151, router ID mnihilm) on Interface enp0s3375 forcing the interface to drop the packet.",
             "event": {
@@ -458,7 +458,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "eque: NetScreen device_id=eufug [est]system-medium-00075: The local device ntincul in the Virtual Security Device group reet tquo",
             "event": {
@@ -470,7 +470,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "imadmini: NetScreen device_id=ide [edq]system-medium-00026(tise): SSH: Attempt to unbind PKA key from admin user 'ntut' (Key ID emullam)",
             "event": {
@@ -482,7 +482,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ihilmole: NetScreen device_id=saquaea [ons]system-high-00048(quas): Route map entry with sequence number gia in route map binck-ospf in virtual router itatio was porinc (2017-8-22 23:52:50)",
             "event": {
@@ -494,7 +494,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "orum: NetScreen device_id=oinBCSed [orem]system-medium-00050(ilm): Track IP enabled (2017-9-6 06:55:24)",
             "event": {
@@ -506,7 +506,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ncididun: NetScreen device_id=hen [periamea]system-medium-00555: Vrouter ali PIMSM cannot process non-multicast address 10.158.18.51",
             "event": {
@@ -518,7 +518,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "umwri: NetScreen device_id=odoc [atura]system-high-00030: SYSTEM CPU utilization is high (oreeu \u003e nvo ) iamqui times in tassita minute (2017-10-4 21:00:32)\u003c\u003ccolabori\u003e",
             "event": {
@@ -530,7 +530,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inc: NetScreen device_id=tect [uiad]system-low-00003: The console debug buffer has been roinBCSe",
             "event": {
@@ -542,7 +542,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "nseq: NetScreen device_id=borumSec [tatemseq]system-medium-00026(dmi): SCS has been tam for eth7686 .",
             "event": {
@@ -554,7 +554,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "uiineavo: NetScreen device_id=sistena [uidexeac]system-high-00620(amquisno): RTSYNC: Event posted to send all the DRP routes to backup device. (2017-11-16 18:08:15)",
             "event": {
@@ -566,7 +566,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "sunt: NetScreen device_id=dquianon [urExc]system-high-00025(iamqui): PKI: The current device quide to save the certificate authority configuration.",
             "event": {
@@ -578,7 +578,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "etdol: NetScreen device_id=Sed [oremeumf]system-high-00076: The local device etur in the Virtual Security Device group fugiatn enima",
             "event": {
@@ -590,7 +590,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "giatquo: NetScreen device_id=lors [its]system-low-00524: SNMP request from an unknown SNMP community public at 10.46.217.155:76 has been received. (2017-12-29 15:15:58)",
             "event": {
@@ -602,7 +602,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "magnaa: NetScreen device_id=sumquiad [No Name]system-high-00628: audit log queue Event Log is overwritten (2018-1-12 22:18:32)",
             "event": {
@@ -614,7 +614,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "tnulapa: NetScreen device_id=madmi [No Name]system-high-00628(adeser): audit log queue Event Log is overwritten (2018-1-27 05:21:06)",
             "event": {
@@ -626,7 +626,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "laboree: NetScreen device_id=udantiu [itametco]system-high-00556(stiaecon): UF-MGR: usBono CPA server port changed to rumexe.",
             "event": {
@@ -638,7 +638,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "nturmag: NetScreen device_id=uredol [maliqua]system-medium-00058(mquia): PIMSM protocol configured on interface eth2266",
             "event": {
@@ -650,7 +650,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ueporroq: NetScreen device_id=ute [No Name]system-low-00625: Session (id tationu src-ip 10.142.21.251 dst-ip 10.154.16.147 dst port 6881) route is valid. (2018-3-11 02:28:49)",
             "event": {
@@ -662,7 +662,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "adipi: NetScreen device_id=mquis [ratvo]system-low-00042(isno): Replay packet detected on IPSec tunnel on enp0s1170 with tunnel ID nderiti! From 10.105.212.51 to 10.119.53.68/1783, giatqu (2018-3-25 09:31:24)",
             "event": {
@@ -674,7 +674,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "emvel: NetScreen device_id=pta [dolo]system-medium-00057(eacommod): uamqu: static multicast route src=10.174.2.175, grp=aparia input ifp = lo6813 output ifp = enp0s90 added",
             "event": {
@@ -686,7 +686,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "giat: NetScreen device_id=ttenb [eirure]system-high-00549(rem): add-route-\u003e untrust-vr: exer",
             "event": {
@@ -698,7 +698,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "lapari: NetScreen device_id=rcitat [cinge]system-high-00536(luptate): IKE gateway eritqu has been elites. pariat",
             "event": {
@@ -710,7 +710,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "accus: NetScreen device_id=CSed [tiu]system-low-00049(upta): The router-id of virtual router \"asper\" used by OSPF, BGP routing instances id has been uninitialized. (dictasun)",
             "event": {
@@ -722,7 +722,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "itanimi: NetScreen device_id=onoru [data]system-high-00064(eosqui): Can not create track-ip list",
             "event": {
@@ -734,7 +734,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "int: NetScreen device_id=ionevo [llitani]system-high-00541(itametco): The system killed OSPF neighbor because the current router could not see itself in the hello packet. Neighbor changed state from etcons to etco state, (neighbor router-id 1iuntN, ip-address 10.89.179.48). (2018-6-19 03:46:49)",
             "event": {
@@ -746,7 +746,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "mmodicon: NetScreen device_id=eetdo [mquisno]system-low-00017(lup): mipsamv From 10.57.108.5:5523 using protocol icmp on interface enp0s4987. The attack occurred 2282 times",
             "event": {
@@ -758,7 +758,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inimve: NetScreen device_id=aea [emipsumd]system-low-00263(ptat): Admin user saq has been accepted via the asiarch server at 10.197.10.110",
             "event": {
@@ -770,7 +770,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "tlab: NetScreen device_id=vel [ionevo]system-high-00622: NHRP : NHRP instance in virtual router ptate is created. (2018-8-1 00:54:32)",
             "event": {
@@ -782,7 +782,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "qui: NetScreen device_id=caboN [imipsam]system-high-00528(catcupid): SSH: Admin user 'ritquiin' at host 10.59.51.171 requested unsupported authentication method texplica",
             "event": {
@@ -794,7 +794,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "udexerci: NetScreen device_id=uae [imveni]system-medium-00071(ptatemse): NSRP: Unit itationu of VSD group setquas nbyCi",
             "event": {
@@ -806,7 +806,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "isno: NetScreen device_id=luptatev [occaeca]system-high-00018(urau): aeca Policy (oNem, itaedict ) was eroi from host 10.80.103.229 by admin fugitsed (2018-9-12 22:02:15)",
             "event": {
@@ -818,7 +818,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "utlabore: NetScreen device_id=edquiano [mSecti]system-high-00207(tDuisaut): RIP database size limit exceeded for uel, RIP route dropped.",
             "event": {
@@ -830,7 +830,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "agn: NetScreen device_id=iqu [quamqua]system-high-00075: NSRP: Unit equeporr of VSD group amremap oremagna",
             "event": {
@@ -842,7 +842,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ntium: NetScreen device_id=ide [quunturm]system-low-00040(isautem): High watermark for early aging has been changed to the default usan",
             "event": {
@@ -854,7 +854,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "catcu: NetScreen device_id=quame [tionemu]system-low-00524(eursi): SNMP host 10.163.9.35 cannot be removed from community uatDu because failure",
             "event": {
@@ -866,7 +866,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "cteturad: NetScreen device_id=modi [No Name]system-low-00625(ecatcu): Session (id ntoccae src-ip 10.51.161.245 dst-ip 10.193.80.21 dst port 5657) route is valid. (2018-11-23 09:15:06)",
             "event": {
@@ -878,7 +878,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "chit: NetScreen device_id=iusmodit [lor]system-high-00524(adeserun): SNMP request has been received, but success",
             "event": {
@@ -890,7 +890,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "vento: NetScreen device_id=litsed [ciun]system-medium-00072: The local device inrepr in the Virtual Security Device group lla changed state",
             "event": {
@@ -902,7 +902,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "rissusci: NetScreen device_id=uaturQ [iusmod]system-medium-00533(mips): VIP server 10.41.222.7 is now responding",
             "event": {
@@ -914,7 +914,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "upta: NetScreen device_id=ivel [tmollita]system-low-00070(deFinib): NSRP: nsrp control channel change to lo4065",
             "event": {
@@ -926,7 +926,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ommodic: NetScreen device_id=mmodic [essequam]system-low-00040(nihi): VPN 'xeaco' from 10.134.20.213 is eavolupt (2019-2-2 20:27:57)",
             "event": {
@@ -938,7 +938,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ptasnul: NetScreen device_id=utaliqui [mcorpor]system-medium-00023(ostru): VIP/load balance server 10.110.144.189 cannot be contacted",
             "event": {
@@ -950,7 +950,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "luptatem: NetScreen device_id=ing [hen]system-medium-00034(umquid): SCS: SCS has been olabo for tasnu with conse existing PKA keys already bound to ruredolo SSH users.",
             "event": {
@@ -962,7 +962,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "iat: NetScreen device_id=orain [equaturQ]system-low-00554: SCAN-MGR: Attempted to load AV pattern file created quia after the AV subscription expired. (Exp: Exce)",
             "event": {
@@ -974,7 +974,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "dese: NetScreen device_id=ptasn [liqui]system-low-00541: ScreenOS invol serial # Loremips: Asset recovery has been cidun",
             "event": {
@@ -986,7 +986,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ole: NetScreen device_id=odi [tper]system-medium-00628(ectetur): audit log queue Event Log is overwritten (2019-4-15 07:40:49)",
             "event": {
@@ -998,7 +998,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "iadolo: NetScreen device_id=ecatcup [No Name]system-high-00628: audit log queue Traffic Log is overwritten (2019-4-29 14:43:23)",
             "event": {
@@ -1010,7 +1010,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "qui: NetScreen device_id=iaecon [dminima]system-high-00538(psaquaea): NACN failed to register to Policy Manager eabillo because of success",
             "event": {
@@ -1022,7 +1022,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "eosqu: NetScreen device_id=reetdolo [umquam]system-low-00075(enderi): The local device labore in the Virtual Security Device group uasiarch changed state from iamquisn to inoperable. (2019-5-28 04:48:31)",
             "event": {
@@ -1034,7 +1034,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "veleumi: NetScreen device_id=volupt [equ]system-high-00535(ure): SCEP_FAILURE message has been received from the CA",
             "event": {
@@ -1046,7 +1046,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "reseo: NetScreen device_id=entoreve [rudexer]system-medium-00026(iruredol): IKE iad: Missing heartbeats have exceeded the threshold. All Phase 1 and 2 SAs have been removed",
             "event": {
@@ -1058,7 +1058,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ptate: NetScreen device_id=oloreeu [imipsa]system-high-00038: OSPF routing instance in vrouter uame taevitae",
             "event": {
@@ -1070,7 +1070,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "archi: NetScreen device_id=caboNe [ptate]system-high-00003(ius): Multiple authentication failures have been detected!",
             "event": {
@@ -1082,7 +1082,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "remap: NetScreen device_id=ntium [veniamqu]system-high-00529: DNS entries have been refreshed by HA",
             "event": {
@@ -1094,7 +1094,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "llumdo: NetScreen device_id=tot [itquii]system-high-00625(erspici): Session (id oreeu src-ip 10.126.150.15 dst-ip 10.185.50.112 dst port 7180) route is invalid. (2019-8-21 23:03:57)",
             "event": {
@@ -1106,7 +1106,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "quepo: NetScreen device_id=tDuisa [iscive]system-medium-00521: Can't connect to E-mail server 10.152.90.59",
             "event": {
@@ -1118,7 +1118,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "lorem: NetScreen device_id=icons [hende]system-low-00077(usBonor): HA link disconnect. Begin to use second path of HA",
             "event": {
@@ -1130,7 +1130,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "preh: NetScreen device_id=dol [No Name]system-low-00625: Session (id gnamal src-ip 10.119.181.171 dst-ip 10.166.144.66 dst port 3051) route is invalid. (2019-10-3 20:11:40)",
             "event": {
@@ -1142,7 +1142,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "avolup: NetScreen device_id=litse [archit]system-high-00041(untutlab): A route-map name in virtual router estqu has been removed",
             "event": {
@@ -1154,7 +1154,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "eddoeiu: NetScreen device_id=consect [eetdolo]system-medium-00038(remipsum): OSPF routing instance in vrouter ons emporin",
             "event": {
@@ -1166,7 +1166,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "texpl: NetScreen device_id=isquames [No Name]system-low-00021: DIP port-translation stickiness was atio by utla via ntm from host 10.96.165.147 to 10.96.218.99:277 (2019-11-15 17:19:22)",
             "event": {
@@ -1178,7 +1178,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "elaudant: NetScreen device_id=ratvolu [odte]system-medium-00021(eum): DIP port-translation stickiness was uidol by repr via idu from host 10.201.72.59 to 10.230.29.67:7478 (2019-11-30 00:21:57)",
             "event": {
@@ -1190,7 +1190,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "toc: NetScreen device_id=rau [sciuntN]system-low-00602: PIMSM Error in initializing interface state change",
             "event": {

--- a/packages/juniper/data_stream/netscreen/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/juniper/data_stream/netscreen/elasticsearch/ingest_pipeline/default.yml
@@ -8,7 +8,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   # User agent
   - user_agent:
       field: user_agent.original

--- a/packages/juniper/data_stream/srx/_dev/test/pipeline/test-atp.log-expected.json
+++ b/packages/juniper/data_stream/srx/_dev/test/pipeline/test-atp.log-expected.json
@@ -72,7 +72,7 @@
             },
             "@timestamp": "2013-12-14T16:06:59.134Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -117,7 +117,7 @@
             },
             "@timestamp": "2016-09-20T17:43:30.330Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -181,7 +181,7 @@
             },
             "@timestamp": "2016-09-20T17:40:30.050Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -300,7 +300,7 @@
             },
             "@timestamp": "2007-02-15T09:17:15.719Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [

--- a/packages/juniper/data_stream/srx/_dev/test/pipeline/test-flow.log-expected.json
+++ b/packages/juniper/data_stream/srx/_dev/test/pipeline/test-flow.log-expected.json
@@ -63,7 +63,7 @@
             },
             "@timestamp": "2019-11-14T08:37:51.184Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -149,7 +149,7 @@
             },
             "@timestamp": "2019-11-14T10:12:46.573Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -255,7 +255,7 @@
             },
             "@timestamp": "2014-05-01T08:26:51.179Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -380,7 +380,7 @@
             },
             "@timestamp": "2014-05-01T08:28:10.933Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -496,7 +496,7 @@
             },
             "@timestamp": "2013-11-04T16:23:09.264Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -598,7 +598,7 @@
             },
             "@timestamp": "2010-09-30T06:55:04.323Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -710,7 +710,7 @@
             },
             "@timestamp": "2010-09-30T06:55:07.188Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -841,7 +841,7 @@
             },
             "@timestamp": "2019-04-12T14:29:06.576Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -950,7 +950,7 @@
             },
             "@timestamp": "2019-04-13T14:33:06.576Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1092,7 +1092,7 @@
             },
             "@timestamp": "2018-10-07T01:32:20.898Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1217,7 +1217,7 @@
             },
             "@timestamp": "2018-06-30T02:17:22.753Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1328,7 +1328,7 @@
             },
             "@timestamp": "2015-09-25T14:19:53.846Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1459,7 +1459,7 @@
             },
             "@timestamp": "2013-01-19T15:18:17.040Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1592,7 +1592,7 @@
             },
             "@timestamp": "2013-01-19T15:18:17.040Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1732,7 +1732,7 @@
             },
             "@timestamp": "2013-01-19T15:18:17.040Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1877,7 +1877,7 @@
             },
             "@timestamp": "2013-01-19T15:18:18.040Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2019,7 +2019,7 @@
             },
             "@timestamp": "2013-01-19T15:18:19.040Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2160,7 +2160,7 @@
             },
             "@timestamp": "2013-01-19T15:18:20.040Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2279,7 +2279,7 @@
             },
             "@timestamp": "2020-11-04T16:23:09.264Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -2364,7 +2364,7 @@
             },
             "@timestamp": "2020-11-14T10:12:46.573Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -2499,7 +2499,7 @@
             },
             "@timestamp": "2020-01-19T15:18:20.040Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2628,7 +2628,7 @@
             },
             "@timestamp": "2020-07-14T14:17:11.928Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -2764,7 +2764,7 @@
             },
             "@timestamp": "2020-07-13T16:43:05.041Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -2883,7 +2883,7 @@
             },
             "@timestamp": "2020-07-13T16:12:05.530Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -3007,7 +3007,7 @@
             },
             "@timestamp": "2020-07-13T16:12:05.530Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/juniper/data_stream/srx/_dev/test/pipeline/test-idp.log-expected.json
+++ b/packages/juniper/data_stream/srx/_dev/test/pipeline/test-idp.log-expected.json
@@ -86,7 +86,7 @@
             },
             "@timestamp": "2020-03-02T23:13:03.193Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -215,7 +215,7 @@
             },
             "@timestamp": "2020-03-02T23:13:03.197Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -339,7 +339,7 @@
             },
             "@timestamp": "2007-02-15T09:17:15.719Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -460,7 +460,7 @@
             },
             "@timestamp": "2017-10-12T21:55:55.792Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -548,7 +548,7 @@
             },
             "@timestamp": "2011-10-23T02:06:26.544Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -639,7 +639,7 @@
             },
             "@timestamp": "2011-10-23T16:28:31.696Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -735,7 +735,7 @@
             },
             "@timestamp": "2012-10-23T17:28:31.696Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/juniper/data_stream/srx/_dev/test/pipeline/test-ids.log-expected.json
+++ b/packages/juniper/data_stream/srx/_dev/test/pipeline/test-ids.log-expected.json
@@ -73,7 +73,7 @@
             },
             "@timestamp": "2018-07-19T23:17:02.309Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -144,7 +144,7 @@
             },
             "@timestamp": "2018-07-19T23:18:02.309Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -245,7 +245,7 @@
             },
             "@timestamp": "2018-07-19T23:19:02.309Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -346,7 +346,7 @@
             },
             "@timestamp": "2018-07-19T23:22:02.309Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -444,7 +444,7 @@
             },
             "@timestamp": "2018-07-19T23:25:02.309Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -544,7 +544,7 @@
             },
             "@timestamp": "2018-07-19T23:26:02.309Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -613,7 +613,7 @@
             },
             "@timestamp": "2018-07-19T23:27:02.309Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -707,7 +707,7 @@
             },
             "@timestamp": "2018-07-19T23:28:02.309Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -786,7 +786,7 @@
             },
             "@timestamp": "2018-07-20T00:19:02.309Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -861,7 +861,7 @@
             },
             "@timestamp": "2018-07-20T00:19:02.309Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -930,7 +930,7 @@
             },
             "@timestamp": "2020-07-17T07:54:43.912Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1001,7 +1001,7 @@
             },
             "@timestamp": "2020-07-17T08:01:43.006Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/juniper/data_stream/srx/_dev/test/pipeline/test-secintel.log-expected.json
+++ b/packages/juniper/data_stream/srx/_dev/test/pipeline/test-secintel.log-expected.json
@@ -66,7 +66,7 @@
             },
             "@timestamp": "2016-10-17T15:18:11.618Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -167,7 +167,7 @@
             },
             "@timestamp": "2016-10-17T15:18:11.618Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [

--- a/packages/juniper/data_stream/srx/_dev/test/pipeline/test-utm.log-expected.json
+++ b/packages/juniper/data_stream/srx/_dev/test/pipeline/test-utm.log-expected.json
@@ -58,7 +58,7 @@
             },
             "@timestamp": "2016-02-18T01:32:50.391Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -151,7 +151,7 @@
             },
             "@timestamp": "2016-02-18T01:32:50.391Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -243,7 +243,7 @@
                 "name": "www.eicar.org/download/eicar.com"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -329,7 +329,7 @@
                 "name": "www.google.com/"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -392,7 +392,7 @@
                 "name": "10.2.1.101/images/junos- srxsme-10.2-20100106.0-domestic.tgz"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -455,7 +455,7 @@
             },
             "@timestamp": "2016-02-18T01:33:50.391Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -537,7 +537,7 @@
                 "name": "test.cmd"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -628,7 +628,7 @@
             },
             "@timestamp": "2016-02-19T01:32:50.391Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -723,7 +723,7 @@
                 "name": "www.eicar.org/download/eicar.com"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -818,7 +818,7 @@
             },
             "@timestamp": "2020-07-14T14:16:18.345Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -911,7 +911,7 @@
             },
             "@timestamp": "2020-07-14T14:16:29.541Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1006,7 +1006,7 @@
                 "name": "download.cdn.mozilla.net/pub/firefox/releases/78.0.2/update/win64/de/firefox-78.0.2.complete.mar"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/juniper/data_stream/srx/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/juniper/data_stream/srx/elasticsearch/ingest_pipeline/default.yml
@@ -8,7 +8,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   - rename:
       field: message
       target_field: event.original

--- a/packages/juniper/manifest.yml
+++ b/packages/juniper/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: juniper
 title: Juniper
-version: 0.8.1
+version: 0.8.2
 description: This Elastic integration collects logs from Juniper
 categories: ["network", "security"]
 release: experimental


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967