### PR TITLE
kafka update to ECS 1.11.0

### DIFF
--- a/packages/kafka/changelog.yml
+++ b/packages/kafka/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.6.1'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1393
 - version: "0.6.0"
   changes:
     - description: Update integration description

--- a/packages/kafka/data_stream/log/_dev/test/pipeline/test-controller-2-0-0.log-expected.json
+++ b/packages/kafka/data_stream/log/_dev/test/pipeline/test-controller-2-0-0.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2018-10-31T15:03:32.474Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "TRACE"
@@ -29,7 +29,7 @@
         {
             "@timestamp": "2018-10-31T15:03:32.474Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "DEBUG"
@@ -55,7 +55,7 @@
         {
             "@timestamp": "2018-10-31T15:03:32.474Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "DEBUG"
@@ -81,7 +81,7 @@
         {
             "@timestamp": "2018-10-31T15:03:32.475Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "TRACE"
@@ -107,7 +107,7 @@
         {
             "@timestamp": "2018-10-31T15:03:32.475Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "DEBUG"
@@ -133,7 +133,7 @@
         {
             "@timestamp": "2018-10-31T15:03:32.475Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "TRACE"
@@ -159,7 +159,7 @@
         {
             "@timestamp": "2018-10-31T15:03:32.475Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "DEBUG"
@@ -185,7 +185,7 @@
         {
             "@timestamp": "2018-10-31T15:03:32.475Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "TRACE"
@@ -211,7 +211,7 @@
         {
             "@timestamp": "2018-10-31T15:08:32.475Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "TRACE"
@@ -237,7 +237,7 @@
         {
             "@timestamp": "2018-10-31T15:08:32.475Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "DEBUG"
@@ -263,7 +263,7 @@
         {
             "@timestamp": "2018-10-31T15:08:32.475Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "DEBUG"
@@ -289,7 +289,7 @@
         {
             "@timestamp": "2018-10-31T15:08:32.475Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "TRACE"
@@ -315,7 +315,7 @@
         {
             "@timestamp": "2018-10-31T15:08:32.475Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "DEBUG"
@@ -341,7 +341,7 @@
         {
             "@timestamp": "2018-10-31T15:08:32.475Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "TRACE"
@@ -367,7 +367,7 @@
         {
             "@timestamp": "2018-10-31T15:08:32.475Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "DEBUG"
@@ -393,7 +393,7 @@
         {
             "@timestamp": "2018-10-31T15:08:32.475Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "TRACE"
@@ -419,7 +419,7 @@
         {
             "@timestamp": "2018-10-31T15:09:30.306Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -445,7 +445,7 @@
         {
             "@timestamp": "2018-10-31T15:09:30.307Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -471,7 +471,7 @@
         {
             "@timestamp": "2018-10-31T15:09:30.396Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -497,7 +497,7 @@
         {
             "@timestamp": "2018-10-31T15:09:30.397Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -523,7 +523,7 @@
         {
             "@timestamp": "2018-10-31T15:09:30.396Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -549,7 +549,7 @@
         {
             "@timestamp": "2018-10-31T15:13:32.475Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "TRACE"

--- a/packages/kafka/data_stream/log/_dev/test/pipeline/test-controller.log-expected.json
+++ b/packages/kafka/data_stream/log/_dev/test/pipeline/test-controller.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2017-08-04T10:48:21.048Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -29,7 +29,7 @@
         {
             "@timestamp": "2017-08-04T10:48:21.063Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -55,7 +55,7 @@
         {
             "@timestamp": "2017-08-04T10:48:21.064Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -81,7 +81,7 @@
         {
             "@timestamp": "2017-08-04T10:48:21.082Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -107,7 +107,7 @@
         {
             "@timestamp": "2017-08-04T10:48:21.085Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "DEBUG"
@@ -133,7 +133,7 @@
         {
             "@timestamp": "2017-08-04T10:48:21.154Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -159,7 +159,7 @@
         {
             "@timestamp": "2017-08-04T10:48:21.156Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -185,7 +185,7 @@
         {
             "@timestamp": "2017-08-04T10:48:21.157Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -211,7 +211,7 @@
         {
             "@timestamp": "2017-08-04T10:48:21.165Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -237,7 +237,7 @@
         {
             "@timestamp": "2017-08-04T11:44:22.588Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "DEBUG"
@@ -263,7 +263,7 @@
         {
             "@timestamp": "2017-08-04T11:44:25.094Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -289,7 +289,7 @@
         {
             "@timestamp": "2017-08-04T11:44:25.095Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -315,7 +315,7 @@
         {
             "@timestamp": "2017-08-04T11:44:25.097Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -341,7 +341,7 @@
         {
             "@timestamp": "2017-08-04T11:44:25.099Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "DEBUG"
@@ -367,7 +367,7 @@
         {
             "@timestamp": "2017-08-04T11:44:25.100Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "DEBUG"
@@ -393,7 +393,7 @@
         {
             "@timestamp": "2017-08-04T11:44:25.105Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -419,7 +419,7 @@
         {
             "@timestamp": "2017-08-04T11:44:25.111Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -445,7 +445,7 @@
         {
             "@timestamp": "2017-08-04T11:44:25.112Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -471,7 +471,7 @@
         {
             "@timestamp": "2017-08-04T11:44:25.112Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -497,7 +497,7 @@
         {
             "@timestamp": "2017-08-04T11:44:25.113Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"

--- a/packages/kafka/data_stream/log/_dev/test/pipeline/test-server-2-0-0.log-expected.json
+++ b/packages/kafka/data_stream/log/_dev/test/pipeline/test-server-2-0-0.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2018-10-17T12:04:41.718Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -29,7 +29,7 @@
         {
             "@timestamp": "2018-10-17T12:14:41.719Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -55,7 +55,7 @@
         {
             "@timestamp": "2018-10-17T12:24:41.719Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -81,7 +81,7 @@
         {
             "@timestamp": "2018-10-17T12:34:41.719Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -107,7 +107,7 @@
         {
             "@timestamp": "2018-10-17T12:44:41.719Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -133,7 +133,7 @@
         {
             "@timestamp": "2018-10-17T12:50:23.313Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -159,7 +159,7 @@
         {
             "@timestamp": "2018-10-17T12:50:23.314Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -185,7 +185,7 @@
         {
             "@timestamp": "2018-10-17T12:50:23.321Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -211,7 +211,7 @@
         {
             "@timestamp": "2018-10-17T12:50:23.322Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -237,7 +237,7 @@
         {
             "@timestamp": "2018-10-17T12:50:23.322Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -263,7 +263,7 @@
         {
             "@timestamp": "2018-10-17T12:50:23.323Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -289,7 +289,7 @@
         {
             "@timestamp": "2018-10-17T12:50:23.323Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -315,7 +315,7 @@
         {
             "@timestamp": "2018-10-17T12:50:23.324Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -341,7 +341,7 @@
         {
             "@timestamp": "2018-10-17T12:50:23.331Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -367,7 +367,7 @@
         {
             "@timestamp": "2018-10-17T12:50:23.348Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -393,7 +393,7 @@
         {
             "@timestamp": "2018-10-17T12:50:23.348Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -419,7 +419,7 @@
         {
             "@timestamp": "2018-10-17T12:50:23.350Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -445,7 +445,7 @@
         {
             "@timestamp": "2018-10-17T12:50:23.351Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -471,7 +471,7 @@
         {
             "@timestamp": "2018-10-17T12:50:23.355Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -497,7 +497,7 @@
         {
             "@timestamp": "2018-10-17T12:50:23.360Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -523,7 +523,7 @@
         {
             "@timestamp": "2018-10-17T12:50:23.361Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -549,7 +549,7 @@
         {
             "@timestamp": "2018-10-17T12:50:23.421Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "WARN"
@@ -575,7 +575,7 @@
         {
             "@timestamp": "2018-10-17T12:50:23.421Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -601,7 +601,7 @@
         {
             "@timestamp": "2018-10-17T12:50:24.508Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -627,7 +627,7 @@
         {
             "@timestamp": "2018-10-17T12:51:56.064Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -653,7 +653,7 @@
         {
             "@timestamp": "2018-10-17T12:51:56.091Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -679,7 +679,7 @@
         {
             "@timestamp": "2018-10-17T12:51:56.098Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -705,7 +705,7 @@
         {
             "@timestamp": "2018-10-17T12:51:56.104Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -731,7 +731,7 @@
         {
             "@timestamp": "2018-10-17T12:54:31.461Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -757,7 +757,7 @@
         {
             "@timestamp": "2018-10-17T12:54:31.481Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -783,7 +783,7 @@
         {
             "@timestamp": "2018-10-17T12:54:31.482Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -809,7 +809,7 @@
         {
             "@timestamp": "2018-10-17T12:54:31.483Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -835,7 +835,7 @@
         {
             "@timestamp": "2018-10-17T12:54:31.501Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "WARN"
@@ -861,7 +861,7 @@
         {
             "@timestamp": "2018-10-17T12:54:31.504Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -887,7 +887,7 @@
         {
             "@timestamp": "2018-10-17T12:54:31.504Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -913,7 +913,7 @@
         {
             "@timestamp": "2018-10-17T12:54:31.508Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -939,7 +939,7 @@
         {
             "@timestamp": "2018-10-17T12:54:31.510Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -965,7 +965,7 @@
         {
             "@timestamp": "2018-10-17T12:54:32.043Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "WARN"
@@ -991,7 +991,7 @@
         {
             "@timestamp": "2018-10-17T12:54:32.044Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1017,7 +1017,7 @@
         {
             "@timestamp": "2018-10-17T12:54:41.719Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1043,7 +1043,7 @@
         {
             "@timestamp": "2018-10-17T12:57:17.790Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1069,7 +1069,7 @@
         {
             "@timestamp": "2018-10-17T12:57:17.809Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1095,7 +1095,7 @@
         {
             "@timestamp": "2018-10-17T12:57:17.810Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1121,7 +1121,7 @@
         {
             "@timestamp": "2018-10-17T12:57:17.812Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1147,7 +1147,7 @@
         {
             "@timestamp": "2018-10-17T12:57:17.816Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1173,7 +1173,7 @@
         {
             "@timestamp": "2018-10-17T12:57:17.816Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1199,7 +1199,7 @@
         {
             "@timestamp": "2018-10-17T12:57:17.816Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1225,7 +1225,7 @@
         {
             "@timestamp": "2018-10-17T12:57:17.816Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1251,7 +1251,7 @@
         {
             "@timestamp": "2018-10-17T12:57:17.817Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1277,7 +1277,7 @@
         {
             "@timestamp": "2018-10-17T12:57:17.833Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1303,7 +1303,7 @@
         {
             "@timestamp": "2018-10-17T12:57:17.833Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1329,7 +1329,7 @@
         {
             "@timestamp": "2018-10-17T12:57:17.835Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1355,7 +1355,7 @@
         {
             "@timestamp": "2018-10-17T12:57:17.836Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1381,7 +1381,7 @@
         {
             "@timestamp": "2018-10-17T12:57:17.836Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1407,7 +1407,7 @@
         {
             "@timestamp": "2018-10-17T12:57:17.837Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1433,7 +1433,7 @@
         {
             "@timestamp": "2018-10-17T12:57:17.838Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1459,7 +1459,7 @@
         {
             "@timestamp": "2018-10-17T12:57:17.839Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1485,7 +1485,7 @@
         {
             "@timestamp": "2018-10-17T12:57:17.896Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "WARN"
@@ -1511,7 +1511,7 @@
         {
             "@timestamp": "2018-10-17T12:57:17.897Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1537,7 +1537,7 @@
         {
             "@timestamp": "2018-10-17T12:57:18.400Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "ERROR"
@@ -1567,7 +1567,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.490Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1593,7 +1593,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.492Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1619,7 +1619,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.494Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1645,7 +1645,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.547Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1671,7 +1671,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.550Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1697,7 +1697,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.556Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1723,7 +1723,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.556Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1749,7 +1749,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.558Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1775,7 +1775,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.558Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1801,7 +1801,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.561Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1827,7 +1827,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.561Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1853,7 +1853,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.567Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1879,7 +1879,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.567Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1905,7 +1905,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.568Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1931,7 +1931,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.568Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1957,7 +1957,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.568Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -1983,7 +1983,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.577Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2009,7 +2009,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.577Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2035,7 +2035,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.583Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2061,7 +2061,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.585Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2087,7 +2087,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.586Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2113,7 +2113,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.594Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2139,7 +2139,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.601Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2165,7 +2165,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.602Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2191,7 +2191,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.602Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2217,7 +2217,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.604Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2243,7 +2243,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.605Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2269,7 +2269,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.606Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2295,7 +2295,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.606Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2321,7 +2321,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.606Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2347,7 +2347,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.606Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2373,7 +2373,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.607Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2399,7 +2399,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.608Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2425,7 +2425,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.608Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2451,7 +2451,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.609Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2477,7 +2477,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.609Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2503,7 +2503,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.610Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2529,7 +2529,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.610Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2555,7 +2555,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.611Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2581,7 +2581,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.611Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2607,7 +2607,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.617Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2633,7 +2633,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.631Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2659,7 +2659,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.637Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2685,7 +2685,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.647Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2711,7 +2711,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.649Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2737,7 +2737,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.846Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2763,7 +2763,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.846Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2789,7 +2789,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.847Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2815,7 +2815,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.847Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2841,7 +2841,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.848Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2867,7 +2867,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.848Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2893,7 +2893,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.848Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2919,7 +2919,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.848Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2945,7 +2945,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.848Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2971,7 +2971,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.849Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -2997,7 +2997,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.849Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3023,7 +3023,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.959Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3049,7 +3049,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.959Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3075,7 +3075,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.960Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3101,7 +3101,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.964Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3127,7 +3127,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.964Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3153,7 +3153,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.964Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3179,7 +3179,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.965Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3205,7 +3205,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.965Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3231,7 +3231,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.968Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3257,7 +3257,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.968Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3283,7 +3283,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.970Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3309,7 +3309,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.972Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3335,7 +3335,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.973Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3361,7 +3361,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.974Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3387,7 +3387,7 @@
         {
             "@timestamp": "2018-10-17T12:58:47.974Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3413,7 +3413,7 @@
         {
             "@timestamp": "2018-10-17T12:58:48.059Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3439,7 +3439,7 @@
         {
             "@timestamp": "2018-10-17T12:58:48.059Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3465,7 +3465,7 @@
         {
             "@timestamp": "2018-10-17T12:58:48.060Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3491,7 +3491,7 @@
         {
             "@timestamp": "2018-10-17T12:58:48.184Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3517,7 +3517,7 @@
         {
             "@timestamp": "2018-10-17T12:58:48.184Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3543,7 +3543,7 @@
         {
             "@timestamp": "2018-10-17T12:58:48.184Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3569,7 +3569,7 @@
         {
             "@timestamp": "2018-10-17T12:58:48.184Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3595,7 +3595,7 @@
         {
             "@timestamp": "2018-10-17T12:58:48.184Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3621,7 +3621,7 @@
         {
             "@timestamp": "2018-10-17T12:58:48.186Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3647,7 +3647,7 @@
         {
             "@timestamp": "2018-10-17T12:58:48.187Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3673,7 +3673,7 @@
         {
             "@timestamp": "2018-10-17T12:58:48.208Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3699,7 +3699,7 @@
         {
             "@timestamp": "2018-10-17T12:58:48.244Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3725,7 +3725,7 @@
         {
             "@timestamp": "2018-10-17T12:58:48.248Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3751,7 +3751,7 @@
         {
             "@timestamp": "2018-10-17T12:58:48.251Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3777,7 +3777,7 @@
         {
             "@timestamp": "2018-10-17T12:58:48.252Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3803,7 +3803,7 @@
         {
             "@timestamp": "2018-10-17T12:58:48.253Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3829,7 +3829,7 @@
         {
             "@timestamp": "2018-10-17T12:58:48.253Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3855,7 +3855,7 @@
         {
             "@timestamp": "2018-10-17T12:58:49.201Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3881,7 +3881,7 @@
         {
             "@timestamp": "2018-10-17T12:58:49.201Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3907,7 +3907,7 @@
         {
             "@timestamp": "2018-10-17T12:58:49.201Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3933,7 +3933,7 @@
         {
             "@timestamp": "2018-10-17T12:58:49.209Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3959,7 +3959,7 @@
         {
             "@timestamp": "2018-10-17T12:58:49.209Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -3985,7 +3985,7 @@
         {
             "@timestamp": "2018-10-17T12:58:49.209Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -4011,7 +4011,7 @@
         {
             "@timestamp": "2018-10-17T12:58:50.209Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -4037,7 +4037,7 @@
         {
             "@timestamp": "2018-10-17T12:58:50.209Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -4063,7 +4063,7 @@
         {
             "@timestamp": "2018-10-17T12:58:50.209Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -4089,7 +4089,7 @@
         {
             "@timestamp": "2018-10-17T12:58:50.224Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -4115,7 +4115,7 @@
         {
             "@timestamp": "2018-10-17T12:58:50.233Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"

--- a/packages/kafka/data_stream/log/_dev/test/pipeline/test-server.log-expected.json
+++ b/packages/kafka/data_stream/log/_dev/test/pipeline/test-server.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2017-08-04T10:48:20.377Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -29,7 +29,7 @@
         {
             "@timestamp": "2017-08-04T10:48:20.379Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -55,7 +55,7 @@
         {
             "@timestamp": "2017-08-04T10:48:20.400Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -81,7 +81,7 @@
         {
             "@timestamp": "2017-08-04T10:48:20.400Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -107,7 +107,7 @@
         {
             "@timestamp": "2017-08-04T10:48:20.401Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -133,7 +133,7 @@
         {
             "@timestamp": "2017-08-04T10:48:20.413Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -159,7 +159,7 @@
         {
             "@timestamp": "2017-08-04T10:48:20.415Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -185,7 +185,7 @@
         {
             "@timestamp": "2017-08-04T10:48:20.420Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -211,7 +211,7 @@
         {
             "@timestamp": "2017-08-04T10:48:20.457Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -237,7 +237,7 @@
         {
             "@timestamp": "2017-08-04T10:48:20.458Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -263,7 +263,7 @@
         {
             "@timestamp": "2017-08-04T10:48:20.748Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "WARN"
@@ -289,7 +289,7 @@
         {
             "@timestamp": "2017-08-04T10:48:20.800Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -315,7 +315,7 @@
         {
             "@timestamp": "2017-08-04T10:48:20.866Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -341,7 +341,7 @@
         {
             "@timestamp": "2017-08-04T10:48:20.873Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -367,7 +367,7 @@
         {
             "@timestamp": "2017-08-04T10:48:21.062Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -393,7 +393,7 @@
         {
             "@timestamp": "2017-08-04T10:48:21.063Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -419,7 +419,7 @@
         {
             "@timestamp": "2017-08-04T10:48:21.095Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -445,7 +445,7 @@
         {
             "@timestamp": "2017-08-04T10:48:21.127Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -471,7 +471,7 @@
         {
             "@timestamp": "2017-08-04T10:48:21.162Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"
@@ -497,7 +497,7 @@
         {
             "@timestamp": "2017-08-04T10:48:21.167Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "INFO"

--- a/packages/kafka/data_stream/log/_dev/test/pipeline/test-state-change-1-1-0.log-expected.json
+++ b/packages/kafka/data_stream/log/_dev/test/pipeline/test-state-change-1-1-0.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2018-07-16T10:17:06.489Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "TRACE"

--- a/packages/kafka/data_stream/log/_dev/test/pipeline/test-state-change-2-0-0.log-expected.json
+++ b/packages/kafka/data_stream/log/_dev/test/pipeline/test-state-change-2-0-0.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2018-10-31T15:09:30.451Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "TRACE"

--- a/packages/kafka/data_stream/log/_dev/test/pipeline/test-state-change-2-2-2.log-expected.json
+++ b/packages/kafka/data_stream/log/_dev/test/pipeline/test-state-change-2-2-2.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2020-04-23T00:28:21.796Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "WARN"
@@ -30,7 +30,7 @@
         {
             "@timestamp": "2020-01-20T01:32:00.705Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "ERROR"

--- a/packages/kafka/data_stream/log/_dev/test/pipeline/test-state-change.log-expected.json
+++ b/packages/kafka/data_stream/log/_dev/test/pipeline/test-state-change.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2017-08-04T10:48:21.428Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "TRACE"

--- a/packages/kafka/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/kafka/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   - rename:
       field: message
       target_field: event.original

--- a/packages/kafka/manifest.yml
+++ b/packages/kafka/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kafka
 title: Kafka
-version: 0.6.0
+version: 0.6.1
 license: basic
 description: This Elastic integration collects logs and metrics from Kafka
 type: integration


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967