### PR TITLE
microsoft update to ECS 1.11.0

### DIFF
--- a/packages/microsoft/changelog.yml
+++ b/packages/microsoft/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.7.2'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1394
 - version: "0.7.1"
   changes:
     - description: Escape special characters in docs

--- a/packages/microsoft/data_stream/defender_atp/_dev/test/pipeline/test-defenderatp.log-expected.json
+++ b/packages/microsoft/data_stream/defender_atp/_dev/test/pipeline/test-defenderatp.log-expected.json
@@ -41,7 +41,7 @@
                 "path": "C:\\Windows\\Temp\\sb-sim-temp-ikyxqi\\sb_10554_bs_h4qpk5"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -132,7 +132,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -224,7 +224,7 @@
                 "vendor": "Microsoft"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -321,7 +321,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [

--- a/packages/microsoft/data_stream/defender_atp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft/data_stream/defender_atp/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   - rename:
       field: message
       target_field: event.original

--- a/packages/microsoft/data_stream/dhcp/_dev/test/pipeline/test-generated.log-expected.json
+++ b/packages/microsoft/data_stream/dhcp/_dev/test/pipeline/test-generated.log-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-905-50: 50,1/29/16,6:09:59,nnumqua,10.133.8.128,sse3269.invalid,01:00:5e:ce:bf:42,ventore,ivelitse,ritin,uredolor,tatemac",
             "event": {
@@ -14,7 +14,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-4257-11030: 11030,2/12/16,1:12:33,oremi,10.124.22.221,ciade5699.domain,umq,ntium,psaq,cer",
             "event": {
@@ -26,7 +26,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-5634-62: 62,2/26/16,8:15:08,equepor,10.196.153.12,sequa6540.www5.localhost,01:00:5e:3a:fe:e3,mest",
             "event": {
@@ -38,7 +38,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-363-11015: 11015,3/12/16,3:17:42,nci,10.103.162.55,orev6153.internal.domain,deF,sist,nnumqu,iatnu",
             "event": {
@@ -50,7 +50,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-4880-57: 57,3/26/16,10:20:16,quipexe,10.162.33.193,agn2581.www5.corp,01:00:5e:ad:16:77,",
             "event": {
@@ -62,7 +62,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-6962-57: 57,4/9/16,5:22:51,moenimi,10.156.15.206,enatus2114.mail.home,01:00:5e:33:84:66",
             "event": {
@@ -74,7 +74,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-5355-60: 60,4/24/16,12:25:25,ntex,10.1.118.72,proident2802.home,01:00:5e:69:9a:1a,eumiu",
             "event": {
@@ -86,7 +86,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-7417-15: 15,5/8/16,7:27:59,orisn,10.70.235.184,ofdeF7240.www.home,01:00:5e:a2:09:ea,tionulam,uameius,ratio,ptas,nevolu",
             "event": {
@@ -98,7 +98,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-5162-59: 59,5/22/16,2:30:33,nci,10.86.118.154,amco5712.www5.localdomain,01:00:5e:35:c0:09,con,uia,quiavo,issusci,mol,taspe,mvolu,radip,tNequ,gelit,tatno",
             "event": {
@@ -110,7 +110,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-4141-10: 10,6/5/16,9:33:08,uam,10.5.62.63,llu4762.mail.localdomain,01:00:5e:f5:8e:0d",
             "event": {
@@ -122,7 +122,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-5408-15: 15,6/20/16,4:35:42,llumd,10.66.3.197,emaper2638.lan,01:00:5e:0b:42:ab,uaerat,boreet,onev,tenima,laboreet",
             "event": {
@@ -134,7 +134,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-5738-11008: 11008,7/4/16,11:38:16,ccaecat,10.58.0.245,uatDuis2964.test,veri,rsita,siutaliq,exercit",
             "event": {
@@ -146,7 +146,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-4243-25: 25,7/18/16,6:40:50,antium,10.103.246.190,iusmodt2597.api.domain,01:00:5e:8b:ba:06,ect,reetdolo,nrepreh,obeataev,lor",
             "event": {
@@ -158,7 +158,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-1579-11011: 11011,8/2/16,1:43:25,natura,10.163.217.10,untNequ5075.www5.domain,erep,iutal,dexe,urerep",
             "event": {
@@ -170,7 +170,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-3971-56: 56,8/16/16,8:45:59,lorem,10.150.193.226,uidolore6237.internal.local,01:00:5e:42:6c:b4,suntinc,elits,llam,llamcorp,ari,eataevit,uptatev,uovol,dmi,olab,mquisnos",
             "event": {
@@ -182,7 +182,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-2933-17: 17,8/30/16,3:48:33,tsed,10.111.61.181,incididu1896.example,01:00:5e:c9:5b:b2,",
             "event": {
@@ -194,7 +194,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-5393-11003: 11003,9/13/16,10:51:07,temsequ,10.111.27.193,idexea3181.www.local,tvol,moll,tatione,inB",
             "event": {
@@ -206,7 +206,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-4171-16: 16,9/28/16,5:53:42,ntsuntin,10.153.112.62,imav3236.mail.domain,01:00:5e:e7:c7:cb",
             "event": {
@@ -218,7 +218,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-7290-32: 32,10/12/16,12:56:16,iam,10.98.34.185,ercit3947.api.local,01:00:5e:a4:f5:60,olupta,turveli,toccae,tatno,nido",
             "event": {
@@ -230,7 +230,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-4125-53: 53,10/26/16,7:58:50,itlabori,10.252.112.103,usan6343.www5.domain,01:00:5e:10:76:60,ender",
             "event": {
@@ -242,7 +242,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-5368-50: 50,11/10/16,3:01:24,atquovo,10.246.117.190,mquaera3924.www5.home,01:00:5e:b9:7e:b1",
             "event": {
@@ -254,7 +254,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-4173-33: 33,11/24/16,10:03:59,undeo,10.82.52.233,atuse2703.localhost,01:00:5e:fa:2b:37",
             "event": {
@@ -266,7 +266,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-5883-52: 52,12/8/16,5:06:33,ips,10.149.59.28,emporinc5075.internal.host,01:00:5e:37:14:9d,tessec",
             "event": {
@@ -278,7 +278,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-6446-36: 36,12/23/16,12:09:07,ist,10.169.144.147,onsequat2984.www5.domain,01:00:5e:59:a3:48,",
             "event": {
@@ -290,7 +290,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-686-12: 12,1/6/17,7:11:41,nsequu,10.66.168.154,omm4276.www.example,01:00:5e:44:c4:69",
             "event": {
@@ -302,7 +302,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-2230-25: 25,1/20/17,2:14:16,torev,10.214.241.84,ctetura4886.www5.lan,01:00:5e:3a:d0:86,ita,ipi,rsitamet,lupt,xea,qua,luptatev,admi,modocons,elaudant,tinvol",
             "event": {
@@ -314,7 +314,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-6103-11018: 11018,2/3/17,9:16:50,lapariat,10.97.38.141,etM953.api.domain,xercitat,lpa,entsu,dun",
             "event": {
@@ -326,7 +326,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-927-58: 58,2/18/17,4:19:24,itaut,10.33.140.180,umdolo7781.api.home,01:00:5e:24:f1:b2",
             "event": {
@@ -338,7 +338,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-4632-51: 51,3/4/17,11:21:59,fugi,10.119.185.63,imadmini2625.www5.localhost,01:00:5e:31:b9:65,dtem",
             "event": {
@@ -350,7 +350,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-5377-50: 50,3/18/17,6:24:33,stl,10.95.193.186,picia6119.mail.host,01:00:5e:60:77:c7,tinvol",
             "event": {
@@ -362,7 +362,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-5524-11019: 11019,4/2/17,1:27:07,moenimi,10.17.21.125,inv5716.mail.invalid,sequatur,uidolo,lumquido,nihi",
             "event": {
@@ -374,7 +374,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-5841-11021: 11021,4/16/17,8:29:41,nofdeF,10.73.69.75,uines6355.internal.localdomain,estqu,inibusBo,tat,tion",
             "event": {
@@ -386,7 +386,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-5705-52: 52,4/30/17,3:32:16,uasia,10.64.70.5,ici3995.lan,01:00:5e:4e:97:83,iscinge,atvol,umiur,imad,msequi",
             "event": {
@@ -398,7 +398,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-1559-11020: 11020,5/14/17,10:34:50,deFinibu,10.45.25.68,rehender4535.www5.test,hil,atquovo,suntinc,xeac",
             "event": {
@@ -410,7 +410,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-2228-20: 20,5/29/17,5:37:24,eli,10.28.127.218,pida2286.internal.home,01:00:5e:cc:0b:8f",
             "event": {
@@ -422,7 +422,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-7427-11006: 11006,6/12/17,12:39:58,psaquae,10.68.93.6,mporain2624.www.localhost,iunt,temveleu,colabo,eme",
             "event": {
@@ -434,7 +434,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-2991-16: 16,6/26/17,7:42:33,civeli,10.116.104.101,gnam2508.mail.example,01:00:5e:e1:73:47,maccusa",
             "event": {
@@ -446,7 +446,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-3458-11003: 11003,7/11/17,2:45:07,idex,10.192.110.182,tutla2716.www.domain,inesci,serror,aliqu,olupta",
             "event": {
@@ -458,7 +458,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-2807-53: 53,7/25/17,9:47:41,ihilm,10.219.84.37,ercit2385.internal.home,01:00:5e:a0:cd:2f,iamquis",
             "event": {
@@ -470,7 +470,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-6972-11012: 11012,8/8/17,4:50:15,ittenbyC,10.148.153.201,conseq557.mail.lan,aaliquaU,ntor,lpaqui,sitame",
             "event": {
@@ -482,7 +482,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-5040-24: 24,8/22/17,11:52:50,utla,10.103.118.137,oei5200.www5.invalid,01:00:5e:c7:b7:18",
             "event": {
@@ -494,7 +494,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-2026-02: 02,9/6/17,6:55:24,nnum,10.137.223.15,adol485.example,01:00:5e:81:99:6f,dol",
             "event": {
@@ -506,7 +506,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-4977-11019: 11019,9/20/17,1:57:58,que,10.213.147.241,etconse7424.internal.lan,lit,asun,estia,eaq",
             "event": {
@@ -518,7 +518,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-1180-11010: 11010,10/4/17,9:00:32,serunt,10.183.233.5,tMalor7410.www.localhost,eaq,amest,corp,modtemp",
             "event": {
@@ -530,7 +530,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-2628-11013: 11013,10/19/17,4:03:07,tNequepo,10.52.186.29,equat2243.www5.localdomain,ione,ihilmole,eriamea,amre",
             "event": {
@@ -542,7 +542,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-2949-11: 11,11/2/17,11:05:41,uptat,10.64.199.102,tmo1835.test,01:00:5e:35:a8:83,fugitse",
             "event": {
@@ -554,7 +554,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-3331-54: 54,11/16/17,6:08:15,etMalor,10.196.143.87,quatD4191.local,01:00:5e:3b:7a:f1,sperna",
             "event": {
@@ -566,7 +566,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-7576-30: 30,12/1/17,1:10:49,tper,10.163.5.243,osqui3661.mail.domain,01:00:5e:1e:d6:07,texp",
             "event": {
@@ -578,7 +578,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-5037-11004: 11004,12/15/17,8:13:24,uela,10.194.114.58,ectio2175.www.localhost,ihilmo,radi,gel,lorsitam",
             "event": {
@@ -590,7 +590,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-6385-1103: 1103,12/29/17,3:15:58,ris,10.212.42.224,liqui6106.internal.home,amvolu,eturadi,uamei,quisno",
             "event": {
@@ -602,7 +602,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-1747-11011: 11011,1/12/18,10:18:32,aliquam,10.244.144.198,eratv6205.internal.lan,reme,acommod,uaUteni,udantium",
             "event": {
@@ -614,7 +614,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-6686-57: 57,1/27/18,5:21:06,stlabo,10.134.192.241,catc6134.localdomain,01:00:5e:5b:99:6c,magnid",
             "event": {
@@ -626,7 +626,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-7582-17: 17,2/10/18,12:23:41,quiratio,10.62.191.18,tevelite245.mail.local,01:00:5e:78:a7:55,gnido",
             "event": {
@@ -638,7 +638,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-6036-50: 50,2/24/18,7:26:15,numqua,10.89.22.113,abo1637.mail.host,01:00:5e:ed:c2:f7",
             "event": {
@@ -650,7 +650,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-4949-11020: 11020,3/11/18,2:28:49,derit,10.90.86.89,piscin6866.internal.host,uptatema,intocc,liqu,eporr",
             "event": {
@@ -662,7 +662,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-6418-59: 59,3/25/18,9:31:24,nofdeFin,10.67.38.204,idex6952.www.localhost,01:00:5e:69:58:0e,ecte,tinvolu,iurer,iciadese,quidolor,tessec,olupta,litse,icabo,itatio,uta",
             "event": {
@@ -674,7 +674,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-4824-11010: 11010,4/8/18,4:33:58,volupt,10.158.237.92,riosamn7650.api.test,rcitati,eni,ionevo,ugiatnu",
             "event": {
@@ -686,7 +686,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-5368-60: 60,4/22/18,11:36:32,mnisi,10.107.168.60,ehen7519.www5.lan,01:00:5e:a7:ac:70,stquido,ommodico,ptas,pta,tetu",
             "event": {
@@ -698,7 +698,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-5740-24: 24,5/7/18,6:39:06,Nequepo,10.207.201.9,boree513.www.corp,01:00:5e:e2:17:79,reetdolo,smo,etcons,iusmodi,uamest",
             "event": {
@@ -710,7 +710,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-1842-11023: 11023,5/21/18,1:41:41,epte,10.20.147.134,aper5651.test,roi,niamqui,orem,sno",
             "event": {
@@ -722,7 +722,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-5263-11007: 11007,6/4/18,8:44:15,saute,10.213.145.202,inventor6088.www.invalid,quamni,iatisu,sec,cons",
             "event": {
@@ -734,7 +734,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-510-20: 20,6/19/18,3:46:49,tae,10.14.81.228,aperiame1458.www5.local,01:00:5e:7e:22:1b",
             "event": {
@@ -746,7 +746,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-4410-11003: 11003,7/3/18,10:49:23,itinvol,10.76.10.73,cipitlab6201.www5.example,ios,evolu,ersp,tquov",
             "event": {
@@ -758,7 +758,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-4554-01: 01,7/17/18,5:51:58,osquira,10.220.5.143,com5308.api.domain,01:00:5e:55:ee:a4,reetdolo,norum,madmi,uidol,mporin",
             "event": {
@@ -770,7 +770,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-3253-ID: ID,8/1/18,12:54:32,roid,10.226.199.190,Nemoenim2039.api.localhost,01:00:5e:f6:ba:65",
             "event": {
@@ -782,7 +782,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-1394-11000: 11000,8/15/18,7:57:06,itessequ,10.20.129.206,iquipe2458.api.host,modtemp,quovol,nve,remag",
             "event": {
@@ -794,7 +794,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-5983-56: 56,8/29/18,2:59:40,tquiin,10.174.176.36,ovol3674.www5.host,01:00:5e:bb:1d:bf,str,idolore,pid,illoin,tanimid,umdo,natuse,gnamal,metMalo,ntexplic,archite",
             "event": {
@@ -806,7 +806,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-7829-32: 32,9/12/18,10:02:15,asi,10.94.38.110,nisist2752.home,01:00:5e:c1:3c:48,exercita",
             "event": {
@@ -818,7 +818,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-2516-11007: 11007,9/27/18,5:04:49,oremeu,10.22.110.210,intoc1426.mail.lan,eeufugia,evit,runtm,molli",
             "event": {
@@ -830,7 +830,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-543-11006: 11006,10/11/18,12:07:23,eturadi,10.218.87.174,rsitvolu3751.mail.lan,olor,ineavo,pexe,niamqui",
             "event": {
@@ -842,7 +842,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-6846-11014: 11014,10/25/18,7:09:57,adeser,10.140.113.244,tqu4367.www5.localhost,quam,quid,fugiat,atisun",
             "event": {
@@ -854,7 +854,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-7741-1103: 1103,11/9/18,2:12:32,dmin,10.159.181.29,inci5738.www5.invalid,rnatur,ofdeFin,essequam,acommo",
             "event": {
@@ -866,7 +866,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-18-11005: 11005,11/23/18,9:15:06,cusant,10.178.173.128,itecto1300.internal.corp,tut,ercita,ciadeser,emquia",
             "event": {
@@ -878,7 +878,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-6789-11015: 11015,12/7/18,4:17:40,uia,10.217.38.30,siut1579.www.domain,eFi,mexe,its,ender",
             "event": {
@@ -890,7 +890,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-1540-11014: 11014,12/21/18,11:20:14,edic,10.178.49.161,ame6223.www5.localhost,meius,billo,labo,oNemoeni",
             "event": {
@@ -902,7 +902,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-2244-32: 32,1/5/19,6:22:49,stenatu,10.215.205.216,ratv5227.www.invalid,01:00:5e:fd:3d:c2,nts",
             "event": {
@@ -914,7 +914,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-5663-11025: 11025,1/19/19,1:25:23,ano,10.175.103.215,aturve1647.mail.localhost,uunturm,temUte,sit,olab",
             "event": {
@@ -926,7 +926,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-6672-12: 12,2/2/19,8:27:57,enderi,10.236.150.115,umwrit5433.www5.domain,01:00:5e:ba:09:4a,tpersp",
             "event": {
@@ -938,7 +938,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-6797-01: 01,2/17/19,3:30:32,oeni,10.223.90.192,llamco7206.www.home,01:00:5e:8f:35:71,orsit,asiar,ise,itau,apariat",
             "event": {
@@ -950,7 +950,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-4494-51: 51,3/3/19,10:33:06,dolore,10.165.192.48,nBCSedut1502.www5.example,01:00:5e:c7:c2:10,odoconse,emp,pisciv,lumdolor,nonp,labo,ulapar,aboreetd,hilm,llitanim,invo",
             "event": {
@@ -962,7 +962,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-7205-50: 50,3/17/19,5:35:40,ama,10.80.152.108,texpli2782.mail.domain,01:00:5e:27:0a:9d,",
             "event": {
@@ -974,7 +974,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-5224-11011: 11011,4/1/19,12:38:14,liqua,10.192.21.74,aco6894.mail.home,emUteni,rum,gnaaliqu,teirured",
             "event": {
@@ -986,7 +986,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-5608-11019: 11019,4/15/19,7:40:49,bor,10.142.25.100,tetu2485.internal.invalid,nby,mve,osqui,sequat",
             "event": {
@@ -998,7 +998,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-3051-1098: 1098,4/29/19,2:43:23,ven,10.162.114.217,doloreme60.www5.localhost,evitaed,inimveni,dex,lor",
             "event": {
@@ -1010,7 +1010,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-2315-01: 01,5/13/19,9:45:57,amcorp,10.57.57.241,liqua6498.api.invalid,01:00:5e:d8:53:15,iduntu,ccaeca,niamq,lapariat,remagn,mquae,consequa,moenimi,olupt,oconsequ,edquiac",
             "event": {
@@ -1022,7 +1022,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-2690-14: 14,5/28/19,4:48:31,quamest,10.152.28.171,rsita2628.www5.local,01:00:5e:7a:4c:6e,miu",
             "event": {
@@ -1034,7 +1034,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-6444-11001: 11001,6/11/19,11:51:06,mex,10.0.132.176,luptat7214.domain,lillum,remips,uisaute,imide",
             "event": {
@@ -1046,7 +1046,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-7037-11: 11,6/25/19,6:53:40,itesseq,10.125.134.213,tpersp2624.mail.example,01:00:5e:0b:fb:4a",
             "event": {
@@ -1058,7 +1058,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-6392-64: 64,7/10/19,1:56:14,mvolu,10.206.96.56,aincidu2687.mail.home,01:00:5e:80:9d:2c,",
             "event": {
@@ -1070,7 +1070,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-5524-1098: 1098,7/24/19,8:58:48,lupta,10.22.187.69,amcor5091.internal.corp,nbyCi,tevel,usc,rem",
             "event": {
@@ -1082,7 +1082,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-1978-11019: 11019,8/7/19,4:01:23,atisund,10.2.128.234,ncidid5410.internal.domain,velite,teturad,perspici,itation",
             "event": {
@@ -1094,7 +1094,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-5469-11024: 11024,8/21/19,11:03:57,porincid,10.223.160.140,nofd988.api.example,ilmol,eri,quunt,olori",
             "event": {
@@ -1106,7 +1106,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-2-11004: 11004,9/5/19,6:06:31,elit,10.137.14.180,borisnis6159.www5.localdomain,inven,eufugi,accusant,onse",
             "event": {
@@ -1118,7 +1118,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-2859-59: 59,9/19/19,1:09:05,inibu,10.106.93.26,isetquas3096.home,01:00:5e:1b:92:a6",
             "event": {
@@ -1130,7 +1130,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-4924-11025: 11025,10/3/19,8:11:40,periam,10.192.182.230,dminima4348.mail.home,tame,naaliq,nte,ulpa",
             "event": {
@@ -1142,7 +1142,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-1738-25: 25,10/18/19,3:14:14,loi,10.24.111.229,volupt2952.api.local,01:00:5e:64:62:d1,sequat,giatquov,tconsec,miurerep,toccaec,fugi,labo,nostrud,gnaal,qui,cupi",
             "event": {
@@ -1154,7 +1154,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-5282-60: 60,11/1/19,10:16:48,lores,10.45.253.103,uii5923.internal.home,01:00:5e:2f:ff:49,rcit,llamco,atu,untincul,ssecil",
             "event": {
@@ -1166,7 +1166,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-3023-11023: 11023,11/15/19,5:19:22,atise,10.95.241.28,oluptas6981.www5.localhost,lor,Sedut,yCiceroi,quunt",
             "event": {
@@ -1178,7 +1178,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-4890-23: 23,11/30/19,12:21:57,dolore,10.84.32.178,vitaed4959.example,01:00:5e:11:45:1e,itaedict",
             "event": {
@@ -1190,7 +1190,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%MSDHCP-4271-55: 55,12/14/19,7:24:31,ruredo,10.72.196.74,boreetdo1725.example,01:00:5e:01:2f:7d",
             "event": {

--- a/packages/microsoft/data_stream/dhcp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft/data_stream/dhcp/elasticsearch/ingest_pipeline/default.yml
@@ -8,7 +8,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   # User agent
   - user_agent:
       field: user_agent.original

--- a/packages/microsoft/manifest.yml
+++ b/packages/microsoft/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft
 title: Microsoft
-version: 0.7.1
+version: 0.7.2
 description: This Elastic integration collects logs from Microsoft products
 categories:
   - "network"


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967