### PR TITLE
nats update to ECS 1.11.0

### DIFF
--- a/packages/nats/changelog.yml
+++ b/packages/nats/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.5.2'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1395
 - version: "0.5.1"
   changes:
     - description: Escape special characters in docs

--- a/packages/nats/data_stream/log/_dev/test/pipeline/test-log-sample.log-expected.json
+++ b/packages/nats/data_stream/log/_dev/test/pipeline/test-log-sample.log-expected.json
@@ -11,7 +11,7 @@
             },
             "@timestamp": "2019-02-06T07:19:40.624Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -41,7 +41,7 @@
             },
             "@timestamp": "2019-02-06T07:19:40.624Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -71,7 +71,7 @@
             },
             "@timestamp": "2019-02-06T07:19:40.624Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -101,7 +101,7 @@
             },
             "@timestamp": "2019-02-06T07:19:40.624Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -141,7 +141,7 @@
             ],
             "@timestamp": "2019-02-06T07:20:08.508Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -188,7 +188,7 @@
             },
             "@timestamp": "2019-02-06T07:20:08.510Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -236,7 +236,7 @@
             },
             "@timestamp": "2019-02-06T07:20:08.512Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -282,7 +282,7 @@
             },
             "@timestamp": "2019-02-06T07:20:08.512Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -328,7 +328,7 @@
             },
             "@timestamp": "2019-02-06T07:20:08.512Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -377,7 +377,7 @@
             },
             "@timestamp": "2019-02-04T15:40:02.717Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -423,7 +423,7 @@
             },
             "@timestamp": "2019-02-04T15:40:02.717Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -473,7 +473,7 @@
             },
             "@timestamp": "2019-02-04T15:40:02.717Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -521,7 +521,7 @@
             },
             "@timestamp": "2019-02-04T15:40:02.718Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -567,7 +567,7 @@
             },
             "@timestamp": "2019-02-04T15:40:02.718Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -616,7 +616,7 @@
             },
             "@timestamp": "2019-02-04T15:40:02.718Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -664,7 +664,7 @@
             },
             "@timestamp": "2019-02-04T15:40:02.717Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -713,7 +713,7 @@
             },
             "@timestamp": "2019-02-04T15:40:02.717Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -759,7 +759,7 @@
             },
             "@timestamp": "2019-02-16T07:20:08.512Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/nats/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nats/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   - rename:
       field: message
       target_field: event.original

--- a/packages/nats/manifest.yml
+++ b/packages/nats/manifest.yml
@@ -1,6 +1,6 @@
 name: nats
 title: NATS
-version: 0.5.1
+version: 0.5.2
 release: experimental
 description: This Elastic integration collects logs and metrics from NATS instances
 type: integration


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967