### PR TITLE
netflow update to ECS 1.11.0

### DIFF
--- a/packages/netflow/changelog.yml
+++ b/packages/netflow/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '1.1.2'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1396
 - version: "1.1.1"
   changes:
     - description: Escape special characters in docs

--- a/packages/netflow/data_stream/log/_dev/test/pipeline/test-netflow-log-events.json-expected.json
+++ b/packages/netflow/data_stream/log/_dev/test/pipeline/test-netflow-log-events.json-expected.json
@@ -81,7 +81,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -186,7 +186,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -291,7 +291,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -396,7 +396,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -501,7 +501,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -606,7 +606,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -711,7 +711,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -816,7 +816,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -921,7 +921,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -1026,7 +1026,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -1131,7 +1131,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -1236,7 +1236,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -1341,7 +1341,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -1446,7 +1446,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -1551,7 +1551,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -1656,7 +1656,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -1761,7 +1761,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -1866,7 +1866,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -1971,7 +1971,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -2076,7 +2076,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -2181,7 +2181,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -2286,7 +2286,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -2391,7 +2391,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -2496,7 +2496,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -2601,7 +2601,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -2706,7 +2706,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -2811,7 +2811,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -2916,7 +2916,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"
@@ -3021,7 +3021,7 @@
             },
             "@timestamp": "2018-07-03T10:47:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "host": {
                 "name": "mbp.local"

--- a/packages/netflow/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/netflow/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -7,7 +7,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   - convert:
       field: network.iana_number
       type: string

--- a/packages/netflow/manifest.yml
+++ b/packages/netflow/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: netflow
 title: NetFlow
-version: 1.1.1
+version: 1.1.2
 license: basic
 description: This Elastic integration collects logs from NetFlow
 type: integration


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967