### PR TITLE
netscout update to ECS 1.11.0

### DIFF
--- a/packages/netscout/changelog.yml
+++ b/packages/netscout/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.4.1'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1397
 - version: "0.4.0"
   changes:
     - description: Update integration description

--- a/packages/netscout/data_stream/sightline/_dev/test/pipeline/test-generated.log-expected.json
+++ b/packages/netscout/data_stream/sightline/_dev/test/pipeline/test-generated.log-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "January 29 06:09:59 pfsp: The configuration was changed on leader olab to version 1.6078 by rci",
             "event": {
@@ -14,7 +14,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "February 12 13:12:33 pfsp: Alert Autoclassification was restarted on 2016-02-12 13:12:33 uredolor by tatemac",
             "event": {
@@ -26,7 +26,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "February 26 20:15:08 ntsunti: Change Log: Username:nseq, Subsystem:itinvol, Setting Type:psa, Message:umq",
             "event": {
@@ -38,7 +38,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "March 12 03:17:42 pfsp: Test syslog message",
             "event": {
@@ -50,7 +50,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "March 26 10:20:16 pfsp: Alert Device ritquiin unreachable by controller umqui since 2016-03-26 10:20:16",
             "event": {
@@ -62,7 +62,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 9 17:22:51 pfsp: Alert Host Detection alert riosam, start 2016-04-9 17:22:51 anonnu, duration 116.480000, direction external, host 10.51.132.10, signatures (utper), impact squame, importance medium, managed_objects (omm), (parent managed object iin)",
             "event": {
@@ -74,7 +74,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 24 00:25:25 pfsp: Autoclassification was restarted on 2016-04-24 00:25:25 nim by incidi",
             "event": {
@@ -86,7 +86,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 8 07:27:59 pfsp: Alert Peakflow device oloremqu unreachable by temvel since 2016-05-08 07:27:59",
             "event": {
@@ -98,7 +98,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 22 14:30:33 pfsp: Autoclassification was restarted on 2016-05-22 14:30:33 serror by anti",
             "event": {
@@ -110,7 +110,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 5 21:33:08 pfsp: script ufugiatn ran at 2016-06-05 21:33:08 tionulam, leader uameius",
             "event": {
@@ -122,7 +122,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 20 04:35:42 pfsp: Alert Test syslog message",
             "event": {
@@ -134,7 +134,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 4 11:38:16 pfsp: configuration was changed on leader uipexea to version 1.5162 by nci",
             "event": {
@@ -146,7 +146,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 18 18:40:50 pfsp: The SNMP restored for router mvolu, leader radip at 2016-07-18 18:40:50 tNequ",
             "event": {
@@ -158,7 +158,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 2 01:43:25 tatno: Protection Mode: Changed protection mode to active for protection groupdquiac,URL:https://mail.example.net/uam/untutl.jpg?llu=uptassi#tamremap",
             "event": {
@@ -170,7 +170,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 16 08:45:59 pfsp: Alert script estqui ran at 2016-08-16 08:45:59 uasiarch, leader emaper",
             "event": {
@@ -182,7 +182,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 30 15:48:33 eum: Blocked Host: Blocked host10.66.171.247atsitby Blocked Countries usingudpdestination10.155.162.162,URL:https://www5.example.org/seq/olorema.jpg?quid=fug#uatDuis",
             "event": {
@@ -194,7 +194,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "September 13 22:51:07 pfsp: Alert TMS 'eip' fault for resource 'lupta' on TMS iusmodt",
             "event": {
@@ -206,7 +206,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "September 28 05:53:42 pfsp: Alert Autoclassification was restarted on 2016-09-28 05:53:42 atatnonp by uiano",
             "event": {
@@ -218,7 +218,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "October 12 12:56:16 temq: Blocked Host: Blocked host10.38.77.13ataquaeabby Blocked Countries usingipv6-icmpdestination10.179.26.34,URL:https://example.org/isiu/nimadmi.gif?ari=equun#suntinc",
             "event": {
@@ -230,7 +230,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "October 26 19:58:50 pfsp: Hardware failure on tatevel since 2016-10-26 19:58:50 GMT: abilloi",
             "event": {
@@ -242,7 +242,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 10 03:01:24 pfsp: The anomaly ore id 2933 status tsed severity very-high classification enimad router incididu router_name eci interface aali interface_name \"lo5882\" porainc",
             "event": {
@@ -254,7 +254,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 24 10:03:59 moll: anomaly: anomaly Bandwidth id 2902 status inim severity high classification deomni router tquovol router_name ntsuntin interface aecatcup interface_name \"lo4987\" oluptate",
             "event": {
@@ -266,7 +266,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "December 8 17:06:33 pfsp: Alert Autoclassification was restarted on 2016-12-08 17:06:33 iam by qua",
             "event": {
@@ -278,7 +278,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "December 23 00:09:07 pfsp: Test syslog message",
             "event": {
@@ -290,7 +290,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "January 6 07:11:41 pfsp: Autoclassification was restarted on 2017-01-06 07:11:41 olupta by turveli",
             "event": {
@@ -302,7 +302,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "January 20 14:14:16 pfsp: Alert Autoclassification was restarted on 2017-01-20 14:14:16 ntutl by caecatc",
             "event": {
@@ -314,7 +314,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "February 3 21:16:50 pfsp: Alert GRE tunnel restored for destination 10.224.68.213, leader taed at 2017-02-03 21:16:50 lup",
             "event": {
@@ -326,7 +326,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "February 18 04:19:24 pfsp: Alert Hardware failure on aperi since 2017-02-18 04:19:24 GMT: lor",
             "event": {
@@ -338,7 +338,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "March 4 11:21:59 pfsp: The BGP Instability for router oin ended",
             "event": {
@@ -350,7 +350,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "March 18 18:24:33 pfsp: Hardware failure on ritatis done at 2017-03-18 18:24:33 oloremi GMT: pitla",
             "event": {
@@ -362,7 +362,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 2 01:27:07 eomnisis: Change Log: Username:mqui, Subsystem:civeli, Setting Type:errorsi, Message:des",
             "event": {
@@ -374,7 +374,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 16 08:29:41 pfsp: Device tdolorem unreachable by controller ono since 2017-04-16 08:29:41",
             "event": {
@@ -386,7 +386,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 30 15:32:16 pfsp: The GRE tunnel down for destination 10.60.185.151, leader uidolo since 2017-04-30 15:32:16 lumquido",
             "event": {
@@ -398,7 +398,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 14 22:34:50 Lor: Test: Test syslog message",
             "event": {
@@ -410,7 +410,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 29 05:37:24 pfsp: Alert script modoco ran at 2017-05-29 05:37:24 , leader estqu",
             "event": {
@@ -422,7 +422,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 12 12:39:58 intoccae: Protection Mode: Changed protection mode to active for protection groupents,URL:https://www.example.net/nse/sinto.gif?CSed=lupt#psaquae",
             "event": {
@@ -434,7 +434,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 26 19:42:33 pfsp: The BGP Trap reetd: Prefix lumqui itinvo mdolore",
             "event": {
@@ -446,7 +446,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 11 02:45:07 pfsp: Device mque reachable again by controller uovolup at 2017-07-11 02:45:07 samvolu",
             "event": {
@@ -458,7 +458,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 25 09:47:41 pfsp: The Host Detection alert eirure, start 2017-07-25 09:47:41 conseq, duration 38.117000, stop 2017-07-25 09:47:41 mpori, , importance very-high, managed_objects (atu), is now unknown, (parent managed object lpaqui)",
             "event": {
@@ -470,7 +470,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 8 16:50:15 pfsp: BGP Trap doloremi: Prefix luptasn hitect dol",
             "event": {
@@ -482,7 +482,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 22 23:52:50 nsecte: BGP: ipv6 instability router tincu threshold ari (exercit) observed sci (quamnih)",
             "event": {
@@ -494,7 +494,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "September 6 06:55:24 emoe: Protection Mode: Changed protection mode to active for protection groupeaq,URL:https://mail.example.net/corp/modtemp.jpg?oluptas=tNequepo#lup",
             "event": {
@@ -506,7 +506,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "September 20 13:57:58 evita: Change Log: Username:suntexp, Subsystem:duntut, Setting Type:magni, Message:pisciv",
             "event": {
@@ -518,7 +518,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "October 4 21:00:32 radipisc: Blocked Host: Blocked host10.136.232.108atabiby Blocked Countries usingrdpdestination10.168.131.247,URL:https://example.net/temqu/edol.jpg?ipi=reseos#pariatu",
             "event": {
@@ -530,7 +530,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "October 19 04:03:07 pfsp: GRE tunnel restored for destination 10.209.182.237, leader tper at 2017-10-19 04:03:07 olor",
             "event": {
@@ -542,7 +542,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 2 11:05:41 pfsp: Alert Device xerc reachable again by controller iutali at 2017-11-02 11:05:41 fdeFi",
             "event": {
@@ -554,7 +554,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 16 18:08:15 pfsp: BGP down for router ati, leader tlabo since 2017-11-16 18:08:15 uames",
             "event": {
@@ -566,7 +566,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "December 1 01:10:49 pfsp: script offi ran at 2017-12-01 01:10:49 , leader giatnu",
             "event": {
@@ -578,7 +578,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "December 15 08:13:24 untex: Blocked Host: Blocked host10.83.23.104attisetqby Blocked Countries usingrdpdestination10.163.161.165,URL:https://www5.example.org/atem/gnido.txt?tmollita=fde#nsecte",
             "event": {
@@ -590,7 +590,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "December 29 15:15:58 pfsp: GRE tunnel restored for destination 10.53.248.4, leader derit at 2017-12-29 15:15:58 dexea",
             "event": {
@@ -602,7 +602,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "January 12 22:18:32 pfsp: Test syslog message",
             "event": {
@@ -614,7 +614,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "January 27 05:21:06 pfsp: Alert Flow down for router tessec, leader olupta since 2018-01-27 05:21:06 litse",
             "event": {
@@ -626,7 +626,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "February 10 12:23:41 pfsp: Alert Host Detection alert sperna, start 2018-02-10 12:23:41 sintocc, duration 24.633000, stop 2018-02-10 12:23:41 scivelit, , importance medium, managed_objects (ehen), is now success, (parent managed object quameius)",
             "event": {
@@ -638,7 +638,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "February 24 19:26:15 ate: Change Log: Username:uiac, Subsystem:epte, Setting Type:idolo, Message:quinesc",
             "event": {
@@ -650,7 +650,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "March 11 02:28:49 pfsp: BGP Instability for router iatisu ended",
             "event": {
@@ -662,7 +662,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "March 25 09:31:24 evolu: Change Log: Username:ersp, Subsystem:tquov, Setting Type:diconseq, Message:inven",
             "event": {
@@ -674,7 +674,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 8 16:33:58 pfsp: Test syslog message",
             "event": {
@@ -686,7 +686,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 22 23:36:32 Sedutp: Test: Test syslog message",
             "event": {
@@ -698,7 +698,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 7 06:39:06 ema: Change Log: Username:rsitv, Subsystem:iciade, Setting Type:ntiumt, Message:iquipe",
             "event": {
@@ -710,7 +710,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 21 13:41:41 quin: Protection Mode: Changed protection mode to active for protection groupupida,URL:https://api.example.com/eufugi/pici.html?ccaecat=tquiin#tse",
             "event": {
@@ -722,7 +722,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 4 20:44:15 minimav: Change Log: Username:udexerci, Subsystem:naal, Setting Type:lore, Message:tnonpro",
             "event": {
@@ -734,7 +734,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 19 03:46:49 pfsp: The Device illoin unreachable by controller tanimid since 2018-06-19 03:46:49",
             "event": {
@@ -746,7 +746,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 3 10:49:23 pfsp: configuration was changed on leader natuse to version 1.4425 by ati",
             "event": {
@@ -758,7 +758,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 17 17:51:58 boree: anomaly: anomaly Bandwidth id 2366 status queips severity low classification itess router iscinge router_name ofdeFini interface irat interface_name \"enp0s4306\" aturauto",
             "event": {
@@ -770,7 +770,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 1 00:54:32 pfsp: SNMP restored for router entsunt, leader ihilm at 2018-08-01 00:54:32 dmin",
             "event": {
@@ -782,7 +782,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 15 07:57:06 pfsp: The Host Detection alert uscipitl, start 2018-08-15 07:57:06 uia, duration 29.657000, direction internal, host 10.54.49.84, signatures (ciad), impact tali, importance medium, managed_objects (mexe), (parent managed object its)",
             "event": {
@@ -794,7 +794,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 29 14:59:40 pfsp: Alert Test syslog message",
             "event": {
@@ -806,7 +806,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "September 12 22:02:15 pfsp: anomaly Bandwidth id 5089 status commodo severity medium classification tutlab router sau router_name atevelit interface meius interface_name \"lo4293\" labo",
             "event": {
@@ -818,7 +818,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "September 27 05:04:49 pfsp: Alert script nre ran at 2018-09-27 05:04:49 veli, leader volupta",
             "event": {
@@ -830,7 +830,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "October 11 12:07:23 pfsp: The BGP instability router uptate threshold mac (iumdol) observed tpersp (stla)",
             "event": {
@@ -842,7 +842,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "October 25 19:09:57 pfsp: Alert TMS 'tem' fault for resource 'dol' on TMS proiden",
             "event": {
@@ -854,7 +854,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 9 02:12:32 pfsp: Device isis reachable again by controller uasiar at 2018-11-09 02:12:32 utlab",
             "event": {
@@ -866,7 +866,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 23 09:15:06 pfsp: Alert script dantium ran at 2018-11-23 09:15:06 lor, leader velillu",
             "event": {
@@ -878,7 +878,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "December 7 16:17:40 pfsp: The script tvolu ran at 2018-12-07 16:17:40 nreprehe, leader tetu",
             "event": {
@@ -890,7 +890,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "December 21 23:20:14 temporin: Blocked Host: Blocked host10.122.76.148atmiuby Blocked Countries usingipv6-icmpdestination10.28.226.128,URL:https://mail.example.org/idunt/luptat.txt?ica=lillum#remips",
             "event": {
@@ -902,7 +902,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "January 5 06:22:49 cola: Protection Mode: Changed protection mode to active for protection groupamcor,URL:https://internal.example.com/ineavol/iosa.html?usc=rem#amvolupt",
             "event": {
@@ -914,7 +914,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "January 19 13:25:23 mnis: Protection Mode: Changed protection mode to active for protection groupequepor,URL:https://internal.example.org/quaUten/nisiut.txt?teturad=perspici#itation",
             "event": {
@@ -926,7 +926,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "February 2 20:27:57 nimave: Protection Mode: Changed protection mode to active for protection groupisciv,URL:https://mail.example.org/nofd/dipisci.txt?ilmol=eri#quunt",
             "event": {
@@ -938,7 +938,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "February 17 03:30:32 iosamnis: Blocked Host: Blocked host10.31.177.226atdeserunby Blocked Countries usingggpdestination10.98.209.10,URL:https://www.example.org/ptateve/enderi.html?toccaec=fugi#labo",
             "event": {
@@ -950,7 +950,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "March 3 10:33:06 estl: Blocked Host: Blocked host10.44.47.27atmmodocby Blocked Countries usingigmpdestination10.179.210.218,URL:https://www.example.org/tanimi/rumSecti.jpg?emporain=ntiumto#umetMalo",
             "event": {
@@ -962,7 +962,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "March 17 17:35:40 pfsp: Alert configuration was changed on leader emvele to version 1.2883 by lor",
             "event": {
@@ -974,7 +974,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 1 00:38:14 pfsp: Alert BGP instability router iquamqua threshold sit (rumSect) observed ita (vitaed)",
             "event": {
@@ -986,7 +986,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 15 07:40:49 pfsp: Alert Test syslog message",
             "event": {
@@ -998,7 +998,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 29 14:43:23 numquam: Change Log: Username:tMal, Subsystem:ommodo, Setting Type:uptat, Message:idex",
             "event": {
@@ -1010,7 +1010,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 13 21:45:57 pfsp: Alert configuration was changed on leader maveni to version 1.2552 by onu",
             "event": {
@@ -1022,7 +1022,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 28 04:48:31 pfsp: Alert BGP Hijack for prefix tlaboree router norumet done",
             "event": {
@@ -1034,7 +1034,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 11 11:51:06 pfsp: Host Detection alert col, start 2019-06-11 11:51:06 mve, duration 177.586000, stop 2019-06-11 11:51:06 tinvolup, , importance very-high, managed_objects (Sedutpe), is now failure, (parent managed object rroq)",
             "event": {
@@ -1046,7 +1046,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 25 18:53:40 pfsp: script remipsum ran at 2019-06-25 18:53:40 , leader tempor",
             "event": {
@@ -1058,7 +1058,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 10 01:56:14 ccae: Change Log: Username:orroqu, Subsystem:elitsed, Setting Type:labore, Message:uela",
             "event": {
@@ -1070,7 +1070,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 24 08:58:48 uto: Test: Test syslog message",
             "event": {
@@ -1082,7 +1082,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 7 16:01:23 remq: Change Log: Username:veniamq, Subsystem:occ, Setting Type:oloreseo, Message:iruredol",
             "event": {
@@ -1094,7 +1094,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 21 23:03:57 cupi: Blocked Host: Blocked host10.151.129.181atduntby Blocked Countries usingggpdestination10.55.156.64,URL:https://www.example.net/itanim/nesciun.txt?mollita=tatem#iae",
             "event": {
@@ -1106,7 +1106,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "September 5 06:06:31 eumi: Protection Mode: Changed protection mode to active for protection groupquasiarc,URL:https://www.example.net/rever/ore.jpg?oluptat=metco#acom",
             "event": {
@@ -1118,7 +1118,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "September 19 13:09:05 pfsp: The Host Detection alert inBCSedu, start 2019-09-19 13:09:05 erspi, duration 77.637000, direction internal, host 10.46.77.76, signatures (iacons), impact occaec, importance medium, managed_objects (uov), (parent managed object quaeab)",
             "event": {
@@ -1130,7 +1130,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "October 3 20:11:40 pfsp: Hardware failure on ntiu since 2019-10-03 20:11:40 GMT: radipisc",
             "event": {
@@ -1142,7 +1142,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "October 18 03:14:14 pfsp: script vitaed ran at 2019-10-18 03:14:14 ser, leader etconsec",
             "event": {
@@ -1154,7 +1154,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 1 10:16:48 upt: Blocked Host: Blocked host10.73.89.189atidoloby Blocked Countries usingicmpdestination10.166.90.130,URL:https://api.example.org/eosquira/pta.htm?econs=lmolesti#apariatu",
             "event": {
@@ -1166,7 +1166,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 15 17:19:22 pfsp: Alert script msequ ran at 2019-11-15 17:19:22 uat, leader lupta",
             "event": {
@@ -1178,7 +1178,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 30 00:21:57 tlabori: Protection Mode: Changed protection mode to active for protection grouplaudan,URL:https://www5.example.com/atcupida/tessequa.htm?dolores=equamnih#taliqui",
             "event": {
@@ -1190,7 +1190,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "December 14 07:24:31 destlabo: Change Log: Username:rcitat, Subsystem:dolorema, Setting Type:emagn, Message:radipis",
             "event": {

--- a/packages/netscout/data_stream/sightline/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/netscout/data_stream/sightline/elasticsearch/ingest_pipeline/default.yml
@@ -8,7 +8,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   # User agent
   - user_agent:
       field: user_agent.original

--- a/packages/netscout/manifest.yml
+++ b/packages/netscout/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: netscout
 title: Arbor Peakflow SP
-version: 0.4.0
+version: 0.4.1
 description: This Elastic integration collects logs from Arbor Peakflow SP
 categories: ["security"]
 release: experimental


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967