### PR TITLE
nginx update to ECS 1.11.0

### DIFF
--- a/packages/nginx/changelog.yml
+++ b/packages/nginx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.8.1'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1398
 - version: "0.8.0"
   changes:
     - description: Update integration description

--- a/packages/nginx/data_stream/access/_dev/test/pipeline/test-access.log-expected.json
+++ b/packages/nginx/data_stream/access/_dev/test/pipeline/test-access.log-expected.json
@@ -39,7 +39,7 @@
             ],
             "@timestamp": "2016-10-25T12:49:33.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "_tmp": {},
             "related": {
@@ -126,7 +126,7 @@
             ],
             "@timestamp": "2016-10-25T12:49:34.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "_tmp": {},
             "related": {
@@ -213,7 +213,7 @@
             ],
             "@timestamp": "2016-10-25T12:50:44.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "_tmp": {},
             "related": {
@@ -299,7 +299,7 @@
             ],
             "@timestamp": "2016-12-07T09:34:43.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "_tmp": {},
             "related": {
@@ -386,7 +386,7 @@
             ],
             "@timestamp": "2016-12-07T09:34:43.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "_tmp": {},
             "related": {
@@ -473,7 +473,7 @@
             ],
             "@timestamp": "2016-12-07T09:43:18.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "_tmp": {},
             "related": {
@@ -559,7 +559,7 @@
             ],
             "@timestamp": "2016-12-07T09:43:21.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "_tmp": {},
             "related": {
@@ -645,7 +645,7 @@
             ],
             "@timestamp": "2016-12-07T09:43:23.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "_tmp": {},
             "related": {
@@ -713,7 +713,7 @@
             ],
             "@timestamp": "2016-12-07T10:04:37.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "_tmp": {},
             "related": {
@@ -781,7 +781,7 @@
             ],
             "@timestamp": "2016-12-07T10:04:58.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "_tmp": {},
             "related": {
@@ -849,7 +849,7 @@
             ],
             "@timestamp": "2016-12-07T10:04:59.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "_tmp": {},
             "related": {
@@ -917,7 +917,7 @@
             ],
             "@timestamp": "2016-12-07T10:05:07.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "_tmp": {},
             "related": {

--- a/packages/nginx/data_stream/access/_dev/test/pipeline/test-nginx.log-expected.json
+++ b/packages/nginx/data_stream/access/_dev/test/pipeline/test-nginx.log-expected.json
@@ -23,7 +23,7 @@
             ],
             "@timestamp": "2016-12-07T10:05:07.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "_tmp": {},
             "related": {
@@ -91,7 +91,7 @@
             ],
             "@timestamp": "2017-05-29T19:02:48.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "_tmp": {},
             "related": {
@@ -179,7 +179,7 @@
             ],
             "@timestamp": "2016-12-07T10:05:07.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "_tmp": {},
             "related": {
@@ -265,7 +265,7 @@
             ],
             "@timestamp": "2016-12-07T10:05:07.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "_tmp": {},
             "related": {
@@ -315,7 +315,7 @@
         {
             "@timestamp": "2018-04-12T07:48:40.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "nginx": {
                 "access": {

--- a/packages/nginx/data_stream/access/_dev/test/pipeline/test-test-with-host.log-expected.json
+++ b/packages/nginx/data_stream/access/_dev/test/pipeline/test-test-with-host.log-expected.json
@@ -27,7 +27,7 @@
             ],
             "@timestamp": "2016-12-07T10:05:07.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "_tmp": {},
             "related": {
@@ -110,7 +110,7 @@
             ],
             "@timestamp": "2016-12-30T06:47:09.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "_tmp": {},
             "related": {
@@ -156,7 +156,7 @@
         {
             "@timestamp": "2018-04-12T07:48:40.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "nginx": {
                 "access": {
@@ -227,7 +227,7 @@
             ],
             "@timestamp": "2017-05-29T19:02:48.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "_tmp": {},
             "related": {

--- a/packages/nginx/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nginx/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -10,7 +10,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   - rename:
       field: message
       target_field: event.original

--- a/packages/nginx/data_stream/error/_dev/test/pipeline/test-error-raw.log-expected.json
+++ b/packages/nginx/data_stream/error/_dev/test/pipeline/test-error-raw.log-expected.json
@@ -9,7 +9,7 @@
             },
             "@timestamp": "2016-10-25T14:49:34.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "nginx": {
                 "error": {
@@ -45,7 +45,7 @@
             },
             "@timestamp": "2016-10-25T14:50:44.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "nginx": {
                 "error": {
@@ -81,7 +81,7 @@
             },
             "@timestamp": "2019-10-30T23:26:34.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "nginx": {
                 "error": {
@@ -117,7 +117,7 @@
             },
             "@timestamp": "2019-11-05T14:50:44.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "nginx": {
                 "error": {

--- a/packages/nginx/data_stream/error/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nginx/data_stream/error/elasticsearch/ingest_pipeline/default.yml
@@ -9,7 +9,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   - rename:
       field: message
       target_field: event.original

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: nginx
 title: Nginx
-version: 0.8.0
+version: 0.8.1
 license: basic
 description: This Elastic integration collects metrics from Nginx instances
 type: integration


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967