### PR TITLE
Update documentation to fit mdx spec

### DIFF
--- a/packages/cef/_dev/build/docs/README.md
+++ b/packages/cef/_dev/build/docs/README.md
@@ -33,7 +33,7 @@ Center (SMC).  In the SMC configure the logs to be forwarded to the address set
 in `var.syslog_host` in format CEF and service UDP on `var.syslog_port`.
 Instructions can be found in [KB
 15002](https://support.forcepoint.com/KBArticle?id=000015002) for configuring
-the SMC.  
+the SMC.
 
 Testing was done with CEF logs from SMC version 6.6.1 and custom string mappings
 were taken from 'CEF Connector Configuration Guide' dated December 5, 2011.
@@ -57,7 +57,7 @@ Check Point CEF extensions are mapped as follows:
 | deviceInboundInterface     | -                           | observer.ingress.interface.name | -                       |
 | deviceOutboundInterface    | -                           | observer.egress.interface.name | -                        |
 | externalId                 | -                           | -                        | checkpoint.uuid                |
-| fileHash                   | -                           | file.hash.{md5,sha1}     | -                              |
+| fileHash                   | -                           | file.hash.\{md5,sha1\}   | -                              |
 | reason                     | -                           | -                        | checkpoint.termination_reason  |
 | requestCookies             | -                           | -                        | checkpoint.cookie              |
 | sourceNtDomain             | -                           | dns.question.name        | -                              |

--- a/packages/cef/changelog.yml
+++ b/packages/cef/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.0"
+  changes:
+    - description: Update documentation to fit mdx spec
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/?
 - version: "0.4.0"
   changes:
     - description: Update integration description

--- a/packages/cef/changelog.yml
+++ b/packages/cef/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update documentation to fit mdx spec
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/?
+      link: https://github.com/elastic/integrations/pull/1401
 - version: "0.4.0"
   changes:
     - description: Update integration description

--- a/packages/cef/docs/README.md
+++ b/packages/cef/docs/README.md
@@ -33,7 +33,7 @@ Center (SMC).  In the SMC configure the logs to be forwarded to the address set
 in `var.syslog_host` in format CEF and service UDP on `var.syslog_port`.
 Instructions can be found in [KB
 15002](https://support.forcepoint.com/KBArticle?id=000015002) for configuring
-the SMC.  
+the SMC.
 
 Testing was done with CEF logs from SMC version 6.6.1 and custom string mappings
 were taken from 'CEF Connector Configuration Guide' dated December 5, 2011.
@@ -57,7 +57,7 @@ Check Point CEF extensions are mapped as follows:
 | deviceInboundInterface     | -                           | observer.ingress.interface.name | -                       |
 | deviceOutboundInterface    | -                           | observer.egress.interface.name | -                        |
 | externalId                 | -                           | -                        | checkpoint.uuid                |
-| fileHash                   | -                           | file.hash.{md5,sha1}     | -                              |
+| fileHash                   | -                           | file.hash.\{md5,sha1\}   | -                              |
 | reason                     | -                           | -                        | checkpoint.termination_reason  |
 | requestCookies             | -                           | -                        | checkpoint.cookie              |
 | sourceNtDomain             | -                           | dns.question.name        | -                              |

--- a/packages/cef/manifest.yml
+++ b/packages/cef/manifest.yml
@@ -1,6 +1,6 @@
 name: cef
 title: CEF
-version: 0.4.0
+version: 0.5.0
 release: experimental
 description: This Elastic integration collects logs in common event format (CEF)
 type: integration

--- a/packages/docker/_dev/build/docs/README.md
+++ b/packages/docker/_dev/build/docs/README.md
@@ -10,7 +10,7 @@ but it should also work there.
 
 ## Running from within Docker
 
-The `docker` Integration will try to connect to the docker socket, by default at `unix:///var/run/docker.sock`. 
+The `docker` Integration will try to connect to the docker socket, by default at `unix:///var/run/docker.sock`.
 If Elastic Agent is running inside docker, you'll need to mount the unix socket inside the container:
 
 ```
@@ -25,7 +25,8 @@ docker run -d \
 ## Module-specific configuration notes
 
 It is strongly recommended that you run Docker metricsets with a
-<<metricset-period,`period`>> that is 3 seconds or longer. The request to the
+[`period`](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-metricbeat.html#metricset-period)
+that is 3 seconds or longer. The request to the
 Docker API already takes up to 2 seconds. Specifying less than 3 seconds will
 result in requests that timeout, and no data will be reported for those
 requests.
@@ -41,7 +42,7 @@ running Docker containers.
 
 {{event "container"}}
 
-### CPU 
+### CPU
 
 The Docker `cpu` data stream collects runtime CPU metrics.
 
@@ -85,7 +86,7 @@ The Docker `image` data stream collects metrics on docker images
 
 {{event "image"}}
 
-### Info 
+### Info
 
 The Docker `info` data stream collects system-wide information based on the
 https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/#/display-system-wide-information[Docker Remote API].

--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.0"
+  changes:
+    - description: Update documentation to fit mdx spec
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/?
 - version: "0.4.0"
   changes:
     - description: Update integration description

--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update documentation to fit mdx spec
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/?
+      link: https://github.com/elastic/integrations/pull/1401
 - version: "0.4.0"
   changes:
     - description: Update integration description

--- a/packages/docker/docs/README.md
+++ b/packages/docker/docs/README.md
@@ -10,7 +10,7 @@ but it should also work there.
 
 ## Running from within Docker
 
-The `docker` Integration will try to connect to the docker socket, by default at `unix:///var/run/docker.sock`. 
+The `docker` Integration will try to connect to the docker socket, by default at `unix:///var/run/docker.sock`.
 If Elastic Agent is running inside docker, you'll need to mount the unix socket inside the container:
 
 ```
@@ -25,7 +25,8 @@ docker run -d \
 ## Module-specific configuration notes
 
 It is strongly recommended that you run Docker metricsets with a
-<<metricset-period,`period`>> that is 3 seconds or longer. The request to the
+[`period`](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-metricbeat.html#metricset-period)
+that is 3 seconds or longer. The request to the
 Docker API already takes up to 2 seconds. Specifying less than 3 seconds will
 result in requests that timeout, and no data will be reported for those
 requests.
@@ -139,7 +140,7 @@ An example event for `container` looks as following:
 }
 ```
 
-### CPU 
+### CPU
 
 The Docker `cpu` data stream collects runtime CPU metrics.
 
@@ -704,7 +705,7 @@ An example event for `image` looks as following:
 }
 ```
 
-### Info 
+### Info
 
 The Docker `info` data stream collects system-wide information based on the
 https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/#/display-system-wide-information[Docker Remote API].

--- a/packages/docker/manifest.yml
+++ b/packages/docker/manifest.yml
@@ -1,6 +1,6 @@
 name: docker
 title: Docker
-version: 0.4.0
+version: 0.5.0
 release: beta
 description: This Elastic integration fetches metrics from Docker instances
 type: integration

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.11.0"
+  changes:
+    - description: Update documentation to fit mdx spec
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/?
 - version: "0.10.0"
   changes:
     - description: Update integration description

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update documentation to fit mdx spec
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/?
+      link: https://github.com/elastic/integrations/pull/1401
 - version: "0.10.0"
   changes:
     - description: Update integration description

--- a/packages/kubernetes/data_stream/state_job/fields/fields.yml
+++ b/packages/kubernetes/data_stream/state_job/fields/fields.yml
@@ -62,7 +62,7 @@
           description: The kind of resource that owns this job (eg. "CronJob")
         - name: is_controller
           type: keyword
-          description: Owner is controller ("true", "false", or "<none>")
+          description: Owner is controller ("true", "false", or `"<none>"`)
     - name: status
       type: group
       description: Kubernetes job status information

--- a/packages/kubernetes/docs/kube-state-metrics.md
+++ b/packages/kubernetes/docs/kube-state-metrics.md
@@ -699,7 +699,7 @@ An example event for `state_job` looks as following:
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |
 | kubernetes.job.completions.desired | The configured completion count for the job (Spec) | long | gauge |
 | kubernetes.job.name | The name of the job resource | keyword |  |
-| kubernetes.job.owner.is_controller | Owner is controller ("true", "false", or "<none>") | keyword |  |
+| kubernetes.job.owner.is_controller | Owner is controller ("true", "false", or `"<none>"`) | keyword |  |
 | kubernetes.job.owner.kind | The kind of resource that owns this job (eg. "CronJob") | keyword |  |
 | kubernetes.job.owner.name | The name of the resource that owns this job | keyword |  |
 | kubernetes.job.parallelism.desired | The configured parallelism of the job (Spec) | long | gauge |

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 0.10.0
+version: 0.11.0
 license: basic
 description: This Elastic integration collects metrics from Kubernetes clusters
 type: integration

--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.0"
+  changes:
+    - description: Update documentation to fit mdx spec
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/?
 - version: "0.1.0"
   changes:
     - description: Update integration description

--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update documentation to fit mdx spec
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/?
+      link: https://github.com/elastic/integrations/pull/1401
 - version: "0.1.0"
   changes:
     - description: Update integration description

--- a/packages/network_traffic/data_stream/memcached/fields/protocol.yml
+++ b/packages/network_traffic/data_stream/memcached/fields/protocol.yml
@@ -171,7 +171,7 @@
     - name: request.exptime
       type: long
       description: >
-        The data expiry time in seconds sent with the memcache command (if present). If the value is <30 days, the expiry time is relative to "now", or else it is an absolute Unix time in seconds (32-bit).
+        The data expiry time in seconds sent with the memcache command (if present). If the value is `< 30` days, the expiry time is relative to "now", or else it is an absolute Unix time in seconds (32-bit).
 
     - name: request.sleep_us
       type: long

--- a/packages/network_traffic/docs/README.md
+++ b/packages/network_traffic/docs/README.md
@@ -937,7 +937,7 @@ Fields published for Memcached packets.
 | memcache.request.count_values | The number of values found in the memcache request message. If the command does not send any data, this field is missing. | long |
 | memcache.request.delta | The counter increment/decrement delta value. | long |
 | memcache.request.dest_class | The destination class id in 'slab reassign' command. | long |
-| memcache.request.exptime | The data expiry time in seconds sent with the memcache command (if present). If the value is <30 days, the expiry time is relative to "now", or else it is an absolute Unix time in seconds (32-bit). | long |
+| memcache.request.exptime | The data expiry time in seconds sent with the memcache command (if present). If the value is `< 30` days, the expiry time is relative to "now", or else it is an absolute Unix time in seconds (32-bit). | long |
 | memcache.request.flags | The memcache command flags sent in the request (if present). | long |
 | memcache.request.initial | The counter increment/decrement initial value parameter (binary protocol only). | long |
 | memcache.request.keys | The list of keys sent in the store or load commands. | array |

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: network_traffic
 title: Network Traffic
-version: 0.1.0
+version: 0.2.0
 license: basic
 description: This Elastic integration sniffs Network Traffic
 type: integration

--- a/packages/postgresql/_dev/build/docs/README.md
+++ b/packages/postgresql/_dev/build/docs/README.md
@@ -6,7 +6,7 @@ This integration periodically fetches logs and metrics from [PostgreSQL](https:/
 
 The `log` dataset was tested with logs from versions 9.5 on Ubuntu, 9.6 on Debian, and finally 10.11, 11.4 and 12.2 on Arch Linux 9.3. CSV format was tested using versions 11 and 13 (distro is not relevant here).
 
-The `activity`, `bgwriter`, `database` and `statement` datasets were tested with PostgreSQL 9.5.3 and is expected to work with all versions >= 9.
+The `activity`, `bgwriter`, `database` and `statement` datasets were tested with PostgreSQL 9.5.3 and is expected to work with all versions `>= 9`.
 
 ## Logs
 

--- a/packages/postgresql/changelog.yml
+++ b/packages/postgresql/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update documentation to fit mdx spec
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/?
+      link: https://github.com/elastic/integrations/pull/1401
 - version: "0.6.0"
   changes:
     - description: Update integration description

--- a/packages/postgresql/changelog.yml
+++ b/packages/postgresql/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.7.0"
+  changes:
+    - description: Update documentation to fit mdx spec
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/?
 - version: "0.6.0"
   changes:
     - description: Update integration description

--- a/packages/postgresql/data_stream/log/fields/fields.yml
+++ b/packages/postgresql/data_stream/log/fields/fields.yml
@@ -36,7 +36,7 @@
     - name: query_name
       type: keyword
       description: |
-        Name given to a query when using extended query protocol. If it is "<unnamed>", or not present, this field is ignored.
+        Name given to a query when using extended query protocol. If it is `"<unnamed>"`, or not present, this field is ignored.
     - name: command_tag
       type: keyword
       description: |

--- a/packages/postgresql/docs/README.md
+++ b/packages/postgresql/docs/README.md
@@ -6,7 +6,7 @@ This integration periodically fetches logs and metrics from [PostgreSQL](https:/
 
 The `log` dataset was tested with logs from versions 9.5 on Ubuntu, 9.6 on Debian, and finally 10.11, 11.4 and 12.2 on Arch Linux 9.3. CSV format was tested using versions 11 and 13 (distro is not relevant here).
 
-The `activity`, `bgwriter`, `database` and `statement` datasets were tested with PostgreSQL 9.5.3 and is expected to work with all versions >= 9.
+The `activity`, `bgwriter`, `database` and `statement` datasets were tested with PostgreSQL 9.5.3 and is expected to work with all versions `>= 9`.
 
 ## Logs
 
@@ -104,7 +104,7 @@ persistent connections, so enable with care.
 | postgresql.log.internal_query_pos | Character count of the internal query (if any). | long |
 | postgresql.log.location | Location of the error in the PostgreSQL source code (if log_error_verbosity is set to verbose). | keyword |
 | postgresql.log.query | Query statement. In the case of CSV parse, look at command_tag to get more context. | keyword |
-| postgresql.log.query_name | Name given to a query when using extended query protocol. If it is "<unnamed>", or not present, this field is ignored. | keyword |
+| postgresql.log.query_name | Name given to a query when using extended query protocol. If it is `"<unnamed>"`, or not present, this field is ignored. | keyword |
 | postgresql.log.query_pos | Character count of the error position (if any). | long |
 | postgresql.log.query_step | Statement step when using extended query protocol (one of statement, parse, bind or execute). | keyword |
 | postgresql.log.session_id | PostgreSQL session. | keyword |

--- a/packages/postgresql/manifest.yml
+++ b/packages/postgresql/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: postgresql
 title: PostgreSQL
-version: 0.6.0
+version: 0.7.0
 license: basic
 description: This Elastic integration collects logs and metrics from PostgreSQL instances
 type: integration

--- a/packages/rabbitmq/changelog.yml
+++ b/packages/rabbitmq/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update documentation to fit mdx spec
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/?
+      link: https://github.com/elastic/integrations/pull/1401
 - version: "0.5.0"
   changes:
     - description: Update integration description

--- a/packages/rabbitmq/changelog.yml
+++ b/packages/rabbitmq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.0"
+  changes:
+    - description: Update documentation to fit mdx spec
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/?
 - version: "0.5.0"
   changes:
     - description: Update integration description

--- a/packages/rabbitmq/data_stream/queue/fields/fields.yml
+++ b/packages/rabbitmq/data_stream/queue/fields/fields.yml
@@ -20,7 +20,7 @@
     - name: state
       type: keyword
       description: |
-        The state of the queue. Normally 'running', but may be "{syncing, MsgCount}" if the queue is synchronising. Queues which are located on cluster nodes that are currently down will be shown with a status of 'down'.
+        The state of the queue. Normally 'running', but may be `"{syncing, MsgCount}"` if the queue is synchronising. Queues which are located on cluster nodes that are currently down will be shown with a status of 'down'.
     - name: arguments.max_priority
       type: long
       description: |

--- a/packages/rabbitmq/docs/README.md
+++ b/packages/rabbitmq/docs/README.md
@@ -634,7 +634,7 @@ An example event for `queue` looks as following:
 | rabbitmq.queue.messages.unacknowledged.count | Number of messages delivered to clients but not yet acknowledged. | long |
 | rabbitmq.queue.messages.unacknowledged.details.rate | How much the count of unacknowledged messages has changed per second in the most recent sampling interval. | float |
 | rabbitmq.queue.name | The name of the queue with non-ASCII characters escaped as in C. | keyword |
-| rabbitmq.queue.state | The state of the queue. Normally 'running', but may be "{syncing, MsgCount}" if the queue is synchronising. Queues which are located on cluster nodes that are currently down will be shown with a status of 'down'. | keyword |
+| rabbitmq.queue.state | The state of the queue. Normally 'running', but may be `"{syncing, MsgCount}"` if the queue is synchronising. Queues which are located on cluster nodes that are currently down will be shown with a status of 'down'. | keyword |
 | rabbitmq.vhost | Virtual host name with non-ASCII characters escaped as in C. | keyword |
 | service.address | Service address | keyword |
 | service.type | Service type | keyword |

--- a/packages/rabbitmq/manifest.yml
+++ b/packages/rabbitmq/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: rabbitmq
 title: RabbitMQ
-version: 0.5.0
+version: 0.6.0
 license: basic
 description: This Elastic integration collects logs and metrics from RabbitMQ instances
 type: integration

--- a/packages/redis/_dev/build/docs/README.md
+++ b/packages/redis/_dev/build/docs/README.md
@@ -8,7 +8,7 @@ The `log` and `slowlog` datasets were tested with logs from Redis versions 1.2.6
 compatibility with any version 1.x, 2.x, or 3.x.
 
 The `info`, `key` and `keyspace` datasets were tested with Redis 3.2.12, 4.0.11 and 5.0-rc4, and are expected to work
-with all versions >= 3.0.
+with all versions `>= 3.0`.
 
 ## Logs
 

--- a/packages/redis/changelog.yml
+++ b/packages/redis/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update documentation to fit mdx spec
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/?
+      link: https://github.com/elastic/integrations/pull/1401
 - version: "0.6.0"
   changes:
     - description: Update integration description

--- a/packages/redis/changelog.yml
+++ b/packages/redis/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.7.0"
+  changes:
+    - description: Update documentation to fit mdx spec
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/?
 - version: "0.6.0"
   changes:
     - description: Update integration description

--- a/packages/redis/data_stream/key/fields/fields.yml
+++ b/packages/redis/data_stream/key/fields/fields.yml
@@ -8,7 +8,7 @@
     - name: id
       type: keyword
       description: |
-        Unique id for this key (With the form <keyspace>:<name>).
+        Unique id for this key (With the form `<keyspace>:<name>`).
     - name: type
       type: keyword
       description: |

--- a/packages/redis/docs/README.md
+++ b/packages/redis/docs/README.md
@@ -8,7 +8,7 @@ The `log` and `slowlog` datasets were tested with logs from Redis versions 1.2.6
 compatibility with any version 1.x, 2.x, or 3.x.
 
 The `info`, `key` and `keyspace` datasets were tested with Redis 3.2.12, 4.0.11 and 5.0-rc4, and are expected to work
-with all versions >= 3.0.
+with all versions `>= 3.0`.
 
 ## Logs
 
@@ -555,7 +555,7 @@ An example event for `key` looks as following:
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | redis.key.expire.ttl | Seconds to expire. | long |
-| redis.key.id | Unique id for this key (With the form <keyspace>:<name>). | keyword |
+| redis.key.id | Unique id for this key (With the form `<keyspace>:<name>`). | keyword |
 | redis.key.length | Length of the key (Number of elements for lists, length for strings, cardinality for sets). | long |
 | redis.key.name | Key name. | keyword |
 | redis.key.type | Key type as shown by `TYPE` command. | keyword |

--- a/packages/redis/manifest.yml
+++ b/packages/redis/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: redis
 title: Redis
-version: 0.6.0
+version: 0.7.0
 license: basic
 description: This integration collects logs and metrics from Redis instances
 type: integration

--- a/packages/zeek/_dev/build/docs/README.md
+++ b/packages/zeek/_dev/build/docs/README.md
@@ -9,8 +9,7 @@ This module has been developed against Zeek 2.6.1, but is expected to
 work with other versions of Zeek.
 
 Zeek requires a Unix-like platform, and it currently supports Linux,
-FreeBSD, and Mac OS X.  Find out how to use Zeek here:
-<https://www.zeek.org/>
+FreeBSD, and Mac OS X.  Find out how to use Zeek [here](https://www.zeek.org/).
 
 ## Logs
 ### capture_loss

--- a/packages/zeek/changelog.yml
+++ b/packages/zeek/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Update documentation to fit mdx spec
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/?
 - version: "1.1.0"
   changes:
     - description: Update integration description

--- a/packages/zeek/changelog.yml
+++ b/packages/zeek/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update documentation to fit mdx spec
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/?
+      link: https://github.com/elastic/integrations/pull/1401
 - version: "1.1.0"
   changes:
     - description: Update integration description

--- a/packages/zeek/docs/README.md
+++ b/packages/zeek/docs/README.md
@@ -9,8 +9,7 @@ This module has been developed against Zeek 2.6.1, but is expected to
 work with other versions of Zeek.
 
 Zeek requires a Unix-like platform, and it currently supports Linux,
-FreeBSD, and Mac OS X.  Find out how to use Zeek here:
-<https://www.zeek.org/>
+FreeBSD, and Mac OS X.  Find out how to use Zeek [here](https://www.zeek.org/).
 
 ## Logs
 ### capture_loss

--- a/packages/zeek/manifest.yml
+++ b/packages/zeek/manifest.yml
@@ -1,6 +1,6 @@
 name: zeek
 title: Zeek
-version: 1.1.0
+version: 1.2.0
 release: ga
 description: This Elastic integration collects logs from Zeek
 type: integration


### PR DESCRIPTION
## What does this PR do?

Our new documentation system doesn't support the following characters unless they're smushed inside backticks: `<`, `>`, `{`, and `}`. This PR updates eight packages that contain syntax incompatible with mdx.

I'm going to be honest, I have no idea if I can just edit `field.yml` files like I did -- so please let me know if I need to go about this differently. To create this PR I updated each package's `field.yml` and/or `_dev/build/docs/README.md` file, then ran `elastic-package build` followed by `elastic-package check`.

## Checklist

- [x] I have added an entry to my package's `changelog.yml` file.

## Related issues

Closes https://github.com/elastic/integrations/issues/1400

## Follow-ups

_Eventually_, it'd be awesome if we could add rules to automatically escape `<`, `>`, `{`, and `}` -- similar to what I see being done in https://github.com/elastic/elastic-package/pull/451.