### PR TITLE
okta update to ECS 1.11.0

### DIFF
--- a/packages/okta/changelog.yml
+++ b/packages/okta/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '1.1.1'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1403
 - version: "1.1.0"
   changes:
     - description: Update integration description

--- a/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-events.json-expected.json
+++ b/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-events.json-expected.json
@@ -31,7 +31,7 @@
             ],
             "@timestamp": "2020-02-14T22:18:51.843Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -161,7 +161,7 @@
             ],
             "@timestamp": "2020-02-14T22:18:51.843Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -291,7 +291,7 @@
             ],
             "@timestamp": "2020-02-14T22:18:51.843Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/okta/data_stream/system/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/okta/data_stream/system/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
       value: "{{_ingest.timestamp}}"
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   - rename:
       field: message
       target_field: event.original

--- a/packages/okta/manifest.yml
+++ b/packages/okta/manifest.yml
@@ -1,6 +1,6 @@
 name: okta
 title: Okta
-version: 1.1.0
+version: 1.1.1
 release: ga
 description: This Elastic integration collects events from Okta
 type: integration


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967