### PR TITLE
osquery update to ECS 1.11.0

### DIFF
--- a/packages/osquery/changelog.yml
+++ b/packages/osquery/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.5.1'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1404
 - version: "0.5.0"
   changes:
     - description: Update integration description

--- a/packages/osquery/data_stream/result/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/osquery/data_stream/result/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
     target_field: "json"
 - set:
     field: ecs.version
-    value: 1.10.0
+    value: '1.11.0'
 - rename:
     field: message
     target_field: event.original

--- a/packages/osquery/manifest.yml
+++ b/packages/osquery/manifest.yml
@@ -1,6 +1,6 @@
 name: osquery
 title: Osquery Log Collection
-version: 0.5.0
+version: 0.5.1
 release: experimental
 description: This Elastic integration collects logs from Osquery instances
 type: integration


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967