### PR TITLE
Add Cluster filter on Kubernetes Overview dashboard

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.9.2"
+  changes:
+    - description: Add missing cluster filter for "orchestrator.cluster.name" field in [Metrics Kubernetes] Overview dashboard and Dashboard section in the integration overview page
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/xyz
 - version: "0.9.1"
   changes:
     - description: Add missing field "kubernetes.daemonset.name" field for state_pod and state_container

--- a/packages/kubernetes/docs/README.md
+++ b/packages/kubernetes/docs/README.md
@@ -80,5 +80,12 @@ the masters won't be visible. In these cases it won't be possible to use `schedu
 
 ## Compatibility
 
-The Kubernetes package is tested with Kubernetes 1.13.x, 1.14.x, 1.15.x, 1.16.x, 1.17.x, and 1.18.x
+The Kubernetes package is tested with Kubernetes 1.13.x, 1.14.x, 1.15.x, 1.16.x, 1.17.x, 1.18.x, 1.19.x, and 1.20.x
 
+## Dashboard
+
+Kubernetes integration is shipped including default dashboards for `apiserver`, `controllermanager`, `overview`, `proxy` and `scheduler`.
+
+If you are using HA for those components, be aware that when gathering data from all instances the dashboard will usually show and average of the metrics. For those scenarios filtering by hosts or service address is possible.
+
+Cluster selector in `overview` dashboard helps in distinguishing and filtering metrics collected from multiple clusters. If you want to focus on a subset of the Kubernetes clusters for monitoring a specific scenario, this cluster selector could be a handy tool. Note that this selector gets populated from the `orchestrator.cluster.name` field that may not always be available. This field gets its value from sources like `kube_config`, `kubeadm-config` configMap, and Google Cloud's meta API for GKE. If the sources mentioned above don't provide this value, metricbeat will not report it. However, you can always use [processors](https://www.elastic.co/guide/en/beats/metricbeat/current/defining-processors.html) to set this field and utilize it in the `cluster overview` dashboard.

--- a/packages/kubernetes/docs/events.md
+++ b/packages/kubernetes/docs/events.md
@@ -132,7 +132,7 @@ An example event for `event` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
 | host.os.version | Operating system version as a raw string. | keyword |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
-| kubernetes.annotations.* | Kubernetes annotations map | object |  |
+| kubernetes.annotations.\* | Kubernetes annotations map | object |  |
 | kubernetes.container.image | Kubernetes container image | keyword |  |
 | kubernetes.container.name | Kubernetes container name | keyword |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |
@@ -156,7 +156,7 @@ An example event for `event` looks as following:
 | kubernetes.event.timestamp.first_occurrence | Timestamp of first occurrence of event | date |  |
 | kubernetes.event.timestamp.last_occurrence | Timestamp of last occurrence of event | date |  |
 | kubernetes.event.type | Type of the given event | keyword |  |
-| kubernetes.labels.* | Kubernetes labels map | object |  |
+| kubernetes.labels.\* | Kubernetes labels map | object |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |
@@ -164,6 +164,6 @@ An example event for `event` looks as following:
 | kubernetes.pod.name | Kubernetes pod name | keyword |  |
 | kubernetes.pod.uid | Kubernetes pod UID | keyword |  |
 | kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |
+| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |
 | kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |
 | service.type | Service type | keyword |  |

--- a/packages/kubernetes/docs/kube-apiserver.md
+++ b/packages/kubernetes/docs/kube-apiserver.md
@@ -143,13 +143,13 @@ An example event for `apiserver` looks as following:
 | kubernetes.apiserver.etcd.object.count | Number of kubernetes objects at etcd | long |  | gauge |
 | kubernetes.apiserver.http.request.count | Request count for response | long |  | counter |
 | kubernetes.apiserver.http.request.duration.us.count | Request count for duration | long | micros | counter |
-| kubernetes.apiserver.http.request.duration.us.percentile.* | Request duration microseconds percentiles | object |  |  |
+| kubernetes.apiserver.http.request.duration.us.percentile.\* | Request duration microseconds percentiles | object |  |  |
 | kubernetes.apiserver.http.request.duration.us.sum | Request duration microseconds cumulative sum | double | micros | counter |
 | kubernetes.apiserver.http.request.size.bytes.count | Request count for size | long | byte | counter |
-| kubernetes.apiserver.http.request.size.bytes.percentile.* | Request size percentiles | object |  |  |
+| kubernetes.apiserver.http.request.size.bytes.percentile.\* | Request size percentiles | object |  |  |
 | kubernetes.apiserver.http.request.size.bytes.sum | Request size cumulative sum | long | byte | counter |
 | kubernetes.apiserver.http.response.size.bytes.count | Response count | long |  | counter |
-| kubernetes.apiserver.http.response.size.bytes.percentile.* | Response size percentiles | object |  |  |
+| kubernetes.apiserver.http.response.size.bytes.percentile.\* | Response size percentiles | object |  |  |
 | kubernetes.apiserver.http.response.size.bytes.sum | Response size cumulative sum | long | byte | counter |
 | kubernetes.apiserver.process.cpu.sec | CPU seconds | double |  | counter |
 | kubernetes.apiserver.process.fds.open.count | Number of open file descriptors | long |  | gauge |
@@ -163,14 +163,14 @@ An example event for `apiserver` looks as following:
 | kubernetes.apiserver.request.count | Number of requests | long |  | counter |
 | kubernetes.apiserver.request.current.count | Inflight requests | long |  | counter |
 | kubernetes.apiserver.request.dry_run | Wether the request uses dry run | keyword |  |  |
-| kubernetes.apiserver.request.duration.us.bucket.* | Request duration, histogram buckets | object |  |  |
+| kubernetes.apiserver.request.duration.us.bucket.\* | Request duration, histogram buckets | object |  |  |
 | kubernetes.apiserver.request.duration.us.count | Request duration, number of operations | long |  | counter |
 | kubernetes.apiserver.request.duration.us.sum | Request duration, sum in microseconds | long |  | counter |
 | kubernetes.apiserver.request.group | API group for the resource | keyword |  |  |
 | kubernetes.apiserver.request.handler | Request handler | keyword |  |  |
 | kubernetes.apiserver.request.host | Request host | keyword |  |  |
 | kubernetes.apiserver.request.kind | Kind of request | keyword |  |  |
-| kubernetes.apiserver.request.latency.bucket.* | Request latency histogram buckets | object |  |  |
+| kubernetes.apiserver.request.latency.bucket.\* | Request latency histogram buckets | object |  |  |
 | kubernetes.apiserver.request.latency.count | Request latency, number of requests | long |  | counter |
 | kubernetes.apiserver.request.latency.sum | Requests latency, sum of latencies in microseconds | long |  | counter |
 | kubernetes.apiserver.request.longrunning.count | Number of requests active long running requests | long |  | counter |

--- a/packages/kubernetes/docs/kube-controller-manager.md
+++ b/packages/kubernetes/docs/kube-controller-manager.md
@@ -143,7 +143,7 @@ An example event for `controllermanager` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
 | host.os.version | Operating system version as a raw string. | keyword |  |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
-| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.annotations.\* | Kubernetes annotations map | object |  |  |
 | kubernetes.container.image | Kubernetes container image | keyword |  |  |
 | kubernetes.container.name | Kubernetes container name | keyword |  |  |
 | kubernetes.controllermanager.client.request.count | Number of requests as client | long |  | counter |
@@ -152,13 +152,13 @@ An example event for `controllermanager` looks as following:
 | kubernetes.controllermanager.host | Request host | keyword |  |  |
 | kubernetes.controllermanager.http.request.count | Request count for response | long |  | counter |
 | kubernetes.controllermanager.http.request.duration.us.count | Request count for duration | long | micros | counter |
-| kubernetes.controllermanager.http.request.duration.us.percentile.* | Request duration microseconds percentiles | object |  |  |
+| kubernetes.controllermanager.http.request.duration.us.percentile.\* | Request duration microseconds percentiles | object |  |  |
 | kubernetes.controllermanager.http.request.duration.us.sum | Request duration microseconds cumulative sum | double | micros | counter |
 | kubernetes.controllermanager.http.request.size.bytes.count | Request count for size | long | byte | counter |
-| kubernetes.controllermanager.http.request.size.bytes.percentile.* | Request size percentiles | object |  |  |
+| kubernetes.controllermanager.http.request.size.bytes.percentile.\* | Request size percentiles | object |  |  |
 | kubernetes.controllermanager.http.request.size.bytes.sum | Request size cumulative sum | long | byte | counter |
 | kubernetes.controllermanager.http.response.size.bytes.count | Response count | long | byte | counter |
-| kubernetes.controllermanager.http.response.size.bytes.percentile.* | Response size percentiles | object |  |  |
+| kubernetes.controllermanager.http.response.size.bytes.percentile.\* | Response size percentiles | object |  |  |
 | kubernetes.controllermanager.http.response.size.bytes.sum | Response size cumulative sum | long | byte | counter |
 | kubernetes.controllermanager.leader.is_master | Whether the node is master | boolean |  |  |
 | kubernetes.controllermanager.method | HTTP method | keyword |  |  |
@@ -179,7 +179,7 @@ An example event for `controllermanager` looks as following:
 | kubernetes.controllermanager.workqueue.unfinished.sec | Unfinished processors | double |  | gauge |
 | kubernetes.controllermanager.zone | Infrastructure zone | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
-| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.labels.\* | Kubernetes labels map | object |  |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |
@@ -187,7 +187,7 @@ An example event for `controllermanager` looks as following:
 | kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
 | kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
 | kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |  |
 | kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
 | service.address | Service address | keyword |  |  |
 | service.type | Service type | keyword |  |  |

--- a/packages/kubernetes/docs/kube-proxy.md
+++ b/packages/kubernetes/docs/kube-proxy.md
@@ -272,13 +272,13 @@ An example event for `proxy` looks as following:
 | kubernetes.proxy.host | Request host | keyword |  |  |
 | kubernetes.proxy.http.request.count | Request count | long |  | counter |
 | kubernetes.proxy.http.request.duration.us.count | Request count for duration | long | micros | counter |
-| kubernetes.proxy.http.request.duration.us.percentile.* | Request duration microseconds percentiles | object |  |  |
+| kubernetes.proxy.http.request.duration.us.percentile.\* | Request duration microseconds percentiles | object |  |  |
 | kubernetes.proxy.http.request.duration.us.sum | Request duration microseconds cumulative sum | double | micros | counter |
 | kubernetes.proxy.http.request.size.bytes.count | Request count for size | long | byte | counter |
-| kubernetes.proxy.http.request.size.bytes.percentile.* | Request size percentiles | object |  |  |
+| kubernetes.proxy.http.request.size.bytes.percentile.\* | Request size percentiles | object |  |  |
 | kubernetes.proxy.http.request.size.bytes.sum | Request size cumulative sum | long | byte | counter |
 | kubernetes.proxy.http.response.size.bytes.count | Response count | long |  | counter |
-| kubernetes.proxy.http.response.size.bytes.percentile.* | Response size percentiles | object |  |  |
+| kubernetes.proxy.http.response.size.bytes.percentile.\* | Response size percentiles | object |  |  |
 | kubernetes.proxy.http.response.size.bytes.sum | Response size cumulative sum | long | byte | counter |
 | kubernetes.proxy.method | HTTP method | keyword |  |  |
 | kubernetes.proxy.process.cpu.sec | CPU seconds | double |  | counter |
@@ -286,10 +286,10 @@ An example event for `proxy` looks as following:
 | kubernetes.proxy.process.memory.resident.bytes | Bytes in resident memory | long | byte | gauge |
 | kubernetes.proxy.process.memory.virtual.bytes | Bytes in virtual memory | long | byte | gauge |
 | kubernetes.proxy.process.started.sec | Seconds since the process started | double |  | gauge |
-| kubernetes.proxy.sync.networkprogramming.duration.us.bucket.* | Network programming duration, histogram buckets | object |  |  |
+| kubernetes.proxy.sync.networkprogramming.duration.us.bucket.\* | Network programming duration, histogram buckets | object |  |  |
 | kubernetes.proxy.sync.networkprogramming.duration.us.count | Network programming duration, number of operations | long |  | counter |
 | kubernetes.proxy.sync.networkprogramming.duration.us.sum | Network programming duration, sum in microseconds | long |  | counter |
-| kubernetes.proxy.sync.rules.duration.us.bucket.* | SyncProxyRules duration, histogram buckets | object |  |  |
+| kubernetes.proxy.sync.rules.duration.us.bucket.\* | SyncProxyRules duration, histogram buckets | object |  |  |
 | kubernetes.proxy.sync.rules.duration.us.count | SyncProxyRules duration, number of operations | long |  | counter |
 | kubernetes.proxy.sync.rules.duration.us.sum | SyncProxyRules duration, sum of durations in microseconds | long |  | counter |
 | service.address | Service address | keyword |  |  |

--- a/packages/kubernetes/docs/kube-scheduler.md
+++ b/packages/kubernetes/docs/kube-scheduler.md
@@ -129,11 +129,11 @@ An example event for `scheduler` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
 | host.os.version | Operating system version as a raw string. | keyword |  |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
-| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.annotations.\* | Kubernetes annotations map | object |  |  |
 | kubernetes.container.image | Kubernetes container image | keyword |  |  |
 | kubernetes.container.name | Kubernetes container name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
-| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.labels.\* | Kubernetes labels map | object |  |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |
@@ -147,13 +147,13 @@ An example event for `scheduler` looks as following:
 | kubernetes.scheduler.host | Request host | keyword |  |  |
 | kubernetes.scheduler.http.request.count | Request count | long |  | counter |
 | kubernetes.scheduler.http.request.duration.us.count | Request count for duration | long | micros | counter |
-| kubernetes.scheduler.http.request.duration.us.percentile.* | Request duration microseconds percentiles | object |  |  |
+| kubernetes.scheduler.http.request.duration.us.percentile.\* | Request duration microseconds percentiles | object |  |  |
 | kubernetes.scheduler.http.request.duration.us.sum | Request duration microseconds cumulative sum | double | micros | counter |
 | kubernetes.scheduler.http.request.size.bytes.count | Request count for size | long | byte | counter |
-| kubernetes.scheduler.http.request.size.bytes.percentile.* | Request size percentiles | object |  |  |
+| kubernetes.scheduler.http.request.size.bytes.percentile.\* | Request size percentiles | object |  |  |
 | kubernetes.scheduler.http.request.size.bytes.sum | Request size cumulative sum | long | byte | counter |
 | kubernetes.scheduler.http.response.size.bytes.count | Response count | long |  | counter |
-| kubernetes.scheduler.http.response.size.bytes.percentile.* | Response size percentiles | object |  |  |
+| kubernetes.scheduler.http.response.size.bytes.percentile.\* | Response size percentiles | object |  |  |
 | kubernetes.scheduler.http.response.size.bytes.sum | Response size cumulative sum | long | byte | counter |
 | kubernetes.scheduler.leader.is_master | Whether the node is master | boolean |  |  |
 | kubernetes.scheduler.method | HTTP method | keyword |  |  |
@@ -166,16 +166,16 @@ An example event for `scheduler` looks as following:
 | kubernetes.scheduler.process.started.sec | Seconds since the process started | double |  | gauge |
 | kubernetes.scheduler.result | Schedule attempt result | keyword |  |  |
 | kubernetes.scheduler.scheduling.duration.seconds.count | Scheduling count | long |  | counter |
-| kubernetes.scheduler.scheduling.duration.seconds.percentile.* | Scheduling duration percentiles | object |  |  |
+| kubernetes.scheduler.scheduling.duration.seconds.percentile.\* | Scheduling duration percentiles | object |  |  |
 | kubernetes.scheduler.scheduling.duration.seconds.sum | Scheduling duration cumulative sum | double |  | counter |
-| kubernetes.scheduler.scheduling.e2e.duration.us.bucket.* | End to end scheduling duration microseconds | object |  |  |
+| kubernetes.scheduler.scheduling.e2e.duration.us.bucket.\* | End to end scheduling duration microseconds | object |  |  |
 | kubernetes.scheduler.scheduling.e2e.duration.us.count | End to end scheduling count | long | micros | counter |
 | kubernetes.scheduler.scheduling.e2e.duration.us.sum | End to end scheduling duration microseconds sum | long | micros | counter |
 | kubernetes.scheduler.scheduling.pod.attempts.count | Pod attempts count | long |  | counter |
-| kubernetes.scheduler.scheduling.pod.preemption.victims.bucket.* | Pod preemption victims | long |  |  |
+| kubernetes.scheduler.scheduling.pod.preemption.victims.bucket.\* | Pod preemption victims | long |  |  |
 | kubernetes.scheduler.scheduling.pod.preemption.victims.count | Pod preemption victims count | long |  | counter |
 | kubernetes.scheduler.scheduling.pod.preemption.victims.sum | Pod preemption victims sum | long |  | counter |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |  |
 | kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
 | service.address | Service address | keyword |  |  |
 | service.type | Service type | keyword |  |  |

--- a/packages/kubernetes/docs/kube-state-metrics.md
+++ b/packages/kubernetes/docs/kube-state-metrics.md
@@ -135,7 +135,7 @@ An example event for `state_container` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
 | host.os.version | Operating system version as a raw string. | keyword |  |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
-| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.annotations.\* | Kubernetes annotations map | object |  |  |
 | kubernetes.container.cpu.limit.cores | Container CPU cores limit | float |  | gauge |
 | kubernetes.container.cpu.limit.nanocores | Container CPU nanocores limit | long |  | gauge |
 | kubernetes.container.cpu.request.cores | Container CPU requested cores | float |  | gauge |
@@ -151,7 +151,7 @@ An example event for `state_container` looks as following:
 | kubernetes.container.status.restarts | Container restarts count | integer |  | counter |
 | kubernetes.daemonset.name | Kubernetes daemonset name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
-| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.labels.\* | Kubernetes labels map | object |  |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |
@@ -159,7 +159,7 @@ An example event for `state_container` looks as following:
 | kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
 | kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
 | kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |  |
 | kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
 | service.address | Service address | keyword |  |  |
 | service.type | Service type | keyword |  |  |
@@ -279,7 +279,7 @@ An example event for `state_cronjob` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
 | host.os.version | Operating system version as a raw string. | keyword |  |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
-| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.annotations.\* | Kubernetes annotations map | object |  |  |
 | kubernetes.container.image | Kubernetes container image | keyword |  |  |
 | kubernetes.container.name | Kubernetes container name | keyword |  |  |
 | kubernetes.cronjob.active.count | Number of active pods for the cronjob | long |  | gauge |
@@ -292,7 +292,7 @@ An example event for `state_cronjob` looks as following:
 | kubernetes.cronjob.next_schedule.sec | Epoch seconds for next cronjob run | double | s | gauge |
 | kubernetes.cronjob.schedule | Cronjob schedule | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
-| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.labels.\* | Kubernetes labels map | object |  |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |
@@ -300,7 +300,7 @@ An example event for `state_cronjob` looks as following:
 | kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
 | kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
 | kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |  |
 | kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
 | service.address | Service address | keyword |  |  |
 | service.type | Service type | keyword |  |  |
@@ -416,7 +416,7 @@ An example event for `state_daemonset` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
 | host.os.version | Operating system version as a raw string. | keyword |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
-| kubernetes.annotations.* | Kubernetes annotations map | object |  |
+| kubernetes.annotations.\* | Kubernetes annotations map | object |  |
 | kubernetes.container.image | Kubernetes container image | keyword |  |
 | kubernetes.container.name | Kubernetes container name | keyword |  |
 | kubernetes.daemonset.name |  | keyword |  |
@@ -425,7 +425,7 @@ An example event for `state_daemonset` looks as following:
 | kubernetes.daemonset.replicas.ready | The number of ready replicas per DaemonSet | long | gauge |
 | kubernetes.daemonset.replicas.unavailable | The number of unavailable replicas per DaemonSet | long | gauge |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |
-| kubernetes.labels.* | Kubernetes labels map | object |  |
+| kubernetes.labels.\* | Kubernetes labels map | object |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |
@@ -433,7 +433,7 @@ An example event for `state_daemonset` looks as following:
 | kubernetes.pod.name | Kubernetes pod name | keyword |  |
 | kubernetes.pod.uid | Kubernetes pod UID | keyword |  |
 | kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |
+| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |
 | kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |
 | service.address | Service address | keyword |  |
 | service.type | Service type | keyword |  |
@@ -550,7 +550,7 @@ An example event for `state_deployment` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
 | host.os.version | Operating system version as a raw string. | keyword |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
-| kubernetes.annotations.* | Kubernetes annotations map | object |  |
+| kubernetes.annotations.\* | Kubernetes annotations map | object |  |
 | kubernetes.container.image | Kubernetes container image | keyword |  |
 | kubernetes.container.name | Kubernetes container name | keyword |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |
@@ -559,7 +559,7 @@ An example event for `state_deployment` looks as following:
 | kubernetes.deployment.replicas.desired | Deployment number of desired replicas (spec) | integer | gauge |
 | kubernetes.deployment.replicas.unavailable | Deployment unavailable replicas | integer | gauge |
 | kubernetes.deployment.replicas.updated | Deployment updated replicas | integer | gauge |
-| kubernetes.labels.* | Kubernetes labels map | object |  |
+| kubernetes.labels.\* | Kubernetes labels map | object |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |
@@ -567,7 +567,7 @@ An example event for `state_deployment` looks as following:
 | kubernetes.pod.name | Kubernetes pod name | keyword |  |
 | kubernetes.pod.uid | Kubernetes pod UID | keyword |  |
 | kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |
+| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |
 | kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |
 | service.address | Service address | keyword |  |
 | service.type | Service type | keyword |  |
@@ -693,13 +693,13 @@ An example event for `state_job` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
 | host.os.version | Operating system version as a raw string. | keyword |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
-| kubernetes.annotations.* | Kubernetes annotations map | object |  |
+| kubernetes.annotations.\* | Kubernetes annotations map | object |  |
 | kubernetes.container.image | Kubernetes container image | keyword |  |
 | kubernetes.container.name | Kubernetes container name | keyword |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |
 | kubernetes.job.completions.desired | The configured completion count for the job (Spec) | long | gauge |
 | kubernetes.job.name | The name of the job resource | keyword |  |
-| kubernetes.job.owner.is_controller | Owner is controller ("true", "false", or "<none>") | keyword |  |
+| kubernetes.job.owner.is_controller | Owner is controller ("true", "false", or "\<none\>") | keyword |  |
 | kubernetes.job.owner.kind | The kind of resource that owns this job (eg. "CronJob") | keyword |  |
 | kubernetes.job.owner.name | The name of the resource that owns this job | keyword |  |
 | kubernetes.job.parallelism.desired | The configured parallelism of the job (Spec) | long | gauge |
@@ -710,7 +710,7 @@ An example event for `state_job` looks as following:
 | kubernetes.job.status.failed | Whether the job failed ("true", "false", or "unknown") | keyword |  |
 | kubernetes.job.time.completed | The time at which the job completed | date |  |
 | kubernetes.job.time.created | The time at which the job was created | date |  |
-| kubernetes.labels.* | Kubernetes labels map | object |  |
+| kubernetes.labels.\* | Kubernetes labels map | object |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |
@@ -718,7 +718,7 @@ An example event for `state_job` looks as following:
 | kubernetes.pod.name | Kubernetes pod name | keyword |  |
 | kubernetes.pod.uid | Kubernetes pod UID | keyword |  |
 | kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |
+| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |
 | kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |
 | service.address | Service address | keyword |  |
 | service.type | Service type | keyword |  |
@@ -860,11 +860,11 @@ An example event for `state_node` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
 | host.os.version | Operating system version as a raw string. | keyword |  |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
-| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.annotations.\* | Kubernetes annotations map | object |  |  |
 | kubernetes.container.image | Kubernetes container image | keyword |  |  |
 | kubernetes.container.name | Kubernetes container name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
-| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.labels.\* | Kubernetes labels map | object |  |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |  |
 | kubernetes.node.cpu.allocatable.cores | Node CPU allocatable cores | float |  | gauge |
 | kubernetes.node.cpu.capacity.cores | Node CPU capacity cores | long |  | gauge |
@@ -884,7 +884,7 @@ An example event for `state_node` looks as following:
 | kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
 | kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
 | kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |  |
 | kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
 | service.address | Service address | keyword |  |  |
 | service.type | Service type | keyword |  |  |
@@ -998,11 +998,11 @@ An example event for `state_persistentvolume` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
 | host.os.version | Operating system version as a raw string. | keyword |  |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
-| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.annotations.\* | Kubernetes annotations map | object |  |  |
 | kubernetes.container.image | Kubernetes container image | keyword |  |  |
 | kubernetes.container.name | Kubernetes container name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
-| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.labels.\* | Kubernetes labels map | object |  |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |
@@ -1014,7 +1014,7 @@ An example event for `state_persistentvolume` looks as following:
 | kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
 | kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
 | kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |  |
 | kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
 | service.address | Service address | keyword |  |  |
 | service.type | Service type | keyword |  |  |
@@ -1128,11 +1128,11 @@ An example event for `state_persistentvolumeclaim` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
 | host.os.version | Operating system version as a raw string. | keyword |  |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
-| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.annotations.\* | Kubernetes annotations map | object |  |  |
 | kubernetes.container.image | Kubernetes container image | keyword |  |  |
 | kubernetes.container.name | Kubernetes container name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
-| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.labels.\* | Kubernetes labels map | object |  |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |
@@ -1146,7 +1146,7 @@ An example event for `state_persistentvolumeclaim` looks as following:
 | kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
 | kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
 | kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |  |
 | kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
 | service.address | Service address | keyword |  |  |
 | service.type | Service type | keyword |  |  |
@@ -1270,12 +1270,12 @@ An example event for `state_pod` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| kubernetes.annotations.* | Kubernetes annotations map | object |
+| kubernetes.annotations.\* | Kubernetes annotations map | object |
 | kubernetes.container.image | Kubernetes container image | keyword |
 | kubernetes.container.name | Kubernetes container name | keyword |
 | kubernetes.daemonset.name | Kubernetes daemonset name | keyword |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |
-| kubernetes.labels.* | Kubernetes labels map | object |
+| kubernetes.labels.\* | Kubernetes labels map | object |
 | kubernetes.namespace | Kubernetes namespace | keyword |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
 | kubernetes.node.name | Kubernetes node name | keyword |
@@ -1287,7 +1287,7 @@ An example event for `state_pod` looks as following:
 | kubernetes.pod.status.scheduled | Kubernetes pod scheduled status (true, false, unknown) | keyword |
 | kubernetes.pod.uid | Kubernetes pod UID | keyword |
 | kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |
+| kubernetes.selectors.\* | Kubernetes Service selectors map | object |
 | kubernetes.statefulset.name | Kubernetes statefulset name | keyword |
 | service.address | Service address | keyword |
 | service.type | Service type | keyword |
@@ -1410,11 +1410,11 @@ An example event for `state_replicaset` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
 | host.os.version | Operating system version as a raw string. | keyword |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
-| kubernetes.annotations.* | Kubernetes annotations map | object |  |
+| kubernetes.annotations.\* | Kubernetes annotations map | object |  |
 | kubernetes.container.image | Kubernetes container image | keyword |  |
 | kubernetes.container.name | Kubernetes container name | keyword |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |
-| kubernetes.labels.* | Kubernetes labels map | object |  |
+| kubernetes.labels.\* | Kubernetes labels map | object |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |
@@ -1427,7 +1427,7 @@ An example event for `state_replicaset` looks as following:
 | kubernetes.replicaset.replicas.labeled | The number of fully labeled replicas per ReplicaSet | long | gauge |
 | kubernetes.replicaset.replicas.observed | The generation observed by the ReplicaSet controller | long | gauge |
 | kubernetes.replicaset.replicas.ready | The number of ready replicas per ReplicaSet | long | gauge |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |
+| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |
 | kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |
 | service.address | Service address | keyword |  |
 | service.type | Service type | keyword |  |
@@ -1537,11 +1537,11 @@ An example event for `state_resourcequota` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
 | host.os.version | Operating system version as a raw string. | keyword |  |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
-| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.annotations.\* | Kubernetes annotations map | object |  |  |
 | kubernetes.container.image | Kubernetes container image | keyword |  |  |
 | kubernetes.container.name | Kubernetes container name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
-| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.labels.\* | Kubernetes labels map | object |  |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |
@@ -1554,7 +1554,7 @@ An example event for `state_resourcequota` looks as following:
 | kubernetes.resourcequota.quota | Quota informed (hard or used) for the resource | double |  | gauge |
 | kubernetes.resourcequota.resource | Resource name the quota applies to | keyword |  |  |
 | kubernetes.resourcequota.type | Quota information type, `hard` or `used` | keyword |  |  |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |  |
 | kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
 | service.address | Service address | keyword |  |  |
 | service.type | Service type | keyword |  |  |
@@ -1670,11 +1670,11 @@ An example event for `state_service` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| kubernetes.annotations.* | Kubernetes annotations map | object |
+| kubernetes.annotations.\* | Kubernetes annotations map | object |
 | kubernetes.container.image | Kubernetes container image | keyword |
 | kubernetes.container.name | Kubernetes container name | keyword |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |
-| kubernetes.labels.* | Kubernetes labels map | object |
+| kubernetes.labels.\* | Kubernetes labels map | object |
 | kubernetes.namespace | Kubernetes namespace | keyword |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
 | kubernetes.node.name | Kubernetes node name | keyword |
@@ -1682,7 +1682,7 @@ An example event for `state_service` looks as following:
 | kubernetes.pod.name | Kubernetes pod name | keyword |
 | kubernetes.pod.uid | Kubernetes pod UID | keyword |
 | kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |
+| kubernetes.selectors.\* | Kubernetes Service selectors map | object |
 | kubernetes.service.cluster_ip | Internal IP for the service. | ip |
 | kubernetes.service.created | Service creation date | date |
 | kubernetes.service.external_ip | Service external IP | keyword |
@@ -1806,11 +1806,11 @@ An example event for `state_statefulset` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
 | host.os.version | Operating system version as a raw string. | keyword |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
-| kubernetes.annotations.* | Kubernetes annotations map | object |  |
+| kubernetes.annotations.\* | Kubernetes annotations map | object |  |
 | kubernetes.container.image | Kubernetes container image | keyword |  |
 | kubernetes.container.name | Kubernetes container name | keyword |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |
-| kubernetes.labels.* | Kubernetes labels map | object |  |
+| kubernetes.labels.\* | Kubernetes labels map | object |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |
@@ -1818,7 +1818,7 @@ An example event for `state_statefulset` looks as following:
 | kubernetes.pod.name | Kubernetes pod name | keyword |  |
 | kubernetes.pod.uid | Kubernetes pod UID | keyword |  |
 | kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |
+| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |
 | kubernetes.statefulset.created | The creation timestamp (epoch) for StatefulSet | long | gauge |
 | kubernetes.statefulset.generation.desired | The desired generation per StatefulSet | long | gauge |
 | kubernetes.statefulset.generation.observed | The observed generation per StatefulSet | long | gauge |
@@ -1937,11 +1937,11 @@ An example event for `state_storageclass` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| kubernetes.annotations.* | Kubernetes annotations map | object |
+| kubernetes.annotations.\* | Kubernetes annotations map | object |
 | kubernetes.container.image | Kubernetes container image | keyword |
 | kubernetes.container.name | Kubernetes container name | keyword |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |
-| kubernetes.labels.* | Kubernetes labels map | object |
+| kubernetes.labels.\* | Kubernetes labels map | object |
 | kubernetes.namespace | Kubernetes namespace | keyword |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
 | kubernetes.node.name | Kubernetes node name | keyword |
@@ -1949,7 +1949,7 @@ An example event for `state_storageclass` looks as following:
 | kubernetes.pod.name | Kubernetes pod name | keyword |
 | kubernetes.pod.uid | Kubernetes pod UID | keyword |
 | kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |
+| kubernetes.selectors.\* | Kubernetes Service selectors map | object |
 | kubernetes.statefulset.name | Kubernetes statefulset name | keyword |
 | kubernetes.storageclass.created | Storage class creation date | date |
 | kubernetes.storageclass.name | Storage class name. | keyword |

--- a/packages/kubernetes/docs/kubelet.md
+++ b/packages/kubernetes/docs/kubelet.md
@@ -200,7 +200,7 @@ An example event for `container` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
 | host.os.version | Operating system version as a raw string. | keyword |  |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
-| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.annotations.\* | Kubernetes annotations map | object |  |  |
 | kubernetes.container.cpu.usage.core.ns | Container CPU Core usage nanoseconds | long |  | gauge |
 | kubernetes.container.cpu.usage.limit.pct | CPU usage as a percentage of the defined limit for the container (or total node allocatable CPU if unlimited) | scaled_float | percent | gauge |
 | kubernetes.container.cpu.usage.nanocores | CPU used nanocores | long |  | gauge |
@@ -227,7 +227,7 @@ An example event for `container` looks as following:
 | kubernetes.container.rootfs.used.bytes | Root filesystem total used in bytes | long | byte | gauge |
 | kubernetes.container.start_time | Start time | date |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
-| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.labels.\* | Kubernetes labels map | object |  |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |
@@ -235,7 +235,7 @@ An example event for `container` looks as following:
 | kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
 | kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
 | kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |  |
 | kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
 | service.address | Service address | keyword |  |  |
 | service.type | Service type | keyword |  |  |
@@ -437,11 +437,11 @@ An example event for `node` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
 | host.os.version | Operating system version as a raw string. | keyword |  |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
-| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.annotations.\* | Kubernetes annotations map | object |  |  |
 | kubernetes.container.image | Kubernetes container image | keyword |  |  |
 | kubernetes.container.name | Kubernetes container name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
-| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.labels.\* | Kubernetes labels map | object |  |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |  |
 | kubernetes.node.cpu.usage.core.ns | Node CPU Core usage nanoseconds | long |  | gauge |
 | kubernetes.node.cpu.usage.nanocores | CPU used nanocores | long |  | gauge |
@@ -471,7 +471,7 @@ An example event for `node` looks as following:
 | kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
 | kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
 | kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |  |
 | kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
 | service.address | Service address | keyword |  |  |
 | service.type | Service type | keyword |  |  |
@@ -650,11 +650,11 @@ An example event for `pod` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
 | host.os.version | Operating system version as a raw string. | keyword |  |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
-| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.annotations.\* | Kubernetes annotations map | object |  |  |
 | kubernetes.container.image | Kubernetes container image | keyword |  |  |
 | kubernetes.container.name | Kubernetes container name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
-| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.labels.\* | Kubernetes labels map | object |  |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |
@@ -678,7 +678,7 @@ An example event for `pod` looks as following:
 | kubernetes.pod.start_time | Start time | date |  |  |
 | kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
 | kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |  |
 | kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
 | service.address | Service address | keyword |  |  |
 | service.type | Service type | keyword |  |  |
@@ -833,11 +833,11 @@ An example event for `system` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
 | host.os.version | Operating system version as a raw string. | keyword |  |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
-| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.annotations.\* | Kubernetes annotations map | object |  |  |
 | kubernetes.container.image | Kubernetes container image | keyword |  |  |
 | kubernetes.container.name | Kubernetes container name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
-| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.labels.\* | Kubernetes labels map | object |  |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |
@@ -845,7 +845,7 @@ An example event for `system` looks as following:
 | kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
 | kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
 | kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |  |
 | kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
 | kubernetes.system.container | Container name | keyword |  |  |
 | kubernetes.system.cpu.usage.core.ns | CPU Core usage nanoseconds | long |  | gauge |
@@ -1007,11 +1007,11 @@ An example event for `volume` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
 | host.os.version | Operating system version as a raw string. | keyword |  |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
-| kubernetes.annotations.* | Kubernetes annotations map | object |  |  |
+| kubernetes.annotations.\* | Kubernetes annotations map | object |  |  |
 | kubernetes.container.image | Kubernetes container image | keyword |  |  |
 | kubernetes.container.name | Kubernetes container name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
-| kubernetes.labels.* | Kubernetes labels map | object |  |  |
+| kubernetes.labels.\* | Kubernetes labels map | object |  |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |
@@ -1019,7 +1019,7 @@ An example event for `volume` looks as following:
 | kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
 | kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
 | kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
-| kubernetes.selectors.* | Kubernetes Service selectors map | object |  |  |
+| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |  |
 | kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
 | kubernetes.volume.fs.available.bytes | Filesystem total available in bytes | long | byte | gauge |
 | kubernetes.volume.fs.capacity.bytes | Filesystem total capacity in bytes | long | byte | gauge |

--- a/packages/kubernetes/kibana/dashboard/kubernetes-AV4RGUqo5NkDleZmzKuZ.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-AV4RGUqo5NkDleZmzKuZ.json
@@ -19,7 +19,9 @@
         },
         "panelsJSON": [
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 12,
                     "i": "1",
@@ -28,11 +30,14 @@
                     "y": 0
                 },
                 "panelIndex": "1",
-                "panelRefName": "panel_0",
-                "version": "7.3.0"
+                "panelRefName": "panel_1",
+                "type": "visualization",
+                "version": "7.14.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 12,
                     "i": "2",
@@ -41,24 +46,30 @@
                     "y": 24
                 },
                 "panelIndex": "2",
-                "panelRefName": "panel_1",
-                "version": "7.3.0"
+                "panelRefName": "panel_2",
+                "type": "visualization",
+                "version": "7.14.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 12,
                     "i": "5",
-                    "w": 12,
-                    "x": 12,
+                    "w": 8,
+                    "x": 16,
                     "y": 0
                 },
                 "panelIndex": "5",
-                "panelRefName": "panel_2",
-                "version": "7.3.0"
+                "panelRefName": "panel_5",
+                "type": "visualization",
+                "version": "7.14.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 12,
                     "i": "6",
@@ -67,11 +78,14 @@
                     "y": 12
                 },
                 "panelIndex": "6",
-                "panelRefName": "panel_3",
-                "version": "7.3.0"
+                "panelRefName": "panel_6",
+                "type": "visualization",
+                "version": "7.14.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 12,
                     "i": "7",
@@ -80,11 +94,14 @@
                     "y": 24
                 },
                 "panelIndex": "7",
-                "panelRefName": "panel_4",
-                "version": "7.3.0"
+                "panelRefName": "panel_7",
+                "type": "visualization",
+                "version": "7.14.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 12,
                     "i": "8",
@@ -93,11 +110,14 @@
                     "y": 36
                 },
                 "panelIndex": "8",
-                "panelRefName": "panel_5",
-                "version": "7.3.0"
+                "panelRefName": "panel_8",
+                "type": "visualization",
+                "version": "7.14.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 12,
                     "i": "9",
@@ -106,24 +126,30 @@
                     "y": 36
                 },
                 "panelIndex": "9",
-                "panelRefName": "panel_6",
-                "version": "7.3.0"
+                "panelRefName": "panel_9",
+                "type": "visualization",
+                "version": "7.14.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 12,
                     "i": "10",
-                    "w": 12,
-                    "x": 0,
+                    "w": 8,
+                    "x": 8,
                     "y": 0
                 },
                 "panelIndex": "10",
-                "panelRefName": "panel_7",
-                "version": "7.3.0"
+                "panelRefName": "panel_10",
+                "type": "visualization",
+                "version": "7.14.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 12,
                     "i": "11",
@@ -132,11 +158,14 @@
                     "y": 48
                 },
                 "panelIndex": "11",
-                "panelRefName": "panel_8",
-                "version": "7.3.0"
+                "panelRefName": "panel_11",
+                "type": "visualization",
+                "version": "7.14.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 12,
                     "i": "12",
@@ -145,11 +174,14 @@
                     "y": 48
                 },
                 "panelIndex": "12",
-                "panelRefName": "panel_9",
-                "version": "7.3.0"
+                "panelRefName": "panel_12",
+                "type": "visualization",
+                "version": "7.14.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 12,
                     "i": "13",
@@ -158,11 +190,14 @@
                     "y": 12
                 },
                 "panelIndex": "13",
-                "panelRefName": "panel_10",
-                "version": "7.3.0"
+                "panelRefName": "panel_13",
+                "type": "visualization",
+                "version": "7.14.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 12,
                     "i": "14",
@@ -171,11 +206,14 @@
                     "y": 12
                 },
                 "panelIndex": "14",
-                "panelRefName": "panel_11",
-                "version": "7.3.0"
+                "panelRefName": "panel_14",
+                "type": "visualization",
+                "version": "7.14.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 12,
                     "i": "15",
@@ -184,83 +222,144 @@
                     "y": 12
                 },
                 "panelIndex": "15",
-                "panelRefName": "panel_12",
-                "version": "7.3.0"
+                "panelRefName": "panel_15",
+                "type": "visualization",
+                "version": "7.14.0"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
+                        "description": "",
+                        "params": {
+                            "controls": [
+                                {
+                                    "fieldName": "orchestrator.cluster.name",
+                                    "id": "1627653028481",
+                                    "indexPatternRefName": "control_19a96b32-b3c9-4aae-a80c-54099f64ffb2_0_index_pattern",
+                                    "label": "Cluster Name",
+                                    "options": {
+                                        "dynamicOptions": true,
+                                        "multiselect": true,
+                                        "order": "desc",
+                                        "size": 5,
+                                        "type": "terms"
+                                    },
+                                    "parent": "",
+                                    "type": "list"
+                                }
+                            ],
+                            "pinFilters": false,
+                            "updateFiltersOnChange": true,
+                            "useTimeFilter": false
+                        },
+                        "title": "",
+                        "type": "input_control_vis",
+                        "uiState": {}
+                    }
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "19a96b32-b3c9-4aae-a80c-54099f64ffb2",
+                    "w": 8,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "19a96b32-b3c9-4aae-a80c-54099f64ffb2",
+                "title": "Cluster Filter [Metrics Kubernetes]",
+                "type": "visualization",
+                "version": "7.14.0"
             }
         ],
         "timeRestore": false,
         "title": "[Metrics Kubernetes] Overview",
         "version": 1
     },
+    "coreMigrationVersion": "7.14.0",
     "id": "kubernetes-AV4RGUqo5NkDleZmzKuZ",
     "migrationVersion": {
-        "dashboard": "7.3.0"
+        "dashboard": "7.14.0"
     },
     "references": [
         {
             "id": "kubernetes-022a54c0-2bf5-11e7-859b-f78b612cde28",
-            "name": "panel_0",
+            "name": "1:panel_1",
             "type": "visualization"
         },
         {
             "id": "kubernetes-44f12b40-2bf4-11e7-859b-f78b612cde28",
-            "name": "panel_1",
+            "name": "2:panel_2",
             "type": "visualization"
         },
         {
             "id": "kubernetes-cd059410-2bfb-11e7-859b-f78b612cde28",
-            "name": "panel_2",
+            "name": "5:panel_5",
             "type": "visualization"
         },
         {
             "id": "kubernetes-e1018b90-2bfb-11e7-859b-f78b612cde28",
-            "name": "panel_3",
+            "name": "6:panel_6",
             "type": "visualization"
         },
         {
             "id": "kubernetes-d6564360-2bfc-11e7-859b-f78b612cde28",
-            "name": "panel_4",
+            "name": "7:panel_7",
             "type": "visualization"
         },
         {
             "id": "kubernetes-16fa4470-2bfd-11e7-859b-f78b612cde28",
-            "name": "panel_5",
+            "name": "8:panel_8",
             "type": "visualization"
         },
         {
             "id": "kubernetes-294546b0-30d6-11e7-8df8-6d3604a72912",
-            "name": "panel_6",
+            "name": "9:panel_9",
             "type": "visualization"
         },
         {
             "id": "kubernetes-408fccf0-30d6-11e7-8df8-6d3604a72912",
-            "name": "panel_7",
+            "name": "10:panel_10",
             "type": "visualization"
         },
         {
             "id": "kubernetes-58e644f0-30d6-11e7-8df8-6d3604a72912",
-            "name": "panel_8",
+            "name": "11:panel_11",
             "type": "visualization"
         },
         {
             "id": "kubernetes-a4c9d360-30df-11e7-8df8-6d3604a72912",
-            "name": "panel_9",
+            "name": "12:panel_12",
             "type": "visualization"
         },
         {
             "id": "kubernetes-174a6ad0-30e0-11e7-8df8-6d3604a72912",
-            "name": "panel_10",
+            "name": "13:panel_13",
             "type": "visualization"
         },
         {
             "id": "kubernetes-7aac4fd0-30e0-11e7-8df8-6d3604a72912",
-            "name": "panel_11",
+            "name": "14:panel_14",
             "type": "visualization"
         },
         {
             "id": "kubernetes-da1ff7c0-30ed-11e7-b9e5-2b5b07213ab3",
-            "name": "panel_12",
+            "name": "15:panel_15",
             "type": "visualization"
+        },
+        {
+            "id": "metrics-*",
+            "name": "19a96b32-b3c9-4aae-a80c-54099f64ffb2:control_19a96b32-b3c9-4aae-a80c-54099f64ffb2_0_index_pattern",
+            "type": "index-pattern"
         }
     ],
     "type": "dashboard"

--- a/packages/kubernetes/kibana/visualization/kubernetes-022a54c0-2bf5-11e7-859b-f78b612cde28.json
+++ b/packages/kubernetes/kibana/visualization/kubernetes-022a54c0-2bf5-11e7-859b-f78b612cde28.json
@@ -2,13 +2,7 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
-                "filter": [],
-                "query": {
-                    "language": "kuery",
-                    "query": "data_stream.dataset: kubernetes.state_deployment"
-                }
-            }
+            "searchSourceJSON": {}
         },
         "title": "Available pods per deployment [Metrics Kubernetes]",
         "uiStateJSON": {},
@@ -60,15 +54,17 @@
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "timeseries"
+                "type": "timeseries",
+                "use_kibana_indexes": false
             },
             "title": "Available pods per deployment [Metrics Kubernetes]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "7.14.0",
     "id": "kubernetes-022a54c0-2bf5-11e7-859b-f78b612cde28",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "7.14.0"
     },
     "references": [],
     "type": "visualization"

--- a/packages/kubernetes/kibana/visualization/kubernetes-16fa4470-2bfd-11e7-859b-f78b612cde28.json
+++ b/packages/kubernetes/kibana/visualization/kubernetes-16fa4470-2bfd-11e7-859b-f78b612cde28.json
@@ -2,13 +2,7 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
-                "filter": [],
-                "query": {
-                    "language": "kuery",
-                    "query": "data_stream.dataset: kubernetes.pod"
-                }
-            }
+            "searchSourceJSON": {}
         },
         "title": "Network in by node  [Metrics Kubernetes]",
         "uiStateJSON": {},
@@ -85,15 +79,17 @@
                 ],
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "timeseries"
+                "type": "timeseries",
+                "use_kibana_indexes": false
             },
             "title": "Network in by node  [Metrics Kubernetes]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "7.14.0",
     "id": "kubernetes-16fa4470-2bfd-11e7-859b-f78b612cde28",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "7.14.0"
     },
     "references": [],
     "type": "visualization"

--- a/packages/kubernetes/kibana/visualization/kubernetes-174a6ad0-30e0-11e7-8df8-6d3604a72912.json
+++ b/packages/kubernetes/kibana/visualization/kubernetes-174a6ad0-30e0-11e7-8df8-6d3604a72912.json
@@ -2,13 +2,7 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
-                "filter": [],
-                "query": {
-                    "language": "kuery",
-                    "query": "data_stream.dataset: kubernetes.state_deployment"
-                }
-            }
+            "searchSourceJSON": {}
         },
         "title": "Unavailable pods [Metrics Kubernetes]",
         "uiStateJSON": {},
@@ -42,6 +36,7 @@
                 "gauge_max": "",
                 "gauge_style": "half",
                 "gauge_width": "10",
+                "hide_last_value_indicator": true,
                 "id": "2fe9d3b0-30d5-11e7-8df8-6d3604a72912",
                 "index_pattern": "metrics-*",
                 "interval": "auto",
@@ -73,15 +68,17 @@
                 ],
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "metric"
+                "type": "metric",
+                "use_kibana_indexes": false
             },
             "title": "Unavailable pods [Metrics Kubernetes]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "7.14.0",
     "id": "kubernetes-174a6ad0-30e0-11e7-8df8-6d3604a72912",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "7.14.0"
     },
     "references": [],
     "type": "visualization"

--- a/packages/kubernetes/kibana/visualization/kubernetes-294546b0-30d6-11e7-8df8-6d3604a72912.json
+++ b/packages/kubernetes/kibana/visualization/kubernetes-294546b0-30d6-11e7-8df8-6d3604a72912.json
@@ -2,13 +2,7 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
-                "filter": [],
-                "query": {
-                    "language": "kuery",
-                    "query": "data_stream.dataset: kubernetes.pod"
-                }
-            }
+            "searchSourceJSON": {}
         },
         "title": "Network out by node  [Metrics Kubernetes]",
         "uiStateJSON": {},
@@ -85,15 +79,17 @@
                 ],
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "timeseries"
+                "type": "timeseries",
+                "use_kibana_indexes": false
             },
             "title": "Network out by node  [Metrics Kubernetes]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "7.14.0",
     "id": "kubernetes-294546b0-30d6-11e7-8df8-6d3604a72912",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "7.14.0"
     },
     "references": [],
     "type": "visualization"

--- a/packages/kubernetes/kibana/visualization/kubernetes-408fccf0-30d6-11e7-8df8-6d3604a72912.json
+++ b/packages/kubernetes/kibana/visualization/kubernetes-408fccf0-30d6-11e7-8df8-6d3604a72912.json
@@ -2,13 +2,7 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
-                "filter": [],
-                "query": {
-                    "language": "kuery",
-                    "query": "data_stream.dataset: kubernetes.state_node"
-                }
-            }
+            "searchSourceJSON": {}
         },
         "title": "Nodes [Metrics Kubernetes]",
         "uiStateJSON": {},
@@ -41,6 +35,7 @@
                 "gauge_inner_width": 10,
                 "gauge_style": "half",
                 "gauge_width": 10,
+                "hide_last_value_indicator": true,
                 "id": "4c4690b0-30e0-11e7-8df8-6d3604a72912",
                 "index_pattern": "metrics-*",
                 "interval": "auto",
@@ -71,15 +66,17 @@
                 ],
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "metric"
+                "type": "metric",
+                "use_kibana_indexes": false
             },
             "title": "Nodes [Metrics Kubernetes]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "7.14.0",
     "id": "kubernetes-408fccf0-30d6-11e7-8df8-6d3604a72912",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "7.14.0"
     },
     "references": [],
     "type": "visualization"

--- a/packages/kubernetes/kibana/visualization/kubernetes-44f12b40-2bf4-11e7-859b-f78b612cde28.json
+++ b/packages/kubernetes/kibana/visualization/kubernetes-44f12b40-2bf4-11e7-859b-f78b612cde28.json
@@ -2,13 +2,7 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
-                "filter": [],
-                "query": {
-                    "language": "kuery",
-                    "query": ""
-                }
-            }
+            "searchSourceJSON": {}
         },
         "title": "CPU usage by node  [Metrics Kubernetes]",
         "uiStateJSON": {},
@@ -140,15 +134,17 @@
                 ],
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "timeseries"
+                "type": "timeseries",
+                "use_kibana_indexes": false
             },
             "title": "CPU usage by node  [Metrics Kubernetes]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "7.14.0",
     "id": "kubernetes-44f12b40-2bf4-11e7-859b-f78b612cde28",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "7.14.0"
     },
     "references": [],
     "type": "visualization"

--- a/packages/kubernetes/kibana/visualization/kubernetes-58e644f0-30d6-11e7-8df8-6d3604a72912.json
+++ b/packages/kubernetes/kibana/visualization/kubernetes-58e644f0-30d6-11e7-8df8-6d3604a72912.json
@@ -2,13 +2,7 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
-                "filter": [],
-                "query": {
-                    "language": "kuery",
-                    "query": ""
-                }
-            }
+            "searchSourceJSON": {}
         },
         "title": "Top CPU intensive pods  [Metrics Kubernetes]",
         "uiStateJSON": {},
@@ -28,6 +22,7 @@
                     "language": "lucene",
                     "query": "data_stream.dataset:kubernetes.container"
                 },
+                "hide_last_value_indicator": true,
                 "id": "5d3692a0-2bfc-11e7-859b-f78b612cde28",
                 "index_pattern": "metrics-*",
                 "interval": "auto",
@@ -73,15 +68,17 @@
                 ],
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "top_n"
+                "type": "top_n",
+                "use_kibana_indexes": false
             },
             "title": "Top CPU intensive pods  [Metrics Kubernetes]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "7.14.0",
     "id": "kubernetes-58e644f0-30d6-11e7-8df8-6d3604a72912",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "7.14.0"
     },
     "references": [],
     "type": "visualization"

--- a/packages/kubernetes/kibana/visualization/kubernetes-7aac4fd0-30e0-11e7-8df8-6d3604a72912.json
+++ b/packages/kubernetes/kibana/visualization/kubernetes-7aac4fd0-30e0-11e7-8df8-6d3604a72912.json
@@ -2,13 +2,7 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
-                "filter": [],
-                "query": {
-                    "language": "kuery",
-                    "query": "data_stream.dataset: kubernetes.state_deployment"
-                }
-            }
+            "searchSourceJSON": {}
         },
         "title": "Unavailable pods per deployment [Metrics Kubernetes]",
         "uiStateJSON": {},
@@ -60,15 +54,17 @@
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "timeseries"
+                "type": "timeseries",
+                "use_kibana_indexes": false
             },
             "title": "Unavailable pods per deployment [Metrics Kubernetes]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "7.14.0",
     "id": "kubernetes-7aac4fd0-30e0-11e7-8df8-6d3604a72912",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "7.14.0"
     },
     "references": [],
     "type": "visualization"

--- a/packages/kubernetes/kibana/visualization/kubernetes-a4c9d360-30df-11e7-8df8-6d3604a72912.json
+++ b/packages/kubernetes/kibana/visualization/kubernetes-a4c9d360-30df-11e7-8df8-6d3604a72912.json
@@ -2,13 +2,7 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
-                "filter": [],
-                "query": {
-                    "language": "kuery",
-                    "query": "data_stream.dataset: kubernetes.container"
-                }
-            }
+            "searchSourceJSON": {}
         },
         "title": "Top memory intensive pods  [Metrics Kubernetes]",
         "uiStateJSON": {},
@@ -27,6 +21,7 @@
                     "language": "lucene",
                     "query": "data_stream.dataset:kubernetes.container"
                 },
+                "hide_last_value_indicator": true,
                 "id": "5d3692a0-2bfc-11e7-859b-f78b612cde28",
                 "index_pattern": "metrics-*",
                 "interval": "auto",
@@ -73,15 +68,17 @@
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "top_n"
+                "type": "top_n",
+                "use_kibana_indexes": false
             },
             "title": "Top memory intensive pods  [Metrics Kubernetes]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "7.14.0",
     "id": "kubernetes-a4c9d360-30df-11e7-8df8-6d3604a72912",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "7.14.0"
     },
     "references": [],
     "type": "visualization"

--- a/packages/kubernetes/kibana/visualization/kubernetes-cd059410-2bfb-11e7-859b-f78b612cde28.json
+++ b/packages/kubernetes/kibana/visualization/kubernetes-cd059410-2bfb-11e7-859b-f78b612cde28.json
@@ -2,13 +2,7 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
-                "filter": [],
-                "query": {
-                    "language": "kuery",
-                    "query": "data_stream.dataset: kubernetes.state_deployment"
-                }
-            }
+            "searchSourceJSON": {}
         },
         "title": "Deployments [Metrics Kubernetes]",
         "uiStateJSON": {},
@@ -41,6 +35,7 @@
                 "gauge_inner_width": 10,
                 "gauge_style": "half",
                 "gauge_width": 10,
+                "hide_last_value_indicator": true,
                 "id": "4c4690b0-30e0-11e7-8df8-6d3604a72912",
                 "index_pattern": "metrics-*",
                 "interval": "auto",
@@ -71,15 +66,17 @@
                 ],
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "metric"
+                "type": "metric",
+                "use_kibana_indexes": false
             },
             "title": "Deployments [Metrics Kubernetes]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "7.14.0",
     "id": "kubernetes-cd059410-2bfb-11e7-859b-f78b612cde28",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "7.14.0"
     },
     "references": [],
     "type": "visualization"

--- a/packages/kubernetes/kibana/visualization/kubernetes-d6564360-2bfc-11e7-859b-f78b612cde28.json
+++ b/packages/kubernetes/kibana/visualization/kubernetes-d6564360-2bfc-11e7-859b-f78b612cde28.json
@@ -2,13 +2,7 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
-                "filter": [],
-                "query": {
-                    "language": "kuery",
-                    "query": ""
-                }
-            }
+            "searchSourceJSON": {}
         },
         "title": "Memory usage by node  [Metrics Kubernetes]",
         "uiStateJSON": {},
@@ -120,15 +114,17 @@
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "timeseries"
+                "type": "timeseries",
+                "use_kibana_indexes": false
             },
             "title": "Memory usage by node  [Metrics Kubernetes]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "7.14.0",
     "id": "kubernetes-d6564360-2bfc-11e7-859b-f78b612cde28",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "7.14.0"
     },
     "references": [],
     "type": "visualization"

--- a/packages/kubernetes/kibana/visualization/kubernetes-da1ff7c0-30ed-11e7-b9e5-2b5b07213ab3.json
+++ b/packages/kubernetes/kibana/visualization/kubernetes-da1ff7c0-30ed-11e7-b9e5-2b5b07213ab3.json
@@ -2,13 +2,7 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
-                "filter": [],
-                "query": {
-                    "language": "kuery",
-                    "query": "data_stream.dataset: kubernetes.state_deployment"
-                }
-            }
+            "searchSourceJSON": {}
         },
         "title": "Available pods [Metrics Kubernetes]",
         "uiStateJSON": {},
@@ -42,6 +36,7 @@
                 "gauge_max": "5",
                 "gauge_style": "half",
                 "gauge_width": "10",
+                "hide_last_value_indicator": true,
                 "id": "2fe9d3b0-30d5-11e7-8df8-6d3604a72912",
                 "index_pattern": "metrics-*",
                 "interval": "auto",
@@ -75,15 +70,17 @@
                 ],
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "metric"
+                "type": "metric",
+                "use_kibana_indexes": false
             },
             "title": "Available pods [Metrics Kubernetes]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "7.14.0",
     "id": "kubernetes-da1ff7c0-30ed-11e7-b9e5-2b5b07213ab3",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "7.14.0"
     },
     "references": [],
     "type": "visualization"

--- a/packages/kubernetes/kibana/visualization/kubernetes-e1018b90-2bfb-11e7-859b-f78b612cde28.json
+++ b/packages/kubernetes/kibana/visualization/kubernetes-e1018b90-2bfb-11e7-859b-f78b612cde28.json
@@ -2,13 +2,7 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
-                "filter": [],
-                "query": {
-                    "language": "kuery",
-                    "query": "data_stream.dataset: kubernetes.state_deployment"
-                }
-            }
+            "searchSourceJSON": {}
         },
         "title": "Desired pods [Metrics Kubernetes]",
         "uiStateJSON": {},
@@ -42,6 +36,7 @@
                 "gauge_max": "5",
                 "gauge_style": "half",
                 "gauge_width": "10",
+                "hide_last_value_indicator": true,
                 "id": "2fe9d3b0-30d5-11e7-8df8-6d3604a72912",
                 "index_pattern": "metrics-*",
                 "interval": "auto",
@@ -74,15 +69,17 @@
                 ],
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "metric"
+                "type": "metric",
+                "use_kibana_indexes": false
             },
             "title": "Desired pods [Metrics Kubernetes]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "7.14.0",
     "id": "kubernetes-e1018b90-2bfb-11e7-859b-f78b612cde28",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "7.14.0"
     },
     "references": [],
     "type": "visualization"


### PR DESCRIPTION
## What does this PR do?
Added a Cluster name selector on the [Metrics Kubernetes] Overview dashboard. This selector will be used as a filter for the dashboard. Also, added a blurb for this selector on the Kubernetes package guide to explain how this selector works and where it sources the data from.

## Why is it important?
We have added a new Cluster name field in the Kubernetes package. This field will not be useful unless users could discover it in some form
in UI.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have added an entry to my package's `changelog.yml` file.

<img width="2560" alt="Screen Shot 2021-07-30 at 9 49 11 AM" src="https://user-images.githubusercontent.com/14043218/127669905-4495c4a5-81e4-41dc-b0c1-d0ad432bf858.png">

