### PR TITLE
postgresql update to ECS 1.11.0

### DIFF
--- a/packages/postgresql/changelog.yml
+++ b/packages/postgresql/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.7.2'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1410
 - version: "0.7.1"
   changes:
     - description: Escape special characters in docs

--- a/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-10-default.log-expected.json
+++ b/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-10-default.log-expected.json
@@ -6,7 +6,7 @@
             },
             "@timestamp": "2020-04-15T10:02:55.244Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -39,7 +39,7 @@
             },
             "@timestamp": "2020-04-15T10:02:55.247Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -72,7 +72,7 @@
             },
             "@timestamp": "2020-04-15T10:04:45.416Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -105,7 +105,7 @@
             },
             "@timestamp": "2020-04-15T10:04:45.416Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -138,7 +138,7 @@
             },
             "@timestamp": "2020-04-15T10:04:45.416Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -171,7 +171,7 @@
             },
             "@timestamp": "2020-04-15T10:06:36.719Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -204,7 +204,7 @@
             },
             "@timestamp": "2020-04-15T10:56:29.569Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {

--- a/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-10-min-duration-statement.log-expected.json
+++ b/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-10-min-duration-statement.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2019-09-22T06:28:24.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -33,7 +33,7 @@
         {
             "@timestamp": "2019-09-22T06:28:24.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -66,7 +66,7 @@
         {
             "@timestamp": "2019-09-22T06:28:24.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -96,7 +96,7 @@
         {
             "@timestamp": "2019-09-22T06:28:24.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -129,7 +129,7 @@
         {
             "@timestamp": "2019-09-22T06:28:24.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -159,7 +159,7 @@
         {
             "@timestamp": "2019-09-22T06:28:24.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {

--- a/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-11-4.log-expected.json
+++ b/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-11-4.log-expected.json
@@ -6,7 +6,7 @@
             },
             "@timestamp": "2019-07-23T12:06:24.406Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -40,7 +40,7 @@
             },
             "@timestamp": "2019-07-23T12:06:24.406Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -73,7 +73,7 @@
             },
             "@timestamp": "2019-07-23T12:06:24.478Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -107,7 +107,7 @@
             },
             "@timestamp": "2019-07-23T12:06:24.478Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -140,7 +140,7 @@
             },
             "@timestamp": "2019-07-23T12:06:24.485Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -174,7 +174,7 @@
             },
             "@timestamp": "2019-07-23T12:06:24.485Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -207,7 +207,7 @@
             },
             "@timestamp": "2019-07-23T12:06:24.485Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -241,7 +241,7 @@
             },
             "@timestamp": "2019-07-23T12:06:24.485Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -274,7 +274,7 @@
             },
             "@timestamp": "2019-07-23T12:06:24.485Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -308,7 +308,7 @@
             },
             "@timestamp": "2019-07-23T12:06:24.485Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -341,7 +341,7 @@
             },
             "@timestamp": "2019-07-23T12:06:24.507Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -375,7 +375,7 @@
             },
             "@timestamp": "2019-07-23T12:06:24.507Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -408,7 +408,7 @@
             },
             "@timestamp": "2019-07-23T12:06:30.536Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -442,7 +442,7 @@
             },
             "@timestamp": "2019-07-23T12:06:30.536Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -475,7 +475,7 @@
             },
             "@timestamp": "2019-07-23T12:06:30.537Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -509,7 +509,7 @@
             },
             "@timestamp": "2019-07-23T12:06:30.537Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -542,7 +542,7 @@
             },
             "@timestamp": "2019-07-23T12:06:33.732Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -576,7 +576,7 @@
             },
             "@timestamp": "2019-07-23T12:06:33.732Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -609,7 +609,7 @@
             },
             "@timestamp": "2019-07-23T12:06:33.732Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -643,7 +643,7 @@
             },
             "@timestamp": "2019-07-23T12:06:33.732Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -676,7 +676,7 @@
             },
             "@timestamp": "2019-07-23T12:06:33.732Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -709,7 +709,7 @@
             },
             "@timestamp": "2019-07-23T12:06:34.877Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -743,7 +743,7 @@
             },
             "@timestamp": "2019-07-23T12:06:34.877Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -776,7 +776,7 @@
             },
             "@timestamp": "2019-07-23T12:06:34.878Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -810,7 +810,7 @@
             },
             "@timestamp": "2019-07-23T12:06:34.878Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -843,7 +843,7 @@
             },
             "@timestamp": "2019-07-23T12:09:57.563Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -877,7 +877,7 @@
             },
             "@timestamp": "2019-07-23T12:09:57.563Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -910,7 +910,7 @@
             },
             "@timestamp": "2019-07-23T12:09:57.565Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -944,7 +944,7 @@
             },
             "@timestamp": "2019-07-23T12:09:57.565Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {

--- a/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-11-autovacuum-csv.log-expected.json
+++ b/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-11-autovacuum-csv.log-expected.json
@@ -6,7 +6,7 @@
             },
             "@timestamp": "2021-01-04T00:37:32.862Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {

--- a/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-11-connection-disconnection-csv.log-expected.json
+++ b/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-11-connection-disconnection-csv.log-expected.json
@@ -6,7 +6,7 @@
             },
             "@timestamp": "2021-01-04T00:04:50.554Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -43,7 +43,7 @@
             },
             "@timestamp": "2021-01-04T00:04:50.568Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -80,7 +80,7 @@
             },
             "@timestamp": "2021-01-04T00:05:06.011Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -126,7 +126,7 @@
             ],
             "@timestamp": "2021-01-04T00:05:06.086Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -176,7 +176,7 @@
             ],
             "@timestamp": "2021-01-04T00:05:12.999Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -228,7 +228,7 @@
             ],
             "@timestamp": "2021-01-04T00:05:17.146Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -280,7 +280,7 @@
             ],
             "@timestamp": "2021-01-04T00:05:23.242Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -332,7 +332,7 @@
             ],
             "@timestamp": "2021-01-04T00:05:28.166Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -384,7 +384,7 @@
             ],
             "@timestamp": "2021-01-04T00:05:29.434Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -436,7 +436,7 @@
             ],
             "@timestamp": "2021-01-04T00:05:31.342Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -488,7 +488,7 @@
             ],
             "@timestamp": "2021-01-04T00:05:37.670Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -540,7 +540,7 @@
             ],
             "@timestamp": "2021-01-04T00:05:51.418Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -583,7 +583,7 @@
             },
             "@timestamp": "2021-01-04T00:05:58.207Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -629,7 +629,7 @@
             ],
             "@timestamp": "2021-01-04T00:05:58.232Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -673,7 +673,7 @@
             },
             "@timestamp": "2021-01-04T00:05:59.807Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -719,7 +719,7 @@
             ],
             "@timestamp": "2021-01-04T00:05:59.833Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -763,7 +763,7 @@
             },
             "@timestamp": "2021-01-04T00:06:03.347Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -809,7 +809,7 @@
             ],
             "@timestamp": "2021-01-04T00:06:03.370Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -853,7 +853,7 @@
             },
             "@timestamp": "2021-01-04T00:06:04.765Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -899,7 +899,7 @@
             ],
             "@timestamp": "2021-01-04T00:06:04.799Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {

--- a/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-11-duration-csv.log-expected.json
+++ b/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-11-duration-csv.log-expected.json
@@ -6,7 +6,7 @@
             },
             "@timestamp": "2021-01-04T00:17:53.742Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -64,7 +64,7 @@
             ],
             "@timestamp": "2021-01-04T00:18:01.055Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -116,7 +116,7 @@
             ],
             "@timestamp": "2021-01-04T00:18:04.650Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {

--- a/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-11-ipv6-csv.log-expected.json
+++ b/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-11-ipv6-csv.log-expected.json
@@ -13,7 +13,7 @@
             ],
             "@timestamp": "2021-01-03T17:45:17.612Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {

--- a/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-11-multi-line-csv.log-expected.json
+++ b/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-11-multi-line-csv.log-expected.json
@@ -13,7 +13,7 @@
             ],
             "@timestamp": "2021-01-04T00:22:01.903Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {

--- a/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-11-parse-bind-csv.log-expected.json
+++ b/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-11-parse-bind-csv.log-expected.json
@@ -13,7 +13,7 @@
             ],
             "@timestamp": "2021-01-04T00:51:56.837Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -66,7 +66,7 @@
             ],
             "@timestamp": "2021-01-04T00:51:56.843Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -120,7 +120,7 @@
             ],
             "@timestamp": "2021-01-04T00:51:56.843Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {

--- a/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-11-start-stop-csv.log-expected.json
+++ b/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-11-start-stop-csv.log-expected.json
@@ -6,7 +6,7 @@
             },
             "@timestamp": "2021-01-03T20:00:46.695Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -43,7 +43,7 @@
             },
             "@timestamp": "2021-01-03T20:00:46.708Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -80,7 +80,7 @@
             },
             "@timestamp": "2021-01-03T20:01:00.349Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -119,7 +119,7 @@
             },
             "@timestamp": "2021-01-03T20:01:02.701Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -165,7 +165,7 @@
             ],
             "@timestamp": "2021-01-03T20:01:02.727Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -215,7 +215,7 @@
             ],
             "@timestamp": "2021-01-03T20:01:07.094Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -267,7 +267,7 @@
             ],
             "@timestamp": "2021-01-03T20:01:07.724Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -310,7 +310,7 @@
             },
             "@timestamp": "2021-01-03T20:01:08.894Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -347,7 +347,7 @@
             },
             "@timestamp": "2021-01-03T20:01:08.899Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -384,7 +384,7 @@
             },
             "@timestamp": "2021-01-03T20:01:08.899Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -421,7 +421,7 @@
             },
             "@timestamp": "2021-01-03T20:01:08.901Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -458,7 +458,7 @@
             },
             "@timestamp": "2021-01-03T20:01:08.910Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -495,7 +495,7 @@
             },
             "@timestamp": "2021-01-03T20:01:08.919Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {

--- a/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-11-tempfile-csv.log-expected.json
+++ b/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-11-tempfile-csv.log-expected.json
@@ -13,7 +13,7 @@
             ],
             "@timestamp": "2021-01-04T00:33:05.565Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -66,7 +66,7 @@
             ],
             "@timestamp": "2021-01-04T00:33:15.885Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -118,7 +118,7 @@
             ],
             "@timestamp": "2021-01-04T00:33:15.885Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -170,7 +170,7 @@
             ],
             "@timestamp": "2021-01-04T00:33:15.885Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -222,7 +222,7 @@
             ],
             "@timestamp": "2021-01-04T00:33:15.885Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {

--- a/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-12-default.log-expected.json
+++ b/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-12-default.log-expected.json
@@ -6,7 +6,7 @@
             },
             "@timestamp": "2020-04-16T09:45:11.844Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -39,7 +39,7 @@
             },
             "@timestamp": "2020-04-16T09:45:11.844Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -72,7 +72,7 @@
             },
             "@timestamp": "2020-04-16T09:45:11.844Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -105,7 +105,7 @@
             },
             "@timestamp": "2020-04-16T09:45:11.846Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -138,7 +138,7 @@
             },
             "@timestamp": "2020-04-16T09:45:11.861Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -171,7 +171,7 @@
             },
             "@timestamp": "2020-04-16T09:45:11.864Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -204,7 +204,7 @@
             },
             "@timestamp": "2020-04-16T10:22:22.579Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -237,7 +237,7 @@
             },
             "@timestamp": "2020-04-16T10:22:22.582Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -270,7 +270,7 @@
             },
             "@timestamp": "2020-04-16T10:22:22.582Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -303,7 +303,7 @@
             },
             "@timestamp": "2020-04-16T10:22:22.596Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {

--- a/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-12-min-duration-statement.log-expected.json
+++ b/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-12-min-duration-statement.log-expected.json
@@ -6,7 +6,7 @@
             },
             "@timestamp": "2020-04-16T10:48:36.677Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -41,7 +41,7 @@
             },
             "@timestamp": "2020-04-16T10:48:40.316Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -76,7 +76,7 @@
             },
             "@timestamp": "2020-04-16T10:48:44.696Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -109,7 +109,7 @@
             },
             "@timestamp": "2020-04-16T10:48:44.696Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -142,7 +142,7 @@
             },
             "@timestamp": "2020-04-16T10:49:16.871Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -177,7 +177,7 @@
             },
             "@timestamp": "2020-04-16T10:49:19.866Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -210,7 +210,7 @@
             },
             "@timestamp": "2020-04-16T10:49:54.907Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -245,7 +245,7 @@
             },
             "@timestamp": "2020-04-16T10:49:55.464Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -280,7 +280,7 @@
             },
             "@timestamp": "2020-04-16T10:50:05.322Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -315,7 +315,7 @@
             },
             "@timestamp": "2020-04-16T10:50:06.741Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {

--- a/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-13-csv.log-expected.json
+++ b/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-13-csv.log-expected.json
@@ -6,7 +6,7 @@
             },
             "@timestamp": "2021-01-04T01:06:13.270Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -44,7 +44,7 @@
             },
             "@timestamp": "2021-01-04T01:06:13.270Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -82,7 +82,7 @@
             },
             "@timestamp": "2021-01-04T01:06:13.270Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -120,7 +120,7 @@
             },
             "@timestamp": "2021-01-04T01:06:13.273Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -158,7 +158,7 @@
             },
             "@timestamp": "2021-01-04T01:06:13.281Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -196,7 +196,7 @@
             },
             "@timestamp": "2021-01-04T01:06:13.289Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -234,7 +234,7 @@
             },
             "@timestamp": "2021-01-04T01:06:20.982Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -281,7 +281,7 @@
             ],
             "@timestamp": "2021-01-04T01:06:21.083Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -332,7 +332,7 @@
             ],
             "@timestamp": "2021-01-04T01:06:25.161Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -385,7 +385,7 @@
             ],
             "@timestamp": "2021-01-04T01:06:41.115Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -438,7 +438,7 @@
             ],
             "@timestamp": "2021-01-04T01:06:54.227Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -491,7 +491,7 @@
             ],
             "@timestamp": "2021-01-04T01:06:55.502Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -544,7 +544,7 @@
             ],
             "@timestamp": "2021-01-04T01:06:58.297Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -597,7 +597,7 @@
             ],
             "@timestamp": "2021-01-04T01:07:01.116Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -650,7 +650,7 @@
             ],
             "@timestamp": "2021-01-04T01:07:04.364Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -703,7 +703,7 @@
             ],
             "@timestamp": "2021-01-04T01:07:07.070Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -756,7 +756,7 @@
             ],
             "@timestamp": "2021-01-04T01:07:13.725Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -809,7 +809,7 @@
             ],
             "@timestamp": "2021-01-04T01:07:19.998Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -855,7 +855,7 @@
             },
             "@timestamp": "2021-01-04T01:07:19.999Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -893,7 +893,7 @@
             },
             "@timestamp": "2021-01-04T01:07:20.001Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -931,7 +931,7 @@
             },
             "@timestamp": "2021-01-04T01:07:20.001Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -969,7 +969,7 @@
             },
             "@timestamp": "2021-01-04T01:07:24.360Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1007,7 +1007,7 @@
             },
             "@timestamp": "2021-01-04T01:07:24.374Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1052,7 +1052,7 @@
             ],
             "@timestamp": "2021-01-04T01:07:24.374Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1106,7 +1106,7 @@
             ],
             "@timestamp": "2021-01-04T01:07:25.950Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {

--- a/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-13-error-code-csv.log-expected.json
+++ b/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-13-error-code-csv.log-expected.json
@@ -13,7 +13,7 @@
             ],
             "@timestamp": "2021-02-14T10:45:33.257Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -66,7 +66,7 @@
             ],
             "@timestamp": "2021-02-14T10:45:48.113Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -119,7 +119,7 @@
             ],
             "@timestamp": "2021-02-14T10:45:48.164Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -171,7 +171,7 @@
             ],
             "@timestamp": "2021-02-14T10:45:48.164Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {

--- a/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-9-6-debian-with-slowlog.log-expected.json
+++ b/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-9-6-debian-with-slowlog.log-expected.json
@@ -6,7 +6,7 @@
             },
             "@timestamp": "2017-07-31T11:36:42.585Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -39,7 +39,7 @@
             },
             "@timestamp": "2017-07-31T11:36:42.605Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -72,7 +72,7 @@
             },
             "@timestamp": "2017-07-31T11:36:42.615Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -105,7 +105,7 @@
             },
             "@timestamp": "2017-07-31T11:36:42.616Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -145,7 +145,7 @@
             ],
             "@timestamp": "2017-07-31T11:36:42.956Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -180,7 +180,7 @@
             },
             "@timestamp": "2017-07-31T11:36:43.557Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -224,7 +224,7 @@
             },
             "@timestamp": "2017-07-31T11:36:44.104Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -268,7 +268,7 @@
             },
             "@timestamp": "2017-07-31T11:36:44.642Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -319,7 +319,7 @@
             ],
             "@timestamp": "2017-07-31T11:39:16.249Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -361,7 +361,7 @@
             ],
             "@timestamp": "2017-07-31T11:39:17.945Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -396,7 +396,7 @@
             },
             "@timestamp": "2017-07-31T11:39:21.025Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -440,7 +440,7 @@
             },
             "@timestamp": "2017-07-31T11:39:31.619Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -484,7 +484,7 @@
             },
             "@timestamp": "2017-07-31T11:39:40.147Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -528,7 +528,7 @@
             },
             "@timestamp": "2017-07-31T11:40:54.310Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -572,7 +572,7 @@
             },
             "@timestamp": "2017-07-31T11:43:22.645Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -616,7 +616,7 @@
             },
             "@timestamp": "2017-07-31T11:46:02.670Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -660,7 +660,7 @@
             },
             "@timestamp": "2017-07-31T11:46:23.016Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -704,7 +704,7 @@
             },
             "@timestamp": "2017-07-31T11:46:55.637Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -748,7 +748,7 @@
             },
             "@timestamp": "2019-05-06T19:00:04.511Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {

--- a/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-9-6-multi-core.log-expected.json
+++ b/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-9-6-multi-core.log-expected.json
@@ -13,7 +13,7 @@
             ],
             "@timestamp": "2017-04-03T20:32:14.322Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -56,7 +56,7 @@
             ],
             "@timestamp": "2017-04-03T20:32:14.322Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -92,7 +92,7 @@
             },
             "@timestamp": "2017-04-03T20:35:22.389Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -137,7 +137,7 @@
             },
             "@timestamp": "2017-07-31T17:36:43.557Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -171,7 +171,7 @@
             },
             "@timestamp": "2017-07-31T17:36:44.227Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -205,7 +205,7 @@
             },
             "@timestamp": "2017-07-31T17:46:02.670Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -246,7 +246,7 @@
             ],
             "@timestamp": "2017-07-31T17:46:23.016Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -289,7 +289,7 @@
             ],
             "@timestamp": "2017-07-31T17:46:55.637Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {

--- a/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-9-6-new-timestamp.log-expected.json
+++ b/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-9-6-new-timestamp.log-expected.json
@@ -6,7 +6,7 @@
             },
             "@timestamp": "2017-07-31T17:36:43.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -40,7 +40,7 @@
             },
             "@timestamp": "2017-07-31T17:36:44.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -74,7 +74,7 @@
             },
             "@timestamp": "2017-07-31T17:46:02.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -115,7 +115,7 @@
             ],
             "@timestamp": "2017-07-31T17:46:23.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -158,7 +158,7 @@
             ],
             "@timestamp": "2017-07-31T17:46:55.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {

--- a/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-query-steps-slowlog.log-expected.json
+++ b/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-query-steps-slowlog.log-expected.json
@@ -6,7 +6,7 @@
             },
             "@timestamp": "2019-09-04T13:52:38.004Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -50,7 +50,7 @@
             },
             "@timestamp": "2019-09-04T13:52:38.004Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {

--- a/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-ubuntu-9-5.log-expected.json
+++ b/packages/postgresql/data_stream/log/_dev/test/pipeline/test-postgresql-ubuntu-9-5.log-expected.json
@@ -13,7 +13,7 @@
             ],
             "@timestamp": "2017-04-03T20:32:14.322Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -55,7 +55,7 @@
             ],
             "@timestamp": "2017-04-03T20:32:14.322Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -97,7 +97,7 @@
             ],
             "@timestamp": "2017-04-03T20:35:22.389Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -139,7 +139,7 @@
             ],
             "@timestamp": "2017-04-03T20:36:56.464Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -181,7 +181,7 @@
             ],
             "@timestamp": "2017-04-03T20:37:12.961Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -223,7 +223,7 @@
             ],
             "@timestamp": "2017-04-07T19:05:28.549Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -265,7 +265,7 @@
             ],
             "@timestamp": "2017-04-07T19:09:41.345Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -307,7 +307,7 @@
             ],
             "@timestamp": "2017-04-07T20:45:30.218Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -349,7 +349,7 @@
             ],
             "@timestamp": "2017-04-07T20:45:30.218Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -391,7 +391,7 @@
             ],
             "@timestamp": "2017-04-07T20:45:30.218Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -433,7 +433,7 @@
             ],
             "@timestamp": "2017-04-07T20:46:09.751Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -475,7 +475,7 @@
             ],
             "@timestamp": "2017-04-07T20:46:09.751Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -517,7 +517,7 @@
             ],
             "@timestamp": "2017-04-07T21:02:51.199Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -559,7 +559,7 @@
             ],
             "@timestamp": "2017-04-07T21:02:51.199Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -601,7 +601,7 @@
             ],
             "@timestamp": "2017-04-07T21:04:36.087Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -643,7 +643,7 @@
             ],
             "@timestamp": "2017-04-07T21:04:36.087Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -685,7 +685,7 @@
             ],
             "@timestamp": "2017-04-07T21:04:51.462Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -727,7 +727,7 @@
             ],
             "@timestamp": "2017-04-07T21:04:51.462Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -769,7 +769,7 @@
             ],
             "@timestamp": "2017-04-07T21:05:06.217Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -811,7 +811,7 @@
             ],
             "@timestamp": "2017-04-07T21:05:06.217Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -853,7 +853,7 @@
             ],
             "@timestamp": "2017-04-07T21:05:18.295Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -895,7 +895,7 @@
             ],
             "@timestamp": "2017-04-07T21:05:18.295Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -937,7 +937,7 @@
             ],
             "@timestamp": "2017-04-07T21:13:47.505Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -979,7 +979,7 @@
             ],
             "@timestamp": "2017-04-07T21:13:47.505Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1021,7 +1021,7 @@
             ],
             "@timestamp": "2017-04-08T10:32:51.056Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1063,7 +1063,7 @@
             ],
             "@timestamp": "2017-04-08T10:32:51.056Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1105,7 +1105,7 @@
             ],
             "@timestamp": "2017-04-08T10:32:51.056Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1147,7 +1147,7 @@
             ],
             "@timestamp": "2017-04-08T19:54:37.443Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1189,7 +1189,7 @@
             ],
             "@timestamp": "2017-04-08T19:54:37.468Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1224,7 +1224,7 @@
             },
             "@timestamp": "2017-04-08T19:54:37.618Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1257,7 +1257,7 @@
             },
             "@timestamp": "2017-04-08T19:54:37.618Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1290,7 +1290,7 @@
             },
             "@timestamp": "2017-04-08T19:54:37.618Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1323,7 +1323,7 @@
             },
             "@timestamp": "2017-04-08T19:54:37.622Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1356,7 +1356,7 @@
             },
             "@timestamp": "2017-04-08T19:54:37.644Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1389,7 +1389,7 @@
             },
             "@timestamp": "2017-04-08T19:56:02.932Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1422,7 +1422,7 @@
             },
             "@timestamp": "2017-04-08T19:56:02.944Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1455,7 +1455,7 @@
             },
             "@timestamp": "2017-04-08T19:56:02.946Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1488,7 +1488,7 @@
             },
             "@timestamp": "2017-04-08T19:56:02.947Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1528,7 +1528,7 @@
             ],
             "@timestamp": "2017-04-08T19:56:03.362Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1563,7 +1563,7 @@
             },
             "@timestamp": "2017-05-27T14:07:53.007Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1596,7 +1596,7 @@
             },
             "@timestamp": "2017-05-27T14:07:53.010Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1629,7 +1629,7 @@
             },
             "@timestamp": "2017-05-27T14:07:53.015Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1662,7 +1662,7 @@
             },
             "@timestamp": "2017-05-27T14:07:53.016Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1702,7 +1702,7 @@
             ],
             "@timestamp": "2017-05-27T14:07:53.463Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1744,7 +1744,7 @@
             ],
             "@timestamp": "2017-05-27T14:08:13.661Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1786,7 +1786,7 @@
             ],
             "@timestamp": "2017-05-27T14:59:26.553Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1828,7 +1828,7 @@
             ],
             "@timestamp": "2017-05-27T14:59:26.555Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1863,7 +1863,7 @@
             },
             "@timestamp": "2017-06-06T05:54:13.753Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1896,7 +1896,7 @@
             },
             "@timestamp": "2017-06-06T05:54:13.753Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1929,7 +1929,7 @@
             },
             "@timestamp": "2017-06-06T05:54:13.753Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1962,7 +1962,7 @@
             },
             "@timestamp": "2017-06-06T05:54:13.755Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -1995,7 +1995,7 @@
             },
             "@timestamp": "2017-06-06T05:54:13.816Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2028,7 +2028,7 @@
             },
             "@timestamp": "2017-06-06T05:55:39.725Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2061,7 +2061,7 @@
             },
             "@timestamp": "2017-06-06T05:55:39.736Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2094,7 +2094,7 @@
             },
             "@timestamp": "2017-06-06T05:55:39.739Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2127,7 +2127,7 @@
             },
             "@timestamp": "2017-06-06T05:55:39.739Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2167,7 +2167,7 @@
             ],
             "@timestamp": "2017-06-06T05:55:40.155Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2209,7 +2209,7 @@
             ],
             "@timestamp": "2017-06-06T05:55:40.156Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2244,7 +2244,7 @@
             },
             "@timestamp": "2017-06-10T17:37:30.681Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2277,7 +2277,7 @@
             },
             "@timestamp": "2017-06-10T17:37:30.695Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2310,7 +2310,7 @@
             },
             "@timestamp": "2017-06-10T17:37:30.702Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2343,7 +2343,7 @@
             },
             "@timestamp": "2017-06-10T17:37:30.702Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2383,7 +2383,7 @@
             ],
             "@timestamp": "2017-06-10T17:37:31.104Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2418,7 +2418,7 @@
             },
             "@timestamp": "2017-06-10T18:27:55.911Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2451,7 +2451,7 @@
             },
             "@timestamp": "2017-06-10T18:27:55.911Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2484,7 +2484,7 @@
             },
             "@timestamp": "2017-06-10T18:27:55.911Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2517,7 +2517,7 @@
             },
             "@timestamp": "2017-06-10T18:27:55.914Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2550,7 +2550,7 @@
             },
             "@timestamp": "2017-06-10T18:27:55.973Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2583,7 +2583,7 @@
             },
             "@timestamp": "2017-06-10T18:27:57.022Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2616,7 +2616,7 @@
             },
             "@timestamp": "2017-06-10T18:27:57.032Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2649,7 +2649,7 @@
             },
             "@timestamp": "2017-06-10T18:27:57.035Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2682,7 +2682,7 @@
             },
             "@timestamp": "2017-06-10T18:27:57.035Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2722,7 +2722,7 @@
             ],
             "@timestamp": "2017-06-10T18:27:57.475Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2757,7 +2757,7 @@
             },
             "@timestamp": "2017-06-17T14:58:03.937Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2790,7 +2790,7 @@
             },
             "@timestamp": "2017-06-17T14:58:03.937Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2823,7 +2823,7 @@
             },
             "@timestamp": "2017-06-17T14:58:03.938Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2856,7 +2856,7 @@
             },
             "@timestamp": "2017-06-17T14:58:03.940Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {
@@ -2889,7 +2889,7 @@
             },
             "@timestamp": "2017-06-17T14:58:04.040Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "postgresql": {
                 "log": {

--- a/packages/postgresql/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/postgresql/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   - rename:
       field: message
       target_field: event.original

--- a/packages/postgresql/manifest.yml
+++ b/packages/postgresql/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: postgresql
 title: PostgreSQL
-version: 0.7.1
+version: 0.7.2
 license: basic
 description: This Elastic integration collects logs and metrics from PostgreSQL instances
 type: integration


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967