### PR TITLE
proofpoint update to ECS 1.11.0

### DIFF
--- a/packages/proofpoint/changelog.yml
+++ b/packages/proofpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.3.1'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1411
 - version: "0.3.0"
   changes:
     - description: Update integration description

--- a/packages/proofpoint/data_stream/emailsecurity/_dev/test/pipeline/test-generated.log-expected.json
+++ b/packages/proofpoint/data_stream/emailsecurity/_dev/test/pipeline/test-generated.log-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "January 29 06:09:59 avolupt low mod=perl cmd=clone cmd=olab id=nto duration=sse",
             "event": {
@@ -14,7 +14,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016/02/12T13:12:33.umdo itessequ session_store[vol]: info luptat high s=nibus mod=mipsumq cmd=gnaali module=enatus rule=mquia folder=ameaqu pri=aqu duration=utper",
             "event": {
@@ -26,7 +26,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "February 26 20:15:08 emape low s=incidi mod=session_connect cmd=nse ip=10.46.185.46 country=temvel lip=iatu prot=serror hops_active=anti routes=ofdeF notroutes=metcons perlwait=roinBCS",
             "event": {
@@ -38,7 +38,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016/03/12T03:17:42.iam mqua queued-eurort[3391]: olab: from=mquisnos, size=5771, class=ore, nrcpts=etconsec, msgid=err, proto=rdp, daemon=mUt, tls_verify=usmodte, auth=ele, relay=tenbyCic5882.api.home [10.69.20.77]",
             "event": {
@@ -50,7 +50,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "March 26 10:20:16 pteursi medium mod=service cmd=refresh cmd=turveli duration=toccae",
             "event": {
@@ -62,7 +62,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 9 17:22:51 ccusan low mod=zerohour type=Ciceroi cmd=refresh id=aveniam version=uradi",
             "event": {
@@ -74,7 +74,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 24 00:25:25 aboreetd high mod=smtpsrv cmd=listen cmd=dun addr=10.89.185.38",
             "event": {
@@ -86,7 +86,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 8 07:27:59 ctetura medium mod=zerohour type=dolore cmd=init id=abor version=iqui",
             "event": {
@@ -98,7 +98,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 22 14:30:33 ritatis oloremi high s=icab mod=av_run cmd=mwr rule=fugi name=inculpaq cleaned=agna vendor=tionemu duration=eomnisis",
             "event": {
@@ -110,7 +110,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016/06/05T21:33:08.incidi picia queued-reinject[mUtenima]: warn emaperi[7183]: sumquiad: from=dexeaco, size=6178, class=colabor, nrcpts=iusmodt, msgid=etdolo, proto=tcp, daemon=lorumw, relay=ommod3671.mail.domain",
             "event": {
@@ -122,7 +122,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 20 04:35:42 imadmi high s=tion mod=session_judge cmd=eataev module=liquide rule=uasia",
             "event": {
@@ -134,7 +134,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016/07/04T11:38:16.uames tati access_run[utaliqu]: warn oriosamn medium s=santium m=iciatisu x=rehender mod=eporroqu cmd=uat rule=tem duration=est",
             "event": {
@@ -146,7 +146,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 18 18:40:50 samvolu err eid=ittenbyC module=isc age=aturve limit=emulla",
             "event": {
@@ -158,7 +158,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016/08/02T01:43:25.itame eumfug zerohour_init[lit]: note asun low mod=quamnih type=oluptate cmd=onseq id=serunt version=aquaeabi",
             "event": {
@@ -170,7 +170,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 16 08:45:59 ento warn eid=pic status=\"evita file suntexp does not contain enough (or correct) info. Fix this or remove the file.\"",
             "event": {
@@ -182,7 +182,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 30 15:48:33 tmo very-high s=abi mod=spam_run cmd=sectetur rule=uioffi policy=oru score=temqu ndrscore=edol ipscore=colab suspectscore=ommodico phishscore=quatD bulkscore=mcolab spamscore=67.309000 adjustscore=tenima adultscore=tsedqu classifier=agnid adjust=proide reason=dolorem scancount=tlab engine=volupt definitions=osqui raw=xerc tests=iutali duration=fdeFi",
             "event": {
@@ -194,7 +194,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016/09/13T22:51:07.sequine ectio dkimv_type[dutper]: err lamcolab: low mod=radi unexpected response type=gel",
             "event": {
@@ -206,7 +206,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "September 28 05:53:42 xeacomm very-high mod=av type=aturQui cmd=load id=utlabor",
             "event": {
@@ -218,7 +218,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "October 12 12:56:16 madmi tur low s=uatD mod=mail_attachment cmd=ariatu id=edquiac file=nci mime=tev type=saute omime=ntocca oext=ostru corrupted=ntoccae protected=autf size=3471 virtual=temquiav",
             "event": {
@@ -230,7 +230,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016/10/26T19:58:50.tor qui queued-aglife[4499]: eavolup: to=fugiatn, delay=docon, xdelay=etconsec, mailer=ios, pri=evolu, relay=ersp3536.www5.lan, dsn=sauteiru, stat=mod",
             "event": {
@@ -242,7 +242,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016/11/10T03:01:24.iquipe itempor mail_env_rcpt[quin]: err upida high s=nve m=remag x=uredol mod=ccaecat cmd=tquiin r=7440 value=temqu verified=ovol routes=ptasn",
             "event": {
@@ -254,7 +254,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 24 10:03:59 idolore low mod=spam type=eetdolo cmd=refresh id=cteturad engine=untut definitions=uamni",
             "event": {
@@ -266,7 +266,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "December 8 17:06:33 orumSe high mod=regulation type=isnost cmd=init id=queips action=cancel dict=itess file=iscinge",
             "event": {
@@ -278,7 +278,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016-12-23T12:09:07.inci atatn queued-alert[temUt]: info avol[752]: STARTTLS=essequam, relay=[10.193.83.81], version=1.5020, verify=str, cipher=iat, bits=etur",
             "event": {
@@ -290,7 +290,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017/01/06T07:11:41.isnostr umqu smtpsrv_run[tinv]: warn adipisc medium mod=isnisi cmd=ritatise rule=uamei duration=siut",
             "event": {
@@ -302,7 +302,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017/01/20T14:14:16.ttenby boris dkimv_run[stenatu]: err isiuta low s=ratv m=riat x=ianon mod=tsed cmd=nts status=\"siut, tconsect\"",
             "event": {
@@ -314,7 +314,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017/02/03T21:16:50.ctetura aveni sendmail[elit]: note seosqui sequamni[3866]: STARTTLS=tdol, relay=sit6590.lan [10.123.143.188], version=ncididun, verify=umSe, cipher=xeacomm, bits=cinge",
             "event": {
@@ -326,7 +326,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "February 18 04:19:24 runtmol very-high mod=spam type=odi cmd=load id=ptass",
             "event": {
@@ -338,7 +338,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "March 4 11:21:59 aec medium mod=spam type=iduntu cmd=load id=ccaeca",
             "event": {
@@ -350,7 +350,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "March 18 18:24:33 leumiu tla very-high s=uaeratv mod=session_connect cmd=isa ip=10.38.65.236 country=dqu lip=pid prot=rExc hops_active=iusmo routes=tame notroutes=naaliq perlwait=nte",
             "event": {
@@ -362,7 +362,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017/04/02T01:27:07.ullamcor itationu dmarc_run[proident]: rprt maliquam medium s=atione m=lores x=ritati mod=orisni cmd=ons rule=remagn duration=ecillu",
             "event": {
@@ -374,7 +374,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 16 08:29:41 umetMalo high mod=av type=utp cmd=refresh id=aeconseq vendor=lor engine=Sedut definitions=yCiceroi signatures=quunt",
             "event": {
@@ -386,7 +386,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 30 15:32:16 aliq low mod=access type=teni cmd=refresh id=dquiac action=accept dict=tore file=elits",
             "event": {
@@ -398,7 +398,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017/05/14T22:34:50.uamnihi risnis mail_release[uov]: info itlab low s=sBono m=loremqu x=tetur mod=amvo cmd=siuta status=failure err=ommodo",
             "event": {
@@ -410,7 +410,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 29 05:37:24 atv high mod=access type=quira cmd=refresh id=rehende action=block dict=obeataev file=tempor",
             "event": {
@@ -422,7 +422,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 12 12:39:58 tlaboree note s=norumet m=dtempo x=tin module=fugitse action=deny size=3916",
             "event": {
@@ -434,7 +434,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017/06/26T19:42:33.aturQu aaliq session_store[mipsamvo]: warn eiusmod very-high s=reetdo m=oreveri x=ehende mod=eaqueip cmd=eum module=lamc rule=umetMal folder=asper pri=umq duration=naal",
             "event": {
@@ -446,7 +446,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017/07/11T02:45:07.uto iuntNequ pdr_ttl[esseq]: warn aincidun low s=veniamq mod=occ ttl=oloreseo reply=\"\\\"iruredol rscore=veniamqu\\\"\"",
             "event": {
@@ -458,7 +458,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 25 09:47:41 minim ataevi low s=repreh mod=av_run cmd=plic rule=irured name=illumqui cleaned=saq vendor=amali duration=ate",
             "event": {
@@ -470,7 +470,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017/08/08T16:50:15.autfugi tasun mail_continue-system-sendmail[duntutla]: err ntium low s=asuntexp mod=adminim cmd=orisni action=cancel err=lmole",
             "event": {
@@ -482,7 +482,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017/08/22T23:52:50.dolorem tem spam_init[exeacomm]: info aspe very-high mod=mides type=ciun cmd=olupta id=tsuntinc engine=inrepreh definitions=quovo",
             "event": {
@@ -494,7 +494,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "September 6 06:55:24 occaec acommodi medium s=quaeab mod=mail_env_rcpt cmd=fici r=5161 value=dipiscin verified=olup routes=aco",
             "event": {
@@ -506,7 +506,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017/09/20T13:57:58.mag tob smtpsrv_load[dolores]: rprt equamnih high mod=deF type=itempo cmd=orumw id=redol",
             "event": {
@@ -518,7 +518,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "October 4 21:00:32 radipis high s=tiumto mod=mail_env_from cmd=litan value=nder qid=stenatus tls=equep routes=ever notroutes=tali host=BCS3474.lan ip=10.1.204.187 sampling=quin",
             "event": {
@@ -530,7 +530,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017/10/19T04:03:07.nculpaq culpaqui regulation_init[tvolup]: note tdolore low mod=col type=obea cmd=emp id=agnaaliq action=cancel dict=uptatem file=oinv",
             "event": {
@@ -542,7 +542,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "queued-reinject[2957]: odt",
             "event": {
@@ -554,7 +554,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017/11/16T18:08:15.caecat rautod rprt[olest]: info eataev very-high s=ritati m=edquia x=itesse mod=mullam cmd=mexerc secprofile_name=meaque rcpts=5808 duration=mip",
             "event": {
@@ -566,7 +566,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017/12/01T01:10:49.deriti sintocc session_throttle[cididu]: rprt uteir high s=mwrit mod=ptat cmd=der rule=equuntur ip=10.219.133.187 rate=quameiu crate=diduntu limit=eiusmod",
             "event": {
@@ -578,7 +578,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "December 15 08:13:24 tassita very-high mod=smtpsrv cmd=run cmd=oremi rule=ugitsedq duration=turmag",
             "event": {
@@ -590,7 +590,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017/12/29T15:15:58.consecte pteurs dkimv_run[catcupi]: info autf very-high s=tiaecon m=uaturve x=amquisno mod=uido cmd=tla signature=mquiad identity=CSe host=lors7553.api.local result=unknown result_detail=rroqui",
             "event": {
@@ -602,7 +602,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018/01/12T22:18:32.itae dtempo cvtd[atnula]: warn ditautf low mod=iquidex cmd=olup",
             "event": {
@@ -614,7 +614,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018/01/27T05:21:06.rspici snisi queued-aglife[766]: olor: to=etquasia, delay=nula, xdelay=quiacons, mailer=uisa, pri=xeacommo, relay=[10.65.174.31], dsn=atur, stat=issu",
             "event": {
@@ -626,7 +626,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018/02/10T12:23:41.ite tasnul note[tuserr]: note tise very-high s=tnul m=expl x=ess module=quiad action=cancel size=6084",
             "event": {
@@ -638,7 +638,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018/02/24T19:26:15.llumq tenim spam_init[eiusmo]: warn ainc medium mod=antiumdo type=ecill cmd=iduntu id=pisci engine=sunt definitions=texplica",
             "event": {
@@ -650,7 +650,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "March 11 02:28:49 ate action_checksubmsg s=con m=tqu x=eirur action=accept score=tametco submsgadjust=mquisnos spamscore=25.933000 suspectscore=cit malwarescore=siar phishscore=isn adultscore=veniamq bulkscore=lup tests=iumtotam",
             "event": {
@@ -662,7 +662,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018/03/25T09:31:24.voluptas velill regulation_init[rspic]: err orinrepr high mod=meum type=borumSec cmd=aecatcup id=snisiut action=allow dict=nre file=inB",
             "event": {
@@ -674,7 +674,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018/04/08T16:33:58.upt ulamc cvt_detect[cept]: err aedictas low pid=4253 mod=orio cmd=gna name=ici status=success err=olu",
             "event": {
@@ -686,7 +686,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018/04/22T23:36:32.seq moll queued-VoltageEncrypt[2861]: sunt: from=dquianon, size=956, class=itesse, nrcpts=iamqui, msgid=quide, proto=igmp, daemon=cididun, relay=str4641.domain [10.151.31.58]",
             "event": {
@@ -698,7 +698,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018/05/07T06:39:06.cti rumSecti session_throttle[riamea]: info eca very-high s=tes mod=equam cmd=isi rule=iaecon ip=10.119.38.124 rate=rep crate=remap limit=deri",
             "event": {
@@ -710,7 +710,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 21 13:41:41 scipit high pid=745 mod=cvt cmd=detect cmd=borisnis name=onorumet status=success err=isiutali",
             "event": {
@@ -722,7 +722,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 4 20:44:15 aedict low mod=cvtd cmd=miurere",
             "event": {
@@ -734,7 +734,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018/06/19T03:46:49.seq rumSe queued-vdedc2v5[tatnonp]: rprt ommo[4821]: idunt: to=expl, delay=olore, xdelay=uian, mailer=atuserro, pri=madminim, relay=[10.52.47.230] [10.113.119.47], dsn=quioff, stat=iuntN",
             "event": {
@@ -746,7 +746,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018/07/03T10:49:23.mquis lorsi filter[tetura]: rprt eeufug high mod=modt sig=iduntutl",
             "event": {
@@ -758,7 +758,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 17 17:51:58 expl very-high pid=prehende mod=cvtd cmd=encrypted encrypted=lup",
             "event": {
@@ -770,7 +770,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 1 00:54:32 umd sumd medium s=dat mod=session_judge cmd=aUtenima module=turQuis rule=taevi",
             "event": {
@@ -782,7 +782,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018/08/15T07:57:06.ercitati eve spf_run[rro]: err oeiusmo very-high s=cusanti m=tconse x=rem mod=tseddoei cmd=teursint rule=etMa duration=llita",
             "event": {
@@ -794,7 +794,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018/08/29T14:59:40.nostrum orroquis av_init[eumi]: info tvo low mod=tuser type=mmo cmd=eve id=nbyCicer vendor=scipit engine=equuntu definitions=quamni signatures=turveli",
             "event": {
@@ -806,7 +806,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "September 12 22:02:15 ihilm medium s=caboNemo mod=mltr uptas",
             "event": {
@@ -818,7 +818,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018/09/27T05:04:49.dol exe info[tis]: note oluptat low eid=tinvolup pid=497 status=tvol",
             "event": {
@@ -830,7 +830,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "October 11 12:07:23 eritqui medium s=atus mod=session_judge cmd=tassitas module=obea rule=velite",
             "event": {
@@ -842,7 +842,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018/10/25T19:09:57.lore luptate av_init[eritqu]: err elites very-high mod=tamr type=serr cmd=usci id=unturmag vendor=dexeaco engine=lupta definitions=ura signatures=oreeufug",
             "event": {
@@ -854,7 +854,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018/11/09T02:12:32.ree itten milter_listen[quipexea]: warn orsitv medium mod=nostrum cmd=autodita addr=10.27.154.247",
             "event": {
@@ -866,7 +866,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018/11/23T09:15:06.utfugi ursintoc dkimv_type[tio]: rprt mmodicon: high mod=trudex unexpected response type=tvol",
             "event": {
@@ -878,7 +878,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018/12/07T16:17:40.rehen uaeab session_throttle[ptat]: warn mipsu high s=eturadip mod=amquaera cmd=rsitamet rule=leumiur ip=10.253.121.154 rate=olesti crate=edquia limit=ihi",
             "event": {
@@ -890,7 +890,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "December 21 23:20:14 emoenimi high pid=5895 mod=cvt cmd=detect cmd=mqu name=onorume status=unknown err=veleu",
             "event": {
@@ -902,7 +902,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "January 5 06:22:49 dquia high s=bori mod=mltr dipi",
             "event": {
@@ -914,7 +914,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "January 19 13:25:23 quovolu high s=dexe mod=mltr nemul",
             "event": {
@@ -926,7 +926,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019/02/02T20:27:57.quatur dminim mail_msg[ptatevel]: warn aperiame very-high s=eirured mod=sequamn cmd=perspici module=inimve rule=aea action=allow attachments=5821 rcpts=296 routes=ptat size=4878 guid=nde hdr_mid=quame qid=orumwri subject=atisu spamscore=66.849000 virusname=tse duration=rad elapsed=iat",
             "event": {
@@ -938,7 +938,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019/02/17T03:30:32.lorum suntexpl sm-msp-queue[iqu]: rprt iquamqu[6293]: audant: to=obeata, ctladdr=uredol, delay=uptat, xdelay=toditau, mailer=uiad, pri=nvolupta, relay=[10.80.133.120] [10.147.147.248], dsn=onpr, stat=uira",
             "event": {
@@ -950,7 +950,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019/03/03T10:33:06.aliqu sequine regulation_refresh[utaliqui]: note isciv very-high mod=econ type=aborio cmd=rve id=catcup action=deny dict=runtmoll file=busBon",
             "event": {
@@ -962,7 +962,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019/03/17T17:35:40.occaeca dan queued-alert[pta]: err upt[4762]: itaedict: to=eroi, delay=onemull, xdelay=mdo, mailer=labore, pri=lorem, relay=[10.68.159.207] [10.232.240.177], dsn=estq, stat=quasiarc",
             "event": {
@@ -974,7 +974,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019/04/01T00:38:14.tDuisaut uel warn[dexerc]: info vol high eid=agn status=\"iqu file: quamqua\"",
             "event": {
@@ -986,7 +986,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 15 07:40:49 uunturm very-high mod=regulation type=iaconseq cmd=init id=tseddo action=cancel dict=rissusci file=ectetur",
             "event": {
@@ -998,7 +998,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 29 14:43:23 quaturve medium mod=zerohour type=gnamali cmd=init id=iumtota version=issusci",
             "event": {
@@ -1010,7 +1010,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019/05/13T21:45:57.ecillumd iumto dmarc_type[sequatu]: rprt tiumtot: medium mod=mdoloree type=que cmd=inBCSed id=cteturad policy_cache_entries=umq",
             "event": {
@@ -1022,7 +1022,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 28 04:48:31 reseo quam very-high s=pariat mod=mail_env_rcpt cmd=icaboNe r=4840 value=lumd verified=tiaec routes=lorem",
             "event": {
@@ -1034,7 +1034,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 11 11:51:06 seq low mod=info sys=lorsita evt=deny active=itation expires=utlabo msg=tat",
             "event": {
@@ -1046,7 +1046,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 25 18:53:40 ididu medium s=epteurs mod=mail_env_from cmd=itse value=rever ofrom=sBonoru qid=ecatcu tls=ntoccae routes=iscive notroutes=amni host=etconse5657.api.lan ip=10.118.249.126 sampling=dminimv",
             "event": {
@@ -1058,7 +1058,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019/07/10T01:56:14.rep nostru access_load[docons]: info emipsumq low mod=qua type=modit cmd=tatione id=aedicta",
             "event": {
@@ -1070,7 +1070,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 24 08:58:48 uas high s=reeufu mod=mail_env_from cmd=umexe value=xce ofrom=omnisis qid=corporis tls=tco routes=stiaec notroutes=Cicero host=ven5410.mail.host ip=10.170.55.203 sampling=deom",
             "event": {
@@ -1082,7 +1082,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019/08/07T16:01:23.Utenima nse info[umq]: note enim low mod=meaquei sys=snisiu evt=allow active=atev expires=vento msg=litsed",
             "event": {
@@ -1094,7 +1094,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 21 23:03:57 susc taed high s=mipsumd mod=mail_continue-system-sendmail cmd=eiusmo action=block err=sum",
             "event": {
@@ -1106,7 +1106,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "September 5 06:06:31 ipex low s=upta cmd=send profile=ivel qid=tmollita rcpts=tionofd",
             "event": {
@@ -1118,7 +1118,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019/09/19T13:09:05.ccaec repreh http_listen[imven]: note usan very-high mod=idolo cmd=olup addr=10.199.46.88",
             "event": {
@@ -1130,7 +1130,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019/10/03T20:11:40.nulapari beataevi queued-VoltageEncrypt[3274]: eruntmol: from=plicab, size=5930, class=dmin, nrcpts=sum, msgid=lloinve, proto=ggp, daemon=nim, relay=Sedutper7794.www5.domain [10.154.22.241]",
             "event": {
@@ -1142,7 +1142,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019/10/18T03:14:14.nvol doloreeu cvtd_encrypted[elillumq]: info loremeum medium pid=obeataev mod=rrorsit encrypted=aincid",
             "event": {
@@ -1154,7 +1154,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 1 10:16:48 nis info pid=472 iin /uteiru: xer",
             "event": {
@@ -1166,7 +1166,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019/11/15T17:19:22.isauteir eritquii soap_listen[atevelit]: note dese low mod=ionula cmd=itaed addr=10.38.111.125",
             "event": {
@@ -1178,7 +1178,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 30 00:21:57 ationem high mod=spam type=ing cmd=load id=ollita",
             "event": {
@@ -1190,7 +1190,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019/12/14T07:24:31.nih ncididu queued-default[4250]: STARTTLS=gitsed, relay=estla4081.corp, version=meumf, verify=rExce, cipher=quisquam, bits=boreet",
             "event": {

--- a/packages/proofpoint/data_stream/emailsecurity/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/proofpoint/data_stream/emailsecurity/elasticsearch/ingest_pipeline/default.yml
@@ -8,7 +8,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   # User agent
   - user_agent:
       field: user_agent.original

--- a/packages/proofpoint/manifest.yml
+++ b/packages/proofpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: proofpoint
 title: Proofpoint Email Security
-version: 0.3.0
+version: 0.3.1
 description: This Elastic integration collects logs from Proofpoint Email Security
 categories: ["security"]
 release: experimental


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967