### PR TITLE
rabbitmq update to ECS 1.11.0

### DIFF
--- a/packages/rabbitmq/changelog.yml
+++ b/packages/rabbitmq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.6.2'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1412
 - version: "0.6.1"
   changes:
     - description: Escape special characters in docs

--- a/packages/rabbitmq/data_stream/log/_dev/test/pipeline/test-rabbitmq.log-expected.json
+++ b/packages/rabbitmq/data_stream/log/_dev/test/pipeline/test-rabbitmq.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2019-04-03T11:13:15.076Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -27,7 +27,7 @@
         {
             "@timestamp": "2019-04-03T11:13:15.510Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -51,7 +51,7 @@
         {
             "@timestamp": "2019-04-03T11:13:15.512Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -75,7 +75,7 @@
         {
             "@timestamp": "2019-04-12T10:00:53.458Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -99,7 +99,7 @@
         {
             "@timestamp": "2019-04-12T10:00:53.550Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -123,7 +123,7 @@
         {
             "@timestamp": "2019-04-12T10:00:53.550Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -147,7 +147,7 @@
         {
             "@timestamp": "2019-04-12T10:00:54.553Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "warning"
@@ -171,7 +171,7 @@
         {
             "@timestamp": "2019-04-12T10:00:54.555Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -195,7 +195,7 @@
         {
             "@timestamp": "2019-04-12T10:00:54.567Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -219,7 +219,7 @@
         {
             "@timestamp": "2019-04-12T10:00:54.567Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -243,7 +243,7 @@
         {
             "@timestamp": "2019-04-12T10:00:54.568Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -267,7 +267,7 @@
         {
             "@timestamp": "2019-04-12T10:00:54.569Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -291,7 +291,7 @@
         {
             "@timestamp": "2019-04-12T10:00:54.579Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -315,7 +315,7 @@
         {
             "@timestamp": "2019-04-12T10:00:54.588Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -339,7 +339,7 @@
         {
             "@timestamp": "2019-04-12T10:00:54.589Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -363,7 +363,7 @@
         {
             "@timestamp": "2019-04-12T10:00:54.598Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -387,7 +387,7 @@
         {
             "@timestamp": "2019-04-12T10:00:54.606Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -411,7 +411,7 @@
         {
             "@timestamp": "2019-04-12T10:00:54.615Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -435,7 +435,7 @@
         {
             "@timestamp": "2019-04-12T10:00:54.615Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -459,7 +459,7 @@
         {
             "@timestamp": "2019-04-12T10:01:01.031Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -483,7 +483,7 @@
         {
             "@timestamp": "2019-04-12T10:11:15.094Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -507,7 +507,7 @@
         {
             "@timestamp": "2019-04-12T10:11:15.101Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -531,7 +531,7 @@
         {
             "@timestamp": "2019-04-12T10:19:14.450Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "error"
@@ -555,7 +555,7 @@
         {
             "@timestamp": "2019-04-12T10:19:14.450Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -579,7 +579,7 @@
         {
             "@timestamp": "2019-04-12T10:19:14.451Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"

--- a/packages/rabbitmq/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/rabbitmq/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   - set:
       field: event.kind
       value: event

--- a/packages/rabbitmq/manifest.yml
+++ b/packages/rabbitmq/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: rabbitmq
 title: RabbitMQ
-version: 0.6.1
+version: 0.6.2
 license: basic
 description: This Elastic integration collects logs and metrics from RabbitMQ instances
 type: integration


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967