### PR TITLE
radware update to ECS 1.11.0

### DIFF
--- a/packages/radware/changelog.yml
+++ b/packages/radware/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.3.1'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1414
 - version: "0.3.0"
   changes:
     - description: Update integration description

--- a/packages/radware/data_stream/defensepro/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/radware/data_stream/defensepro/elasticsearch/ingest_pipeline/default.yml
@@ -8,7 +8,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   # User agent
   - user_agent:
       field: user_agent.original

--- a/packages/radware/manifest.yml
+++ b/packages/radware/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: radware
 title: Radware DefensePro
-version: 0.3.0
+version: 0.3.1
 description: This Elastic integration collects logs from Radware DefensePro
 categories: ["security"]
 release: experimental


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967