### PR TITLE
redis update to ECS 1.11.0

### DIFF
--- a/packages/redis/changelog.yml
+++ b/packages/redis/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.7.2'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1415
 - version: "0.7.1"
   changes:
     - description: Escape special characters in docs

--- a/packages/redis/data_stream/log/_dev/test/pipeline/test-redis-5-0-3.log-expected.json
+++ b/packages/redis/data_stream/log/_dev/test/pipeline/test-redis-5-0-3.log-expected.json
@@ -6,7 +6,7 @@
             },
             "@timestamp": "2018-12-27T11:19:18.874Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "notice"

--- a/packages/redis/data_stream/log/_dev/test/pipeline/test-redis-darwin-3-0-2.log-expected.json
+++ b/packages/redis/data_stream/log/_dev/test/pipeline/test-redis-darwin-3-0-2.log-expected.json
@@ -6,7 +6,7 @@
             },
             "@timestamp": "2021-05-30T12:50:13.457Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "notice"
@@ -32,7 +32,7 @@
             },
             "@timestamp": "2021-05-30T12:50:13.463Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "warning"
@@ -58,7 +58,7 @@
             },
             "@timestamp": "2021-05-30T12:50:13.464Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "notice"
@@ -84,7 +84,7 @@
             },
             "@timestamp": "2021-05-30T12:50:13.464Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "notice"
@@ -110,7 +110,7 @@
             },
             "@timestamp": "2017-05-30T10:52:41.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "event": {
                 "ingested": "2021-06-08T10:08:25.543386600Z",
@@ -131,7 +131,7 @@
             },
             "@timestamp": "2021-05-30T12:52:41.448Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "warning"
@@ -157,7 +157,7 @@
             },
             "@timestamp": "2021-05-30T12:52:41.448Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "notice"
@@ -183,7 +183,7 @@
             },
             "@timestamp": "2021-05-30T12:52:41.452Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "notice"
@@ -209,7 +209,7 @@
             },
             "@timestamp": "2021-05-30T12:52:41.452Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "warning"
@@ -235,7 +235,7 @@
             },
             "@timestamp": "2021-05-30T12:52:42.131Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "notice"
@@ -261,7 +261,7 @@
             },
             "@timestamp": "2021-05-30T12:52:42.133Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "warning"
@@ -287,7 +287,7 @@
             },
             "@timestamp": "2021-05-30T12:52:42.133Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "notice"
@@ -313,7 +313,7 @@
             },
             "@timestamp": "2021-05-30T12:52:42.133Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "notice"
@@ -339,7 +339,7 @@
             },
             "@timestamp": "2017-05-30T10:57:24.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "event": {
                 "ingested": "2021-06-08T10:08:25.543436100Z",
@@ -360,7 +360,7 @@
             },
             "@timestamp": "2021-05-30T12:57:24.231Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "warning"
@@ -386,7 +386,7 @@
             },
             "@timestamp": "2021-05-30T12:57:24.231Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "notice"
@@ -412,7 +412,7 @@
             },
             "@timestamp": "2021-05-30T12:57:24.234Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "notice"
@@ -438,7 +438,7 @@
             },
             "@timestamp": "2021-05-30T12:57:24.234Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "warning"

--- a/packages/redis/data_stream/log/_dev/test/pipeline/test-redis-windows-2-4-6.log-expected.json
+++ b/packages/redis/data_stream/log/_dev/test/pipeline/test-redis-windows-2-4-6.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2021-05-31T04:32:08.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "notice"
@@ -24,7 +24,7 @@
         {
             "@timestamp": "2021-05-31T04:32:08.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "warning"
@@ -45,7 +45,7 @@
         {
             "@timestamp": "2021-05-31T04:32:08.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "notice"
@@ -66,7 +66,7 @@
         {
             "@timestamp": "2021-05-31T04:32:08.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -87,7 +87,7 @@
         {
             "@timestamp": "2021-05-31T04:32:13.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -108,7 +108,7 @@
         {
             "@timestamp": "2021-05-31T04:32:19.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -129,7 +129,7 @@
         {
             "@timestamp": "2021-05-31T04:32:24.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -150,7 +150,7 @@
         {
             "@timestamp": "2021-05-31T04:32:30.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -171,7 +171,7 @@
         {
             "@timestamp": "2021-05-31T04:32:35.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -192,7 +192,7 @@
         {
             "@timestamp": "2021-05-31T04:32:41.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -213,7 +213,7 @@
         {
             "@timestamp": "2021-05-31T04:32:46.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -234,7 +234,7 @@
         {
             "@timestamp": "2021-05-31T04:32:52.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -255,7 +255,7 @@
         {
             "@timestamp": "2021-05-31T04:32:57.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -276,7 +276,7 @@
         {
             "@timestamp": "2021-05-31T04:33:03.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -297,7 +297,7 @@
         {
             "@timestamp": "2021-05-31T04:33:08.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -318,7 +318,7 @@
         {
             "@timestamp": "2021-05-31T04:33:13.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -339,7 +339,7 @@
         {
             "@timestamp": "2021-05-31T04:33:19.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -360,7 +360,7 @@
         {
             "@timestamp": "2021-05-31T04:33:24.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -381,7 +381,7 @@
         {
             "@timestamp": "2021-05-31T04:33:30.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -402,7 +402,7 @@
         {
             "@timestamp": "2021-05-31T04:33:35.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -423,7 +423,7 @@
         {
             "@timestamp": "2021-05-31T04:33:41.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -444,7 +444,7 @@
         {
             "@timestamp": "2021-05-31T04:33:46.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -465,7 +465,7 @@
         {
             "@timestamp": "2021-05-31T04:33:52.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -486,7 +486,7 @@
         {
             "@timestamp": "2021-05-31T04:33:57.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -507,7 +507,7 @@
         {
             "@timestamp": "2021-05-31T04:34:03.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -528,7 +528,7 @@
         {
             "@timestamp": "2021-05-31T04:34:08.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -549,7 +549,7 @@
         {
             "@timestamp": "2021-05-31T04:34:14.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -570,7 +570,7 @@
         {
             "@timestamp": "2021-05-31T04:34:19.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -591,7 +591,7 @@
         {
             "@timestamp": "2021-05-31T04:34:25.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -612,7 +612,7 @@
         {
             "@timestamp": "2021-05-31T04:34:30.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -633,7 +633,7 @@
         {
             "@timestamp": "2021-05-31T04:34:36.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -654,7 +654,7 @@
         {
             "@timestamp": "2021-05-31T04:34:41.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -675,7 +675,7 @@
         {
             "@timestamp": "2021-05-31T04:34:46.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -696,7 +696,7 @@
         {
             "@timestamp": "2021-05-31T04:34:52.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"

--- a/packages/redis/data_stream/log/_dev/test/pipeline/test-redis.log-expected.json
+++ b/packages/redis/data_stream/log/_dev/test/pipeline/test-redis.log-expected.json
@@ -6,7 +6,7 @@
             },
             "@timestamp": "2021-05-30T12:23:52.442Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "notice"
@@ -29,7 +29,7 @@
         {
             "@timestamp": "2021-05-30T10:05:20.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "debug"
@@ -50,7 +50,7 @@
         {
             "@timestamp": "2021-05-31T04:32:08.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "notice"
@@ -74,7 +74,7 @@
             },
             "@timestamp": "2017-05-30T10:57:24.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "event": {
                 "ingested": "2021-06-08T10:08:44.286124900Z",

--- a/packages/redis/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/redis/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   - rename:
       field: message
       target_field: event.original

--- a/packages/redis/manifest.yml
+++ b/packages/redis/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: redis
 title: Redis
-version: 0.7.1
+version: 0.7.2
 license: basic
 description: This integration collects logs and metrics from Redis instances
 type: integration


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967