### PR TITLE
santa update to ECS 1.11.0

### DIFF
--- a/packages/santa/changelog.yml
+++ b/packages/santa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.3.1'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1416
 - version: "0.3.0"
   changes:
     - description: Update integration description

--- a/packages/santa/data_stream/log/_dev/test/pipeline/test-santa-raw.log-expected.json
+++ b/packages/santa/data_stream/log/_dev/test/pipeline/test-santa-raw.log-expected.json
@@ -39,7 +39,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -112,7 +112,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -184,7 +184,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -257,7 +257,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -329,7 +329,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -402,7 +402,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -465,7 +465,7 @@
             },
             "@timestamp": "2018-12-10T21:37:27.247Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -535,7 +535,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -618,7 +618,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -654,7 +654,7 @@
         {
             "@timestamp": "2018-12-17T03:03:52.337Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "I"

--- a/packages/santa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/santa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   - rename:
       field: message
       target_field: event.original

--- a/packages/santa/manifest.yml
+++ b/packages/santa/manifest.yml
@@ -1,6 +1,6 @@
 name: santa
 title: Google Santa
-version: 0.3.0
+version: 0.3.1
 release: experimental
 description: This Elastic integration collects logs from Google Santa instances
 type: integration


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967