### PR TITLE
sonicwall update to ECS 1.11.0

### DIFF
--- a/packages/sonicwall/changelog.yml
+++ b/packages/sonicwall/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.4.2'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1417
 - version: "0.4.1"
   changes:
     - description: Escape special characters in docs

--- a/packages/sonicwall/data_stream/firewall/_dev/test/pipeline/test-general.log-expected.json
+++ b/packages/sonicwall/data_stream/firewall/_dev/test/pipeline/test-general.log-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan  3 13:45:36 192.168.5.1 id=firewall sn=000SERIAL time=\"2007-01-03 14:48:06\" fw=1.1.1.1 pri=6 c=262144 m=98 msg=\"Connection Opened\" n=23419 src=2.2.2.2:36701:WAN dst=1.1.1.1:50000:WAN proto=tcp/50000",
             "event": {
@@ -14,7 +14,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan  3 13:45:36 192.168.5.1 id=firewall sn=000SERIAL time=\"2007-01-03 14:48:07\" fw=1.1.1.1 pri=1 c=32 m=30 msg=\"Administrator login denied due to bad credentials\" n=7 src=2.2.2.2:36701:WAN dst=1.1.1.1:50000:WAN",
             "event": {
@@ -26,7 +26,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan  3 13:45:36 192.168.5.1 id=firewall sn=000SERIAL time=\"2007-01-03 14:48:07\" fw=1.1.1.1 pri=6 c=262144 m=98 msg=\"Connection Opened\" n=23420 src=2.2.2.2:36702:WAN dst=1.1.1.1:50000:WAN proto=tcp/50000",
             "event": {
@@ -38,7 +38,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan  3 13:45:37 192.168.5.1 id=firewall sn=000SERIAL time=\"2007-01-03 14:48:07\" fw=1.1.1.1 pri=6 c=1024 m=537 msg=\"Connection Closed\" n=567996 src=192.168.4.10:27577:WAN dst=192.168.5.10:53:LAN proto=tcp/dns sent=257 rcvd=242",
             "event": {
@@ -50,7 +50,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan  3 13:45:37 192.168.5.1 id=firewall sn=000SERIAL time=\"2007-01-03 14:48:08\" fw=1.1.1.1 pri=6 c=1024 m=537 msg=\"Connection Closed\" n=567997 src=192.168.5.56:4277:LAN dst=192.168.1.100:1026:WAN proto=tcp/1026 sent=3590 rcvd=13042 vpnpolicy=\"name\"",
             "event": {
@@ -62,7 +62,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan  3 13:45:39 192.168.5.1 id=firewall sn=000SERIAL time=\"2007-01-03 14:48:10\" fw=1.1.1.1 pri=6 c=1024 m=537 msg=\"Connection Closed\" n=567999 src=192.168.5.56:4280:LAN dst=192.168.2.81:41850:WAN proto=tcp/41850 sent=386026 rcvd=454118 vpnpolicy=\"name\"",
             "event": {
@@ -74,7 +74,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan  3 13:45:39 192.168.5.1 id=firewall sn=000SERIAL time=\"2007-01-03 14:48:10\" fw=1.1.1.1 pri=6 c=1024 m=537 msg=\"Connection Closed\" n=567999 src=1.1.1.1:500:WAN dst=2.2.2.2:500:WAN proto=udp/500 sent=344 rcvd=152",
             "event": {
@@ -86,7 +86,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan  3 13:45:40 192.168.5.1 id=firewall sn=000SERIAL time=\"2007-01-03 14:48:10\" fw=1.1.1.1 pri=6 c=262144 m=98 msg=\"Connection Opened\" n=23421 src=2.2.2.2:36703:WAN dst=1.1.1.1:50000:WAN proto=tcp/50000",
             "event": {
@@ -98,7 +98,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan  3 13:45:40 192.168.5.1 id=firewall sn=000SERIAL time=\"2007-01-03 14:48:10\" fw=1.1.1.1 pri=1 c=32 m=30 msg=\"Administrator login denied due to bad credentials\" n=8 src=2.2.2.2:36703:WAN dst=1.1.1.1:50000:WAN",
             "event": {
@@ -110,7 +110,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan  3 13:45:40 192.168.5.1 id=firewall sn=000SERIAL time=\"2007-01-03 14:48:11\" fw=1.1.1.1 pri=6 c=262144 m=98 msg=\"Connection Opened\" n=23422 src=2.2.2.2:36704:WAN dst=1.1.1.1:50000:WAN proto=tcp/50000",
             "event": {
@@ -122,7 +122,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan  3 13:45:43 192.168.5.1 id=firewall sn=000SERIAL time=\"2007-01-03 14:48:14\" fw=1.1.1.1 pri=5 c=256 m=38 msg=\"ICMP packet dropped\" n=22070 src=219.89.19.223:1026:WAN dst=1.1.1.1:6822:WAN  type=3 code=3",
             "event": {
@@ -134,7 +134,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan  3 13:45:43 192.168.5.1 id=firewall sn=000SERIAL time=\"2007-01-03 14:48:14\" fw=1.1.1.1 pri=6 c=1024 m=537 msg=\"Connection Closed\" n=568000 src=219.89.19.223:1026:WAN dst=1.1.1.1:0:WAN proto=udp/0",
             "event": {
@@ -146,7 +146,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan  3 13:45:44 192.168.5.1 id=firewall sn=000SERIAL time=\"2007-01-03 14:48:15\" fw=1.1.1.1 pri=6 c=16 m=346 msg=\"IKE Initiator: Start Quick Mode (Phase 2).\" n=171872 src=2.2.2.2:500 dst=1.1.1.1:500",
             "event": {
@@ -158,7 +158,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan  3 13:45:44 192.168.5.1 id=firewall sn=000SERIAL time=\"2007-01-03 14:48:15\" fw=1.1.1.1 pri=6 c=262144 m=98 msg=\"Connection Opened\" n=23423 src=1.1.1.1:500:WAN dst=2.2.2.2:500:WAN proto=udp/500",
             "event": {
@@ -170,7 +170,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan  3 13:45:44 192.168.5.1 id=firewall sn=000SERIAL time=\"2007-01-03 14:48:15\" fw=1.1.1.1 pri=4 c=16 m=483 msg=\"Received notify: INVALID_ID_INFO\" n=171625 src=2.2.2.2:500 dst=1.1.1.1:500",
             "event": {
@@ -182,7 +182,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan  3 13:45:45 192.168.5.1 id=firewall sn=000SERIAL time=\"2007-01-03 14:48:15\" fw=1.1.1.1 pri=6 c=262144 m=98 msg=\"Connection Opened\" n=23424 src=192.168.115.10:11549:WAN dst=192.168.5.10:53:LAN proto=tcp/dns",
             "event": {
@@ -194,7 +194,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan  3 13:45:46 192.168.5.1 id=firewall sn=000SERIAL time=\"2007-01-03 14:48:17\" fw=1.1.1.1 pri=6 c=262144 m=98 msg=\"Connection Opened\" n=23425 src=192.168.5.64:3182:LAN dst=192.168.1.100:445:WAN proto=tcp/445",
             "event": {
@@ -206,7 +206,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan  3 13:45:47 192.168.5.1 id=firewall sn=000SERIAL time=\"2007-01-03 14:48:18\" fw=1.1.1.1 pri=6 c=1024 m=537 msg=\"Connection Closed\" n=568001 src=2.2.2.2:36699:WAN dst=1.1.1.1:50000:WAN proto=tcp/50000 sent=1557 rcvd=957",
             "event": {
@@ -218,7 +218,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan  3 13:45:49 192.168.5.1 id=firewall sn=000SERIAL time=\"2007-01-03 14:48:20\" fw=1.1.1.1 pri=6 c=1024 m=537 msg=\"Connection Closed\" n=568002 src=192.168.5.10:3417:LAN dst=192.168.1.100:53:WAN proto=udp/dns sent=401 rcvd=254 vpnpolicy=\"name\"",
             "event": {
@@ -230,7 +230,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan  3 13:45:50 192.168.5.1 id=firewall sn=000SERIAL time=\"2007-01-03 14:48:20\" fw=1.1.1.1 pri=6 c=262144 m=98 msg=\"Connection Opened\" n=23426 src=192.168.125.75:524:WAN dst=192.168.5.10:3582:LAN proto=udp/3582",
             "event": {
@@ -242,7 +242,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "Jan  3 13:45:50 192.168.5.1 id=firewall sn=000SERIAL time=\"2007-01-03 14:48:21\" fw=1.1.1.1 pri=6 c=262144 m=98 msg=\"Connection Opened\" n=23427 src=192.168.6.10:28503:WAN dst=192.168.5.10:53:LAN proto=tcp/dns",
             "event": {

--- a/packages/sonicwall/data_stream/firewall/_dev/test/pipeline/test-generated.log-expected.json
+++ b/packages/sonicwall/data_stream/firewall/_dev/test/pipeline/test-generated.log-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=nnumqua sn=eacommod time=\"2016/01/29 06:09:59\" fw=10.208.232.8 pri=very-high c=tur m=1197 msg=\"itv\" sess=odoco n=ria src=10.20.234.169:1001:eth5722 dst= 10.208.15.216:4257:lo6125 note= \"ntsunti Protocol:udp\" npcs=ciade",
             "event": {
@@ -14,7 +14,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "idi id=pexe sn=nes time=\"2016/02/12 13:12:33\" fw=10.254.41.82 pri=low c=Ute m=914 msg=\"lupt\" n=dolore src=10.92.136.230:6437:eth7178:nostrud4819.mail.test dst=10.49.111.67:884:eth3598:oreetdol1714.internal.corp",
             "event": {
@@ -26,7 +26,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=umexe sn=estlabo time=\"2016/02/26 20:15:08\" fw=10.186.114.123 pri=high c=olupt m=16 Web site accessed",
             "event": {
@@ -38,7 +38,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=alo sn=eosquir time=\"2016-3-12 3:17:42\" fw=10.149.203.46 pri=medium c=mwritten m=1369 msg=\"ctetur\" n=uidolorsrc=10.150.156.22:6378:eth6183dst=10.227.15.1:410:eth1977srcMac=01:00:5e:84:66:6cdstMac=01:00:5e:f7:a9:ffproto=rdp/ommfw_action=\"allow\"",
             "event": {
@@ -50,7 +50,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "emape id=aer sn=lupt time=\"2016/03/26 10:20:16\" fw=10.26.46.95 pri=medium c=temvel m=127 PPPoE LCP Link Up",
             "event": {
@@ -62,7 +62,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=consec sn=taliquip time=\"2016/04/09 17:22:51\" fw=10.134.172.34 pri=high c=snos m=170 Received a path MTU icmp message from router/gateway",
             "event": {
@@ -74,7 +74,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=tconsec sn=nsequat time=\"2016/04/24 00:25:25\" fw=10.137.246.137 pri=medium c=oluptas m=372 msg=\"llu\" n=uptassi src=10.95.245.65 dst=10.13.70.213",
             "event": {
@@ -86,7 +86,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "llamcorp id=ari sn=eataevit time=\"2016/05/08 07:27:59\" fw=10.50.112.141 pri=very-high c=dmi m=176 Fraudulent Microsoft Certificate Blocked",
             "event": {
@@ -98,7 +98,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "mquisnos id=loremagn sn=iciade time=\"2016/05/22 14:30:33\" fw=10.137.104.79 pri=medium c=mUt m=50 RealAudio decode failure",
             "event": {
@@ -110,7 +110,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=aali sn=ametcons time=\"2016/06/05 21:33:08\" fw=10.244.98.230 pri=low c=iinea m=87 IKE Responder: Accepting IPSec proposal",
             "event": {
@@ -122,7 +122,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "emip id=tvol sn=moll time=\"2016/06/20 04:35:42\" fw=10.228.149.225 pri=high c=deomni m=139 msg=\"accept\" n=onse src=10.136.153.149:3788:enp0s2489 dst= 10.16.52.205",
             "event": {
@@ -134,7 +134,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "orsitame id=quiratio sn=ite time=\"2016/07/04 11:38:16\" fw=10.72.98.186 pri=very-high c=ercit m=15 Newsgroup blocked",
             "event": {
@@ -146,7 +146,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=usan sn=aper time=\"2016/07/18 18:40:50\" fw=10.183.16.166 pri=low c=ender m=70 IPSec packet from illegal host",
             "event": {
@@ -158,7 +158,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=atquovo sn=iumto time=\"2016/08/02 01:43:25\" fw=10.117.18.47 pri=low c=essecill m=129 PPPoE terminated",
             "event": {
@@ -170,7 +170,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=undeo sn=loremip time=\"2016-8-16 8:45:59\" fw=10.134.0.141 pri=very-high c=uis m=1149 msg=\"idolore\" n=onse fw_action=\"cancel\"",
             "event": {
@@ -182,7 +182,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=rveli sn=rsint time=\"2016/08/30 15:48:33\" fw=10.172.146.234 pri=very-high c=Nemoeni m=81 Smurf Amplification Attack Dropped",
             "event": {
@@ -194,7 +194,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=qua sn=luptatev time=\"2016/09/13 22:51:07\" fw=10.123.104.59 pri=low c=elaudant m=1110 msg=\"tinvol\" n=lores",
             "event": {
@@ -206,7 +206,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=tatiset sn=eprehen time=\"2016/09/28 05:53:42\" fw=10.117.146.33 pri=high c=entsu m=10 Problem loading the Filter list; check Filter settings",
             "event": {
@@ -218,7 +218,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=aliq sn=rsitam time=\"2016/10/12 12:56:16\" fw=10.79.33.129 pri=high c=umdolo m=353 msg=\"onproide\" n=Nemoen src=10.241.178.107 dst=10.30.196.102 dstname=fugi4637.www.lan lifeSeconds=imadmini\"",
             "event": {
@@ -230,7 +230,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=itecto sn=erc time=\"2016/10/26 19:58:50\" fw=10.69.57.206 pri=high c=nsec m=68 IPSec Decryption Failed",
             "event": {
@@ -242,7 +242,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=tat sn=tion time=\"2016/11/10 03:01:24\" fw=10.53.150.119 pri=medium c=uasia m=24 msg=\"emp\" n=aperia src=10.157.161.103:383 dst=10.78.151.178:3088 note=\"taut\"",
             "event": {
@@ -254,7 +254,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=tati sn=utaliqu time=\"2016/11/24 10:03:59\" fw=10.53.187.44 pri=high c=iadese m=242 msg=\"imidest\" n=emagnama src= 10.153.136.222 dst= 10.206.136.206:4108",
             "event": {
@@ -266,7 +266,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=nidolo sn=tatn time=\"2016/12/08 17:06:33\" fw=10.18.109.121 pri=very-high c=dolo m=87 msg=\"Loremip\" n=idolor src=10.204.11.20 dst=10.239.201.234",
             "event": {
@@ -278,7 +278,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=quip sn=mporain time=\"2016-12-23 12:09:07\" fw=10.34.161.166 pri=very-high c=sequi m=428 msg=\"rehend\" n=tio src=10.245.200.97:3768:eth4059 dst=10.219.116.137:3452:enp0s3611 srcMac= 01:00:5e:1a:ec:91 dstMac=01:00:5e:e1:73:47 proto=icmp fw_action=\"accept\"",
             "event": {
@@ -290,7 +290,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=idex sn=xerci time=\"2017/01/06 07:11:41\" fw=10.84.206.79 pri=high c=uipe m=401 msg=\"inesci\" n=serror src=10.118.80.140 dst=10.252.122.195 dstname=eFinib",
             "event": {
@@ -302,7 +302,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=ari sn=exercit time=\"2017/01/20 14:14:16\" fw=10.220.244.59 pri=high c=oluptate m=143 Backup firewall has transitioned to Active",
             "event": {
@@ -314,7 +314,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=serunt sn=aquaeabi time=\"2017/02/03 21:16:50\" fw=10.171.157.74 pri=high c=emoe m=104 Retransmitting DHCP REQUEST (Verifying).",
             "event": {
@@ -326,7 +326,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=veniamq sn=one time=\"2017/02/18 04:19:24\" fw=10.4.26.208 pri=very-high c=reseos m=156 Backup received heartbeat from wrong source",
             "event": {
@@ -338,7 +338,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=tin sn=tenima time=\"2017/03/04 11:21:59\" fw=10.241.177.156 pri=medium c=proide m=132 PPPoE discovery process complete",
             "event": {
@@ -350,7 +350,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=tmollita sn=fde time=\"2017-3-18 6:24:33\" fw=10.149.89.126 pri=high c=abo m=794 msg=\"veniamqu\" sid=nse spycat=non spypri=paquioff pktdatId=mquisnos n=maven src=10.86.101.235:3266:lo6501 dst=10.30.153.159:6843:enp0s6487 proto=icmp/eporr fw_action=\"cancel\"",
             "event": {
@@ -362,7 +362,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=aturQui sn=utlabor time=\"2017/04/02 01:27:07\" fw=10.38.249.71 pri=low c=mfugiat m=133 PPPoE starting CHAP Authentication",
             "event": {
@@ -374,7 +374,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=tvolu sn=ecte time=\"2017/04/16 08:29:41\" fw=10.130.14.60 pri=low c=iciadese m=9 No new Filter list available",
             "event": {
@@ -386,7 +386,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "olupta id=litse sn=icabo time=\"2017/04/30 15:32:16\" fw=10.89.208.95 pri=low c=llumdolo m=255 msg=\"nre\" n=ercitat src=10.237.163.139 dst=10.162.172.28",
             "event": {
@@ -398,7 +398,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ionevo id=ugiatnu sn=ciati time=\"2017/05/14 22:34:50\" fw=10.184.122.157 pri=medium c=scivelit m=31 msg=\"allow\" n=ehen src=10.191.23.41:1493:eth4488 dst= 10.250.47.252 ",
             "event": {
@@ -410,7 +410,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=pta sn=tetu time=\"2017/05/29 05:37:24\" fw=10.101.57.134 pri=low c=Nequepo m=12 Problem sending log email; check log settings",
             "event": {
@@ -422,7 +422,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ntocc id=uteirure sn=nevo time=\"2017/06/12 12:39:58\" fw=10.226.23.214 pri=very-high c=adip m=994 msg=\"tium\" n=nnum usr=tenbyCi src=10.16.72.220:1842 dst=10.111.187.12:3577 note=\"quinesc\"",
             "event": {
@@ -434,7 +434,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=tur sn=roi time=\"2017/06/26 19:42:33\" fw=10.106.31.86 pri=low c=sno m=7 Log full; deactivating SonicWALL",
             "event": {
@@ -446,7 +446,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ntocca id=ostru sn=ntoccae time=\"2017/07/11 02:45:07\" fw=10.35.99.92 pri=medium c=iatisu m=866 msg=\"sec\" sess=cons n=sBon",
             "event": {
@@ -458,7 +458,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=ten sn=vita time=\"2017/07/25 09:47:41\" fw=10.35.5.16 pri=high c=emaccusa m=538 msg=\"accept\" n=qui src=10.143.76.137:1414:lo3470 dst= 10.131.61.13",
             "event": {
@@ -470,7 +470,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=evolu sn=ersp time=\"2017/08/08 16:50:15\" fw=10.64.221.30 pri=medium c=inven m=793 msg=\"osquira\" af_polid=tes af_policy=\"mquame\" af_type=\"nihilmol\" af_service=\"xercita\" af_action=\"trud\" n=eriti src=10.99.0.226:2984:eth1766:sequatu341.mail.invalid dst=10.77.129.130:6604:enp0s4138:Nemoenim2039.api.localhost",
             "event": {
@@ -482,7 +482,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=nbyCic sn=utlabor time=\"2017/08/22 23:52:50\" fw=10.27.251.77 pri=medium c=ine m=905 msg=\"lup\" n=tatemUt",
             "event": {
@@ -494,7 +494,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=quovol sn=nve time=\"2017/09/06 06:55:24\" fw=10.104.201.10 pri=very-high c=ccaecat m=94 Diagnostic Code B",
             "event": {
@@ -506,7 +506,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "tau id=exercita sn=ris time=\"2017/09/20 13:57:58\" fw=10.84.25.23 pri=high c=boree m=565 msg=\"intoc\" n=ncidi",
             "event": {
@@ -518,7 +518,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "irat id=onev sn=aturauto time=\"2017/10/04 21:00:32\" fw=10.218.243.47 pri=very-high c=oremi m=37 UDP packet dropped",
             "event": {
@@ -530,7 +530,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=temUt sn=olor time=\"2017/10/19 04:03:07\" fw=10.19.10.148 pri=low c=niamqui m=4 SonicWALL activated",
             "event": {
@@ -542,7 +542,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=ess sn=ipisci time=\"2017/11/02 11:05:41\" fw=10.113.95.59 pri=very-high c=reprehen m=156 Backup received heartbeat from wrong source",
             "event": {
@@ -554,7 +554,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "luptate id=persp sn=entsunt time=\"2017/11/16 18:08:15\" fw=10.206.107.211 pri=low c=fugi m=140 msg=\"accept\" n=inci src=10.230.173.4:2631:enp0s5632 dst= 10.192.27.157",
             "event": {
@@ -566,7 +566,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=cusant sn=atemq time=\"2017/12/01 01:10:49\" fw=10.136.31.188 pri=high c=borios m=118 Sending DHCP REQUEST (Verifying).",
             "event": {
@@ -578,7 +578,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=ercita sn=ciadeser time=\"2017/12/15 08:13:24\" fw=10.175.236.135 pri=medium c=isnisi m=18 ActiveX blocked",
             "event": {
@@ -590,7 +590,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=isiuta sn=orsitam time=\"2017/12/29 15:15:58\" fw=10.159.119.34 pri=high c=psaquaea m=195 msg=\"taevita\" n=ameiusm src=10.227.15.253 dst=10.190.175.158 sport=271 dport=7005 rcvd=6587",
             "event": {
@@ -602,7 +602,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=nre sn=veli time=\"2018/01/12 22:18:32\" fw=10.62.147.186 pri=low c=elitse m=22 Ping of death blocked",
             "event": {
@@ -614,7 +614,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=quasia sn=adi time=\"2018/01/27 05:21:06\" fw=10.9.12.248 pri=medium c=mac m=616 msg=\"block\" n=aveni src=10.29.155.171:1871 dst=10.15.97.155:5935",
             "event": {
@@ -626,7 +626,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=llamco sn=nea time=\"2018/02/10 12:23:41\" fw=10.123.143.188 pri=medium c=orsit m=9 No new Filter list available",
             "event": {
@@ -638,7 +638,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=ise sn=itau time=\"2018/02/24 19:26:15\" fw=10.44.22.97 pri=very-high c=lorsita m=907 msg=\"dolore\" n=uptate",
             "event": {
@@ -650,7 +650,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=odi sn=ptass time=\"2018/03/11 02:28:49\" fw=10.39.10.155 pri=low c=tametcon m=157 HA packet processing error",
             "event": {
@@ -662,7 +662,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=aco sn=tio time=\"2018/03/25 09:31:24\" fw=10.112.38.219 pri=high c=dantium m=261 msg=\"lor\" n=velillu usr=cteturad src= 10.18.204.87 dst= 10.25.32.107",
             "event": {
@@ -674,7 +674,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=utodita sn=aec time=\"2018-4-8 4:33:58\" fw=10.21.89.175 pri=medium c=diconse m=428 msg=\"elitse\" n=reseo src=10.71.238.250:41:lo3856 dst=10.246.0.167:2189:eth2632 srcMac= 01:00:5e:7c:42:0b dstMac=01:00:5e:2c:22:06 proto=icmp fw_action=\"block\"",
             "event": {
@@ -686,7 +686,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=ritin sn=temporin time=\"2018-4-22 11:36:32\" fw=10.122.76.148 pri=high c=tdol m=794 msg=\"upt\" sid=mex spycat=tatem spypri=untutlab pktdatId=amcor n=ica src=10.13.66.97:2000:enp0s5411 dst=10.176.209.227:6362:eth7037 proto=ipv6/siu fw_action=\"allow\"",
             "event": {
@@ -698,7 +698,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=quaea sn=ametcons time=\"2018/05/07 06:39:06\" fw=10.74.46.22 pri=very-high c=tetur m=7 Log full; deactivating SonicWALL",
             "event": {
@@ -710,7 +710,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=ariatur sn=rer time=\"2018/05/21 13:41:41\" fw=10.210.243.175 pri=low c=atisetqu m=240 msg=\"issuscip\" n=uisa src=10.240.49.224 dst=10.77.174.205",
             "event": {
@@ -722,7 +722,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=luptatem sn=uaeratv time=\"2018/06/04 20:44:15\" fw=10.240.190.136 pri=medium c=atcupid m=255 msg=\"quamnih\" n=dminima src=10.44.150.31 dst=10.187.210.173",
             "event": {
@@ -734,7 +734,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=ntutlabo sn=iusmodte time=\"2018-6-19 3:46:49\" fw=10.108.84.24 pri=low c=iosamnis m=606 msg=\"volupt\" n=rem src=10.113.100.237:3887:eth163 dst=10.251.248.228:6909 srcMac= 01:00:5e:8b:c1:b4 dstMac=01:00:5e:c3:ed:55proto=udp fw_action=\"deny\"",
             "event": {
@@ -746,7 +746,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=emvele sn=isnost time=\"2018/07/03 10:49:23\" fw=10.71.112.159 pri=medium c=emqu m=28 Fragmented Packet Dropped",
             "event": {
@@ -758,7 +758,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "sit id=rumSect sn=ita time=\"2018/07/17 17:51:58\" fw=10.139.65.241 pri=low c=teni m=61 Diagnostic Code E",
             "event": {
@@ -770,7 +770,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "oremag id=illu sn=ruredo time=\"2018/08/01 00:54:32\" fw=10.72.196.74 pri=very-high c=ptassita m=906 msg=\"its\" n=lore",
             "event": {
@@ -782,7 +782,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "sBono id=loremqu sn=tetur time=\"2018/08/15 07:57:06\" fw=10.213.94.135 pri=very-high c=urmagn m=237 msg=\"block\" n=uptat src=10.105.46.101:3346:enp0s382 dst= 10.50.44.5:7668:lo1441",
             "event": {
@@ -794,7 +794,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=ddoeius sn=ugiatn time=\"2018/08/29 14:59:40\" fw=10.50.102.128 pri=high c=abore m=328 msg=\"squ\" n=uiadol src=10.60.142.127:1081:eth6291 dst= 10.52.248.251:5776:lo2241",
             "event": {
@@ -806,7 +806,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=onu sn=liquaUte time=\"2018/09/12 22:02:15\" fw=10.137.202.243 pri=high c=tempor m=134 PPPoE starting PAP Authentication",
             "event": {
@@ -818,7 +818,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=mveniamq sn=taedict time=\"2018-9-27 5:04:49\" fw=10.206.69.135 pri=high c=aturve m=880 msg=\"utfug\" n=aturQu note=\"aaliq\" fw_action=\"allow\"",
             "event": {
@@ -830,7 +830,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=uiinea sn=mnisiut time=\"2018/10/11 12:07:23\" fw=10.208.228.129 pri=low c=olup m=441 msg=\"labor\" n=dol src= 10.240.54.28 dst= 10.115.38.80",
             "event": {
@@ -842,7 +842,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=mve sn=uia time=\"2018/10/25 19:09:57\" fw=10.92.237.93 pri=high c=nsequunt m=163 Disconnecting PPPoE due to traffic timeout",
             "event": {
@@ -854,7 +854,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=doei sn=cipitl time=\"2018/11/09 02:12:32\" fw=10.53.127.17 pri=very-high c=strumex m=252 msg=\"eprehend\" n=asnu src=10.102.166.19 dst=10.104.49.142",
             "event": {
@@ -866,7 +866,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=repreh sn=plic time=\"2018/11/23 09:15:06\" fw=10.17.87.79 pri=high c=saq m=199 msg=\"block\" n=ritqu src=10.203.77.154:3916:lo4991 dst= 10.120.25.169:1965:lo4527",
             "event": {
@@ -878,7 +878,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ipsa id=asuntexp sn=adminim time=\"2018/12/07 16:17:40\" fw=10.115.115.26 pri=high c=modoc m=88 IKE Responder: IPSec proposal not acceptable",
             "event": {
@@ -890,7 +890,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=iumt sn=tsed time=\"2018/12/21 23:20:14\" fw=10.249.120.78 pri=medium c=atuse m=34 Login screen timed out",
             "event": {
@@ -902,7 +902,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=loremag sn=tcu time=\"2019/01/05 06:22:49\" fw=10.84.251.253 pri=high c=erspi m=195 msg=\"rorsit\" n=tionemu src=10.77.95.12 dst=10.137.217.159 sport=2310 dport=563 rcvd=1629",
             "event": {
@@ -914,7 +914,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "elillum id=upt sn=rnat time=\"2019/01/19 13:25:23\" fw=10.1.96.93 pri=high c=edolo m=48 Out-of-order command packet dropped",
             "event": {
@@ -926,7 +926,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "doeiu id=deF sn=itempo time=\"2019/02/02 20:27:57\" fw=10.200.237.196 pri=medium c=ecillum m=995 msg=\"isci\" n=dolor src=10.165.48.224:5386 dst=10.191.242.168:5251 note=\"equep\"",
             "event": {
@@ -938,7 +938,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "BCS id=qui sn=ugiatquo time=\"2019/02/17 03:30:32\" fw=10.204.133.116 pri=medium c=autemv m=909 msg=\"emq\" n=plicaboN",
             "event": {
@@ -950,7 +950,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=vol sn=admi time=\"2019/03/03 10:33:06\" fw=10.77.229.168 pri=high c=aquiof m=178 msg=\"ende\" n=abor src=10.185.37.32:708 dst=10.116.173.79:7693",
             "event": {
@@ -962,7 +962,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=olorem sn=gitse time=\"2019/03/17 17:35:40\" fw=10.245.127.213 pri=very-high c=billoinv m=995 msg=\"sci\" n=col src=10.219.42.212:5708 dst=10.57.85.98:3286 note=\"mquisno\"",
             "event": {
@@ -974,7 +974,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=nisiu sn=imad time=\"2019/04/01 00:38:14\" fw=10.30.101.79 pri=high c=tenimad m=97 n=sitametc src= 10.152.35.175:2737:enp0s3423 dst= 10.88.244.209:6953:enp0s2460 proto=ipv6-icmp op=caecat sent=5835 dstname=tquidol",
             "event": {
@@ -986,7 +986,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "undeom id=emullamc sn=tec time=\"2019/04/15 07:40:49\" fw=10.29.118.7 pri=medium c=mveleum m=537 msg=\"accept\" f=exercita n=sBonorum src= 10.132.171.15 dst= 10.107.216.138:3147:lo5057:ugitsedq5067.internal.test proto=rdp sent=5943 rcvd=1635",
             "event": {
@@ -998,7 +998,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=gna sn=isiutali time=\"2019/04/29 14:43:23\" fw=10.156.152.182 pri=very-high c=ons m=137 Wan IP Changed",
             "event": {
@@ -1010,7 +1010,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=uaturve sn=amquisno time=\"2019/05/13 21:45:57\" fw=10.123.74.66 pri=very-high c=mquiad m=351 msg=\"CSe\" n=lors src=10.135.70.159 dst=10.195.223.82",
             "event": {
@@ -1022,7 +1022,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=atu sn=iusm time=\"2019/05/28 04:48:31\" fw=10.20.81.176 pri=low c=stquido m=261 msg=\"rsitvolu\" n=mnisi usr=usmo src=10.22.244.71:1865:eth3249 dst= 10.142.120.198",
             "event": {
@@ -1034,7 +1034,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=oin sn=itseddoe time=\"2019/06/11 11:51:06\" fw=10.141.143.56 pri=low c=erc m=125 Unused AV log entry.",
             "event": {
@@ -1046,7 +1046,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=giatquov sn=olu time=\"2019/06/25 18:53:40\" fw=10.137.103.62 pri=medium c=serror m=105 Sending DHCP DISCOVER.",
             "event": {
@@ -1058,7 +1058,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "emagn id=emulla sn=mips time=\"2019/07/10 01:56:14\" fw=10.201.146.83 pri=very-high c=atnula m=34 Login screen timed out",
             "event": {
@@ -1070,7 +1070,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=itametc sn=ori time=\"2019/07/24 08:58:48\" fw=10.202.74.93 pri=low c=ido m=144 Primary firewall has transitioned to Idle",
             "event": {
@@ -1082,7 +1082,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=doconse sn=etdol time=\"2019/08/07 16:01:23\" fw=10.156.88.51 pri=high c=tura m=658 msg=\"osquirat\" n=equat src=10.56.10.84:5366 dst=10.12.54.142:6543",
             "event": {
@@ -1094,7 +1094,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=min sn=oluptat time=\"2019/08/21 23:03:57\" fw=10.162.129.196 pri=medium c=snisi m=195 msg=\"magnaal\" n=uscip src=10.222.169.140 dst=10.117.63.181 sport=5299 dport=6863 rcvd=7416",
             "event": {
@@ -1106,7 +1106,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=eacommo sn=ueip time=\"2019/09/05 06:06:31\" fw=10.243.252.157 pri=low c=minim m=867 msg=\"scipi\" sess=tur n=acon",
             "event": {
@@ -1118,7 +1118,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "usm id=labori sn=porai time=\"2019/09/19 13:09:05\" fw=10.73.176.98 pri=high c=ostr m=60 Access to Proxy Server Blocked",
             "event": {
@@ -1130,7 +1130,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=lup sn=upta time=\"2019-10-3 8:11:40\" fw=10.247.88.138 pri=very-high c=orissu m=794 msg=\"fic\" sid=sBon spycat=usmod spypri=umdol pktdatId=rumexerc n=isiutali src=10.57.255.4:239:lo1325 dst=10.200.122.184:1176:eth5397 proto=rdp/amvo fw_action=\"allow\"",
             "event": {
@@ -1142,7 +1142,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=mmod sn=iti time=\"2019/10/18 03:14:14\" fw=10.55.81.14 pri=medium c=asp m=19 Java blocked",
             "event": {
@@ -1154,7 +1154,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=mag sn=gelitse time=\"2019/11/01 10:16:48\" fw=10.195.58.44 pri=high c=radip m=413 msg=\"upta\" n=tetura src=10.206.229.61:3467 dst=10.129.101.147:3606",
             "event": {
@@ -1166,7 +1166,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=nostrud sn=cteturad time=\"2019/11/15 17:19:22\" fw=10.150.163.151 pri=high c=veniam m=159 Diagnostic Code F",
             "event": {
@@ -1178,7 +1178,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "id=imavenia sn=expli time=\"2019/11/30 00:21:57\" fw=10.144.57.239 pri=medium c=rur m=520 msg=\"itse\" n=ilm src=10.167.9.200:4003:lo5561 dst= 10.119.4.120:3822:enp0s234",
             "event": {
@@ -1190,7 +1190,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "oluptate id=lit sn=santi time=\"2019/12/14 07:24:31\" fw=10.211.112.194 pri=low c=uis m=1079 msg=\"Clientamcis assigned IP:10.221.220.148\" n=apar",
             "event": {

--- a/packages/sonicwall/data_stream/firewall/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sonicwall/data_stream/firewall/elasticsearch/ingest_pipeline/default.yml
@@ -8,7 +8,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   # User agent
   - user_agent:
       field: user_agent.original

--- a/packages/sonicwall/manifest.yml
+++ b/packages/sonicwall/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: sonicwall
 title: Sonicwall-FW
-version: 0.4.1
+version: 0.4.2
 description: This Elastic integration collects logs from Sonicwall-FW
 categories: ["network", "security"]
 release: experimental


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967