### PR TITLE
sophos update to ECS 1.11.0

### DIFF
--- a/packages/sophos/changelog.yml
+++ b/packages/sophos/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.5.2'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1418
 - version: "0.5.1"
   changes:
     - description: Escape special characters in docs

--- a/packages/sophos/data_stream/utm/_dev/test/pipeline/test-generated.log-expected.json
+++ b/packages/sophos/data_stream/utm/_dev/test/pipeline/test-generated.log-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016:1:29-06:09:59 smtpd[905]: MASTER[nnumqua]: QR globally disabled, status one set to 'disabled'",
             "event": {
@@ -14,7 +14,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016:2:12-13:12:33 astarosg_TVM[5716]: id=ommod severity=medium sys=inima sub=tlabo name=web request blocked, forbidden application detectedaction=accept method=ugiatnu client=stiae facility=nofdeF user=sunt srcip=10.57.170.140 dstip=10.213.231.72 version=1.5102 storage=emips ad_domain=imadmi object=ostrume class=molest type=upt attributes=uiineavocount=tisetq node=irati account=icistatuscode=giatquov cached=eritquii profile=dexeac filteraction=iscinge size=6992 request=oreseos url=https://mail.example.net/tati/utaliqu.html?iquaUten=santium#iciatisu referer=https://www5.example.org/eporroqu/uat.txt?atquovo=suntinc#xeac error=nidolo authtime=tatn dnstime=eli cattime=nnu avscantime=dolo fullreqtime=Loremip device=idolor auth=emeumfu ua=CSed exceptions=lupt group=psaquae category=oinBCSe categoryname=mnisist content-type=sedd reputation=uatD application=iunt app-id=temveleu reason=colabo filename=eme file=numqu extension=qui time=civeli function=block line=agnaali message=gnam fwrule=tat seq=ipitla initf=enp0s7281 outitf=enp0s7084 dstmac=01:00:5e:de:94:f6 srcmac=01:00:5e:1d:c1:c0 proto=den length=tutla tos=olorema prec=;iades ttl=siarchi srcport=2289 dstport=3920 tcpflags=mqu info=apariat prec=tlabore caller=untmolli engine=remi localip=saute host=ercit2385.internal.home extra=run server=10.47.202.102 cookie=quirat set-cookie=llu",
             "event": {
@@ -26,7 +26,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016:2:26-20:15:08 eirure7587.internal.localhost reverseproxy: [mpori] [aaliquaU:medium] [pid 3905:lpaqui] (22)No form context found: [client sitame] No form context found when parsing iadese tag, referer: https://api.example.com/utla/utei.htm?oei=tlabori#oin",
             "event": {
@@ -38,7 +38,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016:3:12-03:17:42 data4478.api.lan confd: id=iquipex severity=very-high sys=uradip sub=wri name=bor client=occa facility=stquidol user=itquiin srcip=10.106.239.55 version=1.3129 storage=atevel object=nsecte class=itame type=eumfug attributes=litcount=asun node=estia account=eaq",
             "event": {
@@ -50,7 +50,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016:3:26-10:20:16 ctetura3009.www5.corp reverseproxy: [lita] [adeseru:medium] [pid 7692:eaq] amest configured -- corp normal operations",
             "event": {
@@ -62,7 +62,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016:4:9-17:22:51 smtpd[1411]: MASTER[inculpa]: QR globally disabled, status one set to 'disabled'",
             "event": {
@@ -74,7 +74,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016:4:24-00:25:25 httpproxy[176]: [nse] disk_cache_zap (non) paquioff",
             "event": {
@@ -86,7 +86,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016:5:8-07:27:59 ptasnu6684.mail.lan reverseproxy: [orumSe] [boree:low] [pid 945:rQuisau] AH01915: Init: (10.18.13.211:205) You configured ofdeFini(irat) on the onev(aturauto) port!",
             "event": {
@@ -98,7 +98,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016:5:22-14:30:33 ssecillu7166.internal.lan barnyard: Initializing daemon mode",
             "event": {
@@ -110,7 +110,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016:6:5-21:33:08 ore5643.api.lan reverseproxy: [metco] [acom:high] [pid 2164:nim] ModSecurity: utaliqu compiled version=\"rsi\"; loaded version=\"taliqui\"",
             "event": {
@@ -122,7 +122,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016:6:20-04:35:42 ciun39.localdomain reverseproxy: [iatqu] [inBCSedu:high] [pid 4006:rorsit] AH00098: pid file tionemu overwritten -- Unclean shutdown of previous Apache run?",
             "event": {
@@ -134,7 +134,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016:7:4-11:38:16 atatnon6064.www.invalid reverseproxy: [magnid] [adol:low] [pid 1263:roide] AH00291: long lost child came home! (pid tem)",
             "event": {
@@ -146,7 +146,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016:7:18-18:40:50 gitse2463.www5.invalid aua: id=tvolup severity=low sys=sci sub=col name=web request blocked srcip=10.42.252.243 user=agnaaliq caller=est engine=mquisno",
             "event": {
@@ -158,7 +158,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016:8:2-01:43:25 httpproxy[2078]: [mol] sc_server_cmd (umdolors) decrypt failed",
             "event": {
@@ -170,7 +170,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016:8:16-08:45:59 oriosam6277.mail.localdomain frox: Listening on 10.169.5.162:6676",
             "event": {
@@ -182,7 +182,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016:8:30-15:48:33 ptate3830.internal.localhost reverseproxy: [quamqua] [ntut:high] [pid 5996:meum] AH02572: Failed to configure at least one certificate and key for mini:Loremip",
             "event": {
@@ -194,7 +194,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016:9:13-22:51:07 nvo6105.invalid reverseproxy: [amquaer] [aqui:medium] [pid 3340:lpa] AH00020: Configuration Failed, isn",
             "event": {
@@ -206,7 +206,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016:9:28-05:53:42 afcd[2492]: Classifier configuration reloaded successfully",
             "event": {
@@ -218,7 +218,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016:10:12-12:56:16 edic2758.api.domain confd: id=olabori severity=medium sys=atatnon sub=lica name=secil client=uisnos facility=olores user=scipit srcip=10.54.169.175 version=1.5889 storage=onorumet object=ptatema class=eavolup type=ipsumq attributes=evitcount=tno node=iss account=taspe",
             "event": {
@@ -230,7 +230,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016:10:26-19:58:50 aua[32]: id=mmo severity=high sys=tlaboru sub=aeabillo name=checking if admin is enabled srcip=10.26.228.145 user=eruntmo caller=nimve engine=usanti",
             "event": {
@@ -242,7 +242,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016:11:10-03:01:24 sshd[2051]: Server listening on 10.59.215.207 port 6195.",
             "event": {
@@ -254,7 +254,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016:11:24-10:03:59 ectobeat3157.mail.local reverseproxy: [uasiarch] [Malor:low] [pid 170:cillumdo] AH02312: Fatal error initialising mod_ssl, ditau.",
             "event": {
@@ -266,7 +266,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016:12:8-17:06:33 ident2323.internal.corp reverseproxy: [hend] [remagna:high] [pid 873:aparia] AH01909: 10.144.21.112:90:epteurs server certificate does NOT include an ID which matches the server name",
             "event": {
@@ -278,7 +278,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2016:12:23-00:09:07 ttenb4581.www.host httpproxy: [rem] main (exer) shutdown finished, exiting",
             "event": {
@@ -290,7 +290,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:1:6-07:11:41 lapari5763.api.invalid frox: Listening on 10.103.2.48:4713",
             "event": {
@@ -302,7 +302,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:1:20-14:14:16 elites4713.www.localhost ulogd: id=serr severity=very-high sys=olore sub=onemul name=portscan detected action=deny fwrule=remeum seq=etur initf=lo6086 outitf=lo272 dstmac=01:00:5e:51:b9:4d srcmac=01:00:5e:15:3a:74 srcip=10.161.51.135 dstip=10.52.190.18 proto=isni length=quid tos=aUten prec=Duis ttl=uisq srcport=7807 dstport=165 tcpflags=accus info=CSed code=tiu type=wri",
             "event": {
@@ -314,7 +314,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:2:3-21:16:50 sam1795.invalid reverseproxy: [lorese] [olupta:low] [pid 3338:iqui] AH02312: Fatal error initialising mod_ssl, animide.",
             "event": {
@@ -326,7 +326,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:2:18-04:19:24 confd[10]: id=arch severity=high sys=data sub=ugits name=ittenb client=tobeatae facility=ntut user=llum srcip=10.232.108.32 version=1.5240 storage=idolo object=mqu class=mquido type=ende attributes=ntmollitcount=tisu node=ionofdeF account=rsp",
             "event": {
@@ -338,7 +338,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:3:4-11:21:59 nostrum6305.internal.localhost astarosg_TVM: id=llitani severity=high sys=itametco sub=etcons name=web request blocked, forbidden url detectedaction=allow method=iuntN client=utfugi facility=ursintoc user=tio srcip=10.89.41.97 dstip=10.231.116.175 version=1.5146 storage=lup ad_domain=mipsamv object=exeacomm class=sequines type=cto attributes=cusacount=nderi node=tem account=tcustatuscode=eumiu cached=nim profile=pteurs filteraction=ercitati size=835 request=ptat url=https://mail.example.net/velillu/ecatcupi.txt?rsitamet=leumiur#ssequamn referer=https://example.com/taliqui/idi.txt?undeomn=ape#itaspe error=ari authtime=umtot dnstime=onemulla cattime=atquo avscantime=borio fullreqtime=equatD device=uidol auth=inculpa ua=ruredol exceptions=iadeseru group=loremagn category=acons categoryname=nimadmi content-type=lapa reputation=emoenimi application=iquipex app-id=mqu reason=onorume filename=abill file=ametcon extension=ofdeFini time=tasnu function=deny line=tionev message=uasiarch fwrule=velites seq=uredolor initf=lo1543 outitf=lo6683 dstmac=01:00:5e:8c:f2:06 srcmac=01:00:5e:6f:71:02 proto=plica length=asiarc tos=lor prec=;nvolupt ttl=dquia srcport=5334 dstport=1525 tcpflags=umfugiat info=quisnos prec=utf caller=dolor engine=dexe localip=nemul host=Duis583.api.local extra=eavolupt server=10.17.51.153 cookie=aperiame set-cookie=stenat",
             "event": {
@@ -350,7 +350,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:3:18-18:24:33 xeaco7887.www.localdomain aua: id=hite severity=very-high sys=ugitsed sub=dminimve name=Packet accepted srcip=10.137.165.144 user=uptate caller=tot engine=reme",
             "event": {
@@ -362,7 +362,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:4:2-01:27:07 reverseproxy[5430]: ARGS:userPermissions: [\\\\x22dashletAccessAlertingRecentAlertsPanel\\\\x22,\\\\x22dashletAccessAlerterTopAlertsDashlet\\\\x22,\\\\x22accessViewRules\\\\x22,\\\\x22deployLiveResources\\\\x22,\\\\x22vi...\"] [severity [hostname \"iscivel3512.invalid\"] [uri \"atcupi\"] [unique_id \"eriti\"]",
             "event": {
@@ -374,7 +374,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:4:16-08:29:41 sockd[6181]: dante/server 1.202 running",
             "event": {
@@ -386,7 +386,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:4:30-15:32:16 dolor5799.home afcd: Classifier configuration reloaded successfully",
             "event": {
@@ -398,7 +398,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:5:14-22:34:50 oreseosq1859.api.lan reverseproxy: [mmodic] [essequam:low] [pid 6691:ficiade] [client uiinea] [uianonn] virus daemon connection problem found in request https://www5.example.com/dantium/ors.htm?sinto=edi#eumiure, referer: https://example.com/adeser/mSe.gif?aute=rchite#rcit",
             "event": {
@@ -410,7 +410,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:5:29-05:37:24 confd-sync[6908]: id=smoditem severity=very-high sys=tev sub=oNemoeni name=luptatem",
             "event": {
@@ -422,7 +422,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:6:12-12:39:58 autodit272.www.localhost reverseproxy: [oriss] [imadmin:very-high] [pid 1121:urve] ModSecurity: sBonoru compiled version=\"everi\"; loaded version=\"squ\"",
             "event": {
@@ -434,7 +434,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:6:26-19:42:33 rporis6787.www5.localdomain reverseproxy: [quasiarc] [pta:low] [pid 3705:liqu] [client ipsu] AH01114: siarch: failed to make connection to backend: 10.148.21.7",
             "event": {
@@ -446,7 +446,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:7:11-02:45:07 reprehe5661.www.lan reverseproxy: rManage\\\\x22,\\\\x22manageLiveSystemSettings\\\\x22,\\\\x22accessViewJobs\\\\x22,\\\\x22exportList\\\\...\"] [ver \"olor\"] [maturity \"corpo\"] [accuracy \"commod\"] iumd [hostname \"ntore4333.api.invalid\"] [uri \"sitv\"] [unique_id \"equam\"]",
             "event": {
@@ -458,7 +458,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:7:25-09:47:41 exim[2384]: aeca-ugitse-ameiu utei:caecat:lumquid oluptat sequatD163.internal.example [10.151.206.38]:5794 lits",
             "event": {
@@ -470,7 +470,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:8:8-16:50:15 elillu5777.www5.lan pluto: \"elaudant\"[olup] 10.230.4.70 #ncu: starting keying attempt quaturve of an unlimited number",
             "event": {
@@ -482,7 +482,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:8:22-23:52:50 ecatcup3022.mail.invalid xl2tpd: Inherited by nproide",
             "event": {
@@ -494,7 +494,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:9:6-06:55:24 qui7797.www.host ipsec_starter: Starting strongSwan umet IPsec [starter]...",
             "event": {
@@ -506,7 +506,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:9:20-13:57:58 nofdeFin2037.mail.example reverseproxy: [quatD] [nevol:high] [pid 3994:Sectio] [client tiumdol] [laud] cannot read reply: Operation now in progress (115), referer: https://example.org/tquov/natu.jpg?uianonnu=por#nve",
             "event": {
@@ -518,7 +518,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:10:4-21:00:32 sockd[7264]: dante/server 1.3714 running",
             "event": {
@@ -530,7 +530,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:10:19-04:03:07 eFinib2403.api.example reverseproxy: [utaliq] [sun:high] [pid 4074:uredol] [client quatD] [enimad] ecatcu while reading reply from cssd, referer: https://mail.example.org/urautod/eveli.html?rese=nonproi#doconse",
             "event": {
@@ -542,7 +542,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:11:2-11:05:41 confd[4939]: id=acons severity=high sys=adipisc sub=omnisist name=orroqui client=sci facility=psamvolu user=itsedqui srcip=10.244.96.61 version=1.2707 storage=onevol object=ese class=reprehen type=Exce attributes=toccacount=tinvolu node=ecatc account=iumt",
             "event": {
@@ -554,7 +554,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:11:16-18:08:15 named[1900]: reloading eddoei iono",
             "event": {
@@ -566,7 +566,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:12:1-01:10:49 obeatae2042.www.domain reverseproxy: [dquian] [isaute:low] [pid 1853:utfugit] (70007)The ula specified has expired: [client quaUteni] AH01110: error reading response",
             "event": {
@@ -578,7 +578,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:12:15-08:13:24 aerat1267.www5.example pop3proxy: Master started",
             "event": {
@@ -590,7 +590,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2017:12:29-15:15:58 writt2238.internal.localdomain reverseproxy: [uaer] [aed:low] [pid 478:ain] [client scingeli] [uatDuis] mod_avscan_check_file_single_part() called with parameter filename=imip",
             "event": {
@@ -602,7 +602,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:1:12-22:18:32 siutaliq4937.api.lan reverseproxy: [siutaliq] [urvel:very-high] [pid 7721:ntium] [imadmi] Hostname in dquiac request (liquide) does not match the server name (uatD)",
             "event": {
@@ -614,7 +614,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:1:27-05:21:06 URID[7596]: T=BCSedut ------ 1 - [exit] accept: ametco",
             "event": {
@@ -626,7 +626,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:2:10-12:23:41 astarosg_TVM[1090]: id=udex severity=low sys=iam sub=animi name=UDP flood detectedaction=allow method=nsectetu client=spici facility=untutl user=hen srcip=10.214.167.164 dstip=10.76.98.53 version=1.3726 storage=uovolup ad_domain=expl object=animi class=mdoloree type=mullamco attributes=tnulcount=ons node=radip account=amremapstatuscode=dolorsit cached=atisund profile=isnostru filteraction=quepo size=5693 request=nisi url=https://api.example.org/iono/secillum.txt?apariat=tse#enbyCi referer=https://example.com/eetdol/aut.jpg?pitlab=tutlabor#imadmi error=nculp authtime=quamnihi dnstime=nimadmi cattime=mquiado avscantime=agn fullreqtime=dip device=urmag auth=nim ua=laboreet exceptions=tutlabo group=incid category=der categoryname=totamrem content-type=eaqu reputation=itani application=mni app-id=runtmol reason=uaer filename=nor file=saut extension=olest time=volu function=block line=osam message=ncid fwrule=loremagn seq=uisau initf=lo1255 outitf=eth965 dstmac=01:00:5e:2f:c3:3e srcmac=01:00:5e:65:2d:fe proto=ictasun length=iumto tos=ciun prec=;prehe ttl=essec srcport=4562 dstport=2390 tcpflags=uaera info=nsequa prec=yCicero caller=orporis engine=oluptate localip=tesseq host=tenbyCi4371.www5.localdomain extra=spernatu server=10.98.126.206 cookie=tion set-cookie=tNeque",
             "event": {
@@ -638,7 +638,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:2:24-19:26:15 ulogd[6722]: id=persp severity=medium sys=orev sub=lapa name=Packet logged action=allow fwrule=adminim seq=isiutali initf=lo7088 outitf=eth6357 dstmac=01:00:5e:9a:fe:91 srcmac=01:00:5e:78:1a:5a srcip=10.203.157.250 dstip=10.32.236.117 proto=turm length=quamei tos=nvento prec=nama ttl=ema srcport=6585 dstport=5550 tcpflags=xeacomm info=oriosa code=erspici type=oreeu",
             "event": {
@@ -650,7 +650,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:3:11-02:28:49 ectob5542.www5.corp reverseproxy: [agni] [ivelit:high] [pid 7755:uovol] AH00959: ap_proxy_connect_backend disabling worker for (10.231.77.26) for volups",
             "event": {
@@ -662,7 +662,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:3:25-09:31:24 iusmo901.www.home httpd: id=scivelit severity=high sys=untut sub=siu name=Authentication successfulaction=allow method=icons client=hende facility=umdol user=Sedutper srcip=10.2.24.156 dstip=10.113.78.101 version=1.2707 storage=amqua ad_domain=nsequatu object=aboNemoe class=mqu type=tse attributes=ntiumdcount=ueip node=amvo account=dolorsistatuscode=acc cached=quinesc profile=ulpaq filteraction=usa size=5474 request=tob url=https://www.example.org/imipsamv/doeiu.jpg?nderit=ficia#tru referer=https://mail.example.org/natuser/olupt.txt?ipsumqu=nsec#smo error=avolup authtime=litse dnstime=archit cattime=nde avscantime=tNequepo fullreqtime=byCicer device=imvenia auth=ipit ua=tdolorem exceptions=nderitin group=mquiado category=ssequa categoryname=nisist content-type=temvele reputation=ofd application=quam app-id=umdol reason=porincid filename=tisetqu file=pici extension=erit time=ehenderi function=block line=fugiatqu message=Duisaute fwrule=uptat seq=hende initf=lo3680 outitf=lo4358 dstmac=01:00:5e:0a:8f:6c srcmac=01:00:5e:34:8c:d2 proto=mnis length=ainci tos=aturve prec=;tiumdol ttl=mporain srcport=6938 dstport=6939 tcpflags=dut info=aecons prec=tionemu caller=edictasu engine=quipexea localip=orsit host=tenima5715.api.example extra=snisiut server=10.92.93.236 cookie=amr set-cookie=mfug port=7174 query=exerc uid=ntoccae",
             "event": {
@@ -674,7 +674,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:4:8-16:33:58 astarosg_TVM[6463]: id=user severity=low sys=sequamn sub=adeseru name=File extension warned and proceededaction=accept method=mquisn client=ulamcol facility=nulamcol user=atatno srcip=10.180.169.49 dstip=10.206.69.71 version=1.3155 storage=risni ad_domain=ccaecat object=dtemp class=onproid type=ica attributes=mnisiscount=edolor node=nonnumqu account=iscivelistatuscode=urve cached=sundeomn profile=tasu filteraction=equunt size=3144 request=ilmo url=https://mail.example.net/isqua/deF.html?iameaq=orainci#adm referer=https://api.example.org/mremap/ate.htm?tlabor=cidunt#ria error=tessec authtime=cupida dnstime=ciade cattime=busBonor avscantime=enima fullreqtime=emseq device=osamni auth=umetMa ua=equatDui exceptions=its group=setquas category=nti categoryname=osamnis content-type=atisetqu reputation=ciduntut application=atisu app-id=edutpe reason=architec filename=incul file=tevelit extension=emse time=eipsaqua function=cancel line=suntincu message=lore fwrule=equatu seq=enbyCi initf=enp0s566 outitf=lo2179 dstmac=01:00:5e:2c:9d:65 srcmac=01:00:5e:1a:03:f5 proto=orema length=iusmo tos=uunturm prec=;mSect ttl=avolupta srcport=3308 dstport=1402 tcpflags=dolo info=tsed prec=corpori caller=cillumd engine=umdol localip=turmagn host=mni4032.lan extra=amrem server=10.202.65.2 cookie=queporr set-cookie=oide",
             "event": {
@@ -686,7 +686,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:4:22-23:36:32 iscing6960.api.invalid reverseproxy: [emipsu] [incidu:very-high] [pid 5350:itation] SSL Library Error: error:itasper:failure",
             "event": {
@@ -698,7 +698,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:5:7-06:39:06 httpd[793]: [ruredo:success] [pid nculpaq:mides] [client iconseq] ModSecurity: Warning. nidolo [file \"runtmoll\"] [line \"tuserror\"] [id \"utlabo\"] [rev \"scip\"] [msg \"imvenia\"] [severity \"low\"] [ver \"1.6420\"] [maturity \"nisi\"] [accuracy \"seq\"] [tag \"ors\"] [hostname \"olupta3647.host\"] [uri \"uaUteni\"] [unique_id \"gitsedqu\"]amqu",
             "event": {
@@ -710,7 +710,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:5:21-13:41:41 named[6633]: FORMERR resolving 'iavolu7814.www5.localhost': 10.194.12.83#elit",
             "event": {
@@ -722,7 +722,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:6:4-20:44:15 astarosg_TVM[5792]: id=elitess severity=low sys=amqua sub=mavenia name=checking if admin is enabledaction=cancel method=doc client=teurs facility=eturadi user=eturadip srcip=10.33.138.154 dstip=10.254.28.41 version=1.4256 storage=volupta ad_domain=dolor object=dolorsit class=tfugits type=lor attributes=oremcount=utper node=ueips account=umqustatuscode=ntexpli cached=siuta profile=porincid filteraction=itame size=1026 request=fugiat url=https://www5.example.org/etcons/aecatc.jpg?ditem=tut#oditautf referer=https://internal.example.org/eddoei/iatqu.htm?itessec=dat#tdol error=emul authtime=ariatu dnstime=luptate cattime=umdolore avscantime=iutaliq fullreqtime=oriosamn device=oluptate auth=tcu ua=mmodo exceptions=rauto group=lup category=orem categoryname=tutl content-type=iusmo reputation=uiavolu application=eri app-id=pis reason=riosam filename=isa file=nonnum extension=Nemoenim time=itati function=cancel line=nes message=atvolupt fwrule=umwritt seq=uae initf=enp0s3792 outitf=lo2114 dstmac=01:00:5e:24:b8:9f srcmac=01:00:5e:a1:a3:9f proto=bil length=itten tos=icer prec=;dolo ttl=siutaliq srcport=1455 dstport=6937 tcpflags=pexeaco info=ercitati prec=dexea caller=tasnul engine=onu localip=orisnisi host=obea2960.mail.corp extra=dolor server=10.45.12.53 cookie=etdo set-cookie=edictas",
             "event": {
@@ -734,7 +734,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:6:19-03:46:49 frox[7744]: Listening on 10.99.134.49:2274",
             "event": {
@@ -746,7 +746,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:7:3-10:49:23 olli5982.www.test reverseproxy: [asp] [uatDui:medium] [pid 212:unde] [client raut] [suscip] virus daemon error found in request ectetu, referer: https://example.com/ariat/ptatemU.txt?cusan=ueipsaq#upid",
             "event": {
@@ -758,7 +758,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:7:17-17:51:58 nsecte3644.internal.test reverseproxy: [tutla] [isund:high] [pid 3136:uidex] [client uptate] Invalid signature, cookie: JSESSIONID",
             "event": {
@@ -770,7 +770,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:8:1-00:54:32 confd[4157]: id=onseq severity=very-high sys=siutaliq sub=aliqu name=serro client=ctet facility=umiurere user=antium srcip=10.32.85.21 version=1.7852 storage=eaco object=onp class=ectetur type=ione attributes=utlaborecount=nci node=acommodi account=etconsec",
             "event": {
@@ -782,7 +782,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:8:15-07:57:06 econseq7119.www.home sshd: error: Could not get shadow information for NOUSER",
             "event": {
@@ -794,7 +794,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:8:29-14:59:40 ant2543.www5.lan reverseproxy: [uaturve] [lapa:high] [pid 3669:idu] [client sed] [utem] cannot read reply: Operation now in progress (115), referer: https://example.com/oremagn/ehenderi.htm?mdolo=ionul#oeiusmo",
             "event": {
@@ -806,7 +806,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:9:12-22:02:15 pluto[7138]: | sent accept notification olore with seqno = urEx",
             "event": {
@@ -818,7 +818,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:9:27-05:04:49 httpd[6562]: id=iurere severity=medium sys=erc sub=atu name=http accessaction=accept method=odte client=uis facility=sedquia user=reetd srcip=10.210.175.52 dstip=10.87.14.186 version=1.7641 storage=tasu ad_domain=mquae object=CSedu class=atae type=aeconseq attributes=boNemocount=duntutla node=mqu account=inimastatuscode=emipsum cached=venia profile=Loremi filteraction=uisnostr size=849 request=vol url=https://internal.example.com/ritat/dipi.jpg?aliquide=aliqui#agnaaliq referer=https://api.example.org/Bonorume/emeumfu.txt?iuntNequ=ender#quid error=mipsa authtime=teturad dnstime=nimide cattime=spernat avscantime=nevolu fullreqtime=itectobe device=rroq auth=itessequ ua=uunt exceptions=pic group=unt category=emUt categoryname=eiru content-type=sauteir reputation=pic application=caecatc app-id=iarc reason=emquia filename=duntutl file=idi extension=reetdo time=pidatatn function=cancel line=ncul message=mcorpor fwrule=ofd seq=lapariat initf=eth65 outitf=lo3615 dstmac=01:00:5e:b3:e3:90 srcmac=01:00:5e:0e:b3:8e proto=consequ length=min tos=riame prec=;gnaal ttl=nti srcport=1125 dstport=605 tcpflags=utlab info=colabo prec=ditem caller=did engine=BCS localip=idex host=nisiuta4810.api.test extra=apa server=10.85.200.58 cookie=esse set-cookie=idexeac port=2294 query=iatquovo uid=rExce",
             "event": {
@@ -830,7 +830,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:10:11-12:07:23 itametc1599.api.test ulogd: id=itaedi severity=low sys=ore sub=ips name=Authentication successful action=block fwrule=iamqu seq=aboN initf=eth2679 outitf=enp0s1164 dstmac=01:00:5e:c3:8a:24 srcmac=01:00:5e:5a:9d:a9 srcip=10.133.45.45 dstip=10.115.166.48 proto=utaliq length=icer tos=essequ prec=oeiu ttl=nsequa srcport=4180 dstport=4884 tcpflags=squa info=etM code=eve type=iru",
             "event": {
@@ -842,7 +842,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:10:25-19:09:57 tiumt5462.mail.localhost sshd: Invalid user admin from runt",
             "event": {
@@ -854,7 +854,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:11:9-02:12:32 vol1450.internal.host sshd: Server listening on 10.71.184.162 port 3506.",
             "event": {
@@ -866,7 +866,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:11:23-09:15:06 ipsec_starter[178]: IP address or index of physical interface changed -\u003e reinit of ipsec interface",
             "event": {
@@ -878,7 +878,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:12:7-16:17:40 rporissu573.api.test reverseproxy: [exercita] [emaperi:very-high] [pid 5943:ddoei] AH02312: Fatal error initialising mod_ssl, nihi.",
             "event": {
@@ -890,7 +890,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2018:12:21-23:20:14 nostru774.corp URID: T=tatnonp ------ 1 - [exit] allow: natuserr",
             "event": {
@@ -902,7 +902,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:1:5-06:22:49 ipsec_starter[6226]: IP address or index of physical interface changed -\u003e reinit of ipsec interface",
             "event": {
@@ -914,7 +914,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:1:19-13:25:23 httpd[5037]: [iadese:unknown] [pid isundeo:emq] [client rehender] ModSecurity: Warning. uat [file \"apa\"] [line \"tani\"] [id \"per\"] [rev \"ngelitse\"] [msg \"olorsita\"] [severity \"medium\"] [ver \"1.7102\"] [maturity \"apariat\"] [accuracy \"iuntNequ\"] [tag \"rExc\"] [hostname \"lorsita2216.www5.example\"] [uri \"turvelil\"] [unique_id \"velitsed\"]rau",
             "event": {
@@ -926,7 +926,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:2:2-20:27:57 sum2208.host reverseproxy: [eir] [nia:medium] [pid 4346:mco] [client ritinvol] [quioffi] mod_avscan_check_file_single_part() called with parameter filename=quamquae",
             "event": {
@@ -938,7 +938,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:2:17-03:30:32 ore6843.local reverseproxy: [usmodite] [aveniam:medium] [pid 5126:xplicab] [client taev] No signature found, cookie: dictasu",
             "event": {
@@ -950,7 +950,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:3:3-10:33:06 Sedu1610.mail.corp reverseproxy: [audant] [porr:medium] [pid 7442:tation] [client uunturma] AH01114: cons: failed to make connection to backend: 10.177.35.133",
             "event": {
@@ -962,7 +962,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:3:17-17:35:40 corpo6737.example reverseproxy: [officiad] [aliquide:very-high] [pid 6600:errorsi] [client raincidu] [orincidi] cannot connect: failure (111)",
             "event": {
@@ -974,7 +974,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:4:1-00:38:14 pop3proxy[6854]: Master started",
             "event": {
@@ -986,7 +986,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:4:15-07:40:49 eratvol314.www.home pop3proxy: Master started",
             "event": {
@@ -998,7 +998,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:4:29-14:43:23 utemvele1838.mail.test reverseproxy: [xplicabo] [aco:high] [pid 2389:ratione] [client nrepr] ModSecurity: Warning. uipex [file \"alorumw\"] [line \"nibus\"] [id \"eiusmo\"] [msg \"rci\"] [hostname \"seosquir715.local\"] [uri \"ercitati\"] [unique_id \"uiration\"]",
             "event": {
@@ -1010,7 +1010,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:5:13-21:45:57 ulapari2656.local reverseproxy: [itessec] [non:very-high] [pid 2237:licaboN] [client nvol] [moenimip] cannot connect: failure (111)",
             "event": {
@@ -1022,7 +1022,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:5:28-04:48:31 reverseproxy[4278]: [ritat] [iscinge:very-high] [pid 4264:rroquisq] [client tnonpro] [nimv] erunt while reading reply from cssd, referer: https://example.org/etcon/ipitlab.gif?utlabore=suscipi#tlabor",
             "event": {
@@ -1034,7 +1034,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:6:11-11:51:06 URID[7418]: T=xer ------ 1 - [exit] cancel: onemul",
             "event": {
@@ -1046,7 +1046,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:6:25-18:53:40 pluto[7201]: | handling event ips for 10.165.217.56 \"econse\" #otamr",
             "event": {
@@ -1058,7 +1058,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:7:10-01:56:14 stla2856.host reverseproxy: [onpro] [adolo:very-high] [pid 7766:siste] ModSecurity for Apache/nisiut (ostr) configured.",
             "event": {
@@ -1070,7 +1070,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:7:24-08:58:48 peri6748.www5.domain reverseproxy: [cingeli] [esseq:high] [pid 2404:aquae] AH00098: pid file otamrema overwritten -- Unclean shutdown of previous Apache run?",
             "event": {
@@ -1082,7 +1082,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:8:7-16:01:23 tnon5442.internal.test reverseproxy: [ive] [tquido:very-high] [pid 6108:taliquip] AH00295: caught accept, ectetu",
             "event": {
@@ -1094,7 +1094,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:8:21-23:03:57 ariatu2606.www.host reverseproxy: [quamestq] [umquid:very-high] [pid 7690:rem] [client its] [inv] not all the file sent to the client: rin, referer: https://example.org/tation/tutlabo.jpg?amvo=ullamco#tati",
             "event": {
@@ -1106,7 +1106,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:9:5-06:06:31 imv1805.api.host ulogd: id=oenim severity=very-high sys=iaturExc sub=orsit name=ICMP flood detected action=cancel fwrule=eos seq=quameius initf=lo4665 outitf=lo3422 dstmac=01:00:5e:d6:f3:bc srcmac=01:00:5e:87:02:08 srcip=10.96.243.231 dstip=10.248.62.55 proto=ugiat length=quiin tos=apar prec=eleumiur ttl=chite srcport=5632 dstport=4206 tcpflags=tevelit info=etc code=lorem type=temvele",
             "event": {
@@ -1118,7 +1118,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:9:19-13:09:05 rita600.www5.localdomain reverseproxy: [ini] [elite:high] [pid 7650:mnisiut] AH00959: ap_proxy_connect_backend disabling worker for (10.132.101.158) for cipitlabs",
             "event": {
@@ -1130,7 +1130,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:10:3-20:11:40 sshd[2014]: Did not receive identification string from rroq",
             "event": {
@@ -1142,7 +1142,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:10:18-03:14:14 admini1122.www.local reverseproxy: [ritte] [umwritte:very-high] [pid 1817:atu] (13)failure: [client vol] AH01095: prefetch request body failed to 10.96.193.132:5342 (orumwr) from bori ()",
             "event": {
@@ -1154,7 +1154,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:11:1-10:16:48 confd[2475]: id=utaliqu severity=low sys=xplicabo sub=quamni name=dol client=sisten facility=remeumf user=acommod srcip=10.96.200.83 version=1.7416 storage=sper object=asia class=roident type=olorem attributes=teursintcount=evelites node=nostr account=lapariat",
             "event": {
@@ -1166,7 +1166,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:11:15-17:19:22 emvel4391.localhost sshd: Did not receive identification string from quelaud",
             "event": {
@@ -1178,7 +1178,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:11:30-00:21:57 confd-sync[5454]: id=smodite severity=high sys=utpersp sub=rnatu name=ico",
             "event": {
@@ -1190,7 +1190,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "2019:12:14-07:24:31 untinc5531.www5.test sshd: error: Could not get shadow information for NOUSER",
             "event": {

--- a/packages/sophos/data_stream/utm/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sophos/data_stream/utm/elasticsearch/ingest_pipeline/default.yml
@@ -8,7 +8,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   # User agent
   - user_agent:
       field: user_agent.original

--- a/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-xg.log-expected.json
+++ b/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-xg.log-expected.json
@@ -37,7 +37,7 @@
             },
             "@timestamp": "2020-05-18T14:38:48.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -163,7 +163,7 @@
             },
             "@timestamp": "2020-05-18T14:38:49.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -292,7 +292,7 @@
             },
             "@timestamp": "2020-05-18T14:38:50.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -420,7 +420,7 @@
             },
             "@timestamp": "2020-05-18T14:38:51.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -515,7 +515,7 @@
             },
             "@timestamp": "2017-01-31T18:34:41.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -610,7 +610,7 @@
             },
             "@timestamp": "2018-06-06T11:10:11.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -705,7 +705,7 @@
             },
             "@timestamp": "2018-06-06T12:50:07.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -800,7 +800,7 @@
             },
             "@timestamp": "2018-06-06T12:51:34.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -886,7 +886,7 @@
             },
             "@timestamp": "2018-06-06T12:53:39.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -979,7 +979,7 @@
             },
             "@timestamp": "2018-06-06T12:56:53.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1073,7 +1073,7 @@
             },
             "@timestamp": "2017-01-31T18:31:11.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1187,7 +1187,7 @@
             },
             "@timestamp": "2020-05-18T14:38:33.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1306,7 +1306,7 @@
             },
             "@timestamp": "2020-05-18T14:38:34.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1442,7 +1442,7 @@
             },
             "@timestamp": "2020-05-18T14:38:35.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1577,7 +1577,7 @@
             },
             "@timestamp": "2020-05-18T14:38:36.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1679,7 +1679,7 @@
             },
             "@timestamp": "2018-06-06T10:51:29.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1781,7 +1781,7 @@
             },
             "@timestamp": "2018-06-06T10:58:29.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1879,7 +1879,7 @@
                 "directory": "/var/www//home/ftp-user/ta_test_file_1ta-cl1-46"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1973,7 +1973,7 @@
                 "directory": "/var/www//home/ftp-user/ta_test_file_1ta-cl1-46"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -2073,7 +2073,7 @@
             },
             "@timestamp": "2017-01-31T18:44:31.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2177,7 +2177,7 @@
             },
             "@timestamp": "2020-05-18T14:38:34.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -2278,7 +2278,7 @@
             },
             "@timestamp": "2020-05-18T14:38:35.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -2376,7 +2376,7 @@
             },
             "@timestamp": "2018-06-05T08:49:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -2481,7 +2481,7 @@
             },
             "@timestamp": "2017-01-31T14:03:33.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -2601,7 +2601,7 @@
             },
             "@timestamp": "2017-02-01T18:20:21.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -2713,7 +2713,7 @@
             },
             "@timestamp": "2017-02-01T18:13:29.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -2823,7 +2823,7 @@
             },
             "@timestamp": "2020-05-18T14:38:51.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -2933,7 +2933,7 @@
             },
             "@timestamp": "2020-05-18T14:38:52.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -3045,7 +3045,7 @@
             },
             "@timestamp": "2020-05-18T14:38:53.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -3125,7 +3125,7 @@
             },
             "@timestamp": "2016-12-02T18:50:20.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -3230,7 +3230,7 @@
             },
             "@timestamp": "2016-12-02T18:50:20.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3339,7 +3339,7 @@
             },
             "@timestamp": "2016-12-02T18:50:22.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3420,7 +3420,7 @@
             },
             "@timestamp": "2020-05-18T14:38:57.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3533,7 +3533,7 @@
             },
             "@timestamp": "2020-05-18T14:38:58.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3593,7 +3593,7 @@
             },
             "@timestamp": "2020-05-18T14:38:59.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -3664,7 +3664,7 @@
             },
             "@timestamp": "2020-05-18T14:39:00.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3731,7 +3731,7 @@
             },
             "@timestamp": "2020-05-18T14:39:01.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -3786,7 +3786,7 @@
             },
             "@timestamp": "2020-05-18T14:39:02.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -3858,7 +3858,7 @@
             },
             "@timestamp": "2020-05-18T14:39:03.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -3937,7 +3937,7 @@
             },
             "@timestamp": "2020-05-18T14:39:04.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4017,7 +4017,7 @@
             },
             "@timestamp": "2020-05-18T14:39:05.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4081,7 +4081,7 @@
             },
             "@timestamp": "2020-05-18T14:39:06.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -4135,7 +4135,7 @@
             },
             "@timestamp": "2020-05-18T14:39:07.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4206,7 +4206,7 @@
             },
             "@timestamp": "2020-05-18T14:39:08.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4262,7 +4262,7 @@
             },
             "@timestamp": "2020-05-18T14:39:09.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -4310,7 +4310,7 @@
             },
             "@timestamp": "2020-05-18T14:39:10.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -4372,7 +4372,7 @@
             },
             "@timestamp": "2020-05-18T14:39:20.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -4453,7 +4453,7 @@
             },
             "@timestamp": "2017-03-16T12:56:01.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -4517,7 +4517,7 @@
             },
             "@timestamp": "2017-03-16T12:53:27.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -4581,7 +4581,7 @@
             },
             "@timestamp": "2017-03-16T12:46:26.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -4636,7 +4636,7 @@
             },
             "@timestamp": "2018-06-06T11:12:10.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -4768,7 +4768,7 @@
             },
             "@timestamp": "2020-05-18T14:38:37.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -4942,7 +4942,7 @@
             },
             "@timestamp": "2020-05-18T14:38:38.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -5075,7 +5075,7 @@
             },
             "@timestamp": "2020-05-18T14:38:39.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -5205,7 +5205,7 @@
             },
             "@timestamp": "2020-05-18T14:38:40.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5360,7 +5360,7 @@
             },
             "@timestamp": "2020-05-18T14:38:41.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -5491,7 +5491,7 @@
             },
             "@timestamp": "2020-05-18T14:38:42.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5614,7 +5614,7 @@
             },
             "@timestamp": "2020-05-18T14:38:43.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -5734,7 +5734,7 @@
             },
             "@timestamp": "2020-05-18T14:38:44.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -5867,7 +5867,7 @@
             },
             "@timestamp": "2020-05-18T14:38:45.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5992,7 +5992,7 @@
             },
             "@timestamp": "2020-05-18T14:38:45.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6116,7 +6116,7 @@
             },
             "@timestamp": "2020-06-05T12:38:53.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6250,7 +6250,7 @@
             },
             "@timestamp": "2018-05-30T13:26:37.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6363,7 +6363,7 @@
             },
             "@timestamp": "2018-06-04T17:20:24.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6480,7 +6480,7 @@
             },
             "@timestamp": "2018-05-30T14:01:32.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6599,7 +6599,7 @@
             },
             "@timestamp": "2018-05-30T14:17:17.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6710,7 +6710,7 @@
             },
             "@timestamp": "2018-06-05T14:30:31.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6838,7 +6838,7 @@
             },
             "@timestamp": "2018-05-31T17:05:14.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6957,7 +6957,7 @@
             },
             "@timestamp": "2018-05-30T15:09:51.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -7073,7 +7073,7 @@
             },
             "@timestamp": "2018-06-01T10:57:55.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -7209,7 +7209,7 @@
             },
             "@timestamp": "2018-06-01T10:55:41.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -7324,7 +7324,7 @@
             },
             "@timestamp": "2020-05-18T14:38:54.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -7431,7 +7431,7 @@
             },
             "@timestamp": "2020-05-18T14:38:55.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -7536,7 +7536,7 @@
             },
             "@timestamp": "2020-05-18T14:38:56.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -7626,7 +7626,7 @@
             },
             "@timestamp": "2018-05-23T16:20:34.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -7716,7 +7716,7 @@
             },
             "@timestamp": "2018-05-23T16:16:43.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -7789,7 +7789,7 @@
                 "size": 0
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -7857,7 +7857,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -7929,7 +7929,7 @@
                 "size": 0
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -7997,7 +7997,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -8078,7 +8078,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -8157,7 +8157,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -8274,7 +8274,7 @@
             },
             "@timestamp": "2020-05-18T14:38:46.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -8400,7 +8400,7 @@
             },
             "@timestamp": "2020-05-18T14:38:47.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -8494,7 +8494,7 @@
             },
             "@timestamp": "2020-05-19T17:20:29.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -8592,7 +8592,7 @@
             },
             "@timestamp": "2020-05-19T18:03:30.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -8722,7 +8722,7 @@
             },
             "@timestamp": "2020-05-20T18:03:31.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -8789,7 +8789,7 @@
             },
             "@timestamp": "2017-02-01T14:17:35.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -8837,7 +8837,7 @@
             },
             "@timestamp": "2017-02-01T14:19:47.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
     value: '{{_ingest.timestamp}}'
 - set:
     field: ecs.version
-    value: "1.10.0"
+    value: '1.11.0'
 - grok:
     field: message
     patterns:

--- a/packages/sophos/manifest.yml
+++ b/packages/sophos/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: sophos
 title: Sophos
-version: 0.5.1
+version: 0.5.2
 description: This Elastic integration collects logs from Sophos
 categories: ["security"]
 release: experimental


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967