### PR TITLE
squid update to ECS 1.11.0

### DIFF
--- a/packages/squid/changelog.yml
+++ b/packages/squid/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.4.1'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1419
 - version: "0.4.0"
   changes:
     - description: Update integration description

--- a/packages/squid/data_stream/log/_dev/test/pipeline/test-access1.log-expected.json
+++ b/packages/squid/data_stream/log/_dev/test/pipeline/test-access1.log-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689312.049   5006 10.105.21.199 TCP_MISS/200 19763 CONNECT login.yahoo.com:443 badeyek DIRECT/209.73.177.115 -",
             "event": {
@@ -14,7 +14,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689320.327   2864 10.105.21.199 TCP_MISS/200 10182 GET http://www.goonernews.com/ badeyek DIRECT/207.58.145.61 text/html",
             "event": {
@@ -26,7 +26,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689320.343   1357 10.105.21.199 TCP_REFRESH_HIT/304 214 GET http://www.goonernews.com/styles.css badeyek DIRECT/207.58.145.61 -",
             "event": {
@@ -38,7 +38,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689321.315      1 10.105.21.199 TCP_HIT/200 1464 GET http://www.goonernews.com/styles.css badeyek NONE/- text/css",
             "event": {
@@ -50,7 +50,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689322.780   1464 10.105.21.199 TCP_HIT/200 5626 GET http://www.google-analytics.com/urchin.js badeyek NONE/- text/javascript",
             "event": {
@@ -62,7 +62,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689323.718   3856 10.105.21.199 TCP_MISS/200 30169 GET http://www.goonernews.com/ badeyek DIRECT/207.58.145.61 text/html",
             "event": {
@@ -74,7 +74,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689324.156   1372 10.105.21.199 TCP_MISS/200 399 GET http://www.google-analytics.com/__utm.gif? badeyek DIRECT/66.102.9.147 image/gif",
             "event": {
@@ -86,7 +86,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689324.266   1457 10.105.21.199 TCP_REFRESH_HIT/304 215 GET http://www.goonernews.com/graphics/newslogo.gif badeyek DIRECT/207.58.145.61 -",
             "event": {
@@ -98,7 +98,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689324.281   1465 10.105.21.199 TCP_REFRESH_HIT/304 215 GET http://www.goonernews.com/shop/arsenal_shop_ad.jpg badeyek DIRECT/207.58.145.61 -",
             "event": {
@@ -110,7 +110,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689325.734   1452 10.105.21.199 TCP_REFRESH_HIT/304 214 GET http://www.goonernews.com/flags/FUS.gif badeyek DIRECT/207.58.145.61 -",
             "event": {
@@ -122,7 +122,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689325.736      2 10.105.21.199 TCP_HIT/200 1353 GET http://www.goonernews.com/flags/FGB.gif badeyek NONE/- image/gif",
             "event": {
@@ -134,7 +134,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689325.953   2603 10.105.21.199 TCP_MISS/200 1013 GET http://as.casalemedia.com/s? badeyek DIRECT/209.85.16.38 text/html",
             "event": {
@@ -146,7 +146,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689326.703   4459 10.105.21.199 TCP_MISS/200 1845 CONNECT us.bc.yahoo.com:443 badeyek DIRECT/68.142.213.132 -",
             "event": {
@@ -158,7 +158,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689327.312   1356 10.105.21.199 TCP_MISS/302 729 GET http://impgb.tradedoubler.com/imp/img/16349696/992098 badeyek DIRECT/217.212.240.172 text/html",
             "event": {
@@ -170,7 +170,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689327.751   3484 10.105.21.199 TCP_MISS/200 1577 GET http://4.adbrite.com/mb/text_group.php? badeyek DIRECT/206.169.136.22 text/html",
             "event": {
@@ -182,7 +182,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689327.803      9 10.105.21.199 TCP_HIT/200 1353 GET http://www.goonernews.com/flags/FFR.gif badeyek NONE/- image/gif",
             "event": {
@@ -194,7 +194,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689329.234   1431 10.105.21.199 TCP_REFRESH_HIT/304 214 GET http://www.goonernews.com/flags/FAU.gif badeyek DIRECT/207.58.145.61 -",
             "event": {
@@ -206,7 +206,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689329.280   1414 10.105.21.199 TCP_REFRESH_HIT/304 213 GET http://www.goonernews.com/graphics/spacer.gif badeyek DIRECT/207.58.145.61 -",
             "event": {
@@ -218,7 +218,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689330.920   1686 10.105.21.199 TCP_MISS/200 1784 GET http://4.adbrite.com/mb/text_group.php? badeyek DIRECT/64.127.126.178 text/html",
             "event": {
@@ -230,7 +230,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689331.313   3997 10.105.21.199 TCP_MISS/302 851 GET http://ff.connextra.com/Ladbrokes/selector/image? badeyek DIRECT/213.160.98.161 -",
             "event": {
@@ -242,7 +242,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689335.275   3962 10.105.21.199 TCP_MISS/200 30904 GET http://dd.connextra.com/servlet/controller? badeyek DIRECT/213.160.98.160 image/gif",
             "event": {
@@ -254,7 +254,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689337.481      4 10.105.47.218 TCP_DENIED/407 1661 GET http://hi5.com/ - NONE/- text/html",
             "event": {
@@ -266,7 +266,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689342.757   3657 10.105.21.199 TCP_MISS/200 12569 CONNECT login.yahoo.com:443 badeyek DIRECT/209.73.177.115 -",
             "event": {
@@ -278,7 +278,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689343.106      1 10.105.33.214 TCP_DENIED/407 1752 GET http://update.messenger.yahoo.com/msgrcli7.html - NONE/- text/html",
             "event": {
@@ -290,7 +290,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689343.782   1371 10.105.33.214 TCP_MISS/200 484 POST http://shttp.msg.yahoo.com/notify/ adeolaegbedokun DIRECT/216.155.194.239 text/plain",
             "event": {
@@ -302,7 +302,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689344.736   4969 10.105.47.218 TCP_MISS/200 29359 GET http://hi5.com/ nazsoau DIRECT/204.13.51.238 text/html",
             "event": {
@@ -314,7 +314,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689344.798   1631 10.105.47.218 TCP_MISS/200 5930 GET http://hi5.com/friend/styles/homepage.css nazsoau DIRECT/204.13.51.238 text/css",
             "event": {
@@ -326,7 +326,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689345.641   1810 10.105.33.214 TCP_MISS/200 1645 POST http://shttp.msg.yahoo.com/notify/ adeolaegbedokun DIRECT/216.155.194.239 text/plain",
             "event": {
@@ -338,7 +338,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689346.267    880 10.105.37.58 TCP_DENIED/407 1812 GET http://rms.adobe.com/read/0600/win_/ENU/read0600win_ENUadbe0000.xml - NONE/- text/html",
             "event": {
@@ -350,7 +350,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689347.190     10 10.105.47.218 TCP_IMS_HIT/304 217 GET http://images.hi5.com/styles/style.css nazsoau NONE/- text/css",
             "event": {
@@ -362,7 +362,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689347.307    116 10.105.47.218 TCP_IMS_HIT/304 217 GET http://images.hi5.com/friend/styles/buttons_en_us.css nazsoau NONE/- text/css",
             "event": {
@@ -374,7 +374,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689347.751   6160 10.105.47.218 TCP_MISS/200 27799 GET http://hi5.com/ nazsoau DIRECT/204.13.51.238 text/html",
             "event": {
@@ -386,7 +386,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689349.064   1758 10.105.47.218 TCP_MISS/200 4470 GET http://hi5.com/friend/styles/headernav.css nazsoau DIRECT/204.13.51.238 text/css",
             "event": {
@@ -398,7 +398,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689350.829   1393 10.105.33.214 TCP_MISS/200 382 POST http://shttp.msg.yahoo.com/notify/ adeolaegbedokun DIRECT/216.155.194.239 text/plain",
             "event": {
@@ -410,7 +410,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689353.439   3667 10.105.33.214 TCP_MISS/200 24095 GET http://insider.msg.yahoo.com/? adeolaegbedokun DIRECT/68.142.194.14 text/html",
             "event": {
@@ -422,7 +422,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689353.939   4899 10.105.33.214 TCP_MISS/200 22964 GET http://radio.launch.yahoo.com/radio/play/playmessenger.asp adeolaegbedokun DIRECT/68.142.219.132 text/html",
             "event": {
@@ -434,7 +434,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689354.877   1349 10.105.33.214 TCP_MISS/200 646 POST http://shttp.msg.yahoo.com/notify/ adeolaegbedokun DIRECT/216.155.194.239 text/plain",
             "event": {
@@ -446,7 +446,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689355.517   1578 10.105.33.214 TCP_MISS/200 699 GET http://address.yahoo.com/yab/us? adeolaegbedokun DIRECT/209.191.93.51 text/xml",
             "event": {
@@ -458,7 +458,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689356.907   6741 10.105.21.199 TCP_MISS/302 734 GET http://fxfeeds.mozilla.org/rss20.xml badeyek DIRECT/63.245.209.21 text/html",
             "event": {
@@ -470,7 +470,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689357.267   6424 10.105.33.214 TCP_MISS/200 31400 GET http://insider.msg.yahoo.com/ycontent/? adeolaegbedokun DIRECT/68.142.231.252 text/xml",
             "event": {
@@ -482,7 +482,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689357.720   2831 10.105.33.214 TCP_MISS/200 21152 GET http://insider.msg.yahoo.com/ycontent/? adeolaegbedokun DIRECT/68.142.194.14 text/xml",
             "event": {
@@ -494,7 +494,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689358.173      1 10.105.37.17 TCP_DENIED/407 1667 CONNECT us.mcafee.com:443 - NONE/- text/html",
             "event": {
@@ -506,7 +506,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689358.174      0 10.105.37.17 TCP_DENIED/407 1767 POST http://us.mcafee.com/apps/agent/submgr/appinstru.asp - NONE/- text/html",
             "event": {
@@ -518,7 +518,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689358.174      0 10.105.37.17 TCP_DENIED/407 1761 POST http://us.mcafee.com/apps/agent/submgr/appsync.asp - NONE/- text/html",
             "event": {
@@ -530,7 +530,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689358.226      0 10.105.37.17 TCP_DENIED/407 1667 CONNECT us.mcafee.com:443 - NONE/- text/html",
             "event": {
@@ -542,7 +542,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689358.486    711 10.105.33.214 TCP_REFRESH_HIT/304 512 GET http://radio.launch.yahoo.com/radio/clientdata/538/images/btn_stations.gif adeolaegbedokun DIRECT/68.142.219.132 -",
             "event": {
@@ -554,7 +554,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689358.683      0 10.105.37.17 TCP_DENIED/407 1667 CONNECT us.mcafee.com:443 - NONE/- text/html",
             "event": {
@@ -566,7 +566,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689359.199    713 10.105.33.214 TCP_REFRESH_HIT/304 512 GET http://radio.launch.yahoo.com/radio/clientdata/538/images/btn_stations_over.gif adeolaegbedokun DIRECT/68.142.219.132 -",
             "event": {
@@ -578,7 +578,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689359.269   1982 10.105.33.214 TCP_MISS/200 362 POST http://shttp.msg.yahoo.com/notify/ adeolaegbedokun DIRECT/216.155.194.239 text/plain",
             "event": {
@@ -590,7 +590,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689359.924    725 10.105.33.214 TCP_REFRESH_HIT/304 511 GET http://radio.launch.yahoo.com/radio/clientdata/538/skins/1/images/bg_left.gif adeolaegbedokun DIRECT/68.142.219.132 -",
             "event": {
@@ -602,7 +602,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689360.611    687 10.105.33.214 TCP_REFRESH_HIT/304 512 GET http://radio.launch.yahoo.com/radio/clientdata/538/images/launchcast_radio.gif adeolaegbedokun DIRECT/68.142.219.132 -",
             "event": {
@@ -614,7 +614,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689360.980      1 10.105.47.191 TCP_DENIED/407 1767 POST http://us.mcafee.com/apps/agent/submgr/appinstru.asp - NONE/- text/html",
             "event": {
@@ -626,7 +626,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689361.188      1 10.105.47.191 TCP_DENIED/407 1761 POST http://us.mcafee.com/apps/agent/submgr/appsync.asp - NONE/- text/html",
             "event": {
@@ -638,7 +638,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689361.393    783 10.105.33.214 TCP_REFRESH_HIT/304 512 GET http://radio.launch.yahoo.com/radio/clientdata/538/skins/1/images/bg_right.gif adeolaegbedokun DIRECT/68.142.219.132 -",
             "event": {
@@ -650,7 +650,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689361.564   2242 10.105.33.214 TCP_REFRESH_HIT/304 512 GET http://radio.launch.yahoo.com/radio/clientdata/538/skins/1/images/bg_center.gif adeolaegbedokun DIRECT/68.142.219.132 -",
             "event": {
@@ -662,7 +662,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689362.220    827 10.105.33.214 TCP_REFRESH_HIT/304 512 GET http://radio.launch.yahoo.com/radio/clientdata/538/skins/1/images/bg_controls_off.gif adeolaegbedokun DIRECT/68.142.219.132 -",
             "event": {
@@ -674,7 +674,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689362.315    751 10.105.33.214 TCP_REFRESH_HIT/304 512 GET http://radio.launch.yahoo.com/radio/common_radio/resources/images/t.gif adeolaegbedokun DIRECT/68.142.219.132 -",
             "event": {
@@ -686,7 +686,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689362.318      3 10.105.33.214 TCP_IMS_HIT/304 218 GET http://radio.launch.yahoo.com/radio/clientdata/538/images/btn_off_state_station.gif adeolaegbedokun NONE/- image/gif",
             "event": {
@@ -698,7 +698,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689362.332     13 10.105.33.214 TCP_IMS_HIT/304 218 GET http://radio.launch.yahoo.com/radio/clientdata/538/skins/1/images/bg_controls_fill.gif adeolaegbedokun NONE/- image/gif",
             "event": {
@@ -710,7 +710,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689362.341      8 10.105.33.214 TCP_HIT/200 2263 GET http://us.i1.yimg.com/us.yimg.com/i/us/toolbar50x50.gif adeolaegbedokun NONE/- image/gif",
             "event": {
@@ -722,7 +722,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689363.423   6517 10.105.21.199 TCP_REFRESH_MISS/200 17396 GET http://newsrss.bbc.co.uk/rss/newsonline_world_edition/front_page/rss.xml badeyek DIRECT/212.58.226.33 application/xml",
             "event": {
@@ -734,7 +734,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689364.361   2140 10.105.33.214 TCP_MISS/200 407 GET http://insider.msg.yahoo.com/ycontent/beacon.php adeolaegbedokun DIRECT/68.142.231.252 image/gif",
             "event": {
@@ -746,7 +746,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689364.402      7 10.105.33.214 TCP_IMS_HIT/304 219 GET http://us.ent1.yimg.com/images.launch.yahoo.com/000/032/457/32457654.jpg adeolaegbedokun NONE/- image/jpeg",
             "event": {
@@ -758,7 +758,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689364.411      8 10.105.33.214 TCP_HIT/200 10593 GET http://us.news1.yimg.com/us.yimg.com/p/ap/20060906/thumb.71d29ded334347c48ac88433d033c9a9.pakistan_bin_laden_nyol440.jpg adeolaegbedokun NONE/- image/jpeg",
             "event": {
@@ -770,7 +770,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689365.312   2420 10.105.33.214 TCP_MISS/302 1270 POST http://radio.launch.yahoo.com/radio/play/authplay.asp adeolaegbedokun DIRECT/68.142.219.132 text/html",
             "event": {
@@ -782,7 +782,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689366.377   1966 10.105.33.214 TCP_MISS/200 10519 GET http://us.news1.yimg.com/us.yimg.com/p/ap/20060908/thumb.443f57762d7349669f609fbf0c97a5f1.academy_awards_host_cacp101.jpg adeolaegbedokun DIRECT/213.160.98.159 image/jpeg",
             "event": {
@@ -794,7 +794,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689368.080   1703 10.105.33.214 TCP_MISS/200 515 GET http://radio.music.yahoo.com/radio/player/ymsgr/initstationfeed.asp? adeolaegbedokun DIRECT/68.142.219.132 text/xml",
             "event": {
@@ -806,7 +806,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689368.370   3057 10.105.33.214 TCP_MISS/200 14411 GET http://radio.music.yahoo.com/radio/player/ymsgr/initstationfeed.asp? adeolaegbedokun DIRECT/68.142.219.132 text/xml",
             "event": {
@@ -818,7 +818,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689368.889    808 10.105.33.214 TCP_MISS/200 1627 GET http://radio.launch.yahoo.com/radio/play/authplay.asp? adeolaegbedokun DIRECT/68.142.219.132 text/html",
             "event": {
@@ -830,7 +830,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689369.097   1226 10.105.37.65 TCP_DENIED/407 1728 GET http://natrocket.kmip.net:5288/iesocks? - NONE/- text/html",
             "event": {
@@ -842,7 +842,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689369.702      0 10.105.37.65 TCP_DENIED/407 1725 GET http://natrocket.kmip.net:5288/return? - NONE/- text/html",
             "event": {
@@ -854,7 +854,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689370.125   1202 10.105.33.214 TCP_MISS/200 13124 GET http://us.news1.yimg.com/us.yimg.com/p/ap/20060907/thumb.1caf18e56db54eafb16da58356eb3382.amazon_com_online_video_watw101.jpg adeolaegbedokun DIRECT/213.160.98.159 image/jpeg",
             "event": {
@@ -866,7 +866,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689370.862    736 10.105.33.214 TCP_MISS/302 912 GET http://radio.launch.yahoo.com/radio/clientdata/515/starter.asp? adeolaegbedokun DIRECT/68.142.219.132 text/html",
             "event": {
@@ -878,7 +878,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689371.690    828 10.105.33.214 TCP_MISS/200 1450 GET http://radio.launch.yahoo.com/radio/player/default.asp? adeolaegbedokun DIRECT/68.142.219.132 text/html",
             "event": {
@@ -890,7 +890,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689371.987   3617 10.105.33.214 TCP_MISS/200 30432 GET http://us.a2.yimg.com/us.yimg.com/a/ya/yahoo_messenger/081106_lrec_msgr_interophitchhiker.swf? adeolaegbedokun DIRECT/213.160.98.152 application/x-shockwave-flash",
             "event": {
@@ -902,7 +902,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689373.315   1626 10.105.33.214 TCP_MISS/200 14643 GET http://radio.launch.yahoo.com/radio/player/stickwall.asp? adeolaegbedokun DIRECT/68.142.219.132 text/html",
             "event": {
@@ -914,7 +914,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689374.065   2078 10.105.33.214 TCP_MISS/200 425 GET http://us.bc.yahoo.com/b? adeolaegbedokun DIRECT/68.142.213.132 image/gif",
             "event": {
@@ -926,7 +926,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689376.221   2130 10.105.33.214 TCP_MISS/200 407 GET http://insider.msg.yahoo.com/ycontent/beacon.php;_ylc=X1MDNTcwMzAyODMEX3IDMgRldnQDdDAEaW50bAN1cwR2ZXIDNywwLDIsMTIw? adeolaegbedokun DIRECT/68.142.194.14 image/gif",
             "event": {
@@ -938,7 +938,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689377.171   3412 10.105.33.214 TCP_MISS/200 1476 CONNECT pclick.internal.yahoo.com:443 adeolaegbedokun DIRECT/216.109.124.55 -",
             "event": {
@@ -950,7 +950,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689377.191     11 10.105.33.214 TCP_IMS_HIT/304 233 GET http://a1568.g.akamai.net/7/1568/1600/20051025184124/radio.launch.yahoo.com/radioapi/includes/js/compVersionedJS/rapiBridge_1_4.js adeolaegbedokun NONE/- application/x-javascript",
             "event": {
@@ -962,7 +962,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689377.424   1159 10.105.33.214 TCP_MISS/304 236 GET http://a1568.g.akamai.net/7/1568/1600/20040405222754/radio.launch.yahoo.com/radio/clientdata/515/other.css adeolaegbedokun DIRECT/213.160.98.159 text/css",
             "event": {
@@ -974,7 +974,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689378.221    797 10.105.33.214 TCP_MISS/304 238 GET http://a1568.g.akamai.net/7/1568/1600/20040405222757/radio.launch.yahoo.com/radio/clientdata/515/skins/1/images/bg_left.gif adeolaegbedokun DIRECT/213.160.98.159 image/gif",
             "event": {
@@ -986,7 +986,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689378.473   3288 10.105.21.199 TCP_MISS/200 2681 CONNECT login.yahoo.com:443 badeyek DIRECT/209.73.177.115 -",
             "event": {
@@ -998,7 +998,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689378.909   1405 10.105.33.214 TCP_MISS/304 136 GET http://a1568.g.akamai.net/7/1568/1600/20050829181418/radio.launch.yahoo.com/radio/common_radio/resources/images/noaccess_msgr_uk.gif adeolaegbedokun DIRECT/213.160.98.167 -",
             "event": {
@@ -1010,7 +1010,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689378.924    702 10.105.33.214 TCP_MISS/304 237 GET http://a1568.g.akamai.net/7/1568/1600/20040405222757/radio.launch.yahoo.com/radio/clientdata/515/skins/1/images/bg_right.gif adeolaegbedokun DIRECT/213.160.98.159 image/gif",
             "event": {
@@ -1022,7 +1022,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689378.929      4 10.105.33.214 TCP_IMS_HIT/304 218 GET http://a1568.g.akamai.net/7/1568/1600/20040405222807/radio.launch.yahoo.com/radio/common_radio/resources/images/t.gif adeolaegbedokun NONE/- image/gif",
             "event": {
@@ -1034,7 +1034,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689379.472    563 10.105.33.214 TCP_MISS/304 238 GET http://a1568.g.akamai.net/7/1568/1600/20040405222757/radio.launch.yahoo.com/radio/clientdata/515/skins/1/images/bg_controls_off.gif adeolaegbedokun DIRECT/213.160.98.167 image/gif",
             "event": {
@@ -1046,7 +1046,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689379.488    560 10.105.33.214 TCP_MISS/304 238 GET http://a1568.g.akamai.net/7/1568/1600/20040405222756/radio.launch.yahoo.com/radio/clientdata/515/skins/1/images/bg_center.gif adeolaegbedokun DIRECT/213.160.98.159 image/gif",
             "event": {
@@ -1058,7 +1058,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689380.159    685 10.105.33.214 TCP_MISS/304 238 GET http://a1568.g.akamai.net/7/1568/1600/20040405222757/radio.launch.yahoo.com/radio/clientdata/515/skins/1/images/bg_controls_fill.gif adeolaegbedokun DIRECT/213.160.98.167 image/gif",
             "event": {
@@ -1070,7 +1070,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689381.267      1 10.105.37.180 TCP_DENIED/407 1728 GET http://www.google.com/supported_domains - NONE/- text/html",
             "event": {
@@ -1082,7 +1082,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689381.659      0 10.105.47.191 TCP_DENIED/407 1782 GET http://us.mcafee.com/apps/agent/en-us/agent5/chknews.asp? - NONE/- text/html",
             "event": {
@@ -1094,7 +1094,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689381.660   2171 10.105.33.214 TCP_MISS/200 449 GET http://launch.adserver.yahoo.com/l? adeolaegbedokun DIRECT/216.109.125.112 image/gif",
             "event": {
@@ -1106,7 +1106,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689382.173   3700 10.105.21.199 TCP_MISS/200 11746 GET http://uk.f250.mail.yahoo.com/dc/launch? badeyek DIRECT/217.12.10.96 text/html",
             "event": {
@@ -1118,7 +1118,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689382.622      1 10.105.37.180 TCP_DENIED/407 1670 CONNECT login.live.com:443 - NONE/- text/html",
             "event": {
@@ -1130,7 +1130,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689384.316   2828 10.105.21.199 TCP_SWAPFAIL_MISS/200 633 GET http://us.js2.yimg.com/us.js.yimg.com/lib/pim/r/dclient/d/js/uk/77cf3e56414f974dfd8616f56f0f632c_1.js badeyek DIRECT/213.160.98.169 application/x-javascript",
             "event": {
@@ -1142,7 +1142,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689385.714   1397 10.105.21.199 TCP_HIT/200 1742 GET http://us.js1.yimg.com/us.yimg.com/lib/hdr/ygma5.css badeyek NONE/- text/css",
             "event": {
@@ -1154,7 +1154,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689387.690   1977 10.105.21.199 TCP_MISS/200 14561 GET http://us.js2.yimg.com/us.js.yimg.com/lib/pim/r/dclient/d/js/uk/f7fc76100697c9c2d25dd0ec35e563b0_1.js badeyek DIRECT/213.160.98.169 application/x-javascript",
             "event": {
@@ -1166,7 +1166,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689387.771     80 10.105.21.199 TCP_HIT/200 68733 GET http://us.js1.yimg.com/us.yimg.com/lib/pim/r/medici/13_15/mail/ac.js badeyek NONE/- application/x-javascript",
             "event": {
@@ -1178,7 +1178,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689387.830      1 10.105.21.199 TCP_HIT/200 898 GET http://us.js2.yimg.com/us.js.yimg.com/lib/common/utils/2/yahoo_2.0.0-b4.js badeyek NONE/- application/x-javascript",
             "event": {
@@ -1190,7 +1190,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "1157689387.832     60 10.105.21.199 TCP_HIT/200 26803 GET http://us.i1.yimg.com/us.yimg.com/i/us/pim/dclient/d/img/liam_ball_1.gif badeyek NONE/- image/gif",
             "event": {

--- a/packages/squid/data_stream/log/_dev/test/pipeline/test-generated.log-expected.json
+++ b/packages/squid/data_stream/log/_dev/test/pipeline/test-generated.log-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.251.224.219 7337 [29/Jan/2016:6:09:59 nto] \"PROPFIND https://example.org/exercita/der.htm?odoco=ria#min ite\" 10.234.224.44 etdo tation \"quasiarc\" liqua ciade 5699 \"https://example.net/umq/ntium.gif?nes=eab#aliqu\" \"Mozilla/5.0 (Linux; Android 10; SM-A715F Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.83 Mobile Safari/537.36 [FB_IAB/Orca-Android;FBAV/266.0.0.16.117;]\" deny",
             "event": {
@@ -14,7 +14,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.102.123.34 7178 [12/Feb/2016:1:12:33 nostrud] \"PURGE https://www.example.org/enderitq/sperna.txt?billoi=oreetdol#nidolor tatemU\" 10.70.36.222 estlabo doeiu \"nia\" olupt volup 208 \"https://example.com/eosquir/orsi.txt?itessequ=vol#luptat\" \"Mozilla/5.0 (Linux; Android 10; SM-A305FN Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.96 Mobile Safari/537.36 YandexSearch/8.10 YandexSearchBrowser/8.10\" deny",
             "event": {
@@ -26,7 +26,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.15.135.248 7269 [26/Feb/2016:8:15:08 mquia] \"OPTIONS https://internal.example.com/aqu/utper.jpg?eFinib=omm#iin proident\" 10.142.172.64 lupt tia \"oloremqu\" temvel iatu 5493 \"https://example.net/dolo/meumfug.gif?roinBCS=ufugiatn#tionulam\" \"Mozilla/5.0 (Linux; Android 8.1.0; SM-A260G Build/OPR6; rv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Rocket/2.1.17(19420) Chrome/81.0.4044.138 Mobile Safari/537.36\" accept",
             "event": {
@@ -38,7 +38,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.44.134.153 5162 [12/Mar/2016:3:17:42 nci] \"GET https://api.example.org/ceroinBC/ratvolup.gif?iatu=ionofde#con uia\" quiavo 1156 \"https://mail.example.com/consec/taliquip.html?radip=tNequ#gelit\" \"Mozilla/5.0 (Linux; Android 9; 5024D_RU Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36 YaApp_Android/10.61 YaSearchBrowser/10.61\" allow 10.81.122.126 taev 160.145000",
             "event": {
@@ -50,7 +50,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.160.95.56 1980 [26/Mar/2016:10:20:16 aqui] \"PUT https://api.example.org/isetq/estqui.gif?magn=equuntu#eos enimad\" 10.171.175.51 boreet onev \"tenima\" laboreet aquaeabi 5738 \"https://api.example.net/veleumi/tia.gif?ude=maveniam#uian\" \"Mozilla/5.0 (Linux; Android 9; POCOPHONE F1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36\" cancel",
             "event": {
@@ -62,7 +62,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.175.107.139 4243 [09/Apr/2016:5:22:51 antium] \"HEAD https://www.example.org/inesci/rsitvolu.txt?pori=occ#ect reetdolo\" 10.12.195.60 uiano mrema \"autfu\" natura aboris 2946 \"https://api.example.com/ssitaspe/gitsedqu.jpg?iutal=dexe#urerep\" \"Mozilla/5.0 (Linux; Android 9; ZTE Blade V1000RU Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36 YaApp_Android/10.91 YaSearchBrowser/10.91\" accept",
             "event": {
@@ -74,7 +74,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.198.136.50 6875 [24/Apr/2016:12:25:25 llam] \"DELETE https://www5.example.com/ari/eataevit.txt?iam=mqua#atat quunt\" 10.207.249.121 iciade tsed \"orai\" mUt usmodte 1296 \"https://www.example.org/ametcons/porainc.jpg?temsequ=emquiavo#nonnu\" \"Mozilla/5.0 (Linux; U; Android 4.0.3; es-us; GT-P3100 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30\" allow",
             "event": {
@@ -86,7 +86,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.34.9.93 124 [08/May/2016:7:27:59 onse] \"PROPFIND https://example.org/tatno/imav.htm?ofdeF=tion#orsitame quiratio\" 10.116.120.216 qua umdo \"sed\" apariat mol 1510 \"https://internal.example.net/turveli/toccae.htm?erc=taliqu#temUten\" \"Mozilla/5.0 (Linux; Android 9; Notepad_K10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Safari/537.36\" accept",
             "event": {
@@ -98,7 +98,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.90.131.186 6343 [22/May/2016:2:30:33 nimadmin] \"HEAD https://example.org/uaera/sitas.txt?aedic=atquovo#iumto aboreetd\" 10.30.216.41 enim saute \"vel\" quu undeo 5794 \"https://mail.example.net/atuse/ddoeiu.gif?idolore=onse#liq\" \"Mozilla/5.0 (Linux; Android 10; STK-L21 Build/HUAWEISTK-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36 YaApp_Android/10.91 YaSearchBrowser/10.91\" accept",
             "event": {
@@ -110,7 +110,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.8.88.110 7618 [05/Jun/2016:9:33:08 ionul] \"CONNECT https://mail.example.org/edquiano/loru.htm?end=enia#nsequu cup\" 10.203.172.203 idestla Nemoeni \"uradi\" aborumSe luptat 6884 \"https://www5.example.org/strude/ctetura.htm?ittenbyC=aperi#lor\" \"Mozilla/5.0 (Linux; Android 9; POCOPHONE F1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36\" accept",
             "event": {
@@ -122,7 +122,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.71.34.9 267 [20/Jun/2016:4:35:42 dolore] \"UNLOCK https://www.example.org/iqui/etc.txt?tatiset=eprehen#xercitat lpa\" 10.158.185.163 rudexerc aliq \"rsitam\" quam adm 987 \"https://www.example.org/ritatis/oloremi.txt?icab=mwr#fugi\" \"Mozilla/5.0 (Linux; U; Android 7.1.2; uz-uz; Redmi 4X Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.141 Mobile Safari/537.36 XiaoMi/MiuiBrowser/12.2.3-g\" allow",
             "event": {
@@ -134,7 +134,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.210.74.24 6423 [04/Jul/2016:11:38:16 untut] \"OPTIONS https://internal.example.net/ommod/sequatur.txt?tlabo=suntexp#ugiatnu stiae\" 10.201.76.240 amqu uines \"nsec\" onse emips 2655 \"https://example.net/tion/eataev.htm?uiineavo=tisetq#irati\" \"Mozilla/5.0 (compatible; Yahoo Ad monitoring; https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html) yahoo.adquality.lwd.desktop/1591143192-10\" accept",
             "event": {
@@ -146,7 +146,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.114.138.121 1939 [18/Jul/2016:6:40:50 tati] \"COPY https://api.example.org/oriosamn/deFinibu.gif?iciatisu=rehender#eporroqu uat\" 10.206.136.206 suntinc xeac \"nidolo\" tatn eli 6462 \"https://www.example.net/pida/nse.html?emeumfu=CSed#lupt\" \"Mozilla/5.0 (Linux; Android 8.0.0; VS996) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36\" deny",
             "event": {
@@ -158,7 +158,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.200.199.166 3727 [02/Aug/2016:1:43:25 amvolup] \"COPY https://mail.example.org/rehend/tio.html?numqu=qui#civeli lum\" 10.134.161.118 tat ipitla \"quae\" maccusa uptat 3458 \"https://www.example.com/xerci/aqu.htm?olorema=iades#siarchi\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 YaBrowser/20.3.0.2221 Yowser/2.5 Safari/537.36\" block",
             "event": {
@@ -170,7 +170,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.122.46.71 2807 [16/Aug/2016:8:45:59 ihilm] \"NONE https://www.example.org/eav/ionevo.txt?siar=orev#iamquis quirat\" 10.76.3.41 isc aturve \"emulla\" mpori aaliquaU 2989 \"https://www5.example.com/ern/psaquae.html?nsectet=utla#utei\" \"Mozilla/5.0 (Linux; Android 8.0.0; VS996) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36\" allow",
             "event": {
@@ -182,7 +182,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.164.250.63 2530 [30/Aug/2016:3:48:33 eritqu] \"PROPFIND https://internal.example.net/wri/bor.jpg?hitect=dol#leumiu namali\" 10.249.213.83 nsecte itame \"eumfug\" lit asun 1250 \"https://api.example.com/oluptate/onseq.html?labore=texp#tMalor\" \"Mozilla/5.0 (Linux; Android 6.0; Lenovo A2016a40 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.106 Mobile Safari/537.36 YaApp_Android/10.30 YaSearchBrowser/10.30\" accept",
             "event": {
@@ -194,7 +194,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.61.242.75 2591 [13/Sep/2016:10:51:07 dantiumt] \"HEAD https://api.example.net/equat/doloreme.htm?ione=ihilmole#eriamea amre\" 10.236.248.65 pisciv iquidex \"radipisc\" tmo fficiade 3280 \"https://www5.example.net/uioffi/oru.jpg?one=etMalor#ipi\" \"Mozilla/5.0 (Linux; Android 9; G8142) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36\" cancel",
             "event": {
@@ -206,7 +206,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.13.59.31 5685 [28/Sep/2016:5:53:42 sperna] \"PUT https://www5.example.com/estia/tper.gif?volupt=osqui#xerc iutali\" 10.214.7.83 liquide etdol \"uela\" boN eprehend 2462 \"https://internal.example.net/lamcolab/ati.jpg?gel=lorsitam#mpo\" \"Mozilla/5.0 (Linux; Android 9; LG-US998) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36\" block",
             "event": {
@@ -218,7 +218,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.89.201.140 2447 [12/Oct/2016:12:56:16 uamei] \"GET https://internal.example.net/sin/rvel.htm?nimid=itatione#isnis uptasn\" 10.49.92.179 osamn isnisiu \"bore\" tsu tcons 3128 \"https://api.example.org/lorinre/olorsita.gif?idata=rumwritt#magnid\" \"Mozilla/5.0 (Linux; Android 8.1.0; SM-A260G Build/OPR6; rv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Rocket/2.1.17(19420) Chrome/81.0.4044.138 Mobile Safari/537.36\" accept",
             "event": {
@@ -230,7 +230,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.235.7.92 5787 [26/Oct/2016:7:58:50 nsecte] \"PURGE https://api.example.org/abo/veniamqu.gif?aliquide=ofde#equat derit\" 10.90.86.89 piscin lapar \"laboree\" tfu udan 5516 \"https://mail.example.net/xeacomm/mveleu.htm?utlabor=rau#idex\" \"Mozilla/5.0 (Linux; Android 6.0; QMobile X700 PRO II) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36\" deny",
             "event": {
@@ -242,7 +242,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.14.211.43 4762 [10/Nov/2016:3:01:24 eiu] \"PROPFIND https://api.example.org/autfu/gnaaliq.jpg?olupta=litse#icabo itatio\" 10.14.48.16 sintoc volupt \"siste\" uiinea Utenima 1612 \"https://www5.example.net/ptatem/Nequepor.html?ugiatnu=ciati#nto\" \"Mozilla/5.0 (Linux; U; Android 4.0.3; es-us; GT-P3100 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30\" cancel",
             "event": {
@@ -254,7 +254,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.47.25.230 5491 [24/Nov/2016:10:03:59 ese] \"CONNECT https://internal.example.net/ptatemq/luptatev.html?Nequepo=ipsumd#ntocc uteirure\" 10.93.123.174 evelit reetdolo \"smo\" etcons iusmodi 1563 \"https://example.com/uiac/epte.gif?itam=aper#santiumd\" \"Mozilla/5.0 (Linux; Android 10; SM-A305FN Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.96 Mobile Safari/537.36 YandexSearch/8.10 YandexSearchBrowser/8.10\" block",
             "event": {
@@ -266,7 +266,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.7.46.36 837 [08/Dec/2016:5:06:33 nonn] \"MKOL https://www5.example.net/quiavol/rrorsi.gif?iatisu=sec#cons sBon\" 10.233.48.103 leumiur tlab \"aperiame\" isc ullamcor 584 \"https://www5.example.com/tateve/itinvol.txt?tenatus=cipitlab#ipsumd\" \"Mozilla/5.0 (Linux; U; Android 4.0.3; es-us; GT-P3100 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30\" cancel",
             "event": {
@@ -278,7 +278,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.93.220.10 2805 [23/Dec/2016:12:09:07 com] \"PROPATCH https://api.example.net/orain/tiumt.jpg?litessec=itas#edquia sequatu\" 10.27.58.92 amvo qui \"tasn\" Nemoenim squirati 63 \"https://mail.example.com/nbyCic/utlabor.html?iciade=ntiumt#iquipe\" \"Mozilla/5.0 (Linux; Android 8.1.0; SM-A260G Build/OPR6; rv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Rocket/2.1.17(19420) Chrome/81.0.4044.138 Mobile Safari/537.36\" accept",
             "event": {
@@ -290,7 +290,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.213.144.249 4427 [06/Jan/2017:7:11:41 taedicta] \"PURGE https://www.example.net/str/idolore.txt?eetdolo=cteturad#untut uamni\" 10.135.217.12 metMalo ntexplic \"archite\" loreme untu 5676 \"https://example.net/con/nisist.gif?ium=esciuntN#idunt\" \"Mozilla/5.0 (Linux; Android 9; G8142) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36\" block",
             "event": {
@@ -302,7 +302,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.13.226.57 3275 [20/Jan/2017:2:14:16 runtm] \"PURGE https://mail.example.net/velitse/oditem.html?torever=oremi#mestq temUt\" 10.233.239.112 npr mquelau \"iadolor\" amcol adeser 3780 \"https://internal.example.com/tqu/reprehen.gif?quam=quid#fugiat\" \"Mozilla/5.0 (Linux; Android 9; Notepad_K10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Safari/537.36\" cancel",
             "event": {
@@ -314,7 +314,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.161.203.252 301 [03/Feb/2017:9:16:50 emquia] \"CONNECT https://internal.example.org/isnisi/ritatise.gif?tamet=quatur#uisa eFi\" 10.21.169.127 rpori ice \"oles\" edic seq 2835 \"https://example.com/tatn/dolorsit.jpg?billo=labo#oNemoeni\" \"Mozilla/5.0 (Linux; Android 9; G8142) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36\" accept",
             "event": {
@@ -326,7 +326,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.17.215.111 148 [18/Feb/2017:4:19:24 ratv] \"LOCK https://www.example.net/ianon/tsed.htm?ameiusm=proide#ano piscinge\" 10.69.139.26 ditemp edqui \"nre\" veli volupta 7124 \"https://api.example.com/ersp/enderi.jpg?adi=umwrit#uptate\" \"Mozilla/5.0 (Linux; Android 6.0; Lenovo A2016a40 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.106 Mobile Safari/537.36 YaApp_Android/10.30 YaSearchBrowser/10.30\" block",
             "event": {
@@ -338,7 +338,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.10.213.83 7206 [04/Mar/2017:11:21:59 nisi] \"COPY https://www5.example.org/ncididun/umSe.jpg?ise=itau#apariat vitaedi\" 10.104.80.189 dolore onsecte \"nBCSedut\" ugiat onulam 1542 \"https://mail.example.org/oditautf/quatu.jpg?lumdolor=nonp#labo\" \"Mozilla/5.0 (Linux; Android 9; G8142) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36\" accept",
             "event": {
@@ -350,7 +350,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.125.131.91 3480 [18/Mar/2017:6:24:33 urv] \"UNLOCK https://example.org/uatur/adminimv.gif?exeacom=roidents#tem dol\" 10.116.230.217 mvele isis \"uasiar\" utlab emUteni 7122 \"https://api.example.org/lor/velillu.html?dolorem=tvolu#nreprehe\" \"Opera/9.80 (Series 60; Opera Mini/7.1.32444/174.101; U; ru) Presto/2.12.423 Version/12.16\" block",
             "event": {
@@ -362,7 +362,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.26.96.202 2751 [02/Apr/2017:1:27:07 rautodi] \"ICP_QUERY https://api.example.com/ven/rQu.html?doloreme=dun#reprehe tincu\" 10.119.90.128 lor oraincid \"intocc\" amcorp ntsunt 4826 \"https://mail.example.com/olo/psumqu.txt?fdeF=iquidexe#diconse\" \"Mozilla/5.0 (Linux; Android 10; STK-L21 Build/HUAWEISTK-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36 YaApp_Android/10.91 YaSearchBrowser/10.91\" cancel",
             "event": {
@@ -374,7 +374,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.0.98.205 126 [16/Apr/2017:8:29:41 edquiac] \"HEAD https://api.example.net/eseru/quamest.html?qua=rsita#ate ipsamvo\" 10.76.110.144 tdol upt \"mex\" tatem untutlab 3386 \"https://mail.example.com/plicab/oremq.html?uisaute=imide#poriss\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 YaBrowser/20.3.0.2221 Yowser/2.5 Safari/537.36\" deny",
             "event": {
@@ -386,7 +386,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.224.11.165 1646 [30/Apr/2017:3:32:16 nof] \"MOVE https://internal.example.org/mvolu/conse.txt?aincidu=nimadmin#isiu licabo\" 10.135.46.242 lupta xeaco \"nvolupt\" oremi elites 1940 \"https://www.example.org/boNemoe/onsequ.html?amvolupt=onevolu#mnis\" \"Mozilla/5.0 (Linux; Android 6.0; QMobile X700 PRO II) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36\" deny",
             "event": {
@@ -398,7 +398,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.27.44.4 4686 [14/May/2017:10:34:50 sequatD] \"TRACE https://internal.example.org/isciv/rroqu.html?uisa=tametco#ilmol eri\" 10.154.53.249 tae autodit \"elit\" cidunt plica 7398 \"https://internal.example.org/emqu/nderi.html?accusant=onse#admin\" \"Mozilla/5.0 (Linux; Android 10; SM-A305FN Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.96 Mobile Safari/537.36 YandexSearch/8.10 YandexSearchBrowser/8.10\" accept",
             "event": {
@@ -410,7 +410,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.93.39.140 4275 [29/May/2017:5:37:24 ute] \"COPY https://www5.example.net/uaeratv/isa.txt?periam=dqu#pid rExc\" 10.150.245.88 orisn reetd \"prehen\" ntutlabo iusmodte 1738 \"https://example.org/isc/Nequepor.txt?rem=idid#tesse\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 YaBrowser/20.3.0.2221 Yowser/2.5 Safari/537.36\" cancel",
             "event": {
@@ -422,7 +422,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.61.92.2 6595 [12/Jun/2017:12:39:58 maliquam] \"UNLOCK https://www5.example.com/orroq/vitaedic.txt?orisni=ons#remagn ecillu\" 10.73.207.70 llamco atu \"untincul\" ssecil commodi 3023 \"https://mail.example.net/tate/onevo.htm?emvele=isnost#olorem\" \"Mozilla/5.0 (Linux; Android 6.0; Lenovo A2016a40 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.106 Mobile Safari/537.36 YaApp_Android/10.30 YaSearchBrowser/10.30\" block",
             "event": {
@@ -434,7 +434,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.84.32.178 5271 [26/Jun/2017:7:42:33 aliq] \"GET https://example.net/mven/olorsit.gif?oremag=illu#ruredo mac\" temUt 2741 \"https://internal.example.com/uamnihi/risnis.html?scingeli=isn#sBono\" \"Mozilla/5.0 (Linux; Android 8.1.0; SM-A260G Build/OPR6; rv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Rocket/2.1.17(19420) Chrome/81.0.4044.138 Mobile Safari/537.36\" allow 10.50.124.116 numquam 104.719000",
             "event": {
@@ -446,7 +446,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.173.222.131 918 [11/Jul/2017:2:45:07 ori] \"TRACE https://www5.example.net/rum/eataevi.html?ulla=iqu#oin hil\" 10.211.234.224 uiadol Duisa \"lupta\" aUt boNem 5564 \"https://api.example.org/maveni/onevo.htm?liquaUte=alorum#obeataev\" \"Mozilla/5.0 (Linux; Android 9; G8142) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36\" accept",
             "event": {
@@ -458,7 +458,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.11.83.126 6581 [25/Jul/2017:9:47:41 naaliq] \"PROPFIND https://mail.example.net/osquir/mod.txt?fugitse=imad#tinvolup tsed\" 10.0.157.225 itam atu \"lloin\" remipsum tempor 1282 \"https://www5.example.net/incidid/rure.htm?edquian=loremeu#aturve\" \"Mozilla/5.0 (Linux; Android 9; POCOPHONE F1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36\" deny",
             "event": {
@@ -470,7 +470,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.228.77.21 6889 [08/Aug/2017:4:50:15 lamc] \"PUT https://api.example.com/asper/umq.txt?itasper=uae#mve uia\" 10.92.237.93 mad onse \"redol\" gnaa mod 5107 \"https://www5.example.com/toditaut/voluptat.htm?strumex=eprehend#asnu\" \"Mozilla/5.0 (Linux; U; Android 4.0.3; es-us; GT-P3100 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30\" cancel",
             "event": {
@@ -482,7 +482,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.102.215.23 3665 [22/Aug/2017:11:52:50 esseq] \"POST https://www5.example.net/quatD/isqua.jpg?oloreseo=iruredol#veniamqu licaboN\" 10.20.28.92 econs ntexpl \"dunt\" litsedq nderiti 409 \"https://api.example.com/Cic/olorema.txt?iscive=quasiar#aeab\" \"Opera/9.80 (Series 60; Opera Mini/7.1.32444/174.101; U; ru) Presto/2.12.423 Version/12.16\" allow",
             "event": {
@@ -494,7 +494,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.45.28.159 5627 [06/Sep/2017:6:55:24 ree] \"NONE https://api.example.net/ation/luptas.html?iatqu=lorsi#repreh plic\" 10.17.87.79 tetur tionula \"ritqu\" ecatcupi uamei 4595 \"https://www5.example.com/onse/olorem.gif?duntutla=ntium#iration\" \"Mozilla/5.0 (Linux; Android 7.0; SM-S337TL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36\" block",
             "event": {
@@ -506,7 +506,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.177.238.45 5137 [20/Sep/2017:1:57:58 ssusci] \"DELETE https://internal.example.com/mpo/unte.jpg?ueipsa=scipitl#eumi quasiarc\" 10.189.94.51 tetura rsp \"oluptat\" metco acom 5704 \"https://api.example.com/tem/exeacomm.txt?taliqui=mides#ciun\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 YaBrowser/20.3.0.2221 Yowser/2.5 Safari/537.36\" allow",
             "event": {
@@ -518,7 +518,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.46.77.76 5169 [04/Oct/2017:9:00:32 anim] \"GET https://www.example.org/uov/quaeab.jpg?moles=dipiscin#olup aco\" 10.101.85.169 natu liquid \"enim\" Finibus radi 5697 \"https://example.com/taed/umdolo.html?rroqu=dquiaco#nibus\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 YaBrowser/20.3.0.2221 Yowser/2.5 Safari/537.36\" accept",
             "event": {
@@ -530,7 +530,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.24.54.129 77 [19/Oct/2017:4:03:07 eprehend] \"HEAD https://example.net/edolo/ugiatquo.jpg?eosquira=pta#snos orsi\" 10.231.7.209 lorsita eavol \"osamnis\" temaccu scipitl 1247 \"https://www5.example.org/caboNem/urExcept.txt?litesseq=atcupida#tessequa\" \"Mozilla/5.0 (Linux; Android 10; ASUS_X01BDA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36\" block",
             "event": {
@@ -542,7 +542,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.121.163.5 7803 [02/Nov/2017:11:05:41 redol] \"CONNECT https://api.example.org/isci/dolor.htm?orinrep=quiavol#nrepreh ratv\" 10.77.129.175 tali BCS \"qui\" ugiatquo incidid 2617 \"https://www.example.com/sBonor/fugits.jpg?amc=vol#admi\" \"Mozilla/5.0 (Linux; Android 9; LG-US998) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36\" allow",
             "event": {
@@ -554,7 +554,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.51.236.148 329 [16/Nov/2017:6:08:15 adol] \"PROPFIND https://mail.example.com/roide/tem.gif?rerepre=nculpaq#culpaqui tvolup\" 10.116.146.114 col obea \"emp\" agnaaliq est 1444 \"https://www.example.com/inculp/onofd.gif?umdolors=dolori#asperna\" \"Mozilla/5.0 (Linux; Android 10; STK-L21 Build/HUAWEISTK-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36 YaApp_Android/10.91 YaSearchBrowser/10.91\" deny",
             "event": {
@@ -566,7 +566,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.244.108.135 6997 [01/Dec/2017:1:10:49 ume] \"NONE https://internal.example.net/rautod/olest.jpg?lapar=ritati#edquia itesse\" 10.217.222.99 ame amvolu \"mip\" tion tobeatae 2512 \"https://api.example.com/iqua/luptat.txt?oremqu=uradi#velitsed\" \"Mozilla/5.0 (Linux; Android 6.0; U20 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.147 Mobile Safari/537.36 YaApp_Android/10.90 YaSearchBrowser/10.90\" block",
             "event": {
@@ -578,7 +578,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.4.69.152 3833 [15/Dec/2017:8:13:24 scivel] \"PUT https://api.example.org/iusmodt/enim.txt?aquio=ersp#iame orroquis\" 10.150.198.112 ntmoll mexer \"estla\" uipexe abor 1370 \"https://www.example.net/remips/illoi.jpg?abori=uisnostr#reetdol\" \"Mozilla/5.0 (Linux; Android 10; SM-A305FN Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.96 Mobile Safari/537.36 YandexSearch/8.10 YandexSearchBrowser/8.10\" block",
             "event": {
@@ -590,7 +590,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.45.114.111 357 [29/Dec/2017:3:15:58 olup] \"POST https://example.org/abillo/undeom.html?oraincid=quaer#eetdo tlab\" 10.45.54.107 seddoeiu nse \"aali\" edictasu mdolors 7490 \"https://www5.example.org/atis/atDuis.txt?nisiut=rumwri#velill\" \"Mozilla/5.0 (Linux; Android 10; SM-A715F Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.83 Mobile Safari/537.36 [FB_IAB/Orca-Android;FBAV/266.0.0.16.117;]\" accept",
             "event": {
@@ -602,7 +602,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.49.242.174 4078 [12/Jan/2018:10:18:32 tat] \"TRACE https://mail.example.net/uam/orumSec.jpg?isnisiu=suntincu#sse venia\" 10.205.28.24 oeni untutlab \"tvolup\" consecte pteurs 742 \"https://www5.example.net/ons/tiaecon.html?unt=tass#tiumdol\" \"Mozilla/5.0 (Linux; Android 6.0; U20 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.147 Mobile Safari/537.36 YaApp_Android/10.90 YaSearchBrowser/10.90\" allow",
             "event": {
@@ -614,7 +614,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.17.202.219 487 [27/Jan/2018:5:21:06 iame] \"HEAD https://www5.example.org/umiurer/rere.txt?mnisi=usmo#iamea imaveni\" 10.183.223.149 cor odoco \"oin\" itseddoe elites 6366 \"https://mail.example.com/eursinto/litesse.html?licaboNe=tautfug#giatquov\" \"Mozilla/5.0 (compatible; Yahoo Ad monitoring; https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html) yahoo.adquality.lwd.desktop/1591143192-10\" deny",
             "event": {
@@ -626,7 +626,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.81.140.173 7623 [10/Feb/2018:12:23:41 itae] \"MOVE https://internal.example.net/atnula/ditautf.jpg?iquidex=olup#remipsu tan\" 10.88.172.222 doconse etdol \"dolorsi\" nturmag tura 6695 \"https://internal.example.org/totam/ntoccae.htm?idunt=atqu#naturau\" \"mobmail android 2.1.3.3150\" cancel",
             "event": {
@@ -638,7 +638,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.162.129.196 4247 [24/Feb/2018:7:26:15 snisi] \"OPTIONS https://api.example.net/uscip/umS.txt?quiacons=uisa#xeacommo Cicero\" 10.247.53.179 issu identsu \"piscivel\" hend eacommo 6835 \"https://example.com/osquira/umd.gif?scipi=tur#acon\" \"mobmail android 2.1.3.3150\" accept",
             "event": {
@@ -650,7 +650,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.110.86.230 536 [11/Mar/2018:2:28:49 eFini] \"UNLOCK https://mail.example.com/mrema/ullamc.txt?eufug=roquisq#temporai uido\" 10.172.148.223 snulap enimadm \"stenatu\" upta atc 3066 \"https://www5.example.net/asnulap/ipi.htm?orissu=fic#sBon\" \"Mozilla/5.0 (Linux; Android 5.1.1; Android Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36 YaApp_Android/9.80 YaSearchBrowser/9.80\" accept",
             "event": {
@@ -662,7 +662,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.93.159.170 3481 [25/Mar/2018:9:31:24 emullam] \"GET https://www5.example.com/isau/itinvol.txt?saquaea=ons#orsitam modico\" 10.232.19.43 porinc riame \"riat\" sseq eriam 729 \"https://internal.example.net/imve/essequam.gif?urQuis=etcon#onsequu\" \"Mozilla/5.0 (Linux; Android 6.0; QMobile X700 PRO II) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36\" deny",
             "event": {
@@ -674,7 +674,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.207.97.192 973 [08/Apr/2018:4:33:58 emp] \"ICP_QUERY https://api.example.net/veli/venia.htm?etdolor=uat#onemulla riaturEx\" 10.55.55.72 nculp asp \"eacom\" mag gelitse 2007 \"https://example.net/lab/llumq.htm?tetura=rumet#uptasnul\" \"Mozilla/5.0 (Linux; Android 7.0; SM-S337TL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36\" cancel",
             "event": {
@@ -686,7 +686,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.41.156.88 203 [22/Apr/2018:11:36:32 oco] \"MOVE https://internal.example.net/ainci/osqu.jpg?sus=imavenia#expli ugiat\" 10.89.73.240 orem ntorever \"pisciv\" fugiatqu seos 5561 \"https://www5.example.net/elillum/veleumi.gif?tvol=oluptate#lit\" \"Mozilla/5.0 (Linux; Android 9; 5024D_RU Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36 YaApp_Android/10.61 YaSearchBrowser/10.61\" deny",
             "event": {
@@ -698,7 +698,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.54.44.231 5292 [07/May/2018:6:39:06 aco] \"CONNECT https://www.example.org/runtm/eturadip.htm?psumd=oloree#seos rios\" 10.101.183.86 mvenia mcorpo \"ntexpl\" abor oreverit 6451 \"https://internal.example.net/tat/eufugia.htm?tau=fficia#est\" \"Mozilla/5.0 (compatible; Yahoo Ad monitoring; https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html) yahoo.adquality.lwd.desktop/1591143192-10\" allow",
             "event": {
@@ -710,7 +710,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.181.177.74 3378 [21/May/2018:1:41:41 itsedd] \"LOCK https://internal.example.org/liquipex/uisnos.html?ventor=lupt#umwri odoc\" 10.130.150.189 oreeu nvo \"iamqui\" tassita colabori 1223 \"https://www.example.net/lpa/isn.htm?iat=ffic#siuta\" \"Mozilla/5.0 (Linux; Android 9; U307AS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36\" accept",
             "event": {
@@ -722,7 +722,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.76.220.3 2492 [04/Jun/2018:8:44:15 serrorsi] \"GET https://api.example.org/mquisnos/lore.txt?siar=isn#veniamq lup\" 10.83.130.95 ipitlabo userror \"eacommo\" nderi liqua 7030 \"https://api.example.net/henderit/remq.jpg?voluptas=velill#rspic\" \"Mozilla/5.0 (Linux; Android 4.1.2; Micromax P410i Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36\" deny",
             "event": {
@@ -734,7 +734,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.219.245.58 7073 [19/Jun/2018:3:46:49 snisiut] \"COPY https://www.example.com/quas/occaeca.htm?ender=dico#uptatem upt\" 10.166.160.217 olor radip \"rchitect\" Dui iameaqu 2429 \"https://api.example.com/asnulap/yCiceroi.jpg?ender=inc#tect\" \"Opera/9.80 (Series 60; Opera Mini/7.1.32444/174.101; U; ru) Presto/2.12.423 Version/12.16\" deny",
             "event": {
@@ -746,7 +746,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.121.121.153 723 [03/Jul/2018:10:49:23 smoditem] \"UNLOCK https://www5.example.org/uidolo/umdolore.jpg?oquisq=abori#sit catcu\" 10.183.243.246 amni tatio \"amquisno\" modoc magnam 3267 \"https://example.com/idatat/onev.html?lesti=oreseo#reprehen\" \"Mozilla/5.0 (Linux; Android 10; STK-L21 Build/HUAWEISTK-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36 YaApp_Android/10.91 YaSearchBrowser/10.91\" cancel",
             "event": {
@@ -758,7 +758,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.54.5.47 1585 [17/Jul/2018:5:51:58 mmodi] \"OPTIONS https://internal.example.net/eniamqu/inimav.htm?imadm=uta#tisu remagnam\" 10.202.224.209 iusmodit aturv \"ectetura\" obeataev umf 3141 \"https://www.example.com/quaeabil/emip.htm?urExc=tDuis#iqu\" \"Mozilla/5.0 (Linux; Android 4.1.2; Micromax P410i Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36\" cancel",
             "event": {
@@ -770,7 +770,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.72.99.69 3172 [01/Aug/2018:12:54:32 oremeumf] \"PROPFIND https://mail.example.net/sintocca/mipsumqu.htm?tnulapar=ico#giatquo lors\" 10.170.234.233 accus uatu \"mquis\" lab uido 2046 \"https://mail.example.com/tena/aal.jpg?CSedu=mcol#lup\" \"Mozilla/5.0 (Linux; Android 9; POCOPHONE F1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36\" allow",
             "event": {
@@ -782,7 +782,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.245.240.47 4017 [15/Aug/2018:7:57:06 itaedict] \"DELETE https://api.example.org/rep/remap.html?siarc=fdeFin#eleumi edic\" 10.142.130.227 olabori odic \"iuta\" liquaUte scivelit 7795 \"https://internal.example.net/scipit/lloinve.htm?evolup=rvelil#isiutali\" \"Mozilla/5.0 (Linux; Android 9; ZTE Blade V1000RU Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36 YaApp_Android/10.91 YaSearchBrowser/10.91\" allow",
             "event": {
@@ -794,7 +794,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.62.188.193 4104 [29/Aug/2018:2:59:40 atu] \"DELETE https://api.example.net/eturad/tDuis.htm?enimadmi=tateveli#osa mini\" 10.61.110.7 oremque quaU \"ufugi\" cin tmo 508 \"https://example.com/oremip/its.jpg?iavol=natuserr#ostrudex\" \"Mozilla/5.0 (compatible; Yahoo Ad monitoring; https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html) yahoo.adquality.lwd.desktop/1591143192-10\" deny",
             "event": {
@@ -806,7 +806,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.172.139.78 6533 [12/Sep/2018:10:02:15 lamco] \"COPY https://www.example.net/hender/ptatemU.htm?mquisnos=tnulapa#madmi tlabore\" 10.68.198.188 doeiu onsectet \"dentsunt\" inea animid 2119 \"https://mail.example.net/onnumqua/quioff.html?upt=atatnonp#nvol\" \"Mozilla/5.0 (Linux; Android 9; 5024D_RU Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36 YaApp_Android/10.61 YaSearchBrowser/10.61\" block",
             "event": {
@@ -818,7 +818,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.172.47.7 2805 [27/Sep/2018:5:04:49 midest] \"CONNECT https://www.example.org/iduntutl/rsitam.htm?ntor=oinBCSed#oid rchit\" 10.169.63.169 ariat midestl \"quatu\" avolu teturad 3465 \"https://api.example.net/iquaUten/prehende.gif?rpo=velites#nonpro\" \"Opera/9.80 (Series 60; Opera Mini/7.1.32444/174.101; U; ru) Presto/2.12.423 Version/12.16\" block",
             "event": {
@@ -830,7 +830,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.32.98.109 5012 [11/Oct/2018:12:07:23 dexercit] \"PURGE https://example.org/itessequ/porissu.html?uip=ectobea#dat aUtenima\" 10.62.10.137 eeufugi deomnisi \"olupta\" oll laboree 3880 \"https://api.example.org/cupidata/stiaecon.htm?rsint=itl#ttenb\" \"Mozilla/5.0 (Linux; Android 9; LG-US998) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36\" cancel",
             "event": {
@@ -842,7 +842,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.176.62.146 5945 [25/Oct/2018:7:09:57 lors] \"COPY https://api.example.net/enimad/tis.txt?mipsumq=ident#nimide quelaud\" 10.255.40.12 rro oeiusmo \"nimv\" emeu tatemac 5192 \"https://www5.example.com/teursint/etMa.gif?lamcolab=ceroinB#umqui\" \"Mozilla/5.0 (Linux; Android 6.0; U20 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.147 Mobile Safari/537.36 YaApp_Android/10.90 YaSearchBrowser/10.90\" deny",
             "event": {
@@ -854,7 +854,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.194.198.46 3387 [09/Nov/2018:2:12:32 cta] \"GET https://api.example.org/taspe/yCiceroi.htm?cti=ommodoc#nse mveniam\" tuser 2694 \"https://internal.example.com/tlaboru/aeabillo.txt?equuntu=quamni#turveli\" \"Mozilla/5.0 (iPhone; CPU iPhone OS 13_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 LightSpeed [FBAN/MessengerLiteForiOS;FBAV/266.0.0.32.114;FBBV/216059178;FBDV/iPhone10,6;FBMD/iPhone;FBSN/iOS;FBSV/13.4.1;FBSS/3;FBCR/;FBID/phone;FBLC/en_US;FBOP/0]\" deny 10.88.98.31 rured 105.243000",
             "event": {
@@ -866,7 +866,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.5.49.20 7503 [23/Nov/2018:9:15:06 macc] \"OPTIONS https://example.com/beat/rro.jpg?uisau=qua#iarchite emsequi\" 10.1.27.133 edqu tationu \"gnaaliq\" olore ntutlab 6881 \"https://www5.example.com/gnama/esciun.html?ratvo=ntutl#volupt\" \"Mozilla/5.0 (Linux; Android 6.0; Lenovo A2016a40 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.106 Mobile Safari/537.36 YaApp_Android/10.30 YaSearchBrowser/10.30\" block",
             "event": {
@@ -878,7 +878,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.11.73.145 6972 [07/Dec/2018:4:17:40 uisautem] \"POST https://www5.example.org/loremq/turmagni.txt?emUtenim=ende#dexea aco\" 10.70.244.155 olorsi caboNemo \"uptas\" temaccus ons 2160 \"https://internal.example.com/ctetur/mvolupta.html?oreeu=mea#ssec\" \"Mozilla/5.0 (iPhone; CPU iPhone OS 13_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 LightSpeed [FBAN/MessengerLiteForiOS;FBAV/266.0.0.32.114;FBBV/216059178;FBDV/iPhone10,6;FBMD/iPhone;FBSN/iOS;FBSV/13.4.1;FBSS/3;FBCR/;FBID/phone;FBLC/en_US;FBOP/0]\" accept",
             "event": {
@@ -890,7 +890,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.204.214.98 985 [21/Dec/2018:11:20:14 equ] \"PURGE https://www5.example.net/deomnisi/ddoe.txt?oremi=ectobeat#ecte abo\" 10.121.80.158 boriosa cillumdo \"ditau\" moenimip uames 7663 \"https://internal.example.com/lor/oreeu.html?eturadip=nost#atus\" \"Mozilla/5.0 (Linux; Android 7.0; SM-S337TL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36\" accept",
             "event": {
@@ -902,7 +902,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.74.115.33 4006 [05/Jan/2019:6:22:49 nsequat] \"PURGE https://api.example.net/tiset/sci.jpg?rauto=doloreeu#lors eumfu\" 10.139.151.19 eumf roquisq \"uasi\" maveniam uis 5533 \"https://www.example.com/imi/animi.htm?ama=tatnonp#ntiumt\" \"Mozilla/5.0 (Linux; Android 10; SM-A305FN Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.96 Mobile Safari/537.36 YandexSearch/8.10 YandexSearchBrowser/8.10\" block",
             "event": {
@@ -914,7 +914,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.191.220.1 6454 [19/Jan/2019:1:25:23 ctetura] \"DELETE https://api.example.net/tDuisau/aturve.htm?tper=pisciv#tconsect pariat\" 10.242.48.203 ctobeat isi \"idexeac\" ntu tdolo 3872 \"https://mail.example.com/olupt/ola.jpg?etquasia=qua#adm\" \"Mozilla/5.0 (Linux; Android 9; Notepad_K10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Safari/537.36\" deny",
             "event": {
@@ -926,7 +926,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.109.88.27 5568 [02/Feb/2019:8:27:57 cidu] \"PROPATCH https://internal.example.com/oluptate/todi.jpg?tdolo=ident#scip eacommod\" 10.254.10.98 adipisc aparia \"maliq\" ccusant epteurs 6661 \"https://www5.example.org/oditau/onsec.gif?temqui=lup#aeca\" \"Mozilla/5.0 (Linux; Android 9; Pixel 3 Build/PD1A.180720.030) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36\" accept",
             "event": {
@@ -938,7 +938,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.5.148.114 4749 [17/Feb/2019:3:30:32 ntin] \"LOCK https://mail.example.com/radipis/lore.html?civeli=eufugia#utlabore tamr\" 10.175.138.42 olore onemul \"trudexe\" remeum etur 890 \"https://mail.example.org/quiav/ctionofd.gif?Finibus=uisautei#nevolu\" \"Mozilla/5.0 (Linux; Android 6.0; ZTE BLADE V7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36\" deny",
             "event": {
@@ -950,7 +950,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.0.0.240 1795 [03/Mar/2019:10:33:06 psa] \"PROPFIND https://internal.example.org/olupta/tio.jpg?idestl=litani#emp arch\" 10.18.199.203 ugits ittenb \"tobeatae\" ntut llum 366 \"https://example.com/equat/estiaec.htm?mquido=ende#ntmollit\" \"Mozilla/5.0 (Linux; Android 9; U307AS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36\" allow",
             "event": {
@@ -962,7 +962,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.1.220.47 6685 [17/Mar/2019:5:35:40 mipsamv] \"NONE https://www5.example.com/sequines/cto.gif?temaccu=uamqua#Neq runt\" 10.73.80.251 pteurs ercitati \"atem\" serro lumquid 5939 \"https://www5.example.org/imaveni/equ.htm?ssequamn=ave#taliqui\" \"Mozilla/5.0 (Linux; Android 10; SM-A715F Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.83 Mobile Safari/537.36 [FB_IAB/Orca-Android;FBAV/266.0.0.16.117;]\" allow",
             "event": {
@@ -974,7 +974,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.153.109.61 7499 [01/Apr/2019:12:38:14 numq] \"PURGE https://www.example.net/periam/ain.gif?iquipex=mqu#onorume abill\" 10.22.34.206 mini mve \"tionev\" uasiarch velites 1745 \"https://api.example.org/equa/edquiaco.gif?olorsit=naaliq#plica\" \"Mozilla/5.0 (Linux; Android 10; STK-L21 Build/HUAWEISTK-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36 YaApp_Android/10.91 YaSearchBrowser/10.91\" block",
             "event": {
@@ -986,7 +986,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.62.168.226 5334 [15/Apr/2019:7:40:49 bori] \"CONNECT https://www.example.net/ecatc/quovolu.jpg?dexe=nemul#Duis lupt\" 10.199.103.185 uipe ipsa \"con\" eirured sequamn 5243 \"https://mail.example.com/ciatisun/duntutl.htm?didun=riaturEx#nde\" \"Mozilla/5.0 (iPhone; CPU iPhone OS 13_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 LightSpeed [FBAN/MessengerLiteForiOS;FBAV/266.0.0.32.114;FBBV/216059178;FBDV/iPhone10,6;FBMD/iPhone;FBSN/iOS;FBSV/13.4.1;FBSS/3;FBCR/;FBID/phone;FBLC/en_US;FBOP/0]\" allow",
             "event": {
@@ -998,7 +998,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.97.33.56 3541 [29/Apr/2019:2:43:23 rad] \"COPY https://example.com/tqui/ssequ.gif?emse=emqui#cipitla tlab\" 10.128.84.27 nula ptate \"volupta\" umfu utla 2478 \"https://www5.example.com/dolo/velites.gif?equa=apari#tsunt\" \"Mozilla/5.0 (Linux; Android 10; ASUS_X01BDA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36\" block",
             "event": {
@@ -1010,7 +1010,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.49.169.175 2103 [13/May/2019:9:45:57 sistena] \"HEAD https://example.com/caboN/imipsam.jpg?catcupid=ritquiin#quisnost sequines\" 10.115.154.104 illum ore \"spici\" Sedut tatis 7767 \"https://www5.example.com/sequines/minimve.gif?toditau=uiad#nvolupta\" \"Mozilla/5.0 (Linux; Android 8.1.0; SM-A260G Build/OPR6; rv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Rocket/2.1.17(19420) Chrome/81.0.4044.138 Mobile Safari/537.36\" allow",
             "event": {
@@ -1022,7 +1022,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.213.100.153 2571 [28/May/2019:4:48:31 iatquo] \"PROPFIND https://www.example.org/oinvento/ali.htm?utaliqui=isciv#osqu ptatemse\" 10.33.112.100 catcup enimad \"magnaali\" velillum ionev 1594 \"https://internal.example.com/ameaq/Quis.html?lestiae=iav#umiure\" \"Mozilla/5.0 (Linux; U; Android 4.0.3; es-us; GT-P3100 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30\" block",
             "event": {
@@ -1034,7 +1034,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.216.143.226 2632 [11/Jun/2019:11:51:06 deomn] \"CONNECT https://api.example.net/quido/llo.htm?tpersp=assi#rch psa\" 10.25.53.93 tvolup oremeu \"lab\" lla urau 6127 \"https://example.net/equamni/atcupi.htm?onemull=mdo#labore\" \"Mozilla/5.0 (Linux; U; Android 4.0.3; es-us; GT-P3100 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30\" cancel",
             "event": {
@@ -1046,7 +1046,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.139.195.188 893 [25/Jun/2019:6:53:40 aliquaU] \"HEAD https://www.example.net/tvolu/imve.txt?gnaaliq=quam#deriti edictasu\" 10.246.115.57 edquiano mSecti \"henderi\" taevitae tevel 5926 \"https://example.com/ita/iquipexe.jpg?quamqua=quuntur#nihi\" \"Mozilla/5.0 (Linux; Android 9; G8142) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36\" allow",
             "event": {
@@ -1058,7 +1058,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.60.56.205 4345 [10/Jul/2019:1:56:14 writtenb] \"NONE https://www5.example.com/ugitsed/dminimve.htm?onse=uiac#tquii tesse\" 10.82.148.126 inBCSedu ita \"ade\" nihilmol nder 2214 \"https://api.example.net/uunturm/iatn.gif?tseddo=diduntut#rroq\" \"Mozilla/5.0 (iPhone; CPU iPhone OS 13_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 LightSpeed [FBAN/MessengerLiteForiOS;FBAV/266.0.0.32.114;FBBV/216059178;FBDV/iPhone10,6;FBMD/iPhone;FBSN/iOS;FBSV/13.4.1;FBSS/3;FBCR/;FBID/phone;FBLC/en_US;FBOP/0]\" block",
             "event": {
@@ -1070,7 +1070,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.245.251.98 261 [24/Jul/2019:8:58:48 mremaper] \"DELETE https://api.example.com/ntium/ide.htm?tamrema=isautem#usan gnamali\" 10.6.11.124 edqui tvolu \"psu\" strud onsequ 5930 \"https://www5.example.net/iumto/sequatu.jpg?runtm=mdoloree#que\" \"Mozilla/5.0 (Linux; Android 6.0; QMobile X700 PRO II) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36\" accept",
             "event": {
@@ -1082,7 +1082,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.99.55.115 1537 [07/Aug/2019:4:01:23 exerci] \"CONNECT https://www5.example.org/iad/ngelits.jpg?mporin=orissusc#utaliqui uov\" 10.145.25.55 litsed lumd \"tiaec\" lorem iamquisn 2079 \"https://mail.example.org/aper/entor.txt?lumdol=edutper#utemve\" \"Mozilla/5.0 (Linux; Android 6.0; ZTE BLADE V7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36\" block",
             "event": {
@@ -1094,7 +1094,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.187.86.64 3325 [21/Aug/2019:11:03:57 atatn] \"TRACE https://mail.example.com/iatnulap/roi.htm?uine=loreeu#eprehe ddoeiusm\" 10.6.88.105 uptatemU rem \"onorumet\" iscivel rinci 249 \"https://internal.example.com/eriti/uptateve.htm?rema=mcol#tion\" \"Mozilla/5.0 (Linux; Android 9; Notepad_K10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Safari/537.36\" allow",
             "event": {
@@ -1106,7 +1106,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.252.146.132 503 [05/Sep/2019:6:06:31 tat] \"CONNECT https://mail.example.org/turv/use.jpg?mtot=macc#illoin eursi\" 10.163.9.35 uatDu umq \"ipsu\" oremip ota 4562 \"https://example.com/epteurs/itse.jpg?modi=cip#tla\" \"Mozilla/5.0 (Linux; Android 8.1.0; SM-A260G Build/OPR6; rv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Rocket/2.1.17(19420) Chrome/81.0.4044.138 Mobile Safari/537.36\" accept",
             "event": {
@@ -1118,7 +1118,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.249.101.177 4465 [19/Sep/2019:1:09:05 quam] \"DELETE https://mail.example.com/umdol/rerepr.txt?emipsumq=orinr#ineavol umdo\" 10.235.160.245 squamest upta \"umquiad\" porinc uameiu 4857 \"https://api.example.org/mipsa/uas.gif?reeufu=umexe#xce\" \"Mozilla/5.0 (Linux; Android 8.1.0; SM-A260G Build/OPR6; rv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Rocket/2.1.17(19420) Chrome/81.0.4044.138 Mobile Safari/537.36\" deny",
             "event": {
@@ -1130,7 +1130,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.140.170.171 773 [03/Oct/2019:8:11:40 deom] \"TRACE https://internal.example.com/rautod/onorumet.htm?mvo=agnidol#nevolup erspici\" 10.73.218.58 quidol tinv \"Utenima\" nse umq 1831 \"https://mail.example.org/meaquei/snisiu.htm?atev=vento#litsed\" \"Mozilla/5.0 (Linux; Android 9; U307AS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36\" block",
             "event": {
@@ -1142,7 +1142,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.248.156.138 2125 [18/Oct/2019:3:14:14 smodit] \"OPTIONS https://example.net/dun/xce.jpg?nsequat=mvol#asiar eiu\" 10.67.148.40 tcons squamest \"ction\" emveleum siuta 2155 \"https://example.com/epteur/onproi.txt?imveniam=sunte#exerc\" \"Opera/9.80 (Series 60; Opera Mini/7.1.32444/174.101; U; ru) Presto/2.12.423 Version/12.16\" deny",
             "event": {
@@ -1154,7 +1154,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.83.154.75 4260 [01/Nov/2019:10:16:48 explicab] \"UNLOCK https://api.example.com/teiru/mquamei.jpg?pta=uradi#sequu orumetMa\" 10.37.33.179 taed eatae \"siutali\" oloremq sum 6106 \"https://www.example.org/ulamc/doe.txt?remquela=toreve#squirat\" \"Mozilla/5.0 (Linux; Android 7.0; MEIZU M6 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.120 Mobile Safari/537.36 YaApp_Android/10.30 YaSearchBrowser/10.30\" accept",
             "event": {
@@ -1166,7 +1166,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.14.29.202 7842 [15/Nov/2019:5:19:22 modoco] \"MKOL https://www5.example.net/dtempor/rroquisq.gif?liquid=uidex#umdolo nimv\" 10.84.107.38 tutla usmod \"ine\" qui itse 2097 \"https://www5.example.org/tasn/exeaco.html?metc=aincidu#reprehe\" \"Mozilla/5.0 (Linux; Android 10; SM-A305FN Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.96 Mobile Safari/537.36 YandexSearch/8.10 YandexSearchBrowser/8.10\" deny",
             "event": {
@@ -1178,7 +1178,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.221.86.133 6682 [30/Nov/2019:12:21:57 edi] \"POST https://api.example.com/ore/adeser.htm?pre=aute#rchite rcit\" 10.204.223.184 oinve ptasnul \"utaliqui\" mcorpor rerepr 6861 \"https://example.com/tuserror/agnama.jpg?deritq=boreetdo#teni\" \"Mozilla/5.0 (Linux; Android 10; SM-A715F Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.83 Mobile Safari/537.36 [FB_IAB/Orca-Android;FBAV/266.0.0.16.117;]\" deny",
             "event": {
@@ -1190,7 +1190,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "10.195.4.70 3844 [14/Dec/2019:7:24:31 mfugiat] \"PUT https://api.example.com/liqu/dolor.htm?ess=umdo#aer quela\" 10.229.39.190 Nequepo edictas \"emac\" rmagnido exeaco 2574 \"https://api.example.org/loremi/nven.htm?usan=ugiatn#squa\" \"Mozilla/5.0 (Linux; Android 10; STK-L21 Build/HUAWEISTK-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36 YaApp_Android/10.91 YaSearchBrowser/10.91\" deny",
             "event": {

--- a/packages/squid/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/squid/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -8,7 +8,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   # User agent
   - user_agent:
       field: user_agent.original

--- a/packages/squid/manifest.yml
+++ b/packages/squid/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: squid
 title: Squid
-version: 0.4.0
+version: 0.4.1
 description: This Elastic integration collects logs from Squid
 categories: ["security"]
 release: experimental


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967