### PR TITLE
stan update to ECS 1.11.0

### DIFF
--- a/packages/stan/changelog.yml
+++ b/packages/stan/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.5.2'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1420
 - version: "0.5.1"
   changes:
     - description: Escape special characters in docs

--- a/packages/stan/data_stream/log/_dev/test/pipeline/test-log-sample.log-expected.json
+++ b/packages/stan/data_stream/log/_dev/test/pipeline/test-log-sample.log-expected.json
@@ -6,7 +6,7 @@
             },
             "@timestamp": "2021-01-13T14:20:06.981Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -36,7 +36,7 @@
             },
             "@timestamp": "2021-01-13T14:20:06.981Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -66,7 +66,7 @@
             },
             "@timestamp": "2021-01-13T14:20:06.981Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -96,7 +96,7 @@
             },
             "@timestamp": "2021-01-13T14:20:06.981Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -126,7 +126,7 @@
             },
             "@timestamp": "2021-01-13T14:20:06.981Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -156,7 +156,7 @@
             },
             "@timestamp": "2021-01-13T14:20:06.981Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "debug"
@@ -186,7 +186,7 @@
             },
             "@timestamp": "2021-01-13T14:20:06.981Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -216,7 +216,7 @@
             },
             "@timestamp": "2021-01-13T14:20:06.982Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -246,7 +246,7 @@
             },
             "@timestamp": "2021-01-13T14:20:06.982Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -276,7 +276,7 @@
             },
             "@timestamp": "2021-01-13T14:20:06.982Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -306,7 +306,7 @@
             },
             "@timestamp": "2021-01-13T14:20:06.982Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -336,7 +336,7 @@
             },
             "@timestamp": "2021-01-13T14:20:06.982Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "debug"
@@ -366,7 +366,7 @@
             },
             "@timestamp": "2021-01-13T14:20:06.982Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "debug"
@@ -403,7 +403,7 @@
             ],
             "@timestamp": "2021-01-13T14:20:07.008Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -445,7 +445,7 @@
             ],
             "@timestamp": "2021-01-13T14:20:07.009Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -487,7 +487,7 @@
             ],
             "@timestamp": "2021-01-13T14:20:07.010Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -522,7 +522,7 @@
             },
             "@timestamp": "2021-01-13T14:20:07.011Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -552,7 +552,7 @@
             },
             "@timestamp": "2021-01-13T14:20:07.011Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -582,7 +582,7 @@
             },
             "@timestamp": "2021-01-13T14:20:07.263Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -612,7 +612,7 @@
             },
             "@timestamp": "2021-01-13T14:20:07.263Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -642,7 +642,7 @@
             },
             "@timestamp": "2021-01-13T14:20:07.263Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -672,7 +672,7 @@
             },
             "@timestamp": "2021-01-13T14:20:07.263Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -702,7 +702,7 @@
             },
             "@timestamp": "2021-01-13T14:20:07.263Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -732,7 +732,7 @@
             },
             "@timestamp": "2021-01-13T14:20:07.263Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -762,7 +762,7 @@
             },
             "@timestamp": "2021-01-13T14:20:07.263Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -792,7 +792,7 @@
             },
             "@timestamp": "2021-01-13T14:20:07.263Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -822,7 +822,7 @@
             },
             "@timestamp": "2021-01-13T14:20:07.263Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -852,7 +852,7 @@
             },
             "@timestamp": "2021-01-13T14:20:07.263Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -889,7 +889,7 @@
             ],
             "@timestamp": "2021-01-13T14:20:08.988Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -924,7 +924,7 @@
             },
             "@timestamp": "2021-01-13T14:20:09.010Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "info"
@@ -963,7 +963,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.499Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1009,7 +1009,7 @@
             ],
             "@timestamp": "2021-01-13T14:22:50.497Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1051,7 +1051,7 @@
             ],
             "@timestamp": "2021-01-13T14:22:50.499Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1093,7 +1093,7 @@
             ],
             "@timestamp": "2021-01-13T14:22:50.499Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1135,7 +1135,7 @@
             ],
             "@timestamp": "2021-01-13T14:22:50.499Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1179,7 +1179,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.499Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1223,7 +1223,7 @@
             ],
             "@timestamp": "2021-01-13T14:22:50.499Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1267,7 +1267,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.499Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1311,7 +1311,7 @@
             ],
             "@timestamp": "2021-01-13T14:22:50.499Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1353,7 +1353,7 @@
             ],
             "@timestamp": "2021-01-13T14:22:50.499Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1395,7 +1395,7 @@
             ],
             "@timestamp": "2021-01-13T14:22:50.499Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1437,7 +1437,7 @@
             ],
             "@timestamp": "2021-01-13T14:22:50.499Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1479,7 +1479,7 @@
             ],
             "@timestamp": "2021-01-13T14:22:50.499Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1523,7 +1523,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.499Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1571,7 +1571,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.499Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1617,7 +1617,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.488Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1666,7 +1666,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.499Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1712,7 +1712,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.499Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1760,7 +1760,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.499Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1804,7 +1804,7 @@
             ],
             "@timestamp": "2021-01-13T14:22:50.499Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1848,7 +1848,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.499Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1896,7 +1896,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.500Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1940,7 +1940,7 @@
             ],
             "@timestamp": "2021-01-13T14:22:50.500Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1984,7 +1984,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.508Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -2032,7 +2032,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.508Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -2078,7 +2078,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.508Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -2126,7 +2126,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.509Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -2172,7 +2172,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.509Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -2218,7 +2218,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.509Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -2266,7 +2266,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.509Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -2312,7 +2312,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.509Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -2360,7 +2360,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.509Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -2406,7 +2406,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.509Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -2452,7 +2452,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.510Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -2500,7 +2500,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.510Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -2546,7 +2546,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.949Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -2594,7 +2594,7 @@
             },
             "@timestamp": "2021-01-13T14:22:50.949Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -2638,7 +2638,7 @@
             ],
             "@timestamp": "2021-01-13T14:22:50.949Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -2680,7 +2680,7 @@
             ],
             "@timestamp": "2021-01-13T14:22:50.949Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/stan/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/stan/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   - rename:
       field: message
       target_field: event.original

--- a/packages/stan/manifest.yml
+++ b/packages/stan/manifest.yml
@@ -1,6 +1,6 @@
 name: stan
 title: STAN
-version: 0.5.1
+version: 0.5.2
 release: beta
 description: This Elastic integration collects logs and metrics from STAN instances
 type: integration


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967