### PR TITLE
suricata update to ECS 1.11.0

### DIFF
--- a/packages/suricata/changelog.yml
+++ b/packages/suricata/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '1.1.2'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1421
 - version: "1.1.1"
   changes:
     - description: Escape special characters in docs

--- a/packages/suricata/data_stream/eve/_dev/test/pipeline/test-eve-6-0.log-expected.json
+++ b/packages/suricata/data_stream/eve/_dev/test/pipeline/test-eve-6-0.log-expected.json
@@ -51,7 +51,7 @@
             },
             "@timestamp": "2021-01-27T00:28:11.488Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [

--- a/packages/suricata/data_stream/eve/_dev/test/pipeline/test-eve-alerts.log-expected.json
+++ b/packages/suricata/data_stream/eve/_dev/test/pipeline/test-eve-alerts.log-expected.json
@@ -37,7 +37,7 @@
             },
             "@timestamp": "2018-10-03T14:42:44.836Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -139,7 +139,7 @@
             },
             "@timestamp": "2018-10-03T16:16:26.711Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -241,7 +241,7 @@
             },
             "@timestamp": "2018-10-03T16:44:50.813Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -343,7 +343,7 @@
             },
             "@timestamp": "2018-10-03T16:45:09.267Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -445,7 +445,7 @@
             },
             "@timestamp": "2018-10-03T16:45:34.481Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -547,7 +547,7 @@
             },
             "@timestamp": "2018-10-03T17:02:38.900Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -649,7 +649,7 @@
             },
             "@timestamp": "2018-10-04T09:34:59.009Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -753,7 +753,7 @@
             },
             "@timestamp": "2018-10-04T09:34:59.168Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -857,7 +857,7 @@
             },
             "@timestamp": "2018-10-04T09:34:59.288Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -961,7 +961,7 @@
             },
             "@timestamp": "2018-10-04T09:34:59.289Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1065,7 +1065,7 @@
             },
             "@timestamp": "2018-10-04T09:34:59.356Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1169,7 +1169,7 @@
             },
             "@timestamp": "2018-10-04T09:34:59.456Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1273,7 +1273,7 @@
             },
             "@timestamp": "2018-10-04T09:34:59.747Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1377,7 +1377,7 @@
             },
             "@timestamp": "2018-10-04T09:34:59.953Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1481,7 +1481,7 @@
             },
             "@timestamp": "2018-10-04T09:35:00.250Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1585,7 +1585,7 @@
             },
             "@timestamp": "2018-10-04T09:35:00.401Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1689,7 +1689,7 @@
             },
             "@timestamp": "2018-10-04T09:35:00.776Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1793,7 +1793,7 @@
             },
             "@timestamp": "2018-10-04T09:35:00.897Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1897,7 +1897,7 @@
             },
             "@timestamp": "2018-10-04T09:35:01.362Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -2000,7 +2000,7 @@
             },
             "@timestamp": "2018-10-04T09:35:01.575Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -2086,7 +2086,7 @@
             },
             "@timestamp": "2018-10-04T09:35:02.796Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hash": [
@@ -2200,7 +2200,7 @@
             },
             "@timestamp": "2020-06-26T15:00:03.342Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hash": [

--- a/packages/suricata/data_stream/eve/_dev/test/pipeline/test-eve-dns-4-1-4.log-expected.json
+++ b/packages/suricata/data_stream/eve/_dev/test/pipeline/test-eve-dns-4-1-4.log-expected.json
@@ -29,7 +29,7 @@
             },
             "@timestamp": "2019-08-22T23:48:27.924Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -92,7 +92,7 @@
             },
             "@timestamp": "2019-08-22T23:48:27.924Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -171,7 +171,7 @@
             },
             "@timestamp": "2019-08-22T23:48:27.950Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -251,7 +251,7 @@
             },
             "@timestamp": "2019-08-22T23:48:27.957Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -316,7 +316,7 @@
             },
             "@timestamp": "2019-08-22T23:48:48.839Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -380,7 +380,7 @@
             },
             "@timestamp": "2019-08-22T23:48:48.839Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -487,7 +487,7 @@
             },
             "@timestamp": "2019-08-22T23:48:48.901Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -598,7 +598,7 @@
             },
             "@timestamp": "2019-08-22T23:48:48.902Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -666,7 +666,7 @@
             },
             "@timestamp": "2019-08-23T01:22:31.812Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -730,7 +730,7 @@
             },
             "@timestamp": "2019-08-23T01:22:31.812Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -805,7 +805,7 @@
             },
             "@timestamp": "2019-08-23T01:22:31.846Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -885,7 +885,7 @@
             },
             "@timestamp": "2019-08-23T01:22:31.846Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -966,7 +966,7 @@
             },
             "@timestamp": "2019-08-23T01:22:31.846Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1047,7 +1047,7 @@
             },
             "@timestamp": "2019-08-23T01:22:31.846Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1128,7 +1128,7 @@
             },
             "@timestamp": "2019-08-23T01:22:31.846Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1206,7 +1206,7 @@
             },
             "@timestamp": "2019-08-23T01:22:31.847Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1286,7 +1286,7 @@
             },
             "@timestamp": "2019-08-23T01:22:31.847Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1367,7 +1367,7 @@
             },
             "@timestamp": "2019-08-23T01:22:31.847Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1448,7 +1448,7 @@
             },
             "@timestamp": "2019-08-23T01:22:31.847Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1529,7 +1529,7 @@
             },
             "@timestamp": "2019-08-23T01:22:31.847Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1596,7 +1596,7 @@
             },
             "@timestamp": "2019-08-23T02:03:36.578Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1660,7 +1660,7 @@
             },
             "@timestamp": "2019-08-23T02:03:36.578Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1767,7 +1767,7 @@
             },
             "@timestamp": "2019-08-23T02:03:36.619Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -1878,7 +1878,7 @@
             },
             "@timestamp": "2019-08-23T02:03:36.626Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/suricata/data_stream/eve/_dev/test/pipeline/test-eve-metadata.log-expected.json
+++ b/packages/suricata/data_stream/eve/_dev/test/pipeline/test-eve-metadata.log-expected.json
@@ -56,7 +56,7 @@
                 ]
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [

--- a/packages/suricata/data_stream/eve/_dev/test/pipeline/test-eve-small.log-expected.json
+++ b/packages/suricata/data_stream/eve/_dev/test/pipeline/test-eve-small.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2018-07-05T19:01:09.820Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -88,7 +88,7 @@
             },
             "@timestamp": "2018-07-05T19:07:20.910Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -165,7 +165,7 @@
             },
             "@timestamp": "2018-07-05T19:43:47.690Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -256,7 +256,7 @@
                 "path": "/ssdp/device-desc.xml"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -360,7 +360,7 @@
             },
             "@timestamp": "2018-07-05T19:51:20.213Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -400,7 +400,7 @@
         {
             "@timestamp": "2018-07-05T19:51:23.009Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "suricata": {
                 "eve": {
@@ -594,7 +594,7 @@
             },
             "@timestamp": "2018-07-05T19:51:50.666Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hash": [
@@ -671,7 +671,7 @@
         {
             "@timestamp": "2018-07-05T19:51:54.001Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -754,7 +754,7 @@
             },
             "@timestamp": "2020-12-09T16:02:43.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -827,7 +827,7 @@
             },
             "@timestamp": "2020-12-09T16:02:58.005Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hash": [
@@ -928,7 +928,7 @@
             },
             "@timestamp": "2020-12-09T16:03:00.179Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1008,7 +1008,7 @@
             },
             "@timestamp": "2020-12-09T16:03:50.083Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/default.yml
@@ -7,7 +7,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: '1.10.0'
+      value: '1.11.0'
   - rename:
       field: message
       target_field: event.original

--- a/packages/suricata/manifest.yml
+++ b/packages/suricata/manifest.yml
@@ -1,6 +1,6 @@
 name: suricata
 title: Suricata
-version: 1.1.1
+version: 1.1.2
 release: ga
 description: This Elastic integration collects events from Suricata instances
 type: integration


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967