### PR TITLE
tomcat update to ECS 1.11.0

### DIFF
--- a/packages/tomcat/changelog.yml
+++ b/packages/tomcat/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.4.2'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1422
 - version: "0.4.1"
   changes:
     - description: Escape special characters in docs

--- a/packages/tomcat/data_stream/log/_dev/test/pipeline/test-generated.log-expected.json
+++ b/packages/tomcat/data_stream/log/_dev/test/pipeline/test-generated.log-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-1516-asdf: 10.251.224.219||eacommod||rci||[29/Jan/2016:6:09:59 OMST]||exercita||https://example.com/illumqui/ventore.html?min=ite#utl||vol||amremap||oremi||ntsunti||5293||https://mail.example.net/turadipi/aeca.htm?ntium=psaq#cer||Mozilla/5.0 (Linux; Android 9; G8142) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||aliqu",
             "event": {
@@ -14,7 +14,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-259-CFYZ: 10.196.153.12||sequa||abo||[12/Feb/2016:1:12:33 PST]||umqui||https://www5.example.net/mdolo/mqui.htm?sumdo=litesse#orev||pisciv||uii||umexe||estlabo||5222||https://mail.example.com/uat/eporr.jpg?byCicer=luptat#agn||Opera/9.80 (Series 60; Opera Mini/7.1.32444/174.101; U; ru) Presto/2.12.423 Version/12.16||nulapari",
             "event": {
@@ -26,7 +26,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "February 26 20:15:08 ctetur5806.api.home %APACHETOMCAT- COOK: 10.156.194.38||gnaali||enatus||[26/Feb/2016:8:15:08 PT]||incid||https://internal.example.com/tetur/idolor.html?ntex=eius#luptat||emape||aer||lupt||tia||7019||https://www.example.com/quis/orisn.txt?anti=ofdeF#metcons||Mozilla/5.0 (Linux; Android 8.1.0; SM-A260G Build/OPR6; rv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Rocket/2.1.17(19420) Chrome/81.0.4044.138 Mobile Safari/537.36||nul",
             "event": {
@@ -38,7 +38,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-1060-INDEX: 10.196.118.192||tinculp||tur||[12/Mar/2016:3:17:42 CT]||equat||https://www5.example.org/nci/ofdeFin.gif?amco=exe#iatu||ionofde||con||uia||quiavo||1156||https://mail.example.com/consec/taliquip.html?radip=tNequ#gelit||Mozilla/5.0 (Linux; Android 9; 5024D_RU Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36 YaApp_Android/10.61 YaSearchBrowser/10.61||tconsec",
             "event": {
@@ -50,7 +50,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-4141-BADMTHD: 10.246.209.145||oluptas||llu||[26/Mar/2016:10:20:16 GMT+02:00]||ommod||https://internal.example.com/aqui/radipis.jpg?llumd=enatuse#magn||equuntu||eos||enimad||rmagni||1998||https://internal.example.net/onev/tenima.jpg?seq=olorema#ccaecat||Mozilla/5.0 (Linux; Android 8.0.0; VS996) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||fug",
             "event": {
@@ -62,7 +62,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-2964-BADMETHOD: 10.114.191.225||uian||tempo||[09/Apr/2016:5:22:51 PST]||exercit||https://internal.example.com/omnis/antium.txt?lupta=iusmodt#doloreeu||pori||occ||ect||reetdolo||2770||https://www5.example.org/uiano/mrema.htm?anim=autfugi#inBCSedu||Mozilla/5.0 (Linux; Android 6.0; QMobile X700 PRO II) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36||tanimi",
             "event": {
@@ -74,7 +74,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 24 00:25:25 erep2696.www.home %APACHETOMCAT- INDEX: 10.38.77.13||aquaeab||liqu||[24/Apr/2016:12:25:25 PT]||ehend||https://www5.example.net/uidolore/niamqu.gif?iat=tevelit#nsequat||loremagn||ipis||gelits||tatevel||3856||https://api.example.com/uovol/dmi.txt?quunt=ptat#ore||Mozilla/5.0 (Linux; Android 4.1.2; Micromax P410i Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36||tsed",
             "event": {
@@ -86,7 +86,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 8 07:27:59 mUt2398.invalid %APACHETOMCAT- DEBUG: 10.11.201.109||boree||ugits||[08/May/2016:7:27:59 CEST]||iinea||https://www.example.org/idexea/riat.txt?tvol=moll#tatione||inB||deomni||tquovol||ntsuntin||3341||https://mail.example.org/imav/ididu.htm?tion=orsitame#quiratio||Mozilla/5.0 (Linux; Android 6.0; Lenovo A2016a40 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.106 Mobile Safari/537.36 YaApp_Android/10.30 YaSearchBrowser/10.30||iam",
             "event": {
@@ -98,7 +98,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-3097-BADMTHD: 10.182.166.181||apariat||mol||[22/May/2016:2:30:33 CT]||olupta||https://api.example.org/toccae/tatno.gif?taliqu=temUten#ccusan||iqu||ollit||usan||aper||5529||https://example.org/uaera/sitas.txt?aedic=atquovo#iumto||Mozilla/5.0 (Linux; Android 4.1.2; Micromax P410i Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36||mquaera",
             "event": {
@@ -110,7 +110,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-6283-null: 10.185.126.247||vel||quu||[05/Jun/2016:9:33:08 OMST]||avol||https://mail.example.net/atuse/ddoeiu.gif?idolore=onse#liq||metcon||smo||litessec||emporinc||5075||https://internal.example.com/atcu/oremagna.jpg?remipsum=liq#ist||Opera/9.80 (Series 60; Opera Mini/7.1.32444/174.101; U; ru) Presto/2.12.423 Version/12.16||caecatc",
             "event": {
@@ -122,7 +122,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 20 04:35:42 siuta2896.www.localhost %APACHETOMCAT- SEARCH: 10.72.114.23||enia||nsequu||[20/Jun/2016:4:35:42 PST]||rsint||https://example.com/idestla/Nemoeni.htm?taed=lup#remeumf||antiumto||strude||ctetura||usmod||1640||https://mail.example.net/lor/fugit.jpg?rsitamet=lupt#xea||Mozilla/5.0 (Linux; Android 6.0; ZTE BLADE V7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||orain",
             "event": {
@@ -134,7 +134,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 4 11:38:16 oin6316.www5.host %APACHETOMCAT- TRACE: 10.129.241.147||lores||lapariat||[04/Jul/2016:11:38:16 PST]||etc||https://example.net/nimadmin/ditautfu.html?lpa=entsu#dun||onproide||luptat||itaut||imaven||152||https://internal.example.net/onproide/Nemoen.gif?pitla=ccu#urE||Mozilla/5.0 (Linux; Android 10; ASUS_X01BDA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36||inculpaq",
             "event": {
@@ -146,7 +146,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 18 18:40:50 tionemu7691.www.local %APACHETOMCAT- BDMTHD: 10.185.101.76||errorsi||des||[18/Jul/2016:6:40:50 GMT+02:00]||stl||https://www5.example.com/ono/stru.jpg?emaperi=tame#tinvol||tectobe||colabor||iusmodt||etdolo||3768||https://internal.example.net/ommod/sequatur.txt?tlabo=suntexp#ugiatnu||Mozilla/5.0 (Linux; Android 5.1.1; Android Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36 YaApp_Android/9.80 YaSearchBrowser/9.80||itecto",
             "event": {
@@ -158,7 +158,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-3217-GET: 10.57.170.140||nsec||onse||[02/Aug/2016:1:43:25 OMST]||inibusBo||https://example.net/tion/eataev.htm?uiineavo=tisetq#irati||ici||giatquov||eritquii||dexeac||3088||https://www.example.org/oreseos/uames.txt?msequi=isnostru#iquaUten||Mozilla/5.0 (Linux; Android 6.0; QMobile X700 PRO II) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36||iadese",
             "event": {
@@ -170,7 +170,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-1109-PUT: 10.33.153.47||hil||atquovo||[16/Aug/2016:8:45:59 GMT+02:00]||iineavo||https://internal.example.com/isno/taliq.htm?nnu=dolo#Loremip||idolor||emeumfu||CSed||lupt||6136||https://internal.example.net/quip/mporain.txt?uatD=iunt#temveleu||Mozilla/5.0 (Linux; Android 10; STK-L21 Build/HUAWEISTK-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36 YaApp_Android/10.91 YaSearchBrowser/10.91||tio",
             "event": {
@@ -182,7 +182,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 30 15:48:33 conse2991.internal.lan %APACHETOMCAT- FGET: 10.116.104.101||gnam||tat||[30/Aug/2016:3:48:33 CET]||lumqui||https://internal.example.net/mdolore/rQuisau.gif?iavolu=den#tutla||olorema||iades||siarchi||datatn||5076||https://internal.example.net/mipsumd/eFinib.jpg?remi=saute#ercit||Mozilla/5.0 (Linux; Android 9; Notepad_K10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Safari/537.36||remagn",
             "event": {
@@ -194,7 +194,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-3361-null: 10.202.194.67||samvolu||ittenbyC||[13/Sep/2016:10:51:07 ET]||eirure||https://internal.example.com/oidentsu/atiset.jpg?ntor=lpaqui#sitame||iadese||nsectet||utla||utei||2716||https://example.com/tlabori/oin.jpg?quisnos=ite#ationul||Mozilla/5.0 (Linux; Android 9; ZTE Blade V1000RU Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36 YaApp_Android/10.91 YaSearchBrowser/10.91||eritqu",
             "event": {
@@ -206,7 +206,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "September 28 05:53:42 wri2784.api.domain %APACHETOMCAT- PUT: 10.153.111.103||itquiin||modocon||[28/Sep/2016:5:53:42 PST]||taevit||https://www5.example.com/etconse/tincu.txt?lit=asun#estia||eaq||occae||ctetura||labore||4621||https://www.example.com/adeseru/emoe.html?atur=itanimi#itame||Mozilla/5.0 (Linux; U; Android 4.0.3; es-us; GT-P3100 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30||rehender",
             "event": {
@@ -218,7 +218,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-1637-DETECT_METHOD_TYPE: 10.52.186.29||equat||doloreme||[12/Oct/2016:12:56:16 GMT+02:00]||ione||https://www5.example.org/eriamea/amre.htm?magni=pisciv#iquidex||radipisc||tmo||fficiade||uscipit||4168||https://internal.example.net/oru/temqu.htm?etMalor=ipi#reseos||Mozilla/5.0 (Linux; Android 8.0.0; VS996) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||mcolab",
             "event": {
@@ -230,7 +230,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "October 26 19:58:50 oquisqu2937.mail.domain %APACHETOMCAT- BDMTHD: 10.209.182.237||tper||olor||[26/Oct/2016:7:58:50 GMT-07:00]||osqui||https://www.example.org/iutali/fdeFi.jpg?liquide=etdol#uela||boN||eprehend||aevit||aboN||3423||https://example.net/tlabo/uames.gif?mpo=offi#giatnu||Mozilla/5.0 (iPhone; CPU iPhone OS 13_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 LightSpeed [FBAN/MessengerLiteForiOS;FBAV/266.0.0.32.114;FBBV/216059178;FBDV/iPhone10,6;FBMD/iPhone;FBSN/iOS;FBSV/13.4.1;FBSS/3;FBCR/;FBID/phone;FBLC/en_US;FBOP/0]||lor",
             "event": {
@@ -242,7 +242,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 10 03:01:24 dolore1287.internal.lan %APACHETOMCAT- CFYZ: 10.63.194.87||quisno||sin||[10/Nov/2016:3:01:24 CT]||aliquam||https://mail.example.net/itatione/isnis.html?oluptate=issus#osamn||isnisiu||bore||tsu||tcons||3128||https://api.example.org/lorinre/olorsita.gif?idata=rumwritt#magnid||Mozilla/5.0 (Linux; Android 8.1.0; SM-A260G Build/OPR6; rv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Rocket/2.1.17(19420) Chrome/81.0.4044.138 Mobile Safari/537.36||dol",
             "event": {
@@ -254,7 +254,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-4307-TRACE: 10.62.191.18||tevelite||orporiss||[24/Nov/2016:10:03:59 OMST]||tlabo||https://www.example.org/emvel/tmollita.htm?numqua=veni#eveli||eroi||dtemp||aliquide||ofde||4940||https://www5.example.org/maven/hende.jpg?labor=didunt#uptatema||Mozilla/5.0 (Linux; Android 10; STK-L21 Build/HUAWEISTK-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36 YaApp_Android/10.91 YaSearchBrowser/10.91||udan",
             "event": {
@@ -266,7 +266,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-6040-CFYZ: 10.238.164.29||aturQui||utlabor||[08/Dec/2016:5:06:33 ET]||temvel||https://example.net/nisi/dant.txt?ecte=tinvolu#iurer||iciadese||quidolor||tessec||olupta||2660||https://example.org/idolor/uisau.jpg?llumdolo=nre#ercitat||Mozilla/5.0 (Linux; Android 7.0; MEIZU M6 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.120 Mobile Safari/537.36 YaApp_Android/10.30 YaSearchBrowser/10.30||uiinea",
             "event": {
@@ -278,7 +278,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-1612-SEARCH: 10.155.230.17||eni||ionevo||[23/Dec/2016:12:09:07 CT]||Ute||https://internal.example.com/sintocc/tlabor.txt?tDuisaut=oinBC#quameius||ipsumdol||tet||etdo||urerepr||4674||https://example.com/tetu/stru.htm?tlabore=Exc#pora||Mozilla/5.0 (Linux; Android 9; POCOPHONE F1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||uteirure",
             "event": {
@@ -290,7 +290,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "January 6 07:11:41 ide2767.www5.local %APACHETOMCAT- RNDMMTD: 10.102.229.102||nnum||tenbyCi||[06/Jan/2017:7:11:41 PST]||tco||https://example.net/officiad/itam.html?madmi=tur#roi||niamqui||orem||sno||atno||5263||https://mail.example.net/ntocca/ostru.txt?quiavol=rrorsi#temquiav||Mozilla/5.0 (Linux; Android 9; G8142) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||sec",
             "event": {
@@ -302,7 +302,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "January 20 14:14:16 sBon1759.invalid %APACHETOMCAT- HEAD: 10.194.14.7||ten||vita||[20/Jan/2017:2:14:16 OMST]||ullamcor||https://mail.example.org/tor/qui.txt?eavolup=fugiatn#docon||etconsec||ios||evolu||ersp||3536||https://www5.example.org/sauteiru/mod.gif?tes=mquame#nihilmol||Mozilla/5.0 (Linux; Android 8.1.0; SM-A260G Build/OPR6; rv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Rocket/2.1.17(19420) Chrome/81.0.4044.138 Mobile Safari/537.36||orain",
             "event": {
@@ -314,7 +314,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-6113-get: 10.99.0.226||madmi||uidol||[03/Feb/2017:9:16:50 ET]||quameius||https://api.example.net/roid/inibusB.jpg?Nemoenim=squirati#Sedutp||utp||ema||rsitv||iciade||5649||https://example.com/lup/tatemUt.html?upida=tvolupt#eufugi||Mozilla/5.0 (Linux; Android 9; Pixel 3 Build/PD1A.180720.030) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36||uredol",
             "event": {
@@ -326,7 +326,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-6945-DETECT_METHOD_TYPE: 10.107.174.213||tenimad||minimav||[18/Feb/2017:4:19:24 OMST]||taedicta||https://www.example.net/str/idolore.txt?eetdolo=cteturad#untut||uamni||ctet||ati||uine||2438||https://api.example.org/loreme/untu.htm?ven=con#nisist||Mozilla/5.0 (Linux; Android 6.0; QMobile X700 PRO II) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36||ium",
             "event": {
@@ -338,7 +338,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "March 4 11:21:59 idunt4707.host %APACHETOMCAT- ABCD: 10.84.25.23||laudant||isnost||[04/Mar/2017:11:21:59 CET]||rQuisau||https://mail.example.org/iscinge/ofdeFini.jpg?molli=velitse#oditem||gitsedqu||borios||rsitvolu||quam||5315||https://www.example.org/ineavo/pexe.htm?iadolor=amcol#adeser||Mozilla/5.0 (Linux; Android 6.0; Lenovo A2016a40 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.106 Mobile Safari/537.36 YaApp_Android/10.30 YaSearchBrowser/10.30||gitsed",
             "event": {
@@ -350,7 +350,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-4367-uGET: 10.193.143.108||idolo||luptate||[18/Mar/2017:6:24:33 PT]||atisun||https://www.example.org/epre/tobeata.html?quia=iduntu#idestlab||rnatur||ofdeFin||essequam||acommo||3105||https://api.example.com/cusant/atemq.gif?itecto=reetdol#totamre||Mozilla/5.0 (Linux; Android 9; ZTE Blade V1000RU Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36 YaApp_Android/10.91 YaSearchBrowser/10.91||ercita",
             "event": {
@@ -362,7 +362,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 2 01:27:07 emquia1497.www5.lan %APACHETOMCAT- INDEX: 10.190.51.22||uamei||siut||[02/Apr/2017:1:27:07 CT]||uisa||https://example.com/mexe/its.htm?ice=oles#edic||seq||tutlab||sau||atevelit||2450||https://example.org/aperia/ccaeca.gif?ttenby=boris#stenatu||Mozilla/5.0 (Linux; Android 9; Notepad_K10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Safari/537.36||orumSe",
             "event": {
@@ -374,7 +374,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 16 08:29:41 riat3854.www5.home %APACHETOMCAT- BADMETHOD: 10.194.90.130||siut||tconsect||[16/Apr/2017:8:29:41 PT]||piscinge||https://www.example.com/velitess/naali.htm?nre=veli#volupta||rnatu||elitse||ima||quasia||2382||https://www5.example.com/quamqua/eacommod.html?iumdol=tpersp#stla||mobmail android 2.1.3.3150||sequamni",
             "event": {
@@ -386,7 +386,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-6198-BDMTHD: 10.10.213.83||nea||psum||[30/Apr/2017:3:32:16 OMST]||ncididun||https://www.example.org/xeacomm/cinge.txt?apariat=vitaedi#lorsita||dolore||uptate||quidexea||ect||23||https://internal.example.com/ate/odoconse.jpg?quatu=veli#tenim||Mozilla/5.0 (iPhone; CPU iPhone OS 13_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 LightSpeed [FBAN/MessengerLiteForiOS;FBAV/266.0.0.32.114;FBBV/216059178;FBDV/iPhone10,6;FBMD/iPhone;FBSN/iOS;FBSV/13.4.1;FBSS/3;FBCR/;FBID/phone;FBLC/en_US;FBOP/0]||labo",
             "event": {
@@ -398,7 +398,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 14 22:34:50 aboreetd5461.host %APACHETOMCAT- uGET: 10.52.125.9||hit||urv||[14/May/2017:10:34:50 ET]||nimid||https://api.example.org/texpli/exeacom.jpg?rita=esseci#tametcon||liqua||mvele||isis||uasiar||2552||https://mail.example.net/loremqu/dantium.htm?teirured=onemulla#dolorem||Mozilla/5.0 (iPhone; CPU iPhone OS 13_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 LightSpeed [FBAN/MessengerLiteForiOS;FBAV/266.0.0.32.114;FBBV/216059178;FBDV/iPhone10,6;FBMD/iPhone;FBSN/iOS;FBSV/13.4.1;FBSS/3;FBCR/;FBID/phone;FBLC/en_US;FBOP/0]||rauto",
             "event": {
@@ -410,7 +410,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-5770-RNDMMTD: 10.19.17.202||nby||mve||[29/May/2017:5:37:24 PT]||isau||https://api.example.net/ibusBon/ven.gif?nsequat=doloreme#dun||reprehe||tincu||suntin||itse||814||https://www5.example.org/intocc/amcorp.html?ssecillu=liqua#olo||Mozilla/5.0 (Linux; Android 9; G8142) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||aec",
             "event": {
@@ -422,7 +422,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 12 12:39:58 iquidexe304.mail.test %APACHETOMCAT- RNDMMTD: 10.195.64.5||oreetd||uat||[12/Jun/2017:12:39:58 PT]||moenimi||https://mail.example.org/oconsequ/edquiac.gif?preh=ercit#etMal||qua||rsita||ate||ipsamvo||344||https://api.example.com/tdol/upt.htm?asper=idunt#luptat||Mozilla/5.0 (Linux; Android 9; POCOPHONE F1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||ica",
             "event": {
@@ -434,7 +434,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 26 19:42:33 remips4828.www5.host %APACHETOMCAT- POST: 10.209.77.194||tvolup||itesseq||[26/Jun/2017:7:42:33 OMST]||snost||https://internal.example.com/llamc/nte.htm?utali=porinc#tetur||xce||dat||aincidu||nimadmin||4843||https://mail.example.com/eumfugi/etdolor.htm?dic=cola#amcor||Mozilla/5.0 (Linux; Android 10; ASUS_X01BDA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36||elites",
             "event": {
@@ -446,7 +446,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-1952-MKCOL: 10.168.6.90||rem||amvolupt||[11/Jul/2017:2:45:07 GMT+02:00]||atisund||https://example.net/ites/isetq.gif?nisiut=tur#avolupt||ariatur||rer||iconseq||porincid||6941||https://mail.example.org/nofd/dipisci.txt?ilmol=eri#quunt||Mozilla/5.0 (Linux; Android 5.1.1; Android Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36 YaApp_Android/9.80 YaSearchBrowser/9.80||tae",
             "event": {
@@ -458,7 +458,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-7717-rndmmtd: 10.89.137.238||plica||ore||[25/Jul/2017:9:47:41 OMST]||emqu||https://mail.example.com/acommod/itsedd.html?admin=stenatu#inibu||est||uptatemU||leumiu||tla||4765||https://api.example.org/isa/niamqui.jpg?dqu=pid#rExc||Mozilla/5.0 (Linux; Android 9; 5024D_RU Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36 YaApp_Android/10.61 YaSearchBrowser/10.61||erun",
             "event": {
@@ -470,7 +470,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-4574-OPTIONS: 10.246.61.213||ntutlabo||iusmodte||[08/Aug/2017:4:50:15 CT]||loi||https://example.org/Nequepor/eirure.htm?idid=tesse#sequat||giatquov||tconsec||miurerep||toccaec||7645||https://www5.example.net/psaqua/ullamcor.txt?qui=cupi#tame||Mozilla/5.0 (Linux; Android 10; ASUS_X01BDA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36||orroq",
             "event": {
@@ -482,7 +482,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 22 23:52:50 orin5238.host %APACHETOMCAT- MKCOL: 10.117.44.138||orem||rcit||[22/Aug/2017:11:52:50 PST]||enderit||https://www.example.org/tanimi/rumSecti.jpg?emporain=ntiumto#umetMalo||oluptas||emvele||isnost||olorem||2760||https://www5.example.net/quunt/acommod.jpg?sit=rumSect#ita||Mozilla/5.0 (Linux; Android 10; ASUS_X01BDA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36||aliq",
             "event": {
@@ -494,7 +494,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-4801-PRONECT: 10.69.30.196||tore||elits||[06/Sep/2017:6:55:24 OMST]||ruredo||https://example.net/temUt/ptassita.gif?uamnihi=risnis#uov||itlab||urmag||omm||equ||4808||https://www.example.net/siuta/urmagn.html?uptat=idex#ptateve||Opera/9.80 (Series 60; Opera Mini/7.1.32444/174.101; U; ru) Presto/2.12.423 Version/12.16||nimveni",
             "event": {
@@ -506,7 +506,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-7668-BADMTHD: 10.135.91.88||ercit||eporroq||[20/Sep/2017:1:57:58 CT]||ugiatn||https://api.example.com/dictasun/abore.txt?modocon=ipsu#ntNeq||tate||urExce||asi||ectiono||2241||https://example.org/onu/liquaUte.txt?velillu=ria#atDu||Mozilla/5.0 (Linux; Android 9; U307AS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||emq",
             "event": {
@@ -518,7 +518,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "October 4 21:00:32 agnaaliq1829.mail.test %APACHETOMCAT- ABCD: 10.81.45.174||tin||fugitse||[04/Oct/2017:9:00:32 CEST]||liquide||https://example.net/Sedutpe/prehen.html?rcit=aecatcup#olabor||estl||erun||iruredol||incidid||7699||https://api.example.org/edquian/loremeu.gif?volupta=dmi#untexpl||Mozilla/5.0 (Linux; Android 9; G8142) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||mipsamvo",
             "event": {
@@ -530,7 +530,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-3517-rndmmtd: 10.87.179.233||mnisiut||avolu||[19/Oct/2017:4:03:07 PST]||eum||https://www.example.org/umetMal/asper.htm?metcons=itasper#uae||mve||uia||iciad||lorem||6137||https://www.example.org/redol/gnaa.htm?aliquamq=dtempori#toditaut||Mozilla/5.0 (Linux; Android 7.0; SM-S337TL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||dexerc",
             "event": {
@@ -542,7 +542,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-2669-COOK: 10.198.57.130||hitec||henderit||[02/Nov/2017:11:05:41 OMST]||perspici||https://api.example.net/mquisn/queips.gif?emUte=molestia#quir||eavolup||emip||ver||erc||294||https://example.com/iuntNequ/esseq.txt?remq=veniamq#occ||Mozilla/5.0 (Linux; Android 6.0; U20 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.147 Mobile Safari/537.36 YaApp_Android/10.90 YaSearchBrowser/10.90||emo",
             "event": {
@@ -554,7 +554,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-494-GET: 10.218.0.197||dolor||econs||[16/Nov/2017:6:08:15 ET]||eritin||https://www.example.net/yCic/nder.jpg?itanim=nesciun#saqu||iscive||quasiar||aeab||teur||609||https://www.example.org/mol/tur.jpg?usmodi=ree#saquaea||Mozilla/5.0 (Linux; Android 9; POCOPHONE F1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||eetd",
             "event": {
@@ -566,7 +566,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "December 1 01:10:49 iatqu7310.api.home %APACHETOMCAT- get: 10.123.199.198||irured||illumqui||[01/Dec/2017:1:10:49 PST]||tionula||https://mail.example.com/ecatcupi/uamei.html?nreprehe=onse#olorem||turvel||eratv||ipsa||asuntexp||1390||https://example.com/oremquel/lmole.jpg?boNem=iumt#tsed||Mozilla/5.0 (Linux; Android 10; ASUS_X01BDA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36||mpo",
             "event": {
@@ -578,7 +578,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "December 15 08:13:24 uamnihil6127.api.domain %APACHETOMCAT- POST: 10.29.119.245||tatnon||leumiur||[15/Dec/2017:8:13:24 ET]||ore||https://internal.example.net/ection/roquisqu.html?ceroinB=nim#utaliqu||rsi||taliqui||mides||ciun||39||https://example.org/iatqu/inBCSedu.gif?urExcep=ema#suntex||Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 YaBrowser/20.3.0.2221 Yowser/2.5 Safari/537.36||anim",
             "event": {
@@ -590,7 +590,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "December 29 15:15:58 uov1629.internal.invalid %APACHETOMCAT- DETECT_METHOD_TYPE: 10.130.175.17||quide||quaU||[29/Dec/2017:3:15:58 PT]||inimav||https://mail.example.net/iutali/itat.txt?Finibus=radi#xeacom||des||atnulapa||billo||rroqu||2170||https://www.example.org/taedi/tquido.html?etconsec=elillum#upt||Mozilla/5.0 (Linux; Android 9; U307AS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||onsectet",
             "event": {
@@ -602,7 +602,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-5752-PROPFIND: 10.166.90.130||mdolore||eosquira||[12/Jan/2018:10:18:32 CET]||lloinven||https://mail.example.net/lmolesti/apariatu.htm?moe=msequ#uat||lupta||npr||etconsec||caboNem||1043||https://internal.example.org/litesseq/atcupida.html?tob=dolores#equamnih||Mozilla/5.0 (Linux; Android 8.1.0; SM-A260G Build/OPR6; rv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Rocket/2.1.17(19420) Chrome/81.0.4044.138 Mobile Safari/537.36||deF",
             "event": {
@@ -614,7 +614,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "January 27 05:21:06 orumw5960.www5.home %APACHETOMCAT- GET: 10.248.111.207||dolor||tiumto||[27/Jan/2018:5:21:06 GMT-07:00]||quiavol||https://api.example.org/ratv/alorum.jpg?tali=BCS#qui||ugiatquo||incidid||quin||autemv||6174||https://internal.example.org/mipsumqu/tatio.jpg?admi=onnu#olorema||Mozilla/5.0 (Linux; Android 9; G8142) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||atatnon",
             "event": {
@@ -626,7 +626,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-2940-asdf: 10.185.37.32||ame||tesseq||[10/Feb/2018:12:23:41 GMT+02:00]||tem||https://internal.example.net/gitse/ugitse.jpg?tvolup=tdolore#ventore||red||sinto||tatev||luptas||3286||https://api.example.net/aev/inrepr.gif?iadese=nisiu#imad||Mozilla/5.0 (Linux; Android 9; ZTE Blade V1000RU Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36 YaApp_Android/10.91 YaSearchBrowser/10.91||ptatem",
             "event": {
@@ -638,7 +638,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-4927-SEARCH: 10.5.194.202||onproide||ntmo||[24/Feb/2018:7:26:15 CET]||riosa||https://example.org/pisc/urEx.html?rautod=olest#eataev||atcupi||atem||qui||otamr||7278||https://internal.example.com/meaque/uid.htm?tion=tobeatae#maccusa||Mozilla/5.0 (Linux; Android 10; LM-V350) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||iqua",
             "event": {
@@ -650,7 +650,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "March 11 02:28:49 deriti6952.mail.domain %APACHETOMCAT- PRONECT: 10.183.34.1||boree||isn||[11/Mar/2018:2:28:49 CEST]||der||https://www5.example.com/aconse/prehe.gif?diduntu=eiusmod#itation||veleum||piciatis||nes||lmolesti||1559||https://www.example.org/emaperia/Section.txt?iame=orroquis#aquio||Mozilla/5.0 (Linux; U; Android 4.0.3; es-us; GT-P3100 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30||ntmoll",
             "event": {
@@ -662,7 +662,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-4472-CFYZ: 10.101.163.40||abor||nBCSe||[25/Mar/2018:9:31:24 CEST]||remips||https://mail.example.net/reetdolo/rationev.html?reetdol=uelauda#ema||odi||ptatems||runtmo||ore||3512||https://internal.example.com/undeom/emullamc.jpg?quaer=eetdo#tlab||Mozilla/5.0 (Linux; Android 4.1.2; Micromax P410i Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36||liq",
             "event": {
@@ -674,7 +674,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 8 16:33:58 nse3421.mail.localhost %APACHETOMCAT- uGET: 10.216.188.152||oremi||ugitsedq||[08/Apr/2018:4:33:58 ET]||atDuis||https://www5.example.com/mUteni/quira.htm?ore=tation#loinve||tatevel||iumdolo||untu||ict||2699||https://internal.example.com/riosamni/icta.gif?umetMa=imadmin#iqui||Mozilla/5.0 (Linux; Android 8.1.0; SM-A260G Build/OPR6; rv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Rocket/2.1.17(19420) Chrome/81.0.4044.138 Mobile Safari/537.36||Nequepo",
             "event": {
@@ -686,7 +686,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-1033-nGET: 10.94.140.77||veniam||isnisiu||[22/Apr/2018:11:36:32 OMST]||dol||https://www5.example.org/setquas/minim.gif?tutlabor=reseosq#gna||isiutali||lumqu||onulamco||ons||5050||https://mail.example.net/unt/tass.html?tla=mquiad#CSe||Opera/9.80 (Series 60; Opera Mini/7.1.32444/174.101; U; ru) Presto/2.12.423 Version/12.16||psa",
             "event": {
@@ -698,7 +698,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-4133-PUT: 10.223.205.204||lor||ccaec||[07/May/2018:6:39:06 PST]||ommo||https://www.example.com/laudanti/umiurer.txt?rsitvolu=mnisi#usmo||iamea||imaveni||uiacon||iam||7526||https://mail.example.org/oin/itseddoe.html?citati=uamei#eursinto||Mozilla/5.0 (Linux; Android 8.1.0; SM-A260G Build/OPR6; rv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Rocket/2.1.17(19420) Chrome/81.0.4044.138 Mobile Safari/537.36||tutla",
             "event": {
@@ -710,7 +710,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 21 13:41:41 tautfug689.localdomain %APACHETOMCAT- PUT: 10.85.137.156||atiset||serror||[21/May/2018:1:41:41 CEST]||isiut||https://mail.example.org/ici/nisiuta.jpg?itae=dtempo#atnula||ditautf||itametc||ori||uamqu||2804||https://example.com/quiac/sunt.gif?etdol=dolorsi#nturmag||Mozilla/5.0 (Linux; Android 9; LG-US998) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||Except",
             "event": {
@@ -722,7 +722,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 4 20:44:15 totam6886.api.localhost %APACHETOMCAT- QUALYS: 10.12.54.142||trudex||liquam||[04/Jun/2018:8:44:15 PST]||lor||https://mail.example.com/eseruntm/lpaquiof.html?magnaal=uscip#umS||iciadese||riatur||oeni||dol||3000||https://www5.example.net/teturadi/ditau.gif?piscivel=hend#eacommo||Mozilla/5.0 (Linux; Android 9; LG-US998) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||aer",
             "event": {
@@ -734,7 +734,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-3864-RNDMMTD: 10.158.6.52||dolorem||sed||[19/Jun/2018:3:46:49 OMST]||Nemoenim||https://example.net/labori/porai.gif?utali=sed#xeac||umdolors||lumdo||acom||eFini||4262||https://internal.example.org/uovol/prehend.html?eque=eufug#est||Mozilla/5.0 (Linux; U; Android 7.1.2; uz-uz; Redmi 4X Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.141 Mobile Safari/537.36 XiaoMi/MiuiBrowser/12.2.3-g||ntincul",
             "event": {
@@ -746,7 +746,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 3 10:49:23 tquo854.api.domain %APACHETOMCAT- MKCOL: 10.195.160.182||ine||urerepre||[03/Jul/2018:10:49:23 CT]||itessequ||https://www5.example.org/orissu/fic.gif?ese=mmodoco#amni||atnul||umfugi||stquidol||Nemoenim||1325||https://example.com/tasnul/tuserr.jpg?amvo=tnul#expl||Mozilla/5.0 (Linux; Android 6.0; ZTE BLADE V7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||isau",
             "event": {
@@ -758,7 +758,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-6084-CONNECT: 10.20.68.117||rQuisaut||quas||[17/Jul/2018:5:51:58 ET]||metco||https://mail.example.com/iuntNeq/eddoei.jpg?sseq=eriam#pernat||udan||archi||iutaliq||urQuis||1742||https://example.net/orum/Bonoru.txt?agnamal=quei#quio||Mozilla/5.0 (Linux; Android 6.0; ZTE BLADE V7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||lamcola",
             "event": {
@@ -770,7 +770,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 1 00:54:32 venia6656.api.domain %APACHETOMCAT- CONNECT: 10.94.136.235||mmod||iti||[01/Aug/2018:12:54:32 PST]||amqu||https://www5.example.com/tanimid/onpr.gif?gelitse=oremqu#idex||radip||upta||tetura||rumet||6923||https://www5.example.org/lestia/nde.jpg?pisci=sunt#texplica||Mozilla/5.0 (Linux; Android 6.0; Lenovo A2016a40 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.106 Mobile Safari/537.36 YaApp_Android/10.30 YaSearchBrowser/10.30||ore",
             "event": {
@@ -782,7 +782,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 15 07:57:06 veniam1216.www5.invalid %APACHETOMCAT- NCIRCLE: 10.152.11.26||expli||ugiat||[15/Aug/2018:7:57:06 GMT+02:00]||oinBCSed||https://www.example.net/ntorever/pisciv.gif?eritq=rehen#ipsamvol||elillum||veleumi||nsequatu||nula||2783||https://example.com/santi/ritati.gif?turadip=dip#idolo||Mozilla/5.0 (compatible; Yahoo Ad monitoring; https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html) yahoo.adquality.lwd.desktop/1591143192-10||aco",
             "event": {
@@ -794,7 +794,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 29 14:59:40 runtm5729.invalid %APACHETOMCAT- PRONECT: 10.82.118.95||bore||ptate||[29/Aug/2018:2:59:40 GMT+02:00]||labo||https://www5.example.com/quu/xeac.htm?abor=oreverit#scip||Finibus||Utenimad||olupta||tau||5211||https://www5.example.com/itametco/vel.htm?rere=pta#nonn||Mozilla/5.0 (Linux; Android 9; 5024D_RU Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36 YaApp_Android/10.61 YaSearchBrowser/10.61||met",
             "event": {
@@ -806,7 +806,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-4322-id: 10.187.152.213||conse||ventor||[12/Sep/2018:10:02:15 CEST]||mag||https://www.example.net/mini/Loremip.html?tur=atnonpr#ita||amquaer||aqui||enby||lpa||3948||https://www5.example.net/iat/ffic.htm?cte=aparia#CSe||Mozilla/5.0 (Linux; Android 9; Notepad_K10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Safari/537.36||ugitsedq",
             "event": {
@@ -818,7 +818,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "September 27 05:04:49 pta6012.www.local %APACHETOMCAT- uGET: 10.98.71.45||destla||fugitse||[27/Sep/2018:5:04:49 GMT+02:00]||eirur||https://www.example.net/duntutla/lamco.txt?isci=Dui#reetdo||ever||civelits||eos||ipitlabo||5440||https://internal.example.net/nonn/hite.htm?ariatur=labo#sautei||Mozilla/5.0 (Linux; Android 4.1.2; Micromax P410i Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36||unt",
             "event": {
@@ -830,7 +830,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-5971-uGET: 10.86.123.33||ugia||meum||[11/Oct/2018:12:07:23 OMST]||doei||https://www5.example.net/tev/nre.html?occaeca=eturadip#ent||rumSecti||Utenima||olore||orumS||757||https://www5.example.org/eursint/orio.txt?iameaqu=aaliquaU#olu||Mozilla/5.0 (Linux; U; Android 7.1.2; uz-uz; Redmi 4X Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.141 Mobile Safari/537.36 XiaoMi/MiuiBrowser/12.2.3-g||yCiceroi",
             "event": {
@@ -842,7 +842,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-2852-FGET: 10.6.112.183||deom||oluptat||[25/Oct/2018:7:09:57 GMT-07:00]||eni||https://www5.example.net/uamnih/nseq.txt?uidolo=umdolore#dmi||tam||oremip||eufugi||dunt||6169||https://api.example.net/uidexeac/sequa.html?modoc=magnam#uinesc||Mozilla/5.0 (Linux; Android 10; LM-V350) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||idatat",
             "event": {
@@ -854,7 +854,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 9 02:12:32 orsi2109.internal.home %APACHETOMCAT- LOCK: 10.227.156.143||sis||idolo||[09/Nov/2018:2:12:32 CEST]||tsedquia||https://example.net/umdolor/isiu.html?mmodi=snostr#eniamqu||inimav||tatevel||midestl||nci||6587||https://www5.example.org/nvolupt/meiusm.htm?aturv=ectetura#obeataev||Mozilla/5.0 (compatible; Yahoo Ad monitoring; https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html) yahoo.adquality.lwd.desktop/1591143192-10||seq",
             "event": {
@@ -866,7 +866,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 23 09:15:06 quaeabil2539.www5.lan %APACHETOMCAT- get: 10.124.129.248||iamqui||quide||[23/Nov/2018:9:15:06 CT]||cididun||https://example.org/ibusBo/untincu.jpg?lesti=sintocca#mipsumqu||eprehen||hilmole||sequ||sectetu||7182||https://example.net/dolor/lorumwri.htm?mquis=lab#uido||Mozilla/5.0 (Linux; Android 6.0; ZTE BLADE V7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||mwrit",
             "event": {
@@ -878,7 +878,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "December 7 16:17:40 aal1598.mail.host %APACHETOMCAT- CONNECT: 10.173.125.112||quiavolu||upta||[07/Dec/2018:4:17:40 OMST]||umtota||https://www5.example.org/magnaa/sumquiad.gif?oluptate=Duisa#consequa||eaqueip||itaedict||olorema||rep||3380||https://www5.example.net/siarc/fdeFin.jpg?tobeata=nesciun#amcolab||Mozilla/5.0 (Linux; Android 8.0.0; VS996) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||isnisiut",
             "event": {
@@ -890,7 +890,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-5227-GET: 10.37.156.140||uisnos||olores||[21/Dec/2018:11:20:14 PST]||epo||https://www.example.org/evolup/rvelil.gif?eavolup=ipsumq#evit||tno||iss||taspe||lum||5911||https://api.example.net/eturad/tDuis.htm?enimadmi=tateveli#osa||Opera/9.80 (Series 60; Opera Mini/7.1.32444/174.101; U; ru) Presto/2.12.423 Version/12.16||idolorem",
             "event": {
@@ -902,7 +902,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-5776-PRONECT: 10.121.225.135||ufugi||cin||[05/Jan/2019:6:22:49 ET]||byC||https://example.com/oremip/its.jpg?iavol=natuserr#ostrudex||nse||miurere||evit||uatu||2448||https://www5.example.org/uamestqu/mpor.jpg?hender=ptatemU#seq||Mozilla/5.0 (Linux; Android 9; 5024D_RU Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36 YaApp_Android/10.61 YaSearchBrowser/10.61||tnulapa",
             "event": {
@@ -914,7 +914,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-7708-DEBUG: 10.123.68.56||expl||olore||[19/Jan/2019:1:25:23 CEST]||dentsunt||https://www.example.org/animid/upta.jpg?onnumqua=quioff#iuntN||ipis||itautfu||nesci||tam||1206||https://mail.example.net/tetura/eeufug.txt?modt=iduntutl#rsitam||Mozilla/5.0 (Linux; Android 10; ASUS_X01BDA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36||ntor",
             "event": {
@@ -926,7 +926,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "February 2 20:27:57 oid218.api.invalid %APACHETOMCAT- RNDMMTD: 10.63.56.164||iquid||evo||[02/Feb/2019:8:27:57 GMT-07:00]||avolu||https://api.example.net/itesse/expl.html?prehende=lup#tpers||orsitv||temseq||uisaute||uun||4638||https://mail.example.net/nemulla/asp.html?ncul=taliq#tautfugi||Mozilla/5.0 (Linux; Android 4.1.2; Micromax P410i Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36||umd",
             "event": {
@@ -938,7 +938,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "February 17 03:30:32 sectetur2674.www5.test %APACHETOMCAT- HEAD: 10.62.10.137||eeufugi||deomnisi||[17/Feb/2019:3:30:32 ET]||issus||https://example.net/deritinv/evelite.html?iav=odico#rsint||itl||ttenb||olor||quiav||6648||https://example.com/eumfu/lors.gif?upidata=ici#usant||Mozilla/5.0 (Linux; Android 10; SM-A305FN Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.96 Mobile Safari/537.36 YandexSearch/8.10 YandexSearchBrowser/8.10||con",
             "event": {
@@ -950,7 +950,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "March 3 10:33:06 sequatD4487.internal.localhost %APACHETOMCAT- INDEX: 10.89.154.115||oeiusmo||nimv||[03/Mar/2019:10:33:06 GMT+02:00]||tconse||https://example.org/tseddoei/teursint.htm?remagnaa=lamcolab#ceroinB||umqui||citation||temsequi||mquia||1119||https://api.example.net/iveli/conseq.htm?ercitat=taspe#yCiceroi||Mozilla/5.0 (Linux; Android 8.0.0; VS996) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||cti",
             "event": {
@@ -962,7 +962,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-4758-TRACE: 10.122.252.130||tuser||mmo||[17/Mar/2019:5:35:40 PST]||tlaboru||https://www5.example.com/ciad/ugiatqu.gif?turveli=isciv#natus||boreet||luptasnu||ento||snostr||3904||https://api.example.org/xerc/Nequep.htm?ria=beat#rro||Mozilla/5.0 (Linux; Android 9; 5024D_RU Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36 YaApp_Android/10.61 YaSearchBrowser/10.61||uisau",
             "event": {
@@ -974,7 +974,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-2573-id: 10.195.152.53||ueporroq||ute||[01/Apr/2019:12:38:14 GMT-07:00]||tationu||https://api.example.com/olore/ntutlab.htm?ameaquei=gnama#esciun||tesse||olupta||isno||oluptas||5560||https://www.example.net/rinrepr/dutp.jpg?modo=uiavo#uisaut||mobmail android 2.1.3.3150||paq",
             "event": {
@@ -986,7 +986,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 15 07:40:49 nul5107.www5.domain %APACHETOMCAT- ABCD: 10.9.255.204||illoin||emUtenim||[15/Apr/2019:7:40:49 CT]||uid||https://mail.example.com/rvelil/adese.htm?incidi=aedictas#rumetMa||mexerci||urEx||ditaut||ctetur||3089||https://mail.example.com/oreeu/mea.jpg?tis=oluptat#emi||Mozilla/5.0 (Linux; Android 4.1.2; Micromax P410i Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36||iaeconse",
             "event": {
@@ -998,7 +998,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "April 29 14:43:23 nimadmin5630.localdomain %APACHETOMCAT- RNDMMTD: 10.214.235.133||equ||nulapari||[29/Apr/2019:2:43:23 GMT-07:00]||tsunt||https://www.example.org/oremi/ectobeat.gif?oreeu=uasiarch#Malor||boriosa||cillumdo||ditau||moenimip||5930||https://internal.example.net/oreetd/lor.txt?etc=eturadip#nost||Mozilla/5.0 (Linux; Android 9; LG-US998) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||evel",
             "event": {
@@ -1010,7 +1010,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "May 13 21:45:57 sequuntu3563.internal.test %APACHETOMCAT- TRACE: 10.5.134.204||apari||iarchit||[13/May/2019:9:45:57 PT]||orum||https://api.example.com/orsitam/tiset.jpg?ati=rauto#doloreeu||lors||eumfu||docons||tur||3197||https://api.example.org/uasi/maveniam.html?rspicia=pitl#imi||Mozilla/5.0 (Linux; Android 5.1.1; Android Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36 YaApp_Android/9.80 YaSearchBrowser/9.80||taevit",
             "event": {
@@ -1022,7 +1022,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-6820-SEARCH: 10.144.111.42||sumquia||vento||[28/May/2019:4:48:31 CEST]||asnu||https://example.org/rep/mveni.txt?utpers=num#ctetura||quaerat||tDuisau||aturve||ptateve||7615||https://internal.example.com/tconsect/pariat.gif?etcon=ctobeat#isi||Mozilla/5.0 (Linux; Android 8.1.0; SM-A260G Build/OPR6; rv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Rocket/2.1.17(19420) Chrome/81.0.4044.138 Mobile Safari/537.36||lorumw",
             "event": {
@@ -1034,7 +1034,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-3071-FGET: 10.122.0.80||olupt||ola||[11/Jun/2019:11:51:06 CT]||etquasia||https://example.net/adm/snostr.jpg?tec=itaspe#con||illumdo||antium||remaper||eseosq||2945||https://www.example.com/uae/ata.htm?snulap=cidu#hilmol||Mozilla/5.0 (Linux; U; Android 7.1.2; uz-uz; Redmi 4X Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.141 Mobile Safari/537.36 XiaoMi/MiuiBrowser/12.2.3-g||quamq",
             "event": {
@@ -1046,7 +1046,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "June 25 18:53:40 tdolo2150.www.example %APACHETOMCAT- ABCD: 10.165.33.19||uamqu||iusmodi||[25/Jun/2019:6:53:40 ET]||aparia||https://mail.example.com/ccusant/epteurs.htm?oidentsu=oditau#onsec||dit||namaliqu||yCic||tetura||1569||https://www.example.net/ttenb/eirure.txt?rem=exer#eeufug||Mozilla/5.0 (Linux; Android 9; LG-US998) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||lapari",
             "event": {
@@ -1058,7 +1058,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "July 10 01:56:14 cinge6032.api.local %APACHETOMCAT- BADMTHD: 10.87.92.17||utlabore||tamr||[10/Jul/2019:1:56:14 CT]||iutaliq||https://mail.example.org/onemul/trudexe.txt?ura=oreeufug#Quisa||quiav||ctionofd||elit||sam||6211||https://internal.example.org/unt/isni.htm?ecillum=olor#amei||Mozilla/5.0 (Linux; Android 7.0; SM-S337TL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||quid",
             "event": {
@@ -1070,7 +1070,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-7615-BADMETHOD: 10.51.52.203||wri||itame||[24/Jul/2019:8:58:48 ET]||dictasun||https://example.com/lorese/olupta.jpg?onsec=idestl#litani||emp||arch||non||mollit||5823||https://internal.example.org/tobeatae/ntut.gif?exe=naa#equat||Mozilla/5.0 (Linux; Android 8.0.0; VS996) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||mqu",
             "event": {
@@ -1082,7 +1082,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "August 7 16:01:23 ende6053.local %APACHETOMCAT- rndmmtd: 10.0.211.86||rsp||imipsa||[07/Aug/2019:4:01:23 CEST]||int||https://internal.example.net/llitani/uscipit.html?etcons=etco#iuntN||utfugi||ursintoc||tio||mmodicon||6776||https://internal.example.net/tvol/lup.gif?ollita=qua#ionula||Mozilla/5.0 (Linux; Android 8.1.0; SM-A260G Build/OPR6; rv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Rocket/2.1.17(19420) Chrome/81.0.4044.138 Mobile Safari/537.36||cusa",
             "event": {
@@ -1094,7 +1094,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-264-OPTIONS: 10.106.34.244||eumiu||nim||[21/Aug/2019:11:03:57 PST]||rehen||https://mail.example.net/ptat/mipsu.htm?eturadip=amquaera#rsitamet||leumiur||ssequamn||ave||taliqui||3714||https://example.net/undeomn/ape.jpg?amco=ons#onsecte||Mozilla/5.0 (Linux; Android 7.0; SM-S337TL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||atquo",
             "event": {
@@ -1106,7 +1106,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-2943-nGET: 10.191.210.188||inculpa||ruredol||[05/Sep/2019:6:06:31 OMST]||ipit||https://www.example.org/quae/periam.html?emoenimi=iquipex#mqu||onorume||abill||ametcon||ofdeFini||7052||https://example.net/tionev/uasiarch.html?qui=ehender#equa||Mozilla/5.0 (Linux; Android 4.1.2; Micromax P410i Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36||nimides",
             "event": {
@@ -1118,7 +1118,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-6165-BDMTHD: 10.2.38.49||asiarc||lor||[19/Sep/2019:1:09:05 GMT+02:00]||snula||https://www.example.com/bori/dipi.gif?utf=dolor#dexe||nemul||Duis||lupt||quatur||5775||https://www.example.org/ipsa/con.gif?uianonnu=tatiset#quira||mobmail android 2.1.3.3150||aea",
             "event": {
@@ -1130,7 +1130,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "October 3 20:11:40 didun1193.example %APACHETOMCAT- id: 10.66.92.90||orumwri||atisu||[03/Oct/2019:8:11:40 PST]||tse||https://example.com/iat/tqui.gif?utaliqui=emse#emqui||cipitla||tlab||vel||ionevo||4580||https://mail.example.com/volupta/umfu.gif?tisetq=tDuisaut#dolo||Mozilla/5.0 (Linux; Android 8.1.0; SM-A260G Build/OPR6; rv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Rocket/2.1.17(19420) Chrome/81.0.4044.138 Mobile Safari/537.36||samvol",
             "event": {
@@ -1142,7 +1142,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "October 18 03:14:14 apari2660.www5.lan %APACHETOMCAT- BADMTHD: 10.97.108.108||fficiad||teirured||[18/Oct/2019:3:14:14 PST]||sistena||https://example.com/caboN/imipsam.jpg?catcupid=ritquiin#quisnost||sequines||olor||sequa||lorum||7649||https://mail.example.com/Sedut/tatis.gif?reeufugi=sequines#minimve||Mozilla/5.0 (Linux; U; Android 7.1.2; uz-uz; Redmi 4X Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.141 Mobile Safari/537.36 XiaoMi/MiuiBrowser/12.2.3-g||toditau",
             "event": {
@@ -1154,7 +1154,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 1 10:16:48 nvolupta238.www.host %APACHETOMCAT- COOK: 10.147.147.248||onpr||uira||[01/Nov/2019:10:16:48 CET]||ptatev||https://api.example.net/uiaco/aliqu.txt?udexerci=uae#imveni||econ||aborio||rve||catcup||177||https://www5.example.org/busBon/norumetM.jpg?vitaedi=rna#cons||Mozilla/5.0 (Linux; Android 9; Notepad_K10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Safari/537.36||lupta",
             "event": {
@@ -1166,7 +1166,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 15 17:19:22 icer123.mail.example %APACHETOMCAT- NCIRCLE: 10.152.190.61||imvenia||culp||[15/Nov/2019:5:19:22 GMT-07:00]||nesciu||https://www.example.org/roinBCSe/eetdolor.html?tla=iaconseq#sed||sedd||atione||tvolup||oremeu||6708||https://api.example.com/dan/pta.html?oNem=itaedict#eroi||Mozilla/5.0 (Linux; Android 8.0.0; VS996) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36||uptateve",
             "event": {
@@ -1178,7 +1178,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "November 30 00:21:57 lumqui6488.api.example %APACHETOMCAT- DETECT_METHOD_TYPE: 10.129.232.105||des||deFini||[30/Nov/2019:12:21:57 GMT-07:00]||aliquaU||https://www.example.net/tvolu/imve.txt?gnaaliq=quam#deriti||edictasu||eturadi||umS||noru||5321||https://api.example.org/taevitae/tevel.htm?vol=ita#iquipexe||Mozilla/5.0 (Linux; Android 8.1.0; SM-A260G Build/OPR6; rv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Rocket/2.1.17(19420) Chrome/81.0.4044.138 Mobile Safari/537.36||quamqua",
             "event": {
@@ -1190,7 +1190,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "%APACHETOMCAT-5473-TRACE: 10.12.173.112||Excepteu||mco||[14/Dec/2019:7:24:31 PT]||undeom||https://internal.example.org/teturadi/radipi.gif?upidatat=mod#niamqui||litsedd||nidol||inBC||hite||423||https://api.example.net/dminimve/remips.txt?uiac=tquii#tesse||Mozilla/5.0 (Linux; Android 9; 5024D_RU Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36 YaApp_Android/10.61 YaSearchBrowser/10.61||emeumfu",
             "event": {

--- a/packages/tomcat/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/tomcat/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -8,7 +8,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   # User agent
   - user_agent:
       field: user_agent.original

--- a/packages/tomcat/manifest.yml
+++ b/packages/tomcat/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: tomcat
 title: Apache Tomcat
-version: 0.4.1
+version: 0.4.2
 description: This Elastic integration collects logs from Apache Tomcat
 categories: ["web", "security"]
 release: experimental


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967