### PR TITLE
traefik update to ECS 1.11.0

### DIFF
--- a/packages/traefik/changelog.yml
+++ b/packages/traefik/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.4.2'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1423
 - version: "0.4.1"
   changes:
     - description: Escape special characters in docs

--- a/packages/traefik/data_stream/access/_dev/test/pipeline/test-format-common.log-expected.json
+++ b/packages/traefik/data_stream/access/_dev/test/pipeline/test-format-common.log-expected.json
@@ -24,7 +24,7 @@
             },
             "@timestamp": "2017-10-02T20:22:07.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -115,7 +115,7 @@
             },
             "@timestamp": "2017-10-02T20:22:08.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -206,7 +206,7 @@
             },
             "@timestamp": "2018-02-28T17:30:33.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -280,7 +280,7 @@
             },
             "@timestamp": "2018-11-29T15:03:51.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -368,7 +368,7 @@
             },
             "@timestamp": "2018-01-19T10:01:02.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -457,7 +457,7 @@
             },
             "@timestamp": "2018-01-19T10:01:02.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -525,7 +525,7 @@
             },
             "@timestamp": "2000-10-10T20:55:36.000Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/traefik/data_stream/access/_dev/test/pipeline/test-format-json.log-expected.json
+++ b/packages/traefik/data_stream/access/_dev/test/pipeline/test-format-json.log-expected.json
@@ -25,7 +25,7 @@
             },
             "@timestamp": "2021-03-16T18:56:54Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [
@@ -101,7 +101,7 @@
             },
             "@timestamp": "2021-03-16T19:08:41Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "ip": [

--- a/packages/traefik/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/traefik/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -6,7 +6,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   - rename:
       field: '@timestamp'
       target_field: event.created

--- a/packages/traefik/manifest.yml
+++ b/packages/traefik/manifest.yml
@@ -1,6 +1,6 @@
 name: traefik
 title: Traefik
-version: 0.4.1
+version: 0.4.2
 release: experimental
 description: This Elastic integration collects logs and metrics from Traefik
 type: integration


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967