### PR TITLE
[Synthetics] adjust category to categorize under elastic_stack

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.1"
+  changes:
+    - description: Adjust category to elastic_stack
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1424
 - version: "0.2.0"
   changes:
     - description: Update integration description

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,8 +2,8 @@ format_version: 1.0.0
 name: synthetics
 title: Elastic Synthetics
 description: This Elastic integration allows you to monitor the availability of your services
-version: 0.2.0
-categories: ["custom"]
+version: 0.2.1
+categories: ["elastic_stack"]
 release: beta
 type: integration
 license: basic


### PR DESCRIPTION
Fixes elastic/kibana#104662

- Enhancement

## What does this PR do?

Adds the synthetics package to Elastic Stack filter option.

<img width="1326" alt="Screen Shot 2021-07-30 at 2 41 41 PM" src="https://user-images.githubusercontent.com/11356435/127697819-ab3c81bc-5950-419f-8fd7-e72ac4dbd30a.png">