### PR TITLE
windows update to ECS 1.11.0

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '1.1.2'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1425
 - version: "1.1.1"
   changes:
     - description: Escape special characters in docs

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-powershell-events.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-powershell-events.json-expected.json
@@ -22,7 +22,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -102,7 +102,7 @@
             ],
             "@timestamp": "2020-05-15T08:11:47.897Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -184,7 +184,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -236,7 +236,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-powershell-operational-events.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-powershell-operational-events.json-expected.json
@@ -22,7 +22,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -102,7 +102,7 @@
             ],
             "@timestamp": "2020-05-15T08:11:47.897Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -184,7 +184,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -236,7 +236,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-1100.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-1100.json-expected.json
@@ -31,7 +31,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information",

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-1102.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-1102.json-expected.json
@@ -41,7 +41,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-1104.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-1104.json-expected.json
@@ -31,7 +31,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "error",

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-1105.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-1105.json-expected.json
@@ -36,7 +36,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information",

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4670-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4670-windowssrv2016.json-expected.json
@@ -62,7 +62,7 @@
             },
             "@timestamp": "2020-07-28T13:22:18.799Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4706-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4706-windowssrv2016.json-expected.json
@@ -50,7 +50,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4707-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4707-windowssrv2016.json-expected.json
@@ -42,7 +42,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4713-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4713-windowssrv2016.json-expected.json
@@ -42,7 +42,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4716-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4716-windowssrv2016.json-expected.json
@@ -50,7 +50,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4717-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4717-windowssrv2016.json-expected.json
@@ -43,7 +43,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4718-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4718-windowssrv2016.json-expected.json
@@ -43,7 +43,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4719-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4719-windowssrv2016.json-expected.json
@@ -50,7 +50,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4719.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4719.json-expected.json
@@ -51,7 +51,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4739-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4739-windowssrv2016.json-expected.json
@@ -49,7 +49,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4743.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4743.json-expected.json
@@ -51,7 +51,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4744.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4744.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-12-18T16:26:46.874Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4745.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4745.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-12-18T16:29:05.017Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4746.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4746.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-12-18T16:31:01.611Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4747.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4747.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-12-18T16:35:16.681Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4748.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4748.json-expected.json
@@ -50,7 +50,7 @@
             },
             "@timestamp": "2019-12-19T08:01:45.982Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4749.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4749.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-12-19T08:03:42.723Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4750.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4750.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-12-19T08:10:57.473Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4751.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4751.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-12-19T08:20:29.088Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4752.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4752.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-12-19T08:21:23.644Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4753.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4753.json-expected.json
@@ -50,7 +50,7 @@
             },
             "@timestamp": "2019-12-19T08:24:36.595Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4759.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4759.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-12-19T08:26:26.143Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4760.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4760.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-12-19T08:28:21.030Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4761.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4761.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-12-19T08:29:38.448Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4762.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4762.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-12-19T08:33:25.967Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4763.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4763.json-expected.json
@@ -50,7 +50,7 @@
             },
             "@timestamp": "2019-12-19T08:34:23.162Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4817-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4817-windowssrv2016.json-expected.json
@@ -47,7 +47,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4902-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4902-windowssrv2016.json-expected.json
@@ -35,7 +35,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information",

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4904-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4904-windowssrv2016.json-expected.json
@@ -54,7 +54,7 @@
             },
             "@timestamp": "2020-08-19T07:56:52.019Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4905-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4905-windowssrv2016.json-expected.json
@@ -54,7 +54,7 @@
             },
             "@timestamp": "2020-08-19T07:56:51.579Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4906-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4906-windowssrv2016.json-expected.json
@@ -34,7 +34,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information",

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4907-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4907-windowssrv2016.json-expected.json
@@ -57,7 +57,7 @@
             },
             "@timestamp": "2020-08-19T07:56:17.112Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4673.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4673.json-expected.json
@@ -56,7 +56,7 @@
             },
             "@timestamp": "2020-04-06T06:39:04.549Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4697.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4697.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2020-04-02T14:34:08.889Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4768.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4768.json-expected.json
@@ -60,7 +60,7 @@
             },
             "@timestamp": "2020-04-01T08:45:44.171Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4769.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4769.json-expected.json
@@ -59,7 +59,7 @@
             },
             "@timestamp": "2020-04-01T08:45:44.171Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4770.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4770.json-expected.json
@@ -54,7 +54,7 @@
             },
             "@timestamp": "2020-04-01T07:32:55.010Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4771.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4771.json-expected.json
@@ -56,7 +56,7 @@
             },
             "@timestamp": "2020-03-31T07:50:27.168Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4776.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4776.json-expected.json
@@ -42,7 +42,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4778.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4778.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2020-04-05T16:33:32.388Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4779.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4779.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2020-04-03T10:18:01.882Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012r2-logon.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012r2-logon.json-expected.json
@@ -67,7 +67,7 @@
             },
             "@timestamp": "2019-03-29T21:10:39.786Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -165,7 +165,7 @@
             },
             "@timestamp": "2019-03-29T21:10:40.255Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -266,7 +266,7 @@
             },
             "@timestamp": "2019-03-29T21:10:40.380Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -367,7 +367,7 @@
             },
             "@timestamp": "2019-03-29T21:10:40.505Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -465,7 +465,7 @@
             },
             "@timestamp": "2019-03-29T21:10:40.630Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -562,7 +562,7 @@
             },
             "@timestamp": "2019-03-29T21:10:53.661Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -659,7 +659,7 @@
             },
             "@timestamp": "2019-03-29T21:10:54.661Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -756,7 +756,7 @@
             },
             "@timestamp": "2019-03-29T21:10:55.458Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -856,7 +856,7 @@
             },
             "@timestamp": "2019-03-29T21:13:17.302Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -953,7 +953,7 @@
             },
             "@timestamp": "2019-03-29T21:13:17.521Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1054,7 +1054,7 @@
             },
             "@timestamp": "2019-03-29T21:13:17.614Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1155,7 +1155,7 @@
             },
             "@timestamp": "2019-03-29T21:13:18.786Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1253,7 +1253,7 @@
             },
             "@timestamp": "2019-03-29T21:20:48.740Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1351,7 +1351,7 @@
             },
             "@timestamp": "2019-03-29T21:20:48.740Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1449,7 +1449,7 @@
             },
             "@timestamp": "2019-03-29T21:20:50.584Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1547,7 +1547,7 @@
             },
             "@timestamp": "2019-03-29T21:23:42.520Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1645,7 +1645,7 @@
             },
             "@timestamp": "2019-03-29T21:26:24.176Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -1750,7 +1750,7 @@
             },
             "@timestamp": "2019-03-29T21:45:35.177Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4722-account-enabled.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4722-account-enabled.json-expected.json
@@ -44,7 +44,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -126,7 +126,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4723-password-change.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4723-password-change.json-expected.json
@@ -45,7 +45,7 @@
                 "outcome": "failure"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -127,7 +127,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4724-password-reset.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4724-password-reset.json-expected.json
@@ -44,7 +44,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -126,7 +126,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4725-account-disabled.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4725-account-disabled.json-expected.json
@@ -44,7 +44,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -126,7 +126,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4726-account-deleted.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4726-account-deleted.json-expected.json
@@ -45,7 +45,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -128,7 +128,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4727.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4727.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-10-22T11:26:12.495Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4728.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4728.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-10-22T11:33:26.861Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4729.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4729.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-10-22T11:33:45.543Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4730.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4730.json-expected.json
@@ -50,7 +50,7 @@
             },
             "@timestamp": "2019-10-22T11:34:01.610Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4731.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4731.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-10-22T11:29:49.358Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4732.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4732.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-10-22T11:31:58.039Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4733.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4733.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-10-22T11:32:14.894Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4734.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4734.json-expected.json
@@ -50,7 +50,7 @@
             },
             "@timestamp": "2019-10-22T11:32:35.127Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4735.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4735.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-10-22T11:32:30.425Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4737.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4737.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-10-22T11:33:57.271Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4738-account-changed.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4738-account-changed.json-expected.json
@@ -70,7 +70,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4740-account-locked-out.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4740-account-locked-out.json-expected.json
@@ -44,7 +44,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4754.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4754.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-10-22T11:34:33.783Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4755.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4755.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-10-22T11:35:09.070Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4756.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4756.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-10-22T11:34:58.413Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4757.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4757.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-10-22T11:35:09.070Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4758.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4758.json-expected.json
@@ -50,7 +50,7 @@
             },
             "@timestamp": "2019-10-22T11:35:13.550Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4764.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4764.json-expected.json
@@ -51,7 +51,7 @@
             },
             "@timestamp": "2019-10-22T11:33:57.271Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4767-account-unlocked.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4767-account-unlocked.json-expected.json
@@ -44,7 +44,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4781-account-renamed.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4781-account-renamed.json-expected.json
@@ -46,7 +46,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -131,7 +131,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4798.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4798.json-expected.json
@@ -46,7 +46,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4799.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4799.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-10-08T10:20:44.472Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-logoff.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-logoff.json-expected.json
@@ -42,7 +42,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -120,7 +120,7 @@
                 "outcome": "success"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2019-4688-process-created.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2019-4688-process-created.json-expected.json
@@ -70,7 +70,7 @@
             },
             "@timestamp": "2019-11-14T17:10:15.151Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2019-4689-process-exited.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2019-4689-process-exited.json-expected.json
@@ -52,7 +52,7 @@
             },
             "@timestamp": "2019-11-14T21:26:49.496Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -134,7 +134,7 @@
             },
             "@timestamp": "2019-11-14T21:27:46.960Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -216,7 +216,7 @@
             },
             "@timestamp": "2019-11-14T21:28:18.460Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-sysmon-operational-events.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-sysmon-operational-events.json-expected.json
@@ -64,7 +64,7 @@
             },
             "@timestamp": "2019-07-18T03:34:01.239Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -160,7 +160,7 @@
             },
             "@timestamp": "2019-07-18T03:34:01.261Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -241,7 +241,7 @@
                 "directory": "C:\\Users\\vagrant\\AppData\\Local\\Temp\\1\\go-build583768550\\b001"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -337,7 +337,7 @@
             },
             "@timestamp": "2019-07-18T03:34:01.449Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -437,7 +437,7 @@
             },
             "@timestamp": "2019-07-18T03:34:01.457Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -512,7 +512,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -582,7 +582,7 @@
                 "directory": "C:\\Windows\\ServiceProfiles\\LocalService\\AppData\\Local"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -676,7 +676,7 @@
             },
             "@timestamp": "2019-07-18T03:34:01.494Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -778,7 +778,7 @@
             },
             "@timestamp": "2019-07-18T03:34:01.810Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -868,7 +868,7 @@
             },
             "@timestamp": "2019-07-18T03:34:01.894Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -968,7 +968,7 @@
             },
             "@timestamp": "2019-07-18T03:34:01.948Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1056,7 +1056,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.085Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1158,7 +1158,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.174Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1296,7 +1296,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.274Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1388,7 +1388,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.291Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1483,7 +1483,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.413Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1584,7 +1584,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.424Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1672,7 +1672,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.427Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1772,7 +1772,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.469Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1840,7 +1840,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -1928,7 +1928,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.485Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -2024,7 +2024,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.500Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -2099,7 +2099,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -2160,7 +2160,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -2275,7 +2275,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.580Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -2375,7 +2375,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.628Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -2521,7 +2521,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.633Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -2655,7 +2655,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.716Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -2803,7 +2803,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.727Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -2909,7 +2909,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.733Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -3059,7 +3059,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.792Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -3203,7 +3203,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.792Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -3295,7 +3295,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.809Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -3431,7 +3431,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.821Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -3526,7 +3526,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.821Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -3663,7 +3663,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.828Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -3754,7 +3754,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.838Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -3845,7 +3845,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.839Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -3975,7 +3975,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.841Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -4095,7 +4095,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.844Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -4153,7 +4153,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -4236,7 +4236,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.956Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -4362,7 +4362,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.005Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -4503,7 +4503,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.070Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -4645,7 +4645,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.093Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -4735,7 +4735,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.099Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -4876,7 +4876,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.107Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -5011,7 +5011,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.107Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -5070,7 +5070,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -5153,7 +5153,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.112Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -5240,7 +5240,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.113Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -5334,7 +5334,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5447,7 +5447,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.146Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -5580,7 +5580,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.146Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -5678,7 +5678,7 @@
             },
             "@timestamp": "2019-03-18T16:57:37.964Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5818,7 +5818,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.182Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -5918,7 +5918,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.183Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6062,7 +6062,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.222Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6161,7 +6161,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.271Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6282,7 +6282,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.271Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6378,7 +6378,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.290Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6470,7 +6470,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.292Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6548,7 +6548,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.315Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6622,7 +6622,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.315Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6677,7 +6677,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -6805,7 +6805,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.333Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6905,7 +6905,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.343Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6997,7 +6997,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.391Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -7056,7 +7056,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -7184,7 +7184,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.393Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -7282,7 +7282,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -7361,7 +7361,7 @@
             },
             "@timestamp": "2019-03-18T16:57:47.847Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -7441,7 +7441,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.070Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -7521,7 +7521,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.148Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -7601,7 +7601,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.214Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -7703,7 +7703,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.468Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -7840,7 +7840,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.581Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -7917,7 +7917,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.250Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -8010,7 +8010,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.872Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -8094,7 +8094,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.250Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -8202,7 +8202,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.889Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -8280,7 +8280,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.250Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -8359,7 +8359,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.250Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -8437,7 +8437,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.250Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -8515,7 +8515,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.251Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -8594,7 +8594,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.251Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -8673,7 +8673,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.251Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -8752,7 +8752,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.264Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -8834,7 +8834,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.276Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -8916,7 +8916,7 @@
             },
             "@timestamp": "2019-03-18T16:57:49.213Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -9024,7 +9024,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.890Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -9116,7 +9116,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.892Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -9251,7 +9251,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.894Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -9392,7 +9392,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.894Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -9533,7 +9533,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.902Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -9668,7 +9668,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.911Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -9768,7 +9768,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.911Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -9875,7 +9875,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.921Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -9966,7 +9966,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.101Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -10102,7 +10102,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.137Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -10248,7 +10248,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.141Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -10383,7 +10383,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.168Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -10461,7 +10461,7 @@
             },
             "@timestamp": "2019-03-18T16:57:49.218Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -10522,7 +10522,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -10573,7 +10573,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -10634,7 +10634,7 @@
                 "directory": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -10695,7 +10695,7 @@
                 "directory": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -10756,7 +10756,7 @@
                 "directory": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data\\Default"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -10817,7 +10817,7 @@
                 "directory": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data\\Default"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -10875,7 +10875,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -10936,7 +10936,7 @@
                 "directory": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data\\Default\\Storage\\ext\\nmmhkkegccagdldgiimedpiccmgmieda\\def"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -11023,7 +11023,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.169Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -11165,7 +11165,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.169Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -11260,7 +11260,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.184Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -11402,7 +11402,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.184Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -11538,7 +11538,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.185Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -11652,7 +11652,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.189Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -11796,7 +11796,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.237Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -11911,7 +11911,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.274Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -11998,7 +11998,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.302Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -12133,7 +12133,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.304Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -12239,7 +12239,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.322Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -12325,7 +12325,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.379Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -12460,7 +12460,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.482Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -12597,7 +12597,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.502Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -12712,7 +12712,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.507Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -12848,7 +12848,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.508Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -12973,7 +12973,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.531Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -13099,7 +13099,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.532Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -13246,7 +13246,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.534Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -13383,7 +13383,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.601Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -13512,7 +13512,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.604Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -13649,7 +13649,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.621Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -13785,7 +13785,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.822Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -13880,7 +13880,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.822Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -14022,7 +14022,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.860Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -14119,7 +14119,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.904Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -14226,7 +14226,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.911Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -14322,7 +14322,7 @@
             },
             "@timestamp": "2019-07-18T03:34:06.056Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -14418,7 +14418,7 @@
             },
             "@timestamp": "2019-07-18T03:34:06.064Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -14513,7 +14513,7 @@
             },
             "@timestamp": "2019-07-18T03:34:06.178Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -14610,7 +14610,7 @@
             },
             "@timestamp": "2019-07-18T03:34:06.455Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -14701,7 +14701,7 @@
             },
             "@timestamp": "2019-07-18T03:34:06.494Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -14801,7 +14801,7 @@
             },
             "@timestamp": "2019-07-18T03:34:06.567Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -14897,7 +14897,7 @@
             },
             "@timestamp": "2019-07-18T03:34:07.228Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -15004,7 +15004,7 @@
             },
             "@timestamp": "2019-07-18T03:34:07.357Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -15101,7 +15101,7 @@
             },
             "@timestamp": "2019-07-18T03:34:07.721Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -15197,7 +15197,7 @@
             },
             "@timestamp": "2019-07-18T03:34:07.774Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -15293,7 +15293,7 @@
             },
             "@timestamp": "2019-07-18T03:34:07.847Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -15436,7 +15436,7 @@
             },
             "@timestamp": "2019-07-18T03:34:07.943Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -15541,7 +15541,7 @@
             },
             "@timestamp": "2019-07-18T03:34:07.945Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -15645,7 +15645,7 @@
             },
             "@timestamp": "2019-07-18T03:34:07.954Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -15781,7 +15781,7 @@
             },
             "@timestamp": "2019-07-18T03:34:07.955Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -15867,7 +15867,7 @@
             },
             "@timestamp": "2019-07-18T03:34:07.955Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -15961,7 +15961,7 @@
             },
             "@timestamp": "2019-07-18T03:34:07.956Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -16103,7 +16103,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.019Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -16194,7 +16194,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.050Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -16289,7 +16289,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.070Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -16429,7 +16429,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.090Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -16576,7 +16576,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.308Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -16672,7 +16672,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.478Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -16814,7 +16814,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.536Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -16956,7 +16956,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.544Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -17092,7 +17092,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.550Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -17223,7 +17223,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.552Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -17364,7 +17364,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.552Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -17709,7 +17709,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.594Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -17865,7 +17865,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.619Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -17963,7 +17963,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.620Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -18062,7 +18062,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.811Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -18142,7 +18142,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.912Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -18233,7 +18233,7 @@
             },
             "@timestamp": "2019-07-18T03:34:09.016Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -18376,7 +18376,7 @@
             },
             "@timestamp": "2019-07-18T03:34:09.048Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -18517,7 +18517,7 @@
             },
             "@timestamp": "2019-07-18T03:34:09.051Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -18611,7 +18611,7 @@
             },
             "@timestamp": "2019-07-18T03:34:09.054Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -18748,7 +18748,7 @@
             },
             "@timestamp": "2019-07-18T03:34:09.126Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -18891,7 +18891,7 @@
             },
             "@timestamp": "2019-07-18T03:34:09.184Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -19026,7 +19026,7 @@
             },
             "@timestamp": "2019-07-18T03:34:09.322Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -19151,7 +19151,7 @@
             },
             "@timestamp": "2019-07-18T03:34:09.730Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -19255,7 +19255,7 @@
             },
             "@timestamp": "2019-07-18T03:34:10.627Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -19358,7 +19358,7 @@
             },
             "@timestamp": "2019-07-18T03:34:10.650Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -19495,7 +19495,7 @@
             },
             "@timestamp": "2019-07-18T03:34:16.329Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -19602,7 +19602,7 @@
             },
             "@timestamp": "2019-07-18T03:34:16.386Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -19748,7 +19748,7 @@
             },
             "@timestamp": "2019-07-18T03:34:16.482Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -19838,7 +19838,7 @@
             },
             "@timestamp": "2019-07-18T03:34:19.578Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -19933,7 +19933,7 @@
             },
             "@timestamp": "2019-07-18T03:34:31.219Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -20025,7 +20025,7 @@
             },
             "@timestamp": "2019-07-18T03:39:02.752Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -20103,7 +20103,7 @@
             },
             "@timestamp": "2019-07-18T03:39:20.413Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -20174,7 +20174,7 @@
             },
             "@timestamp": "2019-07-18T03:39:40.504Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -20245,7 +20245,7 @@
             },
             "@timestamp": "2019-07-18T03:40:40.433Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -20340,7 +20340,7 @@
             },
             "@timestamp": "2019-07-18T03:42:54.033Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -20433,7 +20433,7 @@
             },
             "@timestamp": "2019-07-18T03:43:04.400Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -20529,7 +20529,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -20590,7 +20590,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -20662,7 +20662,7 @@
                 "directory": "C:\\Windows\\System32\\LogFiles\\Scm"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -20753,7 +20753,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hash": [
@@ -20821,7 +20821,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -20888,7 +20888,7 @@
             },
             "@timestamp": "2021-02-25T15:04:48.592Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hash": [
@@ -20951,7 +20951,7 @@
                 "directory": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data\\Default\\Storage\\ext\\gfdkimpbcpahaombhbimeihdjnejgicl\\def"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -21068,7 +21068,7 @@
             },
             "@timestamp": "2019-07-18T03:49:51.154Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/powershell.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/powershell.yml
@@ -24,7 +24,7 @@ processors:
 
   - set:
       field: ecs.version
-      value: 1.10.0
+      value: '1.11.0'
   - set:
       field: log.level
       copy_from: winlog.level

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/powershell_operational.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/powershell_operational.yml
@@ -26,7 +26,7 @@ processors:
 
   - set:
       field: ecs.version
-      value: 1.10.0
+      value: '1.11.0'
   - set:
       field: log.level
       copy_from: winlog.level

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security.yml
@@ -3153,7 +3153,7 @@ processors:
 
   - set:
       field: ecs.version
-      value: 1.10.0
+      value: '1.11.0'
 
   - set:
       field: log.level

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/sysmon_operational.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/sysmon_operational.yml
@@ -5,7 +5,7 @@ processors:
 
   - set:
       field: ecs.version
-      value: 1.10.0
+      value: '1.11.0'
   - rename:
       field: winlog.level
       target_field: log.level

--- a/packages/windows/data_stream/powershell/_dev/test/pipeline/test-events.json-expected.json
+++ b/packages/windows/data_stream/powershell/_dev/test/pipeline/test-events.json-expected.json
@@ -23,7 +23,7 @@
                 "provider_name": "PowerShell"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -82,7 +82,7 @@
                 "provider_name": "PowerShell"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -165,7 +165,7 @@
                 "directory": "C:\\Windows\\system32\\WindowsPowerShell\\v1.0\\Modules\\Microsoft.PowerShell.Archive"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -240,7 +240,7 @@
                 "provider_name": "PowerShell"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"

--- a/packages/windows/data_stream/powershell/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/powershell/elasticsearch/ingest_pipeline/default.yml
@@ -24,7 +24,7 @@ processors:
 
   - set:
       field: ecs.version
-      value: 1.10.0
+      value: '1.11.0'
   - set:
       field: log.level
       copy_from: winlog.level

--- a/packages/windows/data_stream/powershell_operational/_dev/test/pipeline/test-events.json-expected.json
+++ b/packages/windows/data_stream/powershell_operational/_dev/test/pipeline/test-events.json-expected.json
@@ -22,7 +22,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -102,7 +102,7 @@
             ],
             "@timestamp": "2020-05-15T08:11:47.897Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -184,7 +184,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"
@@ -236,7 +236,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "verbose"

--- a/packages/windows/data_stream/powershell_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/powershell_operational/elasticsearch/ingest_pipeline/default.yml
@@ -26,7 +26,7 @@ processors:
 
   - set:
       field: ecs.version
-      value: 1.10.0
+      value: '1.11.0'
   - set:
       field: log.level
       copy_from: winlog.level

--- a/packages/windows/data_stream/sysmon_operational/_dev/test/pipeline/test-events.json-expected.json
+++ b/packages/windows/data_stream/sysmon_operational/_dev/test/pipeline/test-events.json-expected.json
@@ -64,7 +64,7 @@
             },
             "@timestamp": "2019-07-18T03:34:01.239Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -160,7 +160,7 @@
             },
             "@timestamp": "2019-07-18T03:34:01.261Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -241,7 +241,7 @@
                 "directory": "C:\\Users\\vagrant\\AppData\\Local\\Temp\\1\\go-build583768550\\b001"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -337,7 +337,7 @@
             },
             "@timestamp": "2019-07-18T03:34:01.449Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -438,7 +438,7 @@
             },
             "@timestamp": "2019-07-18T03:34:01.457Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -514,7 +514,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -584,7 +584,7 @@
                 "directory": "C:\\Windows\\ServiceProfiles\\LocalService\\AppData\\Local"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -678,7 +678,7 @@
             },
             "@timestamp": "2019-07-18T03:34:01.494Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -780,7 +780,7 @@
             },
             "@timestamp": "2019-07-18T03:34:01.810Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -873,7 +873,7 @@
             },
             "@timestamp": "2019-07-18T03:34:01.894Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -973,7 +973,7 @@
             },
             "@timestamp": "2019-07-18T03:34:01.948Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1062,7 +1062,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.085Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1164,7 +1164,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.174Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1302,7 +1302,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.274Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1402,7 +1402,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.291Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1497,7 +1497,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.413Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1598,7 +1598,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.424Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1687,7 +1687,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.427Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1787,7 +1787,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.469Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -1857,7 +1857,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -1945,7 +1945,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.485Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -2041,7 +2041,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.500Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -2116,7 +2116,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -2177,7 +2177,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -2292,7 +2292,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.580Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -2399,7 +2399,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.628Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -2548,7 +2548,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.633Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -2694,7 +2694,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.716Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -2850,7 +2850,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.727Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -2965,7 +2965,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.733Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -3117,7 +3117,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.792Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -3272,7 +3272,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.792Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -3374,7 +3374,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.809Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -3510,7 +3510,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.821Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -3614,7 +3614,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.821Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -3751,7 +3751,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.828Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -3851,7 +3851,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.838Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -3942,7 +3942,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.839Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -4072,7 +4072,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.841Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -4199,7 +4199,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.844Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -4261,7 +4261,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -4344,7 +4344,7 @@
             },
             "@timestamp": "2019-07-18T03:34:02.956Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -4470,7 +4470,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.005Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -4618,7 +4618,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.070Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -4770,7 +4770,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.093Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -4871,7 +4871,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.099Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -5012,7 +5012,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.107Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -5157,7 +5157,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.107Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -5224,7 +5224,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -5307,7 +5307,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.112Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -5394,7 +5394,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.113Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -5488,7 +5488,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5601,7 +5601,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.146Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -5735,7 +5735,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.146Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -5841,7 +5841,7 @@
             },
             "@timestamp": "2019-03-18T16:57:37.964Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -5981,7 +5981,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.182Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6089,7 +6089,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.183Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6233,7 +6233,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.222Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6343,7 +6343,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.271Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6465,7 +6465,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.271Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6566,7 +6566,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.290Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6658,7 +6658,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.292Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6736,7 +6736,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.315Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6810,7 +6810,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.315Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -6865,7 +6865,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -6993,7 +6993,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.333Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -7102,7 +7102,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.343Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -7195,7 +7195,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.391Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -7254,7 +7254,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -7382,7 +7382,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.393Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -7489,7 +7489,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -7568,7 +7568,7 @@
             },
             "@timestamp": "2019-03-18T16:57:47.847Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -7648,7 +7648,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.070Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -7728,7 +7728,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.148Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -7808,7 +7808,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.214Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -7910,7 +7910,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.468Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -8048,7 +8048,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.581Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -8134,7 +8134,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.250Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -8227,7 +8227,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.872Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -8311,7 +8311,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.250Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -8419,7 +8419,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.889Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -8500,7 +8500,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.250Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -8579,7 +8579,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.250Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -8657,7 +8657,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.250Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -8735,7 +8735,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.251Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -8814,7 +8814,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.251Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -8893,7 +8893,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.251Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -8972,7 +8972,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.264Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -9054,7 +9054,7 @@
             },
             "@timestamp": "2019-03-18T16:57:48.276Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -9136,7 +9136,7 @@
             },
             "@timestamp": "2019-03-18T16:57:49.213Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -9244,7 +9244,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.890Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -9339,7 +9339,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.892Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -9475,7 +9475,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.894Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -9625,7 +9625,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.894Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -9777,7 +9777,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.902Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -9923,7 +9923,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.911Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -10032,7 +10032,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.911Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -10140,7 +10140,7 @@
             },
             "@timestamp": "2019-07-18T03:34:03.921Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -10234,7 +10234,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.101Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -10370,7 +10370,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.137Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -10525,7 +10525,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.141Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -10671,7 +10671,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.168Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -10757,7 +10757,7 @@
             },
             "@timestamp": "2019-03-18T16:57:49.218Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -10818,7 +10818,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -10869,7 +10869,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -10930,7 +10930,7 @@
                 "directory": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -10991,7 +10991,7 @@
                 "directory": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -11052,7 +11052,7 @@
                 "directory": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data\\Default"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -11113,7 +11113,7 @@
                 "directory": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data\\Default"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -11171,7 +11171,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -11232,7 +11232,7 @@
                 "directory": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data\\Default\\Storage\\ext\\nmmhkkegccagdldgiimedpiccmgmieda\\def"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -11319,7 +11319,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.169Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -11461,7 +11461,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.169Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -11566,7 +11566,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.184Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -11708,7 +11708,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.184Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -11854,7 +11854,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.185Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -11977,7 +11977,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.189Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -12124,7 +12124,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.237Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -12250,7 +12250,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.274Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -12342,7 +12342,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.302Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -12477,7 +12477,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.304Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -12592,7 +12592,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.322Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -12681,7 +12681,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.379Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -12816,7 +12816,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.482Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -12962,7 +12962,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.502Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -13087,7 +13087,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.507Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -13228,7 +13228,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.508Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -13362,7 +13362,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.531Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -13494,7 +13494,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.532Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -13647,7 +13647,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.534Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -13795,7 +13795,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.601Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -13934,7 +13934,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.604Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -14078,7 +14078,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.621Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -14223,7 +14223,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.822Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -14327,7 +14327,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.822Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -14469,7 +14469,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.860Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -14573,7 +14573,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.904Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -14680,7 +14680,7 @@
             },
             "@timestamp": "2019-07-18T03:34:04.911Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -14779,7 +14779,7 @@
             },
             "@timestamp": "2019-07-18T03:34:06.056Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -14876,7 +14876,7 @@
             },
             "@timestamp": "2019-07-18T03:34:06.064Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -14972,7 +14972,7 @@
             },
             "@timestamp": "2019-07-18T03:34:06.178Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -15069,7 +15069,7 @@
             },
             "@timestamp": "2019-07-18T03:34:06.455Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -15161,7 +15161,7 @@
             },
             "@timestamp": "2019-07-18T03:34:06.494Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -15261,7 +15261,7 @@
             },
             "@timestamp": "2019-07-18T03:34:06.567Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -15358,7 +15358,7 @@
             },
             "@timestamp": "2019-07-18T03:34:07.228Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -15465,7 +15465,7 @@
             },
             "@timestamp": "2019-07-18T03:34:07.357Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -15562,7 +15562,7 @@
             },
             "@timestamp": "2019-07-18T03:34:07.721Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -15658,7 +15658,7 @@
             },
             "@timestamp": "2019-07-18T03:34:07.774Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -15754,7 +15754,7 @@
             },
             "@timestamp": "2019-07-18T03:34:07.847Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -15897,7 +15897,7 @@
             },
             "@timestamp": "2019-07-18T03:34:07.943Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -16013,7 +16013,7 @@
             },
             "@timestamp": "2019-07-18T03:34:07.945Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -16120,7 +16120,7 @@
             },
             "@timestamp": "2019-07-18T03:34:07.954Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -16258,7 +16258,7 @@
             },
             "@timestamp": "2019-07-18T03:34:07.955Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -16354,7 +16354,7 @@
             },
             "@timestamp": "2019-07-18T03:34:07.955Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -16448,7 +16448,7 @@
             },
             "@timestamp": "2019-07-18T03:34:07.956Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -16590,7 +16590,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.019Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -16691,7 +16691,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.050Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -16786,7 +16786,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.070Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -16926,7 +16926,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.090Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -17081,7 +17081,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.308Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -17187,7 +17187,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.478Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -17329,7 +17329,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.536Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -17481,7 +17481,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.544Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -17628,7 +17628,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.550Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -17769,7 +17769,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.552Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -17919,7 +17919,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.552Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -18275,7 +18275,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.594Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -18482,7 +18482,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.619Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -18593,7 +18593,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.620Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -18692,7 +18692,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.811Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -18772,7 +18772,7 @@
             },
             "@timestamp": "2019-07-18T03:34:08.912Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -18863,7 +18863,7 @@
             },
             "@timestamp": "2019-07-18T03:34:09.016Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -19006,7 +19006,7 @@
             },
             "@timestamp": "2019-07-18T03:34:09.048Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -19158,7 +19158,7 @@
             },
             "@timestamp": "2019-07-18T03:34:09.051Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -19263,7 +19263,7 @@
             },
             "@timestamp": "2019-07-18T03:34:09.054Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -19400,7 +19400,7 @@
             },
             "@timestamp": "2019-07-18T03:34:09.126Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -19552,7 +19552,7 @@
             },
             "@timestamp": "2019-07-18T03:34:09.184Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -19696,7 +19696,7 @@
             },
             "@timestamp": "2019-07-18T03:34:09.322Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -19829,7 +19829,7 @@
             },
             "@timestamp": "2019-07-18T03:34:09.730Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -19938,7 +19938,7 @@
             },
             "@timestamp": "2019-07-18T03:34:10.627Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -20041,7 +20041,7 @@
             },
             "@timestamp": "2019-07-18T03:34:10.650Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -20178,7 +20178,7 @@
             },
             "@timestamp": "2019-07-18T03:34:16.329Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -20294,7 +20294,7 @@
             },
             "@timestamp": "2019-07-18T03:34:16.386Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -20440,7 +20440,7 @@
             },
             "@timestamp": "2019-07-18T03:34:16.482Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -20541,7 +20541,7 @@
             },
             "@timestamp": "2019-07-18T03:34:19.578Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -20636,7 +20636,7 @@
             },
             "@timestamp": "2019-07-18T03:34:31.219Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -20728,7 +20728,7 @@
             },
             "@timestamp": "2019-07-18T03:39:02.752Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -20806,7 +20806,7 @@
             },
             "@timestamp": "2019-07-18T03:39:20.413Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -20877,7 +20877,7 @@
             },
             "@timestamp": "2019-07-18T03:39:40.504Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -20948,7 +20948,7 @@
             },
             "@timestamp": "2019-07-18T03:40:40.433Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -21043,7 +21043,7 @@
             },
             "@timestamp": "2019-07-18T03:42:54.033Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -21136,7 +21136,7 @@
             },
             "@timestamp": "2019-07-18T03:43:04.400Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [
@@ -21232,7 +21232,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -21293,7 +21293,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -21365,7 +21365,7 @@
                 "directory": "C:\\Windows\\System32\\LogFiles\\Scm"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -21456,7 +21456,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hash": [
@@ -21524,7 +21524,7 @@
                 }
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -21591,7 +21591,7 @@
             },
             "@timestamp": "2021-02-25T15:04:48.592Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hash": [
@@ -21654,7 +21654,7 @@
                 "directory": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data\\Default\\Storage\\ext\\gfdkimpbcpahaombhbimeihdjnejgicl\\def"
             },
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "log": {
                 "level": "information"
@@ -21771,7 +21771,7 @@
             },
             "@timestamp": "2019-07-18T03:49:51.154Z",
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "related": {
                 "hosts": [

--- a/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
@@ -5,7 +5,7 @@ processors:
 
   - set:
       field: ecs.version
-      value: 1.10.0
+      value: '1.11.0'
   - rename:
       field: winlog.level
       target_field: log.level

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.1.1
+version: 1.1.2
 description: This Elastic integration collects logs and metrics from Windows
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967