### PR TITLE
zerofox update to ECS 1.11.0

### DIFF
--- a/packages/zerofox/changelog.yml
+++ b/packages/zerofox/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.1.1'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXXX
 - version: "0.1.0"
   changes:
     - description: initial release

--- a/packages/zerofox/data_stream/alerts/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zerofox/data_stream/alerts/elasticsearch/ingest_pipeline/default.yml
@@ -7,7 +7,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: 1.11.0
+      value: '1.11.0'
 
   ## Event JSON decoding.
   - rename:

--- a/packages/zerofox/manifest.yml
+++ b/packages/zerofox/manifest.yml
@@ -1,6 +1,6 @@
 name: zerofox
 title: ZeroFox
-version: 0.1.0
+version: 0.1.1
 release: experimental
 description: ZeroFox Cloud Platform
 type: integration


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967