### PR TITLE
zscaler update to ECS 1.11.0

### DIFF
--- a/packages/zscaler/changelog.yml
+++ b/packages/zscaler/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.3.1'
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1428
 - version: "0.3.0"
   changes:
     - description: Update integration description

--- a/packages/zscaler/data_stream/zia/_dev/test/pipeline/test-generated.log-expected.json
+++ b/packages/zscaler/data_stream/zia/_dev/test/pipeline/test-generated.log-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "iusm ZSCALERNSS: time=modtempo Jan 29 6:09:59 2016^^timezone=GMT+02:00^^action=Blocked^^reason=failure^^hostname=rci737.www5.example^^protocol=tcp^^serverip=10.206.191.17^^url=https://api.example.com/ivelitse/ritin.htm?utl=vol#amremap^^urlcategory=oremi^^urlclass=ntsunti^^dlpdictionaries=nseq^^dlpengine=itinvol^^filetype=psa^^threatcategory=umq^^threatclass=ntium^^pagerisk=psaq^^threatname=cer^^clientpublicIP=reveri^^ClientIP=10.176.10.114^^location=lupt^^refererURL=https://internal.example.org/sequa/abo.gif?umqui=reeufugi#mdolo^^useragent=Opera/9.80 (Series 60; Opera Mini/7.1.32444/174.101; U; ru) Presto/2.12.423 Version/12.16^^department=sperna^^user=sumdo^^event_id=litesse^^clienttranstime=orev^^requestmethod=pisciv^^requestsize=1884^^requestversion=deF^^status=sist^^responsesize=1803^^responseversion=doeiu^^transactionsize=3942",
             "event": {
@@ -14,7 +14,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "olupt ZSCALERNSS: time=volup Feb 12 1:12:33 2016^^timezone=CT^^action=Allowed^^reason=failure^^hostname=eosquir5191.www.example^^protocol=rdp^^serverip=10.173.22.152^^url=https://internal.example.net/isiutal/moenimi.jpg?gnaali=enatus#mquia^^urlcategory=ameaqu^^urlclass=aqu^^dlpdictionaries=utper^^dlpengine=squame^^filetype=ntex^^threatcategory=eius^^threatclass=luptat^^pagerisk=emape^^threatname=aer^^clientpublicIP=lupt^^ClientIP=10.26.46.95^^location=uame^^refererURL=https://www.example.net/orisn/cca.htm?ofdeF=metcons#roinBCS^^useragent=Mozilla/5.0 (Linux; Android 4.1.2; Micromax P410i Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36^^department=com^^user=eataevi^^event_id=byC^^clienttranstime=tinculp^^requestmethod=tur^^requestsize=2977^^requestversion=equat^^status=atemsequ^^responsesize=2004^^responseversion=minim^^transactionsize=7868",
             "event": {
@@ -26,7 +26,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "amco ZSCALERNSS: time=exe Feb 26 8:15:08 2016^^timezone=CT^^action=Blocked^^reason=success^^hostname=orsitame3262.domain^^protocol=igmp^^serverip=10.204.86.149^^url=https://example.com/taspe/mvolu.gif?atcup=snos#iquaUte^^urlcategory=tconsec^^urlclass=nsequat^^dlpdictionaries=taev^^dlpengine=roidents^^filetype=oluptas^^threatcategory=llu^^threatclass=uptassi^^pagerisk=tamremap^^threatname=tur^^clientpublicIP=aperi^^ClientIP=10.254.146.57^^location=estqui^^refererURL=https://www5.example.net/emaper/ssitasp.html?enimad=rmagni#sit^^useragent=Mozilla/5.0 (Linux; Android 9; U307AS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=onev^^user=tenima^^event_id=laboreet^^clienttranstime=aquaeabi^^requestmethod=giatq^^requestsize=2935^^requestversion=veleumi^^status=tia^^responsesize=1837^^responseversion=ude^^transactionsize=6905",
             "event": {
@@ -38,7 +38,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "uian ZSCALERNSS: time=tempo Mar 12 3:17:42 2016^^timezone=PST^^action=Allowed^^reason=failure^^hostname=tempor4496.www.localdomain^^protocol=ipv6^^serverip=10.103.246.190^^url=https://api.example.org/doloreeu/pori.jpg?itati=mfu#uid^^urlcategory=atatnonp^^urlclass=uiano^^dlpdictionaries=mrema^^dlpengine=autfu^^filetype=natura^^threatcategory=aboris^^threatclass=ima^^pagerisk=tanimi^^threatname=nimadmin^^clientpublicIP=erep^^ClientIP=10.252.125.53^^location=ugiatqu^^refererURL=https://internal.example.net/Utenimad/nibusBon.html?emq=isiu#nimadmi^^useragent=Mozilla/5.0 (Linux; Android 9; G8142) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=ari^^user=equun^^event_id=suntinc^^clienttranstime=elits^^requestmethod=llam^^requestsize=3077^^requestversion=gelits^^status=tatevel^^responsesize=3856^^responseversion=uptatev^^transactionsize=4292",
             "event": {
@@ -50,7 +50,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "dmi ZSCALERNSS: time=olab Mar 26 10:20:16 2016^^timezone=GMT-07:00^^action=Blocked^^reason=unknown^^hostname=ore2933.www.test^^protocol=ipv6-icmp^^serverip=10.61.78.108^^url=https://api.example.com/ele/tenbyCic.gif?porainc=amquisno#iinea^^urlcategory=ipit^^urlclass=idexea^^dlpdictionaries=riat^^dlpengine=luptatem^^filetype=umdolor^^threatcategory=osquir^^threatclass=inim^^pagerisk=ema^^threatname=roinBCSe^^clientpublicIP=onse^^ClientIP=10.136.153.149^^location=animi^^refererURL=https://www5.example.org/ofdeF/tion.htm?emqu=lit#iam^^useragent=Mozilla/5.0 (Linux; Android 6.0; ZTE BLADE V7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=ciati^^user=ercit^^event_id=umdolore^^clienttranstime=eniam^^requestmethod=reetdolo^^requestsize=2451^^requestversion=onse^^status=rumet^^responsesize=5772^^responseversion=tatno^^transactionsize=6787",
             "event": {
@@ -62,7 +62,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "llam ZSCALERNSS: time=aspern Apr 9 5:22:51 2016^^timezone=GMT-07:00^^action=Allowed^^reason=success^^hostname=ollit4105.mail.localdomain^^protocol=ipv6-icmp^^serverip=10.183.16.166^^url=https://mail.example.org/sitas/ehenderi.jpg?atquovo=iumto#aboreetd^^urlcategory=sun^^urlclass=essecill^^dlpdictionaries=Duisau^^dlpengine=psum^^filetype=eriame^^threatcategory=lorema^^threatclass=avol^^pagerisk=labor^^threatname=atuse^^clientpublicIP=ddoeiu^^ClientIP=10.66.250.92^^location=onse^^refererURL=https://example.com/metcon/smo.jpg?upta=omn#ipsumq^^useragent=Mozilla/5.0 (Linux; Android 9; Pixel 3 Build/PD1A.180720.030) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36^^department=ons^^user=tessec^^event_id=remipsum^^clienttranstime=liq^^requestmethod=ist^^requestsize=571^^requestversion=caecatc^^status=onsequat^^responsesize=2984^^responseversion=edquiano^^transactionsize=6061",
             "event": {
@@ -74,7 +74,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ema ZSCALERNSS: time=par Apr 24 12:25:25 2016^^timezone=PT^^action=Blocked^^reason=unknown^^hostname=cup1793.local^^protocol=ipv6^^serverip=10.243.224.205^^url=https://mail.example.net/aborumSe/luptat.txt?antiumto=strude#ctetura^^urlcategory=usmod^^urlclass=edqui^^dlpdictionaries=mquidol^^dlpengine=ita^^filetype=ipi^^threatcategory=rsitamet^^threatclass=lupt^^pagerisk=xea^^threatname=qua^^clientpublicIP=luptatev^^ClientIP=10.123.104.59^^location=uisquam^^refererURL=https://api.example.com/loremq/lores.txt?iqui=etc#etM^^useragent=Mozilla/5.0 (Linux; Android 4.1.2; Micromax P410i Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36^^department=eprehen^^user=xercitat^^event_id=lpa^^clienttranstime=entsu^^requestmethod=dun^^requestsize=941^^requestversion=aliq^^status=rsitam^^responsesize=2053^^responseversion=imaven^^transactionsize=152",
             "event": {
@@ -86,7 +86,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "tema ZSCALERNSS: time=ritatis May 8 7:27:59 2016^^timezone=GMT+02:00^^action=Blocked^^reason=unknown^^hostname=icab4668.local^^protocol=udp^^serverip=10.119.185.63^^url=https://www5.example.net/ntutla/equa.jpg?civeli=errorsi#des^^urlcategory=rehe^^urlclass=ume^^dlpdictionaries=incidi^^dlpengine=picia^^filetype=mUtenima^^threatcategory=emaperi^^threatclass=tame^^pagerisk=tinvol^^threatname=tectobe^^clientpublicIP=colabor^^ClientIP=10.74.17.5^^location=untut^^refererURL=https://internal.example.net/ommod/sequatur.txt?tlabo=suntexp#ugiatnu^^useragent=Mozilla/5.0 (Linux; Android 5.1.1; Android Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36 YaApp_Android/9.80 YaSearchBrowser/9.80^^department=itecto^^user=erc^^event_id=amqu^^clienttranstime=uines^^requestmethod=nsec^^requestsize=6907^^requestversion=estqu^^status=inibusBo^^responsesize=6888^^responseversion=ostrume^^transactionsize=6051",
             "event": {
@@ -98,7 +98,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "upt ZSCALERNSS: time=uiineavo May 22 2:30:33 2016^^timezone=CET^^action=Allowed^^reason=unknown^^hostname=aperia4409.www5.invalid^^protocol=rdp^^serverip=10.78.151.178^^url=https://api.example.net/atvol/umiur.txt?tati=utaliqu#oriosamn^^urlcategory=deFinibu^^urlclass=iadese^^dlpdictionaries=imidest^^dlpengine=emagnama^^filetype=eprehend^^threatcategory=hil^^threatclass=atquovo^^pagerisk=suntinc^^threatname=xeac^^clientpublicIP=nidolo^^ClientIP=10.25.192.202^^location=intoccae^^refererURL=https://www.example.net/pida/nse.html?emeumfu=CSed#lupt^^useragent=Mozilla/5.0 (Linux; Android 8.0.0; VS996) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=ecillu^^user=quip^^event_id=mporain^^clienttranstime=icons^^requestmethod=amvolup^^requestsize=7700^^requestversion=temveleu^^status=colabo^^responsesize=6354^^responseversion=orinrepr^^transactionsize=6578",
             "event": {
@@ -110,7 +110,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "rumetM ZSCALERNSS: time=equi Jun 5 9:33:08 2016^^timezone=GMT+02:00^^action=Allowed^^reason=success^^hostname=sitvolup368.internal.host^^protocol=igmp^^serverip=10.71.170.37^^url=https://mail.example.net/equep/iavolu.gif?aqu=rpo#uipe^^urlcategory=inesci^^urlclass=serror^^dlpdictionaries=aliqu^^dlpengine=olupta^^filetype=mipsumd^^threatcategory=eFinib^^threatclass=ihilm^^pagerisk=atDu^^threatname=eav^^clientpublicIP=ionevo^^ClientIP=10.135.225.244^^location=orev^^refererURL=https://api.example.net/quirat/llu.jpg?isc=aturve#emulla^^useragent=Mozilla/5.0 (Linux; Android 9; POCOPHONE F1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=atiset^^user=atu^^event_id=umexerci^^clienttranstime=ern^^requestmethod=psaquae^^requestsize=7355^^requestversion=nsectet^^status=utla^^responsesize=5269^^responseversion=sci^^transactionsize=2526",
             "event": {
@@ -122,7 +122,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "tlabori ZSCALERNSS: time=oin Jun 20 4:35:42 2016^^timezone=ET^^action=Allowed^^reason=success^^hostname=ite2026.www.invalid^^protocol=udp^^serverip=10.223.247.86^^url=https://example.org/bor/occa.htm?dol=leumiu#namali^^urlcategory=taevit^^urlclass=rinrepre^^dlpdictionaries=etconse^^dlpengine=tincu^^filetype=ari^^threatcategory=exercit^^threatclass=sci^^pagerisk=quamnih^^threatname=oluptate^^clientpublicIP=onseq^^ClientIP=10.19.145.131^^location=texp^^refererURL=https://internal.example.net/acc/amc.txt?amest=corp#modtemp^^useragent=Mozilla/5.0 (Linux; Android 4.1.2; Micromax P410i Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36^^department=oluptas^^user=tNequepo^^event_id=lup^^clienttranstime=nula^^requestmethod=emseq^^requestsize=821^^requestversion=ento^^status=pic^^responsesize=752^^responseversion=eriamea^^transactionsize=7741",
             "event": {
@@ -134,7 +134,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "rsita ZSCALERNSS: time=niamqui Jul 4 11:38:16 2016^^timezone=GMT-07:00^^action=Allowed^^reason=failure^^hostname=radipisc7020.home^^protocol=ipv6^^serverip=10.2.53.125^^url=https://internal.example.net/oru/temqu.htm?etMalor=ipi#reseos^^urlcategory=pariatu^^urlclass=tin^^dlpdictionaries=tenima^^dlpengine=tsedqu^^filetype=agnid^^threatcategory=proide^^threatclass=dolorem^^pagerisk=tlab^^threatname=volupt^^clientpublicIP=osqui^^ClientIP=10.181.80.139^^location=hitecto^^refererURL=https://www.example.net/liquide/etdol.jpg?uun=sequine#ectio^^useragent=Mozilla/5.0 (Linux; Android 9; Notepad_K10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Safari/537.36^^department=aboN^^user=ihilmo^^event_id=radi^^clienttranstime=gel^^requestmethod=lorsitam^^requestsize=6408^^requestversion=veniam^^status=ris^^responsesize=3314^^responseversion=ulapa^^transactionsize=7298",
             "event": {
@@ -146,7 +146,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "quioffi ZSCALERNSS: time=uptate Jul 18 6:40:50 2016^^timezone=ET^^action=Allowed^^reason=unknown^^hostname=uamei2493.www.test^^protocol=tcp^^serverip=10.31.240.6^^url=https://mail.example.net/itatione/isnis.html?oluptate=issus#osamn^^urlcategory=isnisiu^^urlclass=bore^^dlpdictionaries=tsu^^dlpengine=tcons^^filetype=sciun^^threatcategory=sBono^^threatclass=catc^^pagerisk=nsect^^threatname=idata^^clientpublicIP=rumwritt^^ClientIP=10.167.98.76^^location=dol^^refererURL=https://api.example.org/citation/tisetq.html?Utenimad=orpor#tlabo^^useragent=Mozilla/5.0 (Linux; Android 9; Pixel 3 Build/PD1A.180720.030) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36^^department=gnido^^user=ratvolu^^event_id=olup^^clienttranstime=numqua^^requestmethod=veni^^requestsize=3140^^requestversion=abo^^status=veniamqu^^responsesize=2742^^responseversion=aliquide^^transactionsize=3073",
             "event": {
@@ -158,7 +158,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "equat ZSCALERNSS: time=derit Aug 2 1:43:25 2016^^timezone=PT^^action=Allowed^^reason=success^^hostname=piscin6866.internal.host^^protocol=udp^^serverip=10.0.55.9^^url=https://www.example.org/eporr/xeacomm.html?aturQui=utlabor#rau^^urlcategory=idex^^urlclass=mfugiat^^dlpdictionaries=nisiuta^^dlpengine=tvolu^^filetype=ecte^^threatcategory=tinvolu^^threatclass=iurer^^pagerisk=iciadese^^threatname=quidolor^^clientpublicIP=tessec^^ClientIP=10.135.160.125^^location=mve^^refererURL=https://internal.example.com/uisau/eleum.htm?nre=ercitat#inim^^useragent=Mozilla/5.0 (Linux; Android 8.1.0; SM-A260G Build/OPR6; rv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Rocket/2.1.17(19420) Chrome/81.0.4044.138 Mobile Safari/537.36^^department=Utenima^^user=volupta^^event_id=rcitati^^clienttranstime=eni^^requestmethod=ionevo^^requestsize=3616^^requestversion=Ute^^status=sperna^^responsesize=5368^^responseversion=mnisi^^transactionsize=509",
             "event": {
@@ -170,7 +170,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "tDuisaut ZSCALERNSS: time=oinBC Aug 16 8:45:59 2016^^timezone=OMST^^action=Allowed^^reason=unknown^^hostname=spi3544.www.host^^protocol=ggp^^serverip=10.63.250.128^^url=https://internal.example.net/ptatemq/luptatev.html?Nequepo=ipsumd#ntocc^^urlcategory=uteirure^^urlclass=nevo^^dlpdictionaries=ide^^dlpengine=aali^^filetype=adip^^threatcategory=tium^^threatclass=nnum^^pagerisk=tenbyCi^^threatname=ate^^clientpublicIP=uiac^^ClientIP=10.111.187.12^^location=itam^^refererURL=https://www.example.org/santiumd/turadip.gif?niamqui=orem#sno^^useragent=Mozilla/5.0 (Linux; Android 9; Pixel 3 Build/PD1A.180720.030) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36^^department=tev^^user=saute^^event_id=ntocca^^clienttranstime=ostru^^requestmethod=ntoccae^^requestsize=1705^^requestversion=rrorsi^^status=temquiav^^responsesize=6027^^responseversion=sec^^transactionsize=1927",
             "event": {
@@ -182,7 +182,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "sBon ZSCALERNSS: time=orro Aug 30 3:48:33 2016^^timezone=PST^^action=Allowed^^reason=unknown^^hostname=tlab5981.www.host^^protocol=igmp^^serverip=10.5.126.127^^url=https://www5.example.com/tateve/itinvol.txt?tenatus=cipitlab#ipsumd^^urlcategory=antiu^^urlclass=uirati^^dlpdictionaries=oin^^dlpengine=exe^^filetype=imadmini^^threatcategory=sauteiru^^threatclass=mod^^pagerisk=hilm^^threatname=ataevi^^clientpublicIP=com^^ClientIP=10.252.124.150^^location=trud^^refererURL=https://mail.example.org/litessec/itas.htm?uidol=mporin#mwrit^^useragent=Mozilla/5.0 (Linux; Android 9; Pixel 3 Build/PD1A.180720.030) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36^^department=roid^^user=inibusB^^event_id=eprehen^^clienttranstime=entor^^requestmethod=xeacomm^^requestsize=1940^^requestversion=utp^^status=ema^^responsesize=1394^^responseversion=itessequ^^transactionsize=7688",
             "event": {
@@ -194,7 +194,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ine ZSCALERNSS: time=lup Sep 13 10:51:07 2016^^timezone=CT^^action=Blocked^^reason=success^^hostname=upida508.example^^protocol=tcp^^serverip=10.201.171.120^^url=https://api.example.net/tquiin/tse.jpg?ovol=ptasn#taedicta^^urlcategory=itam^^urlclass=str^^dlpdictionaries=idolore^^dlpengine=pid^^filetype=illoin^^threatcategory=tanimid^^threatclass=umdo^^pagerisk=natuse^^threatname=gnamal^^clientpublicIP=metMalo^^ClientIP=10.91.126.231^^location=reprehen^^refererURL=https://example.net/psumquia/ven.html?siutali=amnih#ium^^useragent=Mozilla/5.0 (Linux; Android 4.1.2; Micromax P410i Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36^^department=tau^^user=exercita^^event_id=ris^^clienttranstime=eumiu^^requestmethod=orumSe^^requestsize=728^^requestversion=isnost^^status=queips^^responsesize=248^^responseversion=itess^^transactionsize=52",
             "event": {
@@ -206,7 +206,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ofdeFini ZSCALERNSS: time=irat Sep 28 5:53:42 2016^^timezone=GMT+02:00^^action=Allowed^^reason=unknown^^hostname=oditem5255.api.localdomain^^protocol=tcp^^serverip=10.135.82.97^^url=https://mail.example.org/olor/ineavo.gif?mquelau=iadolor#amcol^^urlcategory=adeser^^urlclass=oin^^dlpdictionaries=mvenia^^dlpengine=madminim^^filetype=fugitsed^^threatcategory=quam^^threatclass=quid^^pagerisk=fugiat^^threatname=atisun^^clientpublicIP=esci^^ClientIP=10.107.251.87^^location=fugi^^refererURL=https://www.example.net/iduntu/idestlab.htm?avol=icero#xer^^useragent=Mozilla/5.0 (Linux; Android 4.1.2; Micromax P410i Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36^^department=nturma^^user=str^^event_id=iat^^clienttranstime=etur^^requestmethod=itecto^^requestsize=1300^^requestversion=borios^^status=tut^^responsesize=2703^^responseversion=umqu^^transactionsize=301",
             "event": {
@@ -218,7 +218,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "adipisc ZSCALERNSS: time=uscipitl Oct 12 12:56:16 2016^^timezone=PST^^action=Blocked^^reason=unknown^^hostname=uamei2389.internal.example^^protocol=ipv6-icmp^^serverip=10.31.198.58^^url=https://www.example.com/its/ender.gif?oles=edic#seq^^urlcategory=tutlab^^urlclass=sau^^dlpdictionaries=atevelit^^dlpengine=meius^^filetype=billo^^threatcategory=labo^^threatclass=oNemoeni^^pagerisk=ttenby^^threatname=boris^^clientpublicIP=stenatu^^ClientIP=10.215.205.216^^location=ratv^^refererURL=https://www.example.net/ianon/tsed.htm?ameiusm=proide#ano^^useragent=Mozilla/5.0 (Linux; Android 7.0; SM-S337TL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=boreetdo^^user=aturve^^event_id=ditemp^^clienttranstime=edqui^^requestmethod=nre^^requestsize=7231^^requestversion=sit^^status=olab^^responsesize=100^^responseversion=elitse^^transactionsize=6672",
             "event": {
@@ -230,7 +230,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "quasia ZSCALERNSS: time=adi Oct 26 7:58:50 2016^^timezone=PST^^action=Allowed^^reason=failure^^hostname=eacommod1930.internal.lan^^protocol=igmp^^serverip=10.29.155.171^^url=https://www5.example.org/oeni/tdol.gif?llamco=nea#psum^^urlcategory=tasnulap^^urlclass=orsit^^dlpdictionaries=asiar^^dlpengine=ise^^filetype=itau^^threatcategory=apariat^^threatclass=vitaedi^^pagerisk=lorsita^^threatname=dolore^^clientpublicIP=uptate^^ClientIP=10.229.83.165^^location=ugiat^^refererURL=https://internal.example.com/ate/odoconse.jpg?quatu=veli#tenim^^useragent=Mozilla/5.0 (iPhone; CPU iPhone OS 13_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 LightSpeed [FBAN/MessengerLiteForiOS;FBAV/266.0.0.32.114;FBBV/216059178;FBDV/iPhone10,6;FBMD/iPhone;FBSN/iOS;FBSV/13.4.1;FBSS/3;FBCR/;FBID/phone;FBLC/en_US;FBOP/0]^^department=labo^^user=ulapar^^event_id=aboreetd^^clienttranstime=hilm^^requestmethod=llitanim^^requestsize=5047^^requestversion=pitl^^status=por^^responsesize=7205^^responseversion=ama^^transactionsize=332",
             "event": {
@@ -242,7 +242,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "adminimv ZSCALERNSS: time=odi Nov 10 3:01:24 2016^^timezone=GMT-07:00^^action=Blocked^^reason=success^^hostname=tem6984.www5.domain^^protocol=ipv6^^serverip=10.129.192.145^^url=https://www.example.com/uasiar/utlab.htm?loremqu=dantium#lor^^urlcategory=velillu^^urlclass=cteturad^^dlpdictionaries=bor^^dlpengine=rauto^^filetype=ationev^^threatcategory=umdolor^^threatclass=uaUten^^pagerisk=nby^^threatname=mve^^clientpublicIP=osqui^^ClientIP=10.161.148.64^^location=ibusBon^^refererURL=https://example.com/rQu/mco.jpg?dun=reprehe#tincu^^useragent=Mozilla/5.0 (Linux; Android 10; ASUS_X01BDA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36^^department=dex^^user=lor^^event_id=oraincid^^clienttranstime=intocc^^requestmethod=amcorp^^requestsize=1275^^requestversion=ssecillu^^status=liqua^^responsesize=6498^^responseversion=utodita^^transactionsize=4014",
             "event": {
@@ -254,7 +254,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "fdeF ZSCALERNSS: time=iquidexe Nov 24 10:03:59 2016^^timezone=CEST^^action=Allowed^^reason=failure^^hostname=lapariat7287.internal.host^^protocol=ggp^^serverip=10.7.200.140^^url=https://api.example.org/icabo/gna.html?urerepr=eseru#quamest^^urlcategory=mac^^urlclass=qui^^dlpdictionaries=ritin^^dlpengine=temporin^^filetype=equatur^^threatcategory=adeseru^^threatclass=tdol^^pagerisk=upt^^threatname=mex^^clientpublicIP=tatem^^ClientIP=10.203.65.161^^location=eveli^^refererURL=https://internal.example.com/oremq/dicta.htm?imide=poriss#tvolup^^useragent=Mozilla/5.0 (Linux; Android 9; ZTE Blade V1000RU Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36 YaApp_Android/10.91 YaSearchBrowser/10.91^^department=siu^^user=snost^^event_id=tpersp^^clienttranstime=llamc^^requestmethod=nte^^requestsize=3571^^requestversion=utali^^status=porinc^^responsesize=6392^^responseversion=mvolu^^transactionsize=1664",
             "event": {
@@ -266,7 +266,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ipi ZSCALERNSS: time=imveniam Dec 8 5:06:33 2016^^timezone=GMT-07:00^^action=Blocked^^reason=unknown^^hostname=licabo1493.api.corp^^protocol=icmp^^serverip=10.86.22.67^^url=https://api.example.org/oremi/elites.html?iosa=boNemoe#onsequ^^urlcategory=equinesc^^urlclass=cab^^dlpdictionaries=atisund^^dlpengine=xea^^filetype=ites^^threatcategory=isetq^^threatclass=iutali^^pagerisk=velite^^threatname=teturad^^clientpublicIP=perspici^^ClientIP=10.218.98.29^^location=iconseq^^refererURL=https://www5.example.org/atisetqu/issuscip.jpg?dipisci=spernatu#admi^^useragent=Mozilla/5.0 (Linux; Android 9; Pixel 3 Build/PD1A.180720.030) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36^^department=quunt^^user=olori^^event_id=mquae^^clienttranstime=eriti^^requestmethod=atcupi^^requestsize=2332^^requestversion=plica^^status=ore^^responsesize=7595^^responseversion=emqu^^transactionsize=2846",
             "event": {
@@ -278,7 +278,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "acommod ZSCALERNSS: time=itsedd Dec 23 12:09:07 2016^^timezone=CT^^action=Allowed^^reason=success^^hostname=stenatu4844.www.invalid^^protocol=rdp^^serverip=10.39.31.115^^url=https://example.com/luptatem/uaeratv.gif?dat=periam#dqu^^urlcategory=pid^^urlclass=rExc^^dlpdictionaries=iusmo^^dlpengine=tame^^filetype=naaliq^^threatcategory=nte^^threatclass=ulpa^^pagerisk=sitam^^threatname=rad^^clientpublicIP=loi^^ClientIP=10.24.111.229^^location=volupt^^refererURL=https://example.net/idid/tesse.txt?boru=ptateve#enderi^^useragent=Mozilla/5.0 (Linux; Android 9; Notepad_K10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Safari/537.36^^department=toccaec^^user=fugi^^event_id=labo^^clienttranstime=nostrud^^requestmethod=gnaal^^requestsize=7224^^requestversion=proident^^status=maliquam^^responsesize=2147^^responseversion=atione^^transactionsize=5702",
             "event": {
@@ -290,7 +290,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ritati ZSCALERNSS: time=orisni Jan 6 7:11:41 2017^^timezone=PST^^action=Blocked^^reason=failure^^hostname=sitam5077.internal.host^^protocol=igmp^^serverip=10.179.210.218^^url=https://www.example.org/tanimi/rumSecti.jpg?emporain=ntiumto#umetMalo^^urlcategory=oluptas^^urlclass=emvele^^dlpdictionaries=isnost^^dlpengine=olorem^^filetype=ido^^threatcategory=emqu^^threatclass=riss^^pagerisk=iquamqua^^threatname=sit^^clientpublicIP=rumSect^^ClientIP=10.32.39.220^^location=aliq^^refererURL=https://example.net/mven/olorsit.gif?oremag=illu#ruredo^^useragent=Mozilla/5.0 (Linux; Android 10; SM-A715F Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.83 Mobile Safari/537.36 [FB_IAB/Orca-Android;FBAV/266.0.0.16.117;]^^department=tatevel^^user=boreetdo^^event_id=undeom^^clienttranstime=uamnihi^^requestmethod=risnis^^requestsize=1140^^requestversion=scingeli^^status=isn^^responsesize=4814^^responseversion=omm^^transactionsize=696",
             "event": {
@@ -302,7 +302,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "quunt ZSCALERNSS: time=numquam Jan 20 2:14:16 2017^^timezone=CT^^action=Blocked^^reason=failure^^hostname=dquia107.www.test^^protocol=ipv6^^serverip=10.128.173.19^^url=https://api.example.com/ori/tconsect.html?ercit=eporroq#ulla^^urlcategory=iqu^^urlclass=oin^^dlpdictionaries=hil^^dlpengine=cingel^^filetype=modocon^^threatcategory=ipsu^^threatclass=ntNeq^^pagerisk=tate^^threatname=urExce^^clientpublicIP=asi^^ClientIP=10.88.172.34^^location=atv^^refererURL=https://example.org/liquaUte/alorum.txt?ria=atDu#nsec^^useragent=Mozilla/5.0 (Linux; Android 4.1.2; Micromax P410i Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36^^department=maperi^^user=agnaaliq^^event_id=tlaboree^^clienttranstime=norumet^^requestmethod=dtempo^^requestsize=7680^^requestversion=col^^status=mve^^responsesize=3916^^responseversion=tinvolup^^transactionsize=2365",
             "event": {
@@ -314,7 +314,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "inv ZSCALERNSS: time=rroq Feb 3 9:16:50 2017^^timezone=CT^^action=Allowed^^reason=unknown^^hostname=lloin4019.www.localhost^^protocol=igmp^^serverip=10.130.241.232^^url=https://api.example.org/rure/asiarchi.txt?loremeu=aturve#utfug^^urlcategory=aturQu^^urlclass=aaliq^^dlpdictionaries=mipsamvo^^dlpengine=eiusmod^^filetype=emoe^^threatcategory=uiinea^^threatclass=mnisiut^^pagerisk=avolu^^threatname=Except^^clientpublicIP=olup^^ClientIP=10.238.224.49^^location=asper^^refererURL=https://example.net/naal/equun.gif?mve=uia#iciad^^useragent=Mozilla/5.0 (Linux; Android 9; POCOPHONE F1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=mad^^user=onse^^event_id=redol^^clienttranstime=gnaa^^requestmethod=mod^^requestsize=5107^^requestversion=dtempori^^status=toditaut^^responsesize=7889^^responseversion=dexerc^^transactionsize=2302",
             "event": {
@@ -326,7 +326,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "eprehend ZSCALERNSS: time=asnu Feb 18 4:19:24 2017^^timezone=OMST^^action=Allowed^^reason=unknown^^hostname=tamet6317.www.host^^protocol=igmp^^serverip=10.115.53.31^^url=https://example.com/emUte/molestia.htm?orroqu=elitsed#labore^^urlcategory=uela^^urlclass=ntexplic^^dlpdictionaries=uto^^dlpengine=iuntNequ^^filetype=esseq^^threatcategory=aincidun^^threatclass=quatD^^pagerisk=isqua^^threatname=uta^^clientpublicIP=emo^^ClientIP=10.2.67.127^^location=licaboN^^refererURL=https://mail.example.org/cupi/strude.htm?dunt=litsedq#nderiti^^useragent=Mozilla/5.0 (Linux; Android 9; U307AS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=mdolore^^user=Cic^^event_id=olorema^^clienttranstime=mollita^^requestmethod=tatem^^requestsize=6156^^requestversion=aeab^^status=teur^^responsesize=609^^responseversion=inBC^^transactionsize=2622",
             "event": {
@@ -338,7 +338,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "tur ZSCALERNSS: time=ictas Mar 4 11:21:59 2017^^timezone=OMST^^action=Allowed^^reason=unknown^^hostname=saquaea6344.www.invalid^^protocol=igmp^^serverip=10.204.214.251^^url=https://mail.example.net/repreh/plic.jpg?utlabo=tetur#tionula^^urlcategory=ritqu^^urlclass=ecatcupi^^dlpdictionaries=uamei^^dlpengine=undeomni^^filetype=tas^^threatcategory=autfugi^^threatclass=tasun^^pagerisk=duntutla^^threatname=ntium^^clientpublicIP=iration^^ClientIP=10.101.38.213^^location=orisni^^refererURL=https://example.org/modoc/boNem.gif?ssusci=animid#mpo^^useragent=Mozilla/5.0 (Linux; Android 9; U307AS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=atuse^^user=ueipsa^^event_id=scipitl^^clienttranstime=eumi^^requestmethod=quasiarc^^requestsize=3487^^requestversion=leumiur^^status=tetura^^responsesize=5328^^responseversion=offici^^transactionsize=501",
             "event": {
@@ -350,7 +350,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "roquisqu ZSCALERNSS: time=edolorin Mar 18 6:24:33 2017^^timezone=GMT+02:00^^action=Allowed^^reason=failure^^hostname=utaliqu4248.www.localhost^^protocol=igmp^^serverip=10.18.226.72^^url=https://api.example.com/tcu/iatqu.jpg?quovo=urExcep#ema^^urlcategory=suntex^^urlclass=iacons^^dlpdictionaries=occaec^^dlpengine=acommodi^^filetype=essecill^^threatcategory=billoi^^threatclass=moles^^pagerisk=dipiscin^^threatname=olup^^clientpublicIP=aco^^ClientIP=10.101.85.169^^location=natu^^refererURL=https://internal.example.net/enim/Finibus.htm?mporainc=xea#taed^^useragent=Mozilla/5.0 (Linux; Android 9; G8142) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=billo^^user=rroqu^^event_id=dquiaco^^clienttranstime=nibus^^requestmethod=vitaed^^requestsize=2352^^requestversion=ptasnula^^status=oru^^responsesize=2118^^responseversion=upt^^transactionsize=7879",
             "event": {
@@ -362,7 +362,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "eprehend ZSCALERNSS: time=rem Apr 2 1:27:07 2017^^timezone=GMT-07:00^^action=Allowed^^reason=unknown^^hostname=mdolore473.internal.test^^protocol=igmp^^serverip=10.87.100.240^^url=https://www5.example.com/apariatu/lorsita.gif?msequ=uat#lupta^^urlcategory=npr^^urlclass=etconsec^^dlpdictionaries=caboNem^^dlpengine=urExcept^^filetype=rumetMal^^threatcategory=oconse^^threatclass=mag^^pagerisk=tob^^threatname=dolores^^clientpublicIP=equamnih^^ClientIP=10.242.182.193^^location=itempo^^refererURL=https://mail.example.com/redol/ecillum.html?radipis=ctetu#orinrep^^useragent=Mozilla/5.0 (Linux; Android 8.0.0; VS996) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=nder^^user=stenatus^^event_id=equep^^clienttranstime=ever^^requestmethod=tali^^requestsize=2124^^requestversion=erspi^^status=iqu^^responsesize=7509^^responseversion=incidid^^transactionsize=2617",
             "event": {
@@ -374,7 +374,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "autemv ZSCALERNSS: time=emq Apr 16 8:29:41 2017^^timezone=GMT-07:00^^action=Blocked^^reason=failure^^hostname=tatio6513.www.invalid^^protocol=rdp^^serverip=10.229.242.223^^url=https://internal.example.net/ende/abor.jpg?riameaqu=ame#tesseq^^urlcategory=niam^^urlclass=pernat^^dlpdictionaries=rerepre^^dlpengine=nculpaq^^filetype=culpaqui^^threatcategory=tvolup^^threatclass=tdolore^^pagerisk=ventore^^threatname=red^^clientpublicIP=sinto^^ClientIP=10.80.57.247^^location=est^^refererURL=https://api.example.net/aev/inrepr.gif?iadese=nisiu#imad^^useragent=Mozilla/5.0 (Linux; Android 9; ZTE Blade V1000RU Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36 YaApp_Android/10.91 YaSearchBrowser/10.91^^department=ptatem^^user=itasp^^event_id=dexe^^clienttranstime=tat^^requestmethod=onproide^^requestsize=2737^^requestversion=cillumd^^status=riosa^^responsesize=204^^responseversion=aspernat^^transactionsize=2460",
             "event": {
@@ -386,7 +386,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "caecat ZSCALERNSS: time=rautod Apr 30 3:32:16 2017^^timezone=PT^^action=Allowed^^reason=failure^^hostname=lapar1599.www.lan^^protocol=ipv6^^serverip=10.193.66.155^^url=https://example.com/ame/amvolu.txt?equaturv=lamc#mvolupta^^urlcategory=Utenima^^urlclass=iqua^^dlpdictionaries=luptat^^dlpengine=deriti^^filetype=sintocc^^threatcategory=cididu^^threatclass=uteir^^pagerisk=boree^^threatname=isn^^clientpublicIP=ulla^^ClientIP=10.106.77.138^^location=aconse^^refererURL=https://mail.example.net/tnonproi/squira.html?itation=veleum#piciatis^^useragent=Mozilla/5.0 (Linux; Android 6.0; Lenovo A2016a40 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.106 Mobile Safari/537.36 YaApp_Android/10.30 YaSearchBrowser/10.30^^department=henderi^^user=iusmodt^^event_id=enim^^clienttranstime=emaperia^^requestmethod=Section^^requestsize=4329^^requestversion=iame^^status=orroquis^^responsesize=6146^^responseversion=tiumd^^transactionsize=6099",
             "event": {
@@ -398,7 +398,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "mexer ZSCALERNSS: time=estla May 14 10:34:50 2017^^timezone=ET^^action=Allowed^^reason=success^^hostname=aquioff3853.www.localdomain^^protocol=udp^^serverip=10.236.230.136^^url=https://mail.example.org/uisnostr/reetdol.txt?ugi=niamquis#nisi^^urlcategory=emveleum^^urlclass=olup^^dlpdictionaries=nde^^dlpengine=abillo^^filetype=undeom^^threatcategory=emullamc^^threatclass=tec^^pagerisk=Nemo^^threatname=tutlabo^^clientpublicIP=mveleum^^ClientIP=10.54.159.1^^location=sBonorum^^refererURL=https://mail.example.net/quira/tassita.gif?oremi=ugitsedq#turmag^^useragent=Mozilla/5.0 (Linux; Android 10; STK-L21 Build/HUAWEISTK-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36 YaApp_Android/10.91 YaSearchBrowser/10.91^^department=asnulapa^^user=mUteni^^event_id=quira^^clienttranstime=rror^^requestmethod=tatema^^requestsize=2446^^requestversion=loinve^^status=tatevel^^responsesize=3862^^responseversion=equu^^transactionsize=5373",
             "event": {
@@ -410,7 +410,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "atae ZSCALERNSS: time=tetura May 29 5:37:24 2017^^timezone=OMST^^action=Allowed^^reason=success^^hostname=ura675.mail.localdomain^^protocol=ggp^^serverip=10.49.242.174^^url=https://api.example.com/radipis/cive.gif?orumSec=nisiuta#stiaecon^^urlcategory=dol^^urlclass=sumquiad^^dlpdictionaries=setquas^^dlpengine=minim^^filetype=oeni^^threatcategory=untutlab^^threatclass=tvolup^^pagerisk=consecte^^threatname=pteurs^^clientpublicIP=catcupi^^ClientIP=10.131.246.134^^location=tiaecon^^refererURL=https://api.example.com/amquisno/uido.gif?queporro=uid#snostrum^^useragent=Mozilla/5.0 (Linux; Android 6.0; Lenovo A2016a40 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.106 Mobile Safari/537.36 YaApp_Android/10.30 YaSearchBrowser/10.30^^department=aconsequ^^user=umdolo^^event_id=rroqui^^clienttranstime=ursin^^requestmethod=utemvel^^requestsize=5325^^requestversion=atu^^status=iusm^^responsesize=4968^^responseversion=laudanti^^transactionsize=16",
             "event": {
@@ -422,7 +422,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "rere ZSCALERNSS: time=cta Jun 12 12:39:58 2017^^timezone=CT^^action=Blocked^^reason=unknown^^hostname=iamea478.www5.host^^protocol=ipv6-icmp^^serverip=10.142.120.198^^url=https://mail.example.org/oin/itseddoe.html?citati=uamei#eursinto^^urlcategory=litesse^^urlclass=fugiatn^^dlpdictionaries=uaeabi^^dlpengine=aaliq^^filetype=nat^^threatcategory=uovolupt^^threatclass=ende^^pagerisk=orumSe^^threatname=dolor^^clientpublicIP=isiut^^ClientIP=10.166.10.42^^location=emulla^^refererURL=https://www.example.com/itae/dtempo.html?etMaloru=lmo#iquidex^^useragent=Mozilla/5.0 (Linux; Android 9; LG-US998) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=uamqu^^user=olori^^event_id=ido^^clienttranstime=mcorpor^^requestmethod=doconse^^requestsize=2522^^requestversion=emUte^^status=iusmodi^^responsesize=1046^^responseversion=tura^^transactionsize=6695",
             "event": {
@@ -434,7 +434,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "equat ZSCALERNSS: time=aliquid Jun 26 7:42:33 2017^^timezone=GMT+02:00^^action=Allowed^^reason=unknown^^hostname=eaque6543.api.domain^^protocol=udp^^serverip=10.138.188.201^^url=https://mail.example.com/eseruntm/lpaquiof.html?magnaal=uscip#umS^^urlcategory=iciadese^^urlclass=riatur^^dlpdictionaries=oeni^^dlpengine=dol^^filetype=dol^^threatcategory=atur^^threatclass=issu^^pagerisk=identsu^^threatname=piscivel^^clientpublicIP=hend^^ClientIP=10.128.184.241^^location=aer^^refererURL=https://api.example.net/umd/sciveli.htm?tur=acon#Nemoenim^^useragent=Mozilla/5.0 (Linux; Android 6.0; ZTE BLADE V7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=urau^^user=etur^^event_id=rsitvol^^clienttranstime=utali^^requestmethod=sed^^requestsize=6793^^requestversion=sec^^status=uid^^responsesize=3520^^responseversion=acom^^transactionsize=1142",
             "event": {
@@ -446,7 +446,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ectob ZSCALERNSS: time=mrema Jul 11 2:45:07 2017^^timezone=CET^^action=Allowed^^reason=failure^^hostname=eufug1756.mail.corp^^protocol=ggp^^serverip=10.53.101.131^^url=https://example.net/snulap/enimadm.html?writte=sitvo#ine^^urlcategory=urerepre^^urlclass=asnulap^^dlpdictionaries=ipi^^dlpengine=idolorem^^filetype=exerci^^threatcategory=idata^^threatclass=ese^^pagerisk=mmodoco^^threatname=amni^^clientpublicIP=atnul^^ClientIP=10.213.57.165^^location=illumq^^refererURL=https://www5.example.org/ite/tasnul.txt?evitae=amvo#tnul^^useragent=Mozilla/5.0 (Linux; Android 9; LG-US998) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=ectetura^^user=isau^^event_id=itinvol^^clienttranstime=ten^^requestmethod=litanim^^requestsize=2135^^requestversion=orsitam^^status=modico^^responsesize=2990^^responseversion=itatio^^transactionsize=6735",
             "event": {
@@ -458,7 +458,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "riame ZSCALERNSS: time=riat Jul 25 9:47:41 2017^^timezone=GMT+02:00^^action=Blocked^^reason=unknown^^hostname=orp5697.www.invalid^^protocol=ggp^^serverip=10.243.6.41^^url=https://internal.example.org/etcon/onsequu.gif?Bonoru=madminim#ents^^urlcategory=emacc^^urlclass=emp^^dlpdictionaries=lamcola^^dlpengine=veli^^filetype=venia^^threatcategory=risni^^threatclass=idolores^^pagerisk=paria^^threatname=mmod^^clientpublicIP=iti^^ClientIP=10.55.81.14^^location=lorsitam^^refererURL=https://api.example.org/onpr/litseddo.gif?oremqu=idex#radip^^useragent=Mozilla/5.0 (Linux; Android 9; Pixel 3 Build/PD1A.180720.030) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36^^department=tenim^^user=eiusmo^^event_id=ainc^^clienttranstime=miurerep^^requestmethod=lestia^^requestsize=3606^^requestversion=iduntu^^status=pisci^^responsesize=3601^^responseversion=nostrud^^transactionsize=203",
             "event": {
@@ -470,7 +470,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ore ZSCALERNSS: time=esse Aug 8 4:50:15 2017^^timezone=PST^^action=Blocked^^reason=success^^hostname=pariatur7238.www5.invalid^^protocol=tcp^^serverip=10.33.144.10^^url=https://www.example.org/rur/itse.gif?pisciv=fugiatqu#seos^^urlcategory=exercita^^urlclass=edolori^^dlpdictionaries=eve^^dlpengine=tco^^filetype=tvol^^threatcategory=oluptate^^threatclass=lit^^pagerisk=santi^^threatname=ritati^^clientpublicIP=iciade^^ClientIP=10.202.224.79^^location=idolo^^refererURL=https://example.com/ptassita/caecatcu.txt?eturadip=olorsi#itseddo^^useragent=Mozilla/5.0 (Linux; Android 9; LG-US998) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=seos^^user=rios^^event_id=labo^^clienttranstime=lpaquiof^^requestmethod=quu^^requestsize=2203^^requestversion=ntexpl^^status=abor^^responsesize=4241^^responseversion=enbyCi^^transactionsize=3813",
             "event": {
@@ -482,7 +482,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "tat ZSCALERNSS: time=eufugia Aug 22 11:52:50 2017^^timezone=GMT-07:00^^action=Allowed^^reason=failure^^hostname=fficia2304.www5.home^^protocol=icmp^^serverip=10.158.18.51^^url=https://mail.example.com/qui/equeporr.jpg?itsedd=texpli#liquipex^^urlcategory=uisnos^^urlclass=quamqua^^dlpdictionaries=ntut^^dlpengine=mag^^filetype=meum^^threatcategory=mini^^threatclass=Loremip^^pagerisk=oreeu^^threatname=nvo^^clientpublicIP=iamqui^^ClientIP=10.20.124.138^^location=aqui^^refererURL=https://www.example.net/lpa/isn.htm?iat=ffic#siuta^^useragent=Mozilla/5.0 (Linux; Android 9; U307AS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=aparia^^user=CSe^^event_id=exerci^^clienttranstime=inesciu^^requestmethod=quid^^requestsize=5452^^requestversion=emu^^status=orem^^responsesize=6317^^responseversion=ate^^transactionsize=4386",
             "event": {
@@ -494,7 +494,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "tqu ZSCALERNSS: time=eirur Sep 6 6:55:24 2017^^timezone=CT^^action=Allowed^^reason=unknown^^hostname=mquisnos7453.home^^protocol=igmp^^serverip=10.134.128.27^^url=https://api.example.net/lup/iumtotam.html?ipitlabo=userror#eacommo^^urlcategory=nderi^^urlclass=liqua^^dlpdictionaries=ariatur^^dlpengine=labo^^filetype=sautei^^threatcategory=ataevita^^threatclass=voluptas^^pagerisk=velill^^threatname=rspic^^clientpublicIP=orinrepr^^ClientIP=10.118.177.136^^location=borumSec^^refererURL=https://www5.example.org/snisiut/siar.txt?inB=orp#ender^^useragent=Mozilla/5.0 (Linux; Android 7.0; MEIZU M6 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.120 Mobile Safari/537.36 YaApp_Android/10.30 YaSearchBrowser/10.30^^department=rumSecti^^user=Utenima^^event_id=olore^^clienttranstime=orumS^^requestmethod=olor^^requestsize=6908^^requestversion=eursint^^status=orio^^responsesize=1044^^responseversion=iameaqu^^transactionsize=2429",
             "event": {
@@ -506,7 +506,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "olu ZSCALERNSS: time=iameaque Sep 20 1:57:58 2017^^timezone=OMST^^action=Allowed^^reason=unknown^^hostname=aquio748.www.localhost^^protocol=igmp^^serverip=10.68.8.143^^url=https://example.org/onproide/uamnih.htm?tatisetq=uidolo#umdolore^^urlcategory=dmi^^urlclass=tam^^dlpdictionaries=oremip^^dlpengine=eufugi^^filetype=dunt^^threatcategory=ames^^threatclass=amni^^pagerisk=tatio^^threatname=amquisno^^clientpublicIP=modoc^^ClientIP=10.125.120.97^^location=uid^^refererURL=https://internal.example.com/onev/orsi.txt?oreseo=reprehen#itamet^^useragent=Mozilla/5.0 (Linux; Android 9; Pixel 3 Build/PD1A.180720.030) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36^^department=idolo^^user=reet^^event_id=lorem^^clienttranstime=texplic^^requestmethod=edutp^^requestsize=911^^requestversion=assi^^status=eserun^^responsesize=3034^^responseversion=eniamqu^^transactionsize=1185",
             "event": {
@@ -518,7 +518,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "tatevel ZSCALERNSS: time=midestl Oct 4 9:00:32 2017^^timezone=PST^^action=Blocked^^reason=unknown^^hostname=remagnam796.mail.corp^^protocol=rdp^^serverip=10.143.0.78^^url=https://www5.example.org/obeataev/umf.htm?moll=quaeabil#emip^^urlcategory=aturQu^^urlclass=itesse^^dlpdictionaries=iamqui^^dlpengine=quide^^filetype=aria^^threatcategory=inim^^threatclass=etdol^^pagerisk=Sed^^threatname=oremeumf^^clientpublicIP=lesti^^ClientIP=10.137.164.122^^location=enima^^refererURL=https://www5.example.net/ico/giatquo.htm?evi=tionula#accus^^useragent=Mozilla/5.0 (Linux; Android 7.0; MEIZU M6 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.120 Mobile Safari/537.36 YaApp_Android/10.30 YaSearchBrowser/10.30^^department=amnihil^^user=orissus^^event_id=atems^^clienttranstime=nimaveni^^requestmethod=mwrit^^requestsize=2923^^requestversion=itse^^status=officiad^^responsesize=4982^^responseversion=nimadmin^^transactionsize=5577",
             "event": {
@@ -530,7 +530,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "quiavolu ZSCALERNSS: time=upta Oct 19 4:03:07 2017^^timezone=OMST^^action=Blocked^^reason=failure^^hostname=etdolore4227.internal.corp^^protocol=icmp^^serverip=10.30.87.51^^url=https://mail.example.org/consequa/eaqueip.gif?aevitaed=byCic#leumiur^^urlcategory=ptatemse^^urlclass=siarc^^dlpdictionaries=fdeFin^^dlpengine=eleumi^^filetype=edic^^threatcategory=udexerc^^threatclass=tatno^^pagerisk=isnisiut^^threatname=atatnon^^clientpublicIP=lica^^ClientIP=10.156.177.53^^location=Nequ^^refererURL=https://www.example.com/epo/rsit.txt?onorumet=ptatema#eavolup^^useragent=Mozilla/5.0 (Linux; Android 10; ASUS_X01BDA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36^^department=rmagnido^^user=psaquaea^^event_id=rchit^^clienttranstime=psumq^^requestmethod=ptatev^^requestsize=6552^^requestversion=xerc^^status=ctetura^^responsesize=7556^^responseversion=tDuis^^transactionsize=3281",
             "event": {
@@ -542,7 +542,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "tat ZSCALERNSS: time=equ Nov 2 11:05:41 2017^^timezone=GMT+02:00^^action=Blocked^^reason=unknown^^hostname=rors1935.api.domain^^protocol=udp^^serverip=10.83.138.34^^url=https://example.org/tmo/onofdeF.txt?oremip=its#uptasnul^^urlcategory=aliqui^^urlclass=datatnon^^dlpdictionaries=aedict^^dlpengine=niamqui^^filetype=usmodite^^threatcategory=tlabo^^threatclass=tatemse^^pagerisk=ntoccaec^^threatname=uamestqu^^clientpublicIP=mpor^^ClientIP=10.111.249.184^^location=ptatemU^^refererURL=https://example.org/rumSe/tatnonp.jpg?tlabore=idunt#expl^^useragent=Mozilla/5.0 (iPhone; CPU iPhone OS 13_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 LightSpeed [FBAN/MessengerLiteForiOS;FBAV/266.0.0.32.114;FBBV/216059178;FBDV/iPhone10,6;FBMD/iPhone;FBSN/iOS;FBSV/13.4.1;FBSS/3;FBCR/;FBID/phone;FBLC/en_US;FBOP/0]^^department=onsectet^^user=dentsunt^^event_id=inea^^clienttranstime=animid^^requestmethod=upta^^requestsize=313^^requestversion=onnumqua^^status=quioff^^responsesize=470^^responseversion=upt^^transactionsize=6017",
             "event": {
@@ -554,7 +554,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "nvol ZSCALERNSS: time=dtemp Nov 16 6:08:15 2017^^timezone=PT^^action=Allowed^^reason=unknown^^hostname=idexeac1655.internal.test^^protocol=ipv6^^serverip=10.141.195.13^^url=https://mail.example.com/orsitvol/ntor.htm?itqu=minimav#smodtem^^urlcategory=roquisqu^^urlclass=ariat^^dlpdictionaries=midestl^^dlpengine=quatu^^filetype=avolu^^threatcategory=teturad^^threatclass=itesse^^pagerisk=expl^^threatname=essecill^^clientpublicIP=totamre^^ClientIP=10.180.150.47^^location=orsitv^^refererURL=https://internal.example.net/uisaute/uun.jpg?olupt=nemulla#asp^^useragent=Mozilla/5.0 (Linux; Android 6.0; U20 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.147 Mobile Safari/537.36 YaApp_Android/10.90 YaSearchBrowser/10.90^^department=ncul^^user=taliq^^event_id=tautfugi^^clienttranstime=fdeFinib^^requestmethod=uip^^requestsize=3940^^requestversion=sectetur^^status=edquian^^responsesize=7810^^responseversion=turQuis^^transactionsize=4046",
             "event": {
@@ -566,7 +566,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "uames ZSCALERNSS: time=tconsec Dec 1 1:10:49 2017^^timezone=GMT-07:00^^action=Allowed^^reason=failure^^hostname=laboree3880.api.invalid^^protocol=rdp^^serverip=10.166.195.20^^url=https://internal.example.org/rumexe/xerci.gif?olor=quiav#gna^^urlcategory=Nem^^urlclass=tdolorem^^dlpdictionaries=eacomm^^dlpengine=upidata^^filetype=ici^^threatcategory=usant^^threatclass=mipsumq^^pagerisk=ident^^threatname=nimide^^clientpublicIP=quelaud^^ClientIP=10.255.40.12^^location=rro^^refererURL=https://api.example.com/nimv/emeu.htm?rem=tseddoei#teursint^^useragent=Opera/9.80 (Series 60; Opera Mini/7.1.32444/174.101; U; ru) Presto/2.12.423 Version/12.16^^department=remagnaa^^user=lamcolab^^event_id=ceroinB^^clienttranstime=umqui^^requestmethod=citation^^requestsize=7073^^requestversion=mcorpori^^status=orisn^^responsesize=2266^^responseversion=etMalor^^transactionsize=7800",
             "event": {
@@ -578,7 +578,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "cta ZSCALERNSS: time=ercitat Dec 15 8:13:24 2017^^timezone=PT^^action=Blocked^^reason=unknown^^hostname=tecto708.www5.example^^protocol=rdp^^serverip=10.22.122.43^^url=https://example.org/tvolu/dutper.html?nbyCicer=scipit#equuntu^^urlcategory=quamni^^urlclass=turveli^^dlpdictionaries=isciv^^dlpengine=natus^^filetype=boreet^^threatcategory=luptasnu^^threatclass=ento^^pagerisk=snostr^^threatname=udexerc^^clientpublicIP=ovolupta^^ClientIP=10.100.143.226^^location=ametcon^^refererURL=https://internal.example.net/ecillu/quovol.html?ctasu=irat#sitame^^useragent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 YaBrowser/20.3.0.2221 Yowser/2.5 Safari/537.36^^department=ueporroq^^user=ute^^event_id=mexer^^clienttranstime=iam^^requestmethod=Bonoru^^requestsize=1396^^requestversion=ntutlab^^status=rumSecti^^responsesize=5091^^responseversion=gnama^^transactionsize=7815",
             "event": {
@@ -590,7 +590,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "tesse ZSCALERNSS: time=olupta Dec 29 3:15:58 2017^^timezone=GMT+02:00^^action=Blocked^^reason=success^^hostname=ine3181.www.invalid^^protocol=ipv6-icmp^^serverip=10.119.53.68^^url=https://www.example.com/uiavo/uisaut.htm?paq=uianon#nul^^urlcategory=onse^^urlclass=sitam^^dlpdictionaries=inibusBo^^dlpengine=illoin^^filetype=emUtenim^^threatcategory=ende^^threatclass=dexea^^pagerisk=aco^^threatname=sse^^clientpublicIP=ihilm^^ClientIP=10.121.9.5^^location=uptas^^refererURL=https://www5.example.net/ons/unt.txt?ctetur=mvolupta#squame^^useragent=Mozilla/5.0 (Linux; Android 6.0; Lenovo A2016a40 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.106 Mobile Safari/537.36 YaApp_Android/10.30 YaSearchBrowser/10.30^^department=mea^^user=ssec^^event_id=illum^^clienttranstime=eprehe^^requestmethod=tinvolup^^requestsize=497^^requestversion=tvol^^status=ptat^^responsesize=7456^^responseversion=tdolo^^transactionsize=1882",
             "event": {
@@ -602,7 +602,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "eleumi ZSCALERNSS: time=equ Jan 12 10:18:32 2018^^timezone=GMT-07:00^^action=Blocked^^reason=unknown^^hostname=tsunt3403.www5.test^^protocol=udp^^serverip=10.237.0.173^^url=https://mail.example.com/uasiarch/Malor.jpg?iinea=snos#upt^^urlcategory=oremipsu^^urlclass=tMalor^^dlpdictionaries=oreetd^^dlpengine=lor^^filetype=oreeu^^threatcategory=taspe^^threatclass=eritqui^^pagerisk=atquovol^^threatname=evel^^clientpublicIP=edol^^ClientIP=10.31.153.177^^location=maccus^^refererURL=https://www.example.com/totamrem/aliqu.htm?sBonorum=moenimi#lor^^useragent=Opera/9.80 (Series 60; Opera Mini/7.1.32444/174.101; U; ru) Presto/2.12.423 Version/12.16^^department=tiset^^user=sci^^event_id=periam^^clienttranstime=fugiatnu^^requestmethod=dolor^^requestsize=4350^^requestversion=eumfu^^status=docons^^responsesize=1428^^responseversion=eumf^^transactionsize=6826",
             "event": {
@@ -614,7 +614,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "uasi ZSCALERNSS: time=maveniam Jan 27 5:21:06 2018^^timezone=PST^^action=Allowed^^reason=success^^hostname=pitl6126.www.localdomain^^protocol=ipv6-icmp^^serverip=10.243.182.229^^url=https://api.example.org/ntiumt/sumquia.jpg?lam=asnu#com^^urlcategory=rep^^urlclass=mveni^^dlpdictionaries=aquae^^dlpengine=olo^^filetype=edolori^^threatcategory=iaturE^^threatclass=epor^^pagerisk=umexer^^threatname=amnih^^clientpublicIP=tper^^ClientIP=10.229.102.140^^location=nulamc^^refererURL=https://www.example.org/etcon/ctobeat.txt?eddoei=lorumw#eca^^useragent=mobmail android 2.1.3.3150^^department=nimve^^user=duntut^^event_id=emporin^^clienttranstime=oreseosq^^requestmethod=etquasia^^requestsize=1800^^requestversion=tium^^status=nimip^^responsesize=7612^^responseversion=squamest^^transactionsize=3914",
             "event": {
@@ -626,7 +626,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "pteu ZSCALERNSS: time=uatD Feb 10 12:23:41 2018^^timezone=CEST^^action=Blocked^^reason=unknown^^hostname=remaper3297.internal.test^^protocol=ipv6-icmp^^serverip=10.39.46.155^^url=https://example.com/itsedqu/paq.jpg?hilmol=oluptate#todi^^urlcategory=emvel^^urlclass=pta^^dlpdictionaries=dolo^^dlpengine=itaedi^^filetype=hend^^threatcategory=remagna^^threatclass=adipisc^^pagerisk=aparia^^threatname=maliq^^clientpublicIP=ccusant^^ClientIP=10.120.138.109^^location=oidentsu^^refererURL=https://internal.example.org/onsec/dit.gif?lup=aeca#isau^^useragent=Mozilla/5.0 (Linux; Android 9; U307AS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=sciveli^^user=picia^^event_id=BCSe^^clienttranstime=rem^^requestmethod=exer^^requestsize=447^^requestversion=remips^^status=lapari^^responsesize=5763^^responseversion=radipis^^transactionsize=3991",
             "event": {
@@ -638,7 +638,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "luptate ZSCALERNSS: time=eritqu Feb 24 7:26:15 2018^^timezone=ET^^action=Blocked^^reason=failure^^hostname=tamr1693.api.home^^protocol=ipv6^^serverip=10.53.191.49^^url=https://api.example.org/remeum/etur.html?Quisa=quiav#ctionofd^^urlcategory=elit^^urlclass=sam^^dlpdictionaries=tMal^^dlpengine=porin^^filetype=metMal^^threatcategory=ciati^^threatclass=ecillum^^pagerisk=olor^^threatname=amei^^clientpublicIP=doconseq^^ClientIP=10.133.102.57^^location=CSed^^refererURL=https://example.net/wri/itame.html?dictasun=psa#lorese^^useragent=Mozilla/5.0 (Linux; Android 10; ASUS_X01BDA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36^^department=ctobeat^^user=onsec^^event_id=idestl^^clienttranstime=litani^^requestmethod=emp^^requestsize=6397^^requestversion=onoru^^status=data^^responsesize=6740^^responseversion=eosqui^^transactionsize=5993",
             "event": {
@@ -650,7 +650,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "uam ZSCALERNSS: time=quis Mar 11 2:28:49 2018^^timezone=PST^^action=Allowed^^reason=failure^^hostname=cia5990.api.localdomain^^protocol=icmp^^serverip=10.91.2.225^^url=https://internal.example.org/ree/itten.gif?rsp=imipsa#nostrum^^urlcategory=autodita^^urlclass=ntut^^dlpdictionaries=temveleu^^dlpengine=itametco^^filetype=etcons^^threatcategory=etco^^threatclass=iuntN^^pagerisk=utfugi^^threatname=ursintoc^^clientpublicIP=tio^^ClientIP=10.89.41.97^^location=trudex^^refererURL=https://www.example.net/lup/mipsamv.htm?qua=ionula#pexeaco^^useragent=Mozilla/5.0 (Linux; Android 8.1.0; SM-A260G Build/OPR6; rv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Rocket/2.1.17(19420) Chrome/81.0.4044.138 Mobile Safari/537.36^^department=nderi^^user=tem^^event_id=tcu^^clienttranstime=eumiu^^requestmethod=nim^^requestsize=141^^requestversion=rehen^^status=uaeab^^responsesize=5521^^responseversion=serro^^transactionsize=1078",
             "event": {
@@ -662,7 +662,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "eturadip ZSCALERNSS: time=amquaera Mar 25 9:31:24 2018^^timezone=PT^^action=Allowed^^reason=success^^hostname=riatu2467.lan^^protocol=tcp^^serverip=10.221.20.165^^url=https://www.example.net/ritquiin/reseo.jpg?ari=umtot#onemulla^^urlcategory=atquo^^urlclass=borio^^dlpdictionaries=equatD^^dlpengine=uidol^^filetype=inculpa^^threatcategory=ruredol^^threatclass=iadeseru^^pagerisk=loremagn^^threatname=acons^^clientpublicIP=nimadmi^^ClientIP=10.7.18.226^^location=umiurer^^refererURL=https://internal.example.com/oluptass/uidol.txt?ametcon=ofdeFini#tasnu^^useragent=Mozilla/5.0 (Linux; Android 7.0; MEIZU M6 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.120 Mobile Safari/537.36 YaApp_Android/10.30 YaSearchBrowser/10.30^^department=tionev^^user=uasiarch^^event_id=velites^^clienttranstime=uredolor^^requestmethod=epreh^^requestsize=5810^^requestversion=edquiaco^^status=sequatD^^responsesize=4211^^responseversion=naaliq^^transactionsize=4508",
             "event": {
@@ -674,7 +674,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "asiarc ZSCALERNSS: time=lor Apr 8 4:33:58 2018^^timezone=GMT+02:00^^action=Allowed^^reason=unknown^^hostname=pici1525.www5.corp^^protocol=ipv6^^serverip=10.178.148.188^^url=https://mail.example.com/dexe/nemul.jpg?yCicero=inimave#eavolupt^^urlcategory=uipe^^urlclass=ipsa^^dlpdictionaries=con^^dlpengine=eirured^^filetype=sequamn^^threatcategory=perspici^^threatclass=inimve^^pagerisk=aea^^threatname=emipsumd^^clientpublicIP=didun^^ClientIP=10.155.252.123^^location=asiarch^^refererURL=https://www5.example.net/utla/deomni.gif?fugi=nse#nesciu^^useragent=Mozilla/5.0 (Linux; Android 5.1.1; Android Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36 YaApp_Android/9.80 YaSearchBrowser/9.80^^department=ssequ^^user=inrepreh^^event_id=rit^^clienttranstime=velitess^^requestmethod=niam^^requestsize=6665^^requestversion=vel^^status=ionevo^^responsesize=4580^^responseversion=ptate^^transactionsize=52",
             "event": {
@@ -686,7 +686,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "umfu ZSCALERNSS: time=utla Apr 22 11:36:32 2018^^timezone=CET^^action=Blocked^^reason=failure^^hostname=dolo6418.internal.host^^protocol=ipv6-icmp^^serverip=10.190.42.245^^url=https://mail.example.org/caecat/uel.html?enim=umq#sistena^^urlcategory=qui^^urlclass=caboN^^dlpdictionaries=imipsam^^dlpengine=eumiu^^filetype=tatevel^^threatcategory=quela^^threatclass=uamquaer^^pagerisk=texplica^^threatname=enimi^^clientpublicIP=illum^^ClientIP=10.220.1.249^^location=iqu^^refererURL=https://api.example.org/eumfugia/reeufugi.gif?uredol=uptat#toditau^^useragent=Opera/9.80 (Series 60; Opera Mini/7.1.32444/174.101; U; ru) Presto/2.12.423 Version/12.16^^department=quuntur^^user=olup^^event_id=aeab^^clienttranstime=uradipis^^requestmethod=aerat^^requestsize=2910^^requestversion=uira^^status=eosqui^^responsesize=3723^^responseversion=quinesc^^transactionsize=4724",
             "event": {
@@ -698,7 +698,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "aliqu ZSCALERNSS: time=sequine May 7 6:39:06 2018^^timezone=GMT-07:00^^action=Allowed^^reason=unknown^^hostname=imveni193.www5.host^^protocol=udp^^serverip=10.112.190.154^^url=https://mail.example.com/runtmoll/busBon.txt?ionev=vitaedi#rna^^urlcategory=cons^^urlclass=Except^^dlpdictionaries=lestiae^^dlpengine=iav^^filetype=umiure^^threatcategory=isiut^^threatclass=tin^^pagerisk=rporiss^^threatname=billoinv^^clientpublicIP=etconse^^ClientIP=10.55.38.153^^location=quido^^refererURL=https://example.org/uames/tla.gif?rch=psa#nreprehe^^useragent=Mozilla/5.0 (Linux; U; Android 7.1.2; uz-uz; Redmi 4X Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.141 Mobile Safari/537.36 XiaoMi/MiuiBrowser/12.2.3-g^^department=tvolup^^user=oremeu^^event_id=lab^^clienttranstime=lla^^requestmethod=urau^^requestsize=6127^^requestversion=upt^^status=equamni^^responsesize=363^^responseversion=eroi^^transactionsize=916",
             "event": {
@@ -710,7 +710,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "mdo ZSCALERNSS: time=labore May 21 1:41:41 2018^^timezone=OMST^^action=Allowed^^reason=success^^hostname=ionu3320.api.localhost^^protocol=igmp^^serverip=10.195.153.42^^url=https://api.example.com/lits/tvolu.jpg?squir=gnaaliq#quam^^urlcategory=deriti^^urlclass=edictasu^^dlpdictionaries=eturadi^^dlpengine=umS^^filetype=noru^^threatcategory=aliquide^^threatclass=tDuisaut^^pagerisk=uel^^threatname=dexerc^^clientpublicIP=vol^^ClientIP=10.250.48.82^^location=iqu^^refererURL=https://api.example.com/quuntur/nihi.gif?oremagna=aqu#utemvele^^useragent=Mozilla/5.0 (Linux; Android 9; G8142) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=serrorsi^^user=tsedquia^^event_id=rsit^^clienttranstime=quis^^requestmethod=upidatat^^requestsize=2982^^requestversion=nihilmo^^status=reetdo^^responsesize=6578^^responseversion=nidol^^transactionsize=4345",
             "event": {
@@ -722,7 +722,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "hite ZSCALERNSS: time=umfugi Jun 4 8:44:15 2018^^timezone=CT^^action=Blocked^^reason=unknown^^hostname=remips1499.www.local^^protocol=ipv6^^serverip=10.252.164.230^^url=https://mail.example.net/loremi/queporro.jpg?ade=nihilmol#nder^^urlcategory=ano^^urlclass=rumexer^^dlpdictionaries=eab^^dlpengine=iaconseq^^filetype=tseddo^^threatcategory=diduntut^^threatclass=rroq^^pagerisk=olore^^threatname=eratvolu^^clientpublicIP=oconsequ^^ClientIP=10.60.52.219^^location=untNeq^^refererURL=https://internal.example.org/scipit/litess.jpg?ide=quunturm#quovo^^useragent=mobmail android 2.1.3.3150^^department=usan^^user=gnamali^^event_id=iumtota^^clienttranstime=issusci^^requestmethod=fdeFin^^requestsize=2871^^requestversion=psu^^status=strud^^responsesize=501^^responseversion=saute^^transactionsize=7421",
             "event": {
@@ -734,7 +734,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "iumto ZSCALERNSS: time=sequatu Jun 19 3:46:49 2018^^timezone=CT^^action=Allowed^^reason=success^^hostname=mdoloree96.domain^^protocol=ggp^^serverip=10.187.16.73^^url=https://api.example.com/nge/psum.gif?exerci=isnostru#iad^^urlcategory=ngelits^^urlclass=volupt^^dlpdictionaries=billoi^^dlpengine=reseo^^filetype=quam^^threatcategory=ulpaquio^^threatclass=dipisc^^pagerisk=litsed^^threatname=lumd^^clientpublicIP=tiaec^^ClientIP=10.122.102.156^^location=totamr^^refererURL=https://mail.example.org/aper/entor.txt?lumdol=edutper#utemve^^useragent=Mozilla/5.0 (Linux; Android 6.0; ZTE BLADE V7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=metMa^^user=emoen^^event_id=ptate^^clienttranstime=mipsumqu^^requestmethod=turad^^requestsize=1704^^requestversion=billo^^status=doloremi^^responsesize=3365^^responseversion=iciatis^^transactionsize=2052",
             "event": {
@@ -746,7 +746,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "cul ZSCALERNSS: time=tate Jul 3 10:49:23 2018^^timezone=CEST^^action=Allowed^^reason=failure^^hostname=iatnulap7662.internal.local^^protocol=igmp^^serverip=10.120.215.174^^url=https://internal.example.org/ddoeiusm/apa.txt?uptatemU=rem#onorumet^^urlcategory=iscivel^^urlclass=rinci^^dlpdictionaries=eacomm^^dlpengine=aboNem^^filetype=mull^^threatcategory=ent^^threatclass=rema^^pagerisk=mcol^^threatname=tion^^clientpublicIP=umquia^^ClientIP=10.248.108.55^^location=itation^^refererURL=https://internal.example.org/tat/uredo.html?essequam=imav#mtot^^useragent=Opera/9.80 (Series 60; Opera Mini/7.1.32444/174.101; U; ru) Presto/2.12.423 Version/12.16^^department=tionemu^^user=prehend^^event_id=ntexplic^^clienttranstime=rvelillu^^requestmethod=uatDu^^requestsize=4620^^requestversion=isu^^status=moll^^responsesize=2104^^responseversion=ota^^transactionsize=4562",
             "event": {
@@ -758,7 +758,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "eniamq ZSCALERNSS: time=aloru Jul 17 5:51:58 2018^^timezone=PT^^action=Allowed^^reason=success^^hostname=sBonoru1929.example^^protocol=ggp^^serverip=10.51.161.245^^url=https://www5.example.net/yCice/uinesci.htm?taevitae=dminimv#quam^^urlcategory=saute^^urlclass=umdol^^dlpdictionaries=rerepr^^dlpengine=ipiscin^^filetype=trudexe^^threatcategory=qua^^threatclass=modit^^pagerisk=tatione^^threatname=aedicta^^clientpublicIP=squamest^^ClientIP=10.15.254.181^^location=emipsum^^refererURL=https://example.com/eFini/atDuisa.jpg?mips=dolo#reeufu^^useragent=Mozilla/5.0 (Linux; Android 9; 5024D_RU Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36 YaApp_Android/10.61 YaSearchBrowser/10.61^^department=adipis^^user=abo^^event_id=suntex^^clienttranstime=uptatema^^requestmethod=uteiru^^requestsize=4600^^requestversion=Cicero^^status=ven^^responsesize=5410^^responseversion=ficia^^transactionsize=7526",
             "event": {
@@ -770,7 +770,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "deFinibu ZSCALERNSS: time=iaecons Aug 1 12:54:32 2018^^timezone=ET^^action=Blocked^^reason=success^^hostname=onorumet4871.lan^^protocol=ipv6^^serverip=10.7.152.238^^url=https://api.example.com/itinvolu/adeserun.txt?tinv=Utenima#nse^^urlcategory=umq^^urlclass=enim^^dlpdictionaries=oreve^^dlpengine=metco^^filetype=xercita^^threatcategory=atev^^threatclass=vento^^pagerisk=litsed^^threatname=ciun^^clientpublicIP=rehender^^ClientIP=10.129.66.196^^location=mmodicon^^refererURL=https://api.example.com/tqu/emips.gif?tinvolu=ptat#amquisn^^useragent=Mozilla/5.0 (Linux; Android 9; ZTE Blade V1000RU Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36 YaApp_Android/10.91 YaSearchBrowser/10.91^^department=dol^^user=equamn^^event_id=scipi^^clienttranstime=rem^^requestmethod=reh^^requestsize=3604^^requestversion=gnama^^status=ursintoc^^responsesize=6628^^responseversion=ction^^transactionsize=491",
             "event": {
@@ -782,7 +782,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "siuta ZSCALERNSS: time=atcu Aug 15 7:57:06 2018^^timezone=PST^^action=Blocked^^reason=success^^hostname=onproi4354.www5.invalid^^protocol=ggp^^serverip=10.29.162.157^^url=https://www.example.org/sci/isquames.gif?tlabor=itecto#loreeuf^^urlcategory=orainci^^urlclass=orese^^dlpdictionaries=aev^^dlpengine=uelaudan^^filetype=lab^^threatcategory=sequa^^threatclass=orinrep^^pagerisk=pta^^threatname=uradi^^clientpublicIP=sequu^^ClientIP=10.185.107.27^^location=susc^^refererURL=https://www.example.org/eatae/siutali.html?quelauda=rcit#dolo^^useragent=Mozilla/5.0 (iPhone; CPU iPhone OS 13_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 LightSpeed [FBAN/MessengerLiteForiOS;FBAV/266.0.0.32.114;FBBV/216059178;FBDV/iPhone10,6;FBMD/iPhone;FBSN/iOS;FBSV/13.4.1;FBSS/3;FBCR/;FBID/phone;FBLC/en_US;FBOP/0]^^department=orese^^user=evelite^^event_id=remquela^^clienttranstime=toreve^^requestmethod=squirat^^requestsize=2977^^requestversion=equunt^^status=mto^^responsesize=4116^^responseversion=atio^^transactionsize=6258",
             "event": {
@@ -794,7 +794,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "rem ZSCALERNSS: time=consecte Aug 29 2:59:40 2018^^timezone=ET^^action=Blocked^^reason=success^^hostname=beataevi7552.api.test^^protocol=ipv6^^serverip=10.215.63.248^^url=https://mail.example.org/umdolo/nimv.htm?equunt=tutla#usmod^^urlcategory=ine^^urlclass=qui^^dlpdictionaries=itse^^dlpengine=lapari^^filetype=Bonor^^threatcategory=ipex^^threatclass=odita^^pagerisk=metc^^threatname=aincidu^^clientpublicIP=reprehe^^ClientIP=10.138.0.214^^location=uisaut^^refererURL=https://internal.example.org/ommodic/mmodic.txt?esse=nihi#xeaco^^useragent=Mozilla/5.0 (Linux; Android 9; 5024D_RU Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36 YaApp_Android/10.61 YaSearchBrowser/10.61^^department=uianonn^^user=eavolupt^^event_id=dantium^^clienttranstime=ors^^requestmethod=dqu^^requestsize=6682^^requestversion=edi^^status=eumiure^^responsesize=1926^^responseversion=eacomm^^transactionsize=2676",
             "event": {
@@ -806,7 +806,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "pre ZSCALERNSS: time=aute Sep 12 10:02:15 2018^^timezone=PST^^action=Allowed^^reason=success^^hostname=rvelill1981.www.invalid^^protocol=udp^^serverip=10.26.115.88^^url=https://mail.example.net/tvol/ostru.htm?oei=iquipex#byCice^^urlcategory=deritq^^urlclass=boreetdo^^dlpdictionaries=teni^^dlpengine=iin^^filetype=nostr^^threatcategory=luptatem^^threatclass=tNequepo^^pagerisk=liq^^threatname=eleumiu^^clientpublicIP=etdol^^ClientIP=10.12.130.224^^location=magnido^^refererURL=https://www.example.org/dolor/ing.jpg?umdo=aer#quela^^useragent=Mozilla/5.0 (Linux; Android 10; STK-L21 Build/HUAWEISTK-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36 YaApp_Android/10.91 YaSearchBrowser/10.91^^department=itatis^^user=Nequepo^^event_id=edictas^^clienttranstime=emac^^requestmethod=rmagnido^^requestsize=6135^^requestversion=elitsedd^^status=hitecto^^responsesize=6315^^responseversion=repreh^^transactionsize=1238",
             "event": {
@@ -818,7 +818,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "usan ZSCALERNSS: time=ugiatn Sep 27 5:04:49 2018^^timezone=GMT+02:00^^action=Blocked^^reason=failure^^hostname=quia7214.example^^protocol=igmp^^serverip=10.193.152.42^^url=https://mail.example.org/pariatur/cita.html?equuntur=rve#atemacc^^urlcategory=labore^^urlclass=iqua^^dlpdictionaries=ciunt^^dlpengine=exea^^filetype=ostrumex^^threatcategory=eruntmol^^threatclass=plicab^^pagerisk=imide^^threatname=uiineav^^clientpublicIP=nder^^ClientIP=10.91.20.27^^location=asia^^refererURL=https://api.example.com/psamvolu/teturad.jpg?iavol=psumdol#urautodi^^useragent=Mozilla/5.0 (Linux; Android 6.0; QMobile X700 PRO II) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36^^department=modtempo^^user=edict^^event_id=nost^^clienttranstime=orisnis^^requestmethod=umq^^requestsize=2801^^requestversion=quatur^^status=isiutali^^responsesize=1508^^responseversion=emquel^^transactionsize=365",
             "event": {
@@ -830,7 +830,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "iavol ZSCALERNSS: time=utemvel Oct 11 12:07:23 2018^^timezone=PST^^action=Allowed^^reason=failure^^hostname=aturExc7343.invalid^^protocol=ipv6^^serverip=10.146.69.38^^url=https://example.org/aturE/aaliqu.gif?nvol=doloreeu#elillumq^^urlcategory=loremeum^^urlclass=luptatem^^dlpdictionaries=ing^^dlpengine=hen^^filetype=riameaqu^^threatcategory=etd^^threatclass=omnisi^^pagerisk=dolor^^threatname=rsp^^clientpublicIP=quir^^ClientIP=10.55.192.102^^location=tsuntinc^^refererURL=https://example.org/onproid/ciduntut.html?xer=iat#orain^^useragent=Mozilla/5.0 (Linux; Android 4.1.2; Micromax P410i Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36^^department=uame^^user=quia^^event_id=Exce^^clienttranstime=nim^^requestmethod=userro^^requestsize=1008^^requestversion=uta^^status=tsun^^responsesize=7120^^responseversion=gni^^transactionsize=5280",
             "event": {
@@ -842,7 +842,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "tione ZSCALERNSS: time=nibus Oct 25 7:09:57 2018^^timezone=GMT-07:00^^action=Allowed^^reason=success^^hostname=olo7317.www5.localhost^^protocol=udp^^serverip=10.249.1.143^^url=https://internal.example.org/olorin/orisnisi.gif?eritquii=atevelit#dese^^urlcategory=ptasn^^urlclass=liqui^^dlpdictionaries=ectetur^^dlpengine=eacomm^^filetype=temqu^^threatcategory=tdolore^^threatclass=Utenim^^pagerisk=quisno^^threatname=quaUten^^clientpublicIP=eufugia^^ClientIP=10.124.177.226^^location=iarc^^refererURL=https://www5.example.org/ncidunt/uiac.jpg?luptat=ehend#involupt^^useragent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 YaBrowser/20.3.0.2221 Yowser/2.5 Safari/537.36^^department=tincul^^user=isciveli^^event_id=ntutlab^^clienttranstime=sitamet^^requestmethod=onevo^^requestsize=3736^^requestversion=nsequ^^status=ing^^responsesize=3291^^responseversion=vitaed^^transactionsize=7672",
             "event": {
@@ -854,7 +854,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "modit ZSCALERNSS: time=quamnih Nov 9 2:12:32 2018^^timezone=OMST^^action=Blocked^^reason=failure^^hostname=uiin1342.mail.invalid^^protocol=rdp^^serverip=10.167.176.220^^url=https://example.org/vel/preh.html?sequamni=edutpers#deo^^urlcategory=eni^^urlclass=quipe^^dlpdictionaries=oluptat^^dlpengine=stenatus^^filetype=eabillo^^threatcategory=iaecon^^threatclass=ect^^pagerisk=tquid^^threatname=seru^^clientpublicIP=oriss^^ClientIP=10.146.228.249^^location=psumdolo^^refererURL=https://example.net/bor/magnido.html?emagnaal=nih#ncididu^^useragent=Mozilla/5.0 (iPhone; CPU iPhone OS 13_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 LightSpeed [FBAN/MessengerLiteForiOS;FBAV/266.0.0.32.114;FBBV/216059178;FBDV/iPhone10,6;FBMD/iPhone;FBSN/iOS;FBSV/13.4.1;FBSS/3;FBCR/;FBID/phone;FBLC/en_US;FBOP/0]^^department=gitsed^^user=estla^^event_id=ione^^clienttranstime=ecillum^^requestmethod=maccu^^requestsize=5298^^requestversion=quisquam^^status=boreet^^responsesize=620^^responseversion=Malorumw^^transactionsize=5212",
             "event": {
@@ -866,7 +866,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "issu ZSCALERNSS: time=tconsect Nov 23 9:15:06 2018^^timezone=OMST^^action=Allowed^^reason=unknown^^hostname=agna5654.www.corp^^protocol=tcp^^serverip=10.200.74.101^^url=https://example.com/nonproi/dolor.jpg?molli=oeiusm#aUtenim^^urlcategory=ntincul^^urlclass=nnumquam^^dlpdictionaries=etdol^^dlpengine=sed^^filetype=uep^^threatcategory=ametco^^threatclass=nde^^pagerisk=reprehe^^threatname=umdolo^^clientpublicIP=duntutl^^ClientIP=10.203.47.23^^location=empor^^refererURL=https://mail.example.net/teveli/utperspi.html?luptate=aturvel#ostrumex^^useragent=Mozilla/5.0 (Linux; Android 10; SM-A305FN Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.96 Mobile Safari/537.36 YandexSearch/8.10 YandexSearchBrowser/8.10^^department=sedquia^^user=litesse^^event_id=ntmo^^clienttranstime=aliqu^^requestmethod=iqu^^requestsize=4429^^requestversion=ationula^^status=doconse^^responsesize=4822^^responseversion=oreeufug^^transactionsize=5020",
             "event": {
@@ -878,7 +878,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "tenima ZSCALERNSS: time=emagnam Dec 7 4:17:40 2018^^timezone=CT^^action=Blocked^^reason=success^^hostname=ites5711.internal.host^^protocol=ggp^^serverip=10.162.78.48^^url=https://example.com/sedqui/iuntNe.gif?epteu=nvent#uepor^^urlcategory=umSecti^^urlclass=eabil^^dlpdictionaries=ibusB^^dlpengine=rporis^^filetype=etco^^threatcategory=mip^^threatclass=ereprehe^^pagerisk=olu^^threatname=nofdeF^^clientpublicIP=riaturEx^^ClientIP=10.24.23.209^^location=itautfu^^refererURL=https://internal.example.org/ole/odi.txt?mporain=ectetur#adipisc^^useragent=Mozilla/5.0 (Linux; Android 9; U307AS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=iumd^^user=ntore^^event_id=tect^^clienttranstime=ion^^requestmethod=tutl^^requestsize=3811^^requestversion=bor^^status=ameaquei^^responsesize=4147^^responseversion=uelaud^^transactionsize=1306",
             "event": {
@@ -890,7 +890,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ngelit ZSCALERNSS: time=quiano Dec 21 11:20:14 2018^^timezone=GMT+02:00^^action=Allowed^^reason=success^^hostname=oluptat2848.api.home^^protocol=igmp^^serverip=10.55.151.53^^url=https://www5.example.net/lits/Nemoen.txt?elillu=seruntmo#imidest^^urlcategory=oeiusmod^^urlclass=uidolore^^dlpdictionaries=iacon^^dlpengine=ncu^^filetype=quaturve^^threatcategory=ciad^^threatclass=diconseq^^pagerisk=utod^^threatname=ostr^^clientpublicIP=amcorp^^ClientIP=10.211.66.68^^location=uptatem^^refererURL=https://mail.example.org/nproide/mali.htm?siutali=mfugi#ceroinBC^^useragent=Mozilla/5.0 (Linux; Android 9; G8142) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=maveni^^user=squir^^event_id=commod^^clienttranstime=umqu^^requestmethod=umet^^requestsize=5891^^requestversion=amestqu^^status=aliqua^^responsesize=1782^^responseversion=teirure^^transactionsize=1210",
             "event": {
@@ -902,7 +902,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "dipisciv ZSCALERNSS: time=nsequun Jan 5 6:22:49 2019^^timezone=ET^^action=Blocked^^reason=unknown^^hostname=ngelitse7535.internal.lan^^protocol=rdp^^serverip=10.110.16.169^^url=https://example.org/eius/evo.jpg?iarchit=volupt#ipis^^urlcategory=usBonor^^urlclass=mide^^dlpdictionaries=sten^^dlpengine=enderi^^filetype=labore^^threatcategory=uasiarch^^threatclass=iamquisn^^pagerisk=magnama^^threatname=reprehe^^clientpublicIP=citatio^^ClientIP=10.209.203.156^^location=esciunt^^refererURL=https://www.example.com/liquide/BCSedut.htm?litani=temse#samvo^^useragent=Mozilla/5.0 (Linux; Android 9; G8142) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=roinBCSe^^user=mes^^event_id=labori^^clienttranstime=ditau^^requestmethod=lupta^^requestsize=6650^^requestversion=tam^^status=olu^^responsesize=409^^responseversion=iut^^transactionsize=3808",
             "event": {
@@ -914,7 +914,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "deser ZSCALERNSS: time=boris Jan 19 1:25:23 2019^^timezone=PST^^action=Allowed^^reason=success^^hostname=tiumtot3611.internal.localdomain^^protocol=udp^^serverip=10.84.9.150^^url=https://www5.example.net/equun/veli.gif?tem=iadeseru#uiineavo^^urlcategory=enimadmi^^urlclass=qui^^dlpdictionaries=ita^^dlpengine=lamco^^filetype=natuser^^threatcategory=Excepteu^^threatclass=omnis^^pagerisk=tati^^threatname=orinc^^clientpublicIP=teursi^^ClientIP=10.107.68.114^^location=nofdeFin^^refererURL=https://internal.example.org/ollit/umfug.htm?lumquid=Sectio#tiumdol^^useragent=Mozilla/5.0 (Linux; Android 9; LG-US998) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=ocons^^user=sequatDu^^event_id=nsecte^^clienttranstime=pta^^requestmethod=uianonnu^^requestsize=5724^^requestversion=veleumi^^status=volupt^^responsesize=6822^^responseversion=itatise^^transactionsize=3714",
             "event": {
@@ -926,7 +926,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "userro ZSCALERNSS: time=oree Feb 2 8:27:57 2019^^timezone=CEST^^action=Blocked^^reason=failure^^hostname=gnaa4656.api.example^^protocol=igmp^^serverip=10.26.222.144^^url=https://internal.example.com/ecatcu/tMalo.txt?nse=rauto#rese^^urlcategory=nonproi^^urlclass=doconse^^dlpdictionaries=henderi^^dlpengine=tisunde^^filetype=ende^^threatcategory=quidolor^^threatclass=lloin^^pagerisk=eomnis^^threatname=proiden^^clientpublicIP=moenimip^^ClientIP=10.124.119.48^^location=atquo^^refererURL=https://www.example.com/ern/ationula.jpg?nsequun=ateveli#aqua^^useragent=Mozilla/5.0 (Linux; Android 10; SM-A305FN Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.96 Mobile Safari/537.36 YandexSearch/8.10 YandexSearchBrowser/8.10^^department=amn^^user=nre^^event_id=sintoc^^clienttranstime=rinci^^requestmethod=ici^^requestsize=7328^^requestversion=Nequepor^^status=aUten^^responsesize=4127^^responseversion=tatnon^^transactionsize=977",
             "event": {
@@ -938,7 +938,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "mnisis ZSCALERNSS: time=onsequa Feb 17 3:30:32 2019^^timezone=GMT+02:00^^action=Allowed^^reason=failure^^hostname=psaqu6066.www5.localhost^^protocol=ipv6-icmp^^serverip=10.164.190.2^^url=https://mail.example.org/ntutlabo/leumiure.htm?eacommo=amqua#tionevol^^urlcategory=itvo^^urlclass=asi^^dlpdictionaries=tobe^^dlpengine=ssequa^^filetype=emp^^threatcategory=emoeni^^threatclass=officiad^^pagerisk=veniam^^threatname=labo^^clientpublicIP=ssecill^^ClientIP=10.223.11.164^^location=tate^^refererURL=https://internal.example.net/ali/ionu.txt?cte=ariatu#ess^^useragent=Mozilla/5.0 (Linux; Android 10; LM-V350) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=risnisiu^^user=ten^^event_id=datatno^^clienttranstime=equepor^^requestmethod=antium^^requestsize=5241^^requestversion=texp^^status=mvolup^^responsesize=4382^^responseversion=ema^^transactionsize=6673",
             "event": {
@@ -950,7 +950,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "nsec ZSCALERNSS: time=iaeco Mar 3 10:33:06 2019^^timezone=OMST^^action=Blocked^^reason=failure^^hostname=iavol5202.api.example^^protocol=udp^^serverip=10.14.37.8^^url=https://www.example.org/ugitsed/ritatis.jpg?xplic=stenat#mquis^^urlcategory=rume^^urlclass=samnisiu^^dlpdictionaries=yCiceroi^^dlpengine=evolupta^^filetype=citat^^threatcategory=prehende^^threatclass=vitaedic^^pagerisk=remip^^threatname=rsita^^clientpublicIP=rehe^^ClientIP=10.121.181.243^^location=midest^^refererURL=https://example.org/olupta/modi.txt?rnatur=tseddo#utaliq^^useragent=Mozilla/5.0 (Linux; Android 6.0; Lenovo A2016a40 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.106 Mobile Safari/537.36 YaApp_Android/10.30 YaSearchBrowser/10.30^^department=errorsi^^user=umwr^^event_id=olor^^clienttranstime=cupida^^requestmethod=rinc^^requestsize=7719^^requestversion=roqu^^status=dquia^^responsesize=1460^^responseversion=strude^^transactionsize=6667",
             "event": {
@@ -962,7 +962,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ptate ZSCALERNSS: time=oloreeu Mar 17 5:35:40 2019^^timezone=ET^^action=Blocked^^reason=success^^hostname=uame1361.api.local^^protocol=udp^^serverip=10.90.20.202^^url=https://mail.example.com/aute/dictasu.gif?ptas=iadolo#cidu^^urlcategory=nonp^^urlclass=abillo^^dlpdictionaries=tinv^^dlpengine=iar^^filetype=nse^^threatcategory=turQuis^^threatclass=tat^^pagerisk=pta^^threatname=henderi^^clientpublicIP=onsec^^ClientIP=10.10.93.133^^location=tau^^refererURL=https://www.example.net/urad/upt.gif?sitamet=xerc#mcolabor^^useragent=Mozilla/5.0 (Linux; Android 9; ZTE Blade V1000RU Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36 YaApp_Android/10.91 YaSearchBrowser/10.91^^department=quipe^^user=evita^^event_id=ostrude^^clienttranstime=itsed^^requestmethod=nia^^requestsize=7548^^requestversion=rehe^^status=eseosqu^^responsesize=3488^^responseversion=sundeo^^transactionsize=3076",
             "event": {
@@ -974,7 +974,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "laud ZSCALERNSS: time=uido Apr 1 12:38:14 2019^^timezone=ET^^action=Allowed^^reason=success^^hostname=rsitame4049.internal.corp^^protocol=tcp^^serverip=10.34.98.144^^url=https://mail.example.net/enbyCic/aturau.gif?orroqui=sci#psamvolu^^urlcategory=itsedqui^^urlclass=oreve^^dlpdictionaries=omn^^dlpengine=onevol^^filetype=ese^^threatcategory=reprehen^^threatclass=Exce^^pagerisk=tocca^^threatname=tinvolu^^clientpublicIP=ecatc^^ClientIP=10.77.102.206^^location=quin^^refererURL=https://api.example.com/sedqui/ueporroq.htm?eetdol=tia#lup^^useragent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 YaBrowser/20.3.0.2221 Yowser/2.5 Safari/537.36^^department=inBCSed^^user=tectobe^^event_id=pariatu^^clienttranstime=uiacons^^requestmethod=ulapa^^requestsize=4143^^requestversion=henderit^^status=ident^^responsesize=4610^^responseversion=mquae^^transactionsize=1789",
             "event": {
@@ -986,7 +986,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "lit ZSCALERNSS: time=uiine Apr 15 7:40:49 2019^^timezone=ET^^action=Blocked^^reason=unknown^^hostname=elit912.www5.test^^protocol=udp^^serverip=10.176.233.249^^url=https://example.org/olu/mqua.txt?mdolore=ita#aeratvol^^urlcategory=odite^^urlclass=atn^^dlpdictionaries=sectet^^dlpengine=boreetd^^filetype=ueporro^^threatcategory=cto^^threatclass=essequa^^pagerisk=gnidolor^^threatname=itlabori^^clientpublicIP=amestqui^^ClientIP=10.75.144.118^^location=qua^^refererURL=https://api.example.com/pteurs/intocc.gif?veni=turmag#dutper^^useragent=Mozilla/5.0 (Linux; Android 8.0.0; VS996) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=aconseq^^user=isnos^^event_id=ntin^^clienttranstime=tenatus^^requestmethod=odic^^requestsize=3588^^requestversion=intocca^^status=equuntu^^responsesize=3976^^responseversion=ine^^transactionsize=3409",
             "event": {
@@ -998,7 +998,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "rcit ZSCALERNSS: time=secte Apr 29 2:43:23 2019^^timezone=GMT-07:00^^action=Allowed^^reason=unknown^^hostname=tat6671.www.local^^protocol=udp^^serverip=10.149.6.107^^url=https://api.example.net/mnisiut/eabil.jpg?psumqui=trude#ccusa^^urlcategory=ndeomni^^urlclass=chite^^dlpdictionaries=obeatae^^dlpengine=rehen^^filetype=uam^^threatcategory=vitaedi^^threatclass=uis^^pagerisk=emagnaal^^threatname=uunturm^^clientpublicIP=nonnumq^^ClientIP=10.236.55.236^^location=aerat^^refererURL=https://www.example.org/eata/maliquam.jpg?gnamali=olabor#ionem^^useragent=Mozilla/5.0 (Linux; Android 10; LM-V350) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=eseosqu^^user=redolo^^event_id=mveleu^^clienttranstime=cillumdo^^requestmethod=mvele^^requestsize=4686^^requestversion=isnost^^status=lumdolor^^responsesize=559^^responseversion=aspe^^transactionsize=4318",
             "event": {
@@ -1010,7 +1010,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "erita ZSCALERNSS: time=eursint May 13 9:45:57 2019^^timezone=CET^^action=Blocked^^reason=failure^^hostname=uis5050.www.local^^protocol=igmp^^serverip=10.97.202.149^^url=https://api.example.net/uamestq/eetdol.html?ctionofd=uianonnu#ntNeque^^urlcategory=magnidol^^urlclass=meumfug^^dlpdictionaries=irat^^dlpengine=uatu^^filetype=gel^^threatcategory=modt^^threatclass=atcupi^^pagerisk=xeacomm^^threatname=tla^^clientpublicIP=itaspe^^ClientIP=10.13.125.101^^location=uisautei^^refererURL=https://mail.example.net/ihilmol/scinge.jpg?str=yCiceroi#loremeu^^useragent=Mozilla/5.0 (Linux; Android 4.1.2; Micromax P410i Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36^^department=velitess^^user=colab^^event_id=itte^^clienttranstime=niamquis^^requestmethod=uaUten^^requestsize=7772^^requestversion=exeacomm^^status=uptat^^responsesize=982^^responseversion=ore^^transactionsize=7330",
             "event": {
@@ -1022,7 +1022,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "poriss ZSCALERNSS: time=enatus May 28 4:48:31 2019^^timezone=GMT+02:00^^action=Blocked^^reason=failure^^hostname=ficiad1312.api.host^^protocol=igmp^^serverip=10.141.66.163^^url=https://mail.example.net/ius/msequ.jpg?ptat=tionula#gnido^^urlcategory=usmo^^urlclass=squirati^^dlpdictionaries=uasi^^dlpengine=quaeabi^^filetype=sequ^^threatcategory=gna^^threatclass=itautf^^pagerisk=aev^^threatname=uovolup^^clientpublicIP=tMaloru^^ClientIP=10.230.61.102^^location=rautod^^refererURL=https://example.net/minimav/uovo.html?orinrep=tNequ#eca^^useragent=Mozilla/5.0 (Linux; Android 6.0; ZTE BLADE V7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=serr^^user=umdolo^^event_id=iduntut^^clienttranstime=admini^^requestmethod=mini^^requestsize=3181^^requestversion=cididun^^status=iamqu^^responsesize=1324^^responseversion=iunt^^transactionsize=2218",
             "event": {
@@ -1034,7 +1034,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "uisaut ZSCALERNSS: time=apar Jun 11 11:51:06 2019^^timezone=OMST^^action=Blocked^^reason=unknown^^hostname=itaspe921.mail.invalid^^protocol=tcp^^serverip=10.10.25.145^^url=https://www.example.org/iat/acom.html?umdolo=oluptass#umqu^^urlcategory=rsitam^^urlclass=aliqui^^dlpdictionaries=uipexea^^dlpengine=sauteiru^^filetype=nibusB^^threatcategory=eetdolo^^threatclass=issuscip^^pagerisk=iduntu^^threatname=nde^^clientpublicIP=naturau^^ClientIP=10.224.249.228^^location=odit^^refererURL=https://www5.example.net/lapa/enia.jpg?deserun=ugia#isiuta^^useragent=Mozilla/5.0 (Linux; Android 10; LM-V350) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36^^department=ugiatq^^user=mnisiuta^^event_id=nrepre^^clienttranstime=eumfu^^requestmethod=remap^^requestsize=1954^^requestversion=yCicero^^status=dqui^^responsesize=6666^^responseversion=oin^^transactionsize=3838",
             "event": {
@@ -1046,7 +1046,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "eiusm ZSCALERNSS: time=assit Jun 25 6:53:40 2019^^timezone=PT^^action=Blocked^^reason=unknown^^hostname=archite4407.mail.invalid^^protocol=ipv6-icmp^^serverip=10.234.34.40^^url=https://www.example.com/onorum/umiure.gif?lites=admini#trumexer^^urlcategory=maveniam^^urlclass=ctobeat^^dlpdictionaries=emoenim^^dlpengine=oqui^^filetype=olab^^threatcategory=remagnam^^threatclass=neavolu^^pagerisk=adipi^^threatname=idid^^clientpublicIP=ela^^ClientIP=10.247.255.107^^location=lore^^refererURL=https://www5.example.org/olorsi/everitat.htm?iamq=ercitat#velillu^^useragent=Mozilla/5.0 (Linux; Android 9; Notepad_K10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Safari/537.36^^department=elitsed^^user=aeabillo^^event_id=dolori^^clienttranstime=mco^^requestmethod=nofdeF^^requestsize=245^^requestversion=writt^^status=ent^^responsesize=3750^^responseversion=uaer^^transactionsize=2304",
             "event": {
@@ -1058,7 +1058,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "tectobe ZSCALERNSS: time=ain Jul 10 1:56:14 2019^^timezone=OMST^^action=Blocked^^reason=success^^hostname=aria1424.mail.home^^protocol=igmp^^serverip=10.124.81.20^^url=https://mail.example.org/veni/rspi.htm?ntium=imadmi#dquiac^^urlcategory=liquide^^urlclass=uatD^^dlpdictionaries=reh^^dlpengine=uel^^filetype=tmollit^^threatcategory=ametco^^threatclass=ilmoles^^pagerisk=xeaco^^threatname=texpl^^clientpublicIP=tqua^^ClientIP=10.250.102.42^^location=totamr^^refererURL=https://internal.example.com/iciat/uira.htm?cti=orsitvo#elit^^useragent=Mozilla/5.0 (Linux; Android 9; Pixel 3 Build/PD1A.180720.030) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36^^department=tenby^^user=tNequ^^event_id=piciatis^^clienttranstime=ritten^^requestmethod=tatisetq^^requestsize=2753^^requestversion=madmi^^status=icia^^responsesize=412^^responseversion=eroi^^transactionsize=2077",
             "event": {
@@ -1070,7 +1070,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "riatur ZSCALERNSS: time=amrema Jul 24 8:58:48 2019^^timezone=OMST^^action=Allowed^^reason=unknown^^hostname=Bonoru7444.www5.example^^protocol=rdp^^serverip=10.166.205.159^^url=https://www.example.com/tem/litsedq.htm?ium=utfugit#beat^^urlcategory=odita^^urlclass=borisn^^dlpdictionaries=itanimid^^dlpengine=ianonnum^^filetype=cte^^threatcategory=iratio^^threatclass=proid^^pagerisk=inculp^^threatname=atnu^^clientpublicIP=ntmo^^ClientIP=10.154.188.132^^location=atevelit^^refererURL=https://internal.example.com/iconsequ/adipisci.txt?gnido=iamq#Utenim^^useragent=Mozilla/5.0 (compatible; Yahoo Ad monitoring; https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html) yahoo.adquality.lwd.desktop/1591143192-10^^department=uisa^^user=uptat^^event_id=siutal^^clienttranstime=umetMalo^^requestmethod=onevolu^^requestsize=4181^^requestversion=sedquian^^status=involu^^responsesize=5294^^responseversion=nsequatD^^transactionsize=7089",
             "event": {
@@ -1082,7 +1082,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "liquid ZSCALERNSS: time=uamq Aug 7 4:01:23 2019^^timezone=CEST^^action=Allowed^^reason=success^^hostname=icero1297.internal.domain^^protocol=ipv6-icmp^^serverip=10.46.71.46^^url=https://www.example.com/amcola/eumiurer.gif?stiaeco=equu#laborisn^^urlcategory=atisetq^^urlclass=mSectio^^dlpdictionaries=rsinto^^dlpengine=nonnumqu^^filetype=atis^^threatcategory=todit^^threatclass=upta^^pagerisk=fug^^threatname=ulpaq^^clientpublicIP=rured^^ClientIP=10.138.193.38^^location=udex^^refererURL=https://api.example.com/uin/isci.htm?nsectetu=spici#untutl^^useragent=Mozilla/5.0 (compatible; Yahoo Ad monitoring; https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html) yahoo.adquality.lwd.desktop/1591143192-10^^department=tate^^user=sintocca^^event_id=ugiat^^clienttranstime=asuntex^^requestmethod=uovolup^^requestsize=745^^requestversion=amali^^status=uiav^^responsesize=274^^responseversion=mullamco^^transactionsize=7843",
             "event": {
@@ -1094,7 +1094,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ons ZSCALERNSS: time=radip Aug 21 11:03:57 2019^^timezone=CT^^action=Blocked^^reason=unknown^^hostname=oloremeu5047.www5.invalid^^protocol=tcp^^serverip=10.254.119.31^^url=https://api.example.net/sedquian/lamcorpo.html?sequatD=Nequepo#veleum^^urlcategory=eturad^^urlclass=tor^^dlpdictionaries=hender^^dlpengine=moditemp^^filetype=pitlab^^threatcategory=tutlabor^^threatclass=imadmi^^pagerisk=nculp^^threatname=quamnihi^^clientpublicIP=nimadmi^^ClientIP=10.172.159.251^^location=nima^^refererURL=https://mail.example.org/tur/tlaboru.htm?tutlabo=incid#der^^useragent=Mozilla/5.0 (Linux; Android 6.0; U20 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.147 Mobile Safari/537.36 YaApp_Android/10.90 YaSearchBrowser/10.90^^department=tconsect^^user=usm^^event_id=uunturma^^clienttranstime=namaliqu^^requestmethod=tatemacc^^requestsize=2324^^requestversion=nor^^status=saut^^responsesize=2804^^responseversion=stiaeco^^transactionsize=1508",
             "event": {
@@ -1106,7 +1106,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "osam ZSCALERNSS: time=ncid Sep 5 6:06:31 2019^^timezone=PT^^action=Allowed^^reason=unknown^^hostname=edutpe1255.internal.lan^^protocol=ipv6-icmp^^serverip=10.195.62.230^^url=https://www5.example.com/ictasun/iumto.txt?erro=admin#uisnostr^^urlcategory=nemul^^urlclass=amqua^^dlpdictionaries=isnost^^dlpengine=eaco^^filetype=oremeu^^threatcategory=uis^^threatclass=isnost^^pagerisk=itvolu^^threatname=citation^^clientpublicIP=spernatu^^ClientIP=10.98.126.206^^location=tion^^refererURL=https://internal.example.org/uidolore/uatDuisa.htm?uipe=alo#ufugia^^useragent=Mozilla/5.0 (Linux; Android 10; SM-A715F Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.83 Mobile Safari/537.36 [FB_IAB/Orca-Android;FBAV/266.0.0.16.117;]^^department=atatnonp^^user=ptassit^^event_id=sequat^^clienttranstime=Uteni^^requestmethod=oriosa^^requestsize=7244^^requestversion=temporai^^status=totamrem^^responsesize=4957^^responseversion=dminimve^^transactionsize=1182",
             "event": {
@@ -1118,7 +1118,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "idolo ZSCALERNSS: time=citat Sep 19 1:09:05 2019^^timezone=PT^^action=Blocked^^reason=unknown^^hostname=nderit1171.www5.domain^^protocol=rdp^^serverip=10.144.93.186^^url=https://www5.example.org/oriosa/ssusc.htm?atemacc=rsitvolu#isi^^urlcategory=umquia^^urlclass=evolu^^dlpdictionaries=quidolo^^dlpengine=utlabore^^filetype=texplica^^threatcategory=boru^^threatclass=ntut^^pagerisk=elaud^^threatname=acomm^^clientpublicIP=edquia^^ClientIP=10.84.140.5^^location=laboris^^refererURL=https://www.example.org/lpaquiof/isisten.txt?culp=Ciceroin#aeco^^useragent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 YaBrowser/20.3.0.2221 Yowser/2.5 Safari/537.36^^department=mull^^user=eroi^^event_id=adminim^^clienttranstime=naturau^^requestmethod=nima^^requestsize=4943^^requestversion=sed^^status=mUten^^responsesize=6658^^responseversion=tfugitse^^transactionsize=6480",
             "event": {
@@ -1130,7 +1130,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "uianon ZSCALERNSS: time=iutal Oct 3 8:11:40 2019^^timezone=ET^^action=Allowed^^reason=success^^hostname=nos4114.api.lan^^protocol=rdp^^serverip=10.31.58.6^^url=https://mail.example.net/tseddoei/byCi.gif?assitas=nul#ame^^urlcategory=lites^^urlclass=sec^^dlpdictionaries=aqua^^dlpengine=meumf^^filetype=olu^^threatcategory=ectet^^threatclass=tquovo^^pagerisk=orev^^threatname=lapa^^clientpublicIP=xeacom^^ClientIP=10.198.84.190^^location=henderi^^refererURL=https://mail.example.com/dminim/sse.gif?equ=turvelil#lor^^useragent=Mozilla/5.0 (Linux; Android 5.1.1; Android Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36 YaApp_Android/9.80 YaSearchBrowser/9.80^^department=ern^^user=unt^^event_id=volu^^clienttranstime=iineavo^^requestmethod=qua^^requestsize=6831^^requestversion=tenbyC^^status=xeacomm^^responsesize=6855^^responseversion=psu^^transactionsize=5856",
             "event": {
@@ -1142,7 +1142,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "ept ZSCALERNSS: time=nem Oct 18 3:14:14 2019^^timezone=ET^^action=Allowed^^reason=unknown^^hostname=oremeum4231.internal.host^^protocol=ipv6^^serverip=10.139.90.218^^url=https://www5.example.org/liquipe/rehe.gif?niamqu=uioffi#suntin^^urlcategory=consequa^^urlclass=tionu^^dlpdictionaries=umqua^^dlpengine=ommod^^filetype=ione^^threatcategory=mnihi^^threatclass=rrorsi^^pagerisk=icons^^threatname=voluptat^^clientpublicIP=volu^^ClientIP=10.131.81.172^^location=llamcor^^refererURL=https://mail.example.com/veri/run.txt?enimadm=empo#apa^^useragent=Mozilla/5.0 (Linux; U; Android 4.0.3; es-us; GT-P3100 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30^^department=icons^^user=hende^^event_id=umdol^^clienttranstime=Sedutper^^requestmethod=exe^^requestsize=6188^^requestversion=preh^^status=dol^^responsesize=3128^^responseversion=gnamal^^transactionsize=6119",
             "event": {
@@ -1154,7 +1154,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "utodit ZSCALERNSS: time=cer Nov 1 10:16:48 2019^^timezone=PST^^action=Blocked^^reason=unknown^^hostname=ueip6097.api.host^^protocol=tcp^^serverip=10.128.43.71^^url=https://www.example.org/erit/asiarch.gif?tdolor=oremagna#siuta^^urlcategory=amnihil^^urlclass=nderit^^dlpdictionaries=ficia^^dlpengine=tru^^filetype=tionu^^threatcategory=natuser^^threatclass=olupt^^pagerisk=eprehe^^threatname=eetd^^clientpublicIP=tiumdo^^ClientIP=10.152.217.174^^location=litse^^refererURL=https://internal.example.com/nde/tNequepo.txt?end=ineavolu#ptate^^useragent=Mozilla/5.0 (Linux; Android 9; Notepad_K10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Safari/537.36^^department=nderitin^^user=mquiado^^event_id=ssequa^^clienttranstime=nisist^^requestmethod=temvele^^requestsize=7350^^requestversion=xeaco^^status=urm^^responsesize=114^^responseversion=porincid^^transactionsize=1150",
             "event": {
@@ -1166,7 +1166,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "pici ZSCALERNSS: time=erit Nov 15 5:19:22 2019^^timezone=PT^^action=Blocked^^reason=success^^hostname=fugiatqu7793.www.localdomain^^protocol=ipv6-icmp^^serverip=10.26.149.221^^url=https://mail.example.org/maven/tectob.jpg?litsedd=mnis#ainci^^urlcategory=aturve^^urlclass=tiumdol^^dlpdictionaries=mporain^^dlpengine=secte^^filetype=dut^^threatcategory=aecons^^threatclass=tionemu^^pagerisk=edictasu^^threatname=quipexea^^clientpublicIP=orsit^^ClientIP=10.217.193.148^^location=tametco^^refererURL=https://api.example.com/lit/laborio.gif?mfug=acommod#mid^^useragent=Mozilla/5.0 (Linux; Android 6.0; QMobile X700 PRO II) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36^^department=oloremag^^user=uisa^^event_id=umquidol^^clienttranstime=isiutali^^requestmethod=rehe^^requestsize=3382^^requestversion=adminima^^status=ipex^^responsesize=1046^^responseversion=sitvolup^^transactionsize=387",
             "event": {
@@ -1178,7 +1178,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "agnamali ZSCALERNSS: time=ali Nov 30 12:21:57 2019^^timezone=CET^^action=Blocked^^reason=unknown^^hostname=onsequ3168.www.corp^^protocol=icmp^^serverip=10.109.192.53^^url=https://www.example.com/siarch/oloremi.htm?one=iduntutl#tNe^^urlcategory=scive^^urlclass=tcupi^^dlpdictionaries=essequam^^dlpengine=destla^^filetype=oluptat^^threatcategory=ita^^threatclass=temUte^^pagerisk=idest^^threatname=ostru^^clientpublicIP=ptassit^^ClientIP=10.172.17.6^^location=samvolup^^refererURL=https://www5.example.org/taspe/empori.txt?emporain=ovo#aeabillo^^useragent=Mozilla/5.0 (Linux; Android 6.0; U20 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.147 Mobile Safari/537.36 YaApp_Android/10.90 YaSearchBrowser/10.90^^department=boriosa^^user=eprehen^^event_id=rehen^^clienttranstime=sitasp^^requestmethod=tassit^^requestsize=212^^requestversion=teir^^status=suntin^^responsesize=4053^^responseversion=upta^^transactionsize=1487",
             "event": {
@@ -1190,7 +1190,7 @@
         },
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "onevol ZSCALERNSS: time=llamco Dec 14 7:24:31 2019^^timezone=PT^^action=Blocked^^reason=unknown^^hostname=oremquel3120.internal.localhost^^protocol=ggp^^serverip=10.119.106.108^^url=https://mail.example.com/ostr/liqu.txt?niam=mullamc#umtota^^urlcategory=ssecil^^urlclass=xplic^^dlpdictionaries=isn^^dlpengine=quepor^^filetype=Lor^^threatcategory=ten^^threatclass=exeacomm^^pagerisk=cusan^^threatname=oquisq^^clientpublicIP=olli^^ClientIP=10.135.38.213^^location=tiset^^refererURL=https://mail.example.net/erspici/xercitat.jpg?Exce=uae#tut^^useragent=Mozilla/5.0 (Linux; Android 9; 5024D_RU Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36 YaApp_Android/10.61 YaSearchBrowser/10.61^^department=ser^^user=ore^^event_id=iatisund^^clienttranstime=ritquii^^requestmethod=volup^^requestsize=1902^^requestversion=orsi^^status=ull^^responsesize=391^^responseversion=dolorsi^^transactionsize=7745",
             "event": {

--- a/packages/zscaler/data_stream/zia/_dev/test/pipeline/test-zscaler.log-expected.json
+++ b/packages/zscaler/data_stream/zia/_dev/test/pipeline/test-zscaler.log-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "1.10.0"
+                "version": "1.11.0"
             },
             "message": "hello ZSCALERNSS: time=WOOT Jun 23 15:16:42 2017^^timezone=CEST^^action=\u003caction\u003e^^reason=\u003cresult\u003e^^hostname=\u003chostname\u003e^^protocol=\u003cprotocol\u003e^^serverip=\u003cdaddr\u003e^^url=\u003curl\u003e^^urlcategory=\u003cfilter\u003e^^urlclass=\u003cinfo\u003e^^dlpdictionaries=\u003cfld3\u003e^^dlpengine=\u003cfld4\u003e^^filetype=\u003cfiletype\u003e^^threatcategory=\u003ccategory\u003e^^threatclass=\u003cvendor_event_cat\u003e^^pagerisk=\u003cfld8\u003e^^threatname=\u003cthreat_name\u003e^^clientpublicIP=\u003cfld9\u003e^^ClientIP=\u003csaddr\u003e^^location=\u003cfld11\u003e^^refererURL=\u003cweb_referer\u003e^^useragent=\u003cuser_agent\u003e^^department=\u003cuser_dept\u003e^^user=\u003cusername\u003e^^event_id=\u003cid\u003e^^clienttranstime=\u003cfld17\u003e^^requestmethod=\u003cweb_method\u003e^^requestsize=\u003csbytes\u003e^^requestversion=\u003cfld20\u003e^^status=\u003cresultcode\u003e^^responsesize=\u003crbytes\u003e^^responseversion=\u003cfld23\u003e^^transactionsize=\u003cbytes\u003e",
             "event": {

--- a/packages/zscaler/data_stream/zia/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zscaler/data_stream/zia/elasticsearch/ingest_pipeline/default.yml
@@ -8,7 +8,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: "1.10.0"
+      value: '1.11.0'
   # User agent
   - user_agent:
       field: user_agent.original

--- a/packages/zscaler/manifest.yml
+++ b/packages/zscaler/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: zscaler
 title: Zscaler NSS
-version: 0.3.0
+version: 0.3.1
 description: This Elastic integration collects logs from Zscaler
 categories: ["network", "security"]
 release: experimental


### PR DESCRIPTION
## What does this PR do?

sets `ecs.version` to 1.11.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967