### PR TITLE
zoom update to ECS 1.11.0

### DIFF
--- a/packages/zoom/_dev/build/build.yml
+++ b/packages/zoom/_dev/build/build.yml
@@ -1,0 +1,3 @@
+dependencies:
+  ecs:
+    reference: git@1.11

--- a/packages/zoom/changelog.yml
+++ b/packages/zoom/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.1"
+  changes:
+    - description: update to ECS 1.11.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1430
 - version: "0.5.0"
   changes:
     - description: Update integration description

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-account.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-account.json-expected.json
@@ -5,6 +5,9 @@
                 "product": "Webhook",
                 "vendor": "Zoom"
             },
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "uLohghhRgfgrbTayCX6r2Q_qQsQ",
@@ -23,7 +26,7 @@
             },
             "event": {
                 "action": "account.created",
-                "ingested": "2021-04-23T12:57:47.052047832Z",
+                "ingested": "2021-07-30T21:20:17.216724127Z",
                 "category": [
                     "iam"
                 ],
@@ -50,6 +53,9 @@
                 "vendor": "Zoom"
             },
             "@timestamp": "2019-07-01T17:03:04.527Z",
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "iKoRgfbaTazDX6r2Q_eQsQL",
@@ -72,7 +78,7 @@
             },
             "event": {
                 "action": "account.updated",
-                "ingested": "2021-04-23T12:57:47.052050896Z",
+                "ingested": "2021-07-30T21:20:17.216726872Z",
                 "category": [
                     "iam"
                 ],
@@ -102,6 +108,9 @@
                 "product": "Webhook",
                 "vendor": "Zoom"
             },
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "gdjfdhjLsuhfvhjd",
@@ -120,7 +129,7 @@
             },
             "event": {
                 "action": "account.disassociated",
-                "ingested": "2021-04-23T12:57:47.052051898Z",
+                "ingested": "2021-07-30T21:20:17.216727353Z",
                 "category": [
                     "iam"
                 ],

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-account.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-account.json-expected.json
@@ -26,7 +26,7 @@
             },
             "event": {
                 "action": "account.created",
-                "ingested": "2021-07-30T21:20:17.216724127Z",
+                "ingested": "2021-08-04T21:21:25.957758089Z",
                 "category": [
                     "iam"
                 ],
@@ -78,7 +78,7 @@
             },
             "event": {
                 "action": "account.updated",
-                "ingested": "2021-07-30T21:20:17.216726872Z",
+                "ingested": "2021-08-04T21:21:25.957761026Z",
                 "category": [
                     "iam"
                 ],
@@ -129,7 +129,7 @@
             },
             "event": {
                 "action": "account.disassociated",
-                "ingested": "2021-07-30T21:20:17.216727353Z",
+                "ingested": "2021-08-04T21:21:25.957762249Z",
                 "category": [
                     "iam"
                 ],

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-chat-channel.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-chat-channel.json-expected.json
@@ -29,7 +29,7 @@
             },
             "event": {
                 "action": "chat_channel.created",
-                "ingested": "2021-07-30T21:20:17.291420889Z",
+                "ingested": "2021-08-04T21:21:26.250415950Z",
                 "type": [
                     "creation"
                 ],
@@ -68,7 +68,7 @@
             },
             "event": {
                 "action": "chat_channel.updated",
-                "ingested": "2021-07-30T21:20:17.291423819Z",
+                "ingested": "2021-08-04T21:21:26.250419740Z",
                 "type": [
                     "change"
                 ],
@@ -107,7 +107,7 @@
             },
             "event": {
                 "action": "chat_channel.deleted",
-                "ingested": "2021-07-30T21:20:17.291426177Z",
+                "ingested": "2021-08-04T21:21:26.250426398Z",
                 "type": [
                     "deletion"
                 ],
@@ -148,7 +148,7 @@
             },
             "event": {
                 "action": "chat_channel.member_invited",
-                "ingested": "2021-07-30T21:20:17.291426668Z",
+                "ingested": "2021-08-04T21:21:26.250428800Z",
                 "type": [
                     "user"
                 ],
@@ -187,7 +187,7 @@
             },
             "event": {
                 "action": "chat_channel.member_joined",
-                "ingested": "2021-07-30T21:20:17.291427147Z",
+                "ingested": "2021-08-04T21:21:26.250430420Z",
                 "type": [
                     "user"
                 ],
@@ -226,7 +226,7 @@
             },
             "event": {
                 "action": "chat_channel.member_left",
-                "ingested": "2021-07-30T21:20:17.291427545Z",
+                "ingested": "2021-08-04T21:21:26.250431762Z",
                 "type": [
                     "user"
                 ],

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-chat-channel.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-chat-channel.json-expected.json
@@ -6,6 +6,9 @@
                 "vendor": "Zoom"
             },
             "@timestamp": "2020-02-10T21:39:50.388Z",
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "z8dfgdfguQrdfgdf",
@@ -26,7 +29,7 @@
             },
             "event": {
                 "action": "chat_channel.created",
-                "ingested": "2021-04-23T12:57:47.172290801Z",
+                "ingested": "2021-07-30T21:20:17.291420889Z",
                 "type": [
                     "creation"
                 ],
@@ -45,6 +48,9 @@
                 "vendor": "Zoom"
             },
             "@timestamp": "2020-02-10T21:59:05.584Z",
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "z8dfgdfguQrdfgdf"
@@ -62,7 +68,7 @@
             },
             "event": {
                 "action": "chat_channel.updated",
-                "ingested": "2021-04-23T12:57:47.172294707Z",
+                "ingested": "2021-07-30T21:20:17.291423819Z",
                 "type": [
                     "change"
                 ],
@@ -81,6 +87,9 @@
                 "vendor": "Zoom"
             },
             "@timestamp": "2020-02-10T21:59:05.584Z",
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "z8dfgdfguQrdfgdf"
@@ -98,7 +107,7 @@
             },
             "event": {
                 "action": "chat_channel.deleted",
-                "ingested": "2021-04-23T12:57:47.172295722Z",
+                "ingested": "2021-07-30T21:20:17.291426177Z",
                 "type": [
                     "deletion"
                 ],
@@ -117,6 +126,9 @@
                 "vendor": "Zoom"
             },
             "@timestamp": "2020-02-10T21:39:50.388Z",
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "z8dfgdfguQrdfgdf",
@@ -136,7 +148,7 @@
             },
             "event": {
                 "action": "chat_channel.member_invited",
-                "ingested": "2021-04-23T12:57:47.172296584Z",
+                "ingested": "2021-07-30T21:20:17.291426668Z",
                 "type": [
                     "user"
                 ],
@@ -155,6 +167,9 @@
                 "vendor": "Zoom"
             },
             "@timestamp": "2020-02-10T21:39:50.388Z",
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "z8dfgdfguQrdfgdf"
@@ -172,7 +187,7 @@
             },
             "event": {
                 "action": "chat_channel.member_joined",
-                "ingested": "2021-04-23T12:57:47.172297418Z",
+                "ingested": "2021-07-30T21:20:17.291427147Z",
                 "type": [
                     "user"
                 ],
@@ -191,6 +206,9 @@
                 "vendor": "Zoom"
             },
             "@timestamp": "2020-02-10T21:39:50.388Z",
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "z8dfgdfguQrdfgdf"
@@ -208,7 +226,7 @@
             },
             "event": {
                 "action": "chat_channel.member_left",
-                "ingested": "2021-04-23T12:57:47.172298266Z",
+                "ingested": "2021-07-30T21:20:17.291427545Z",
                 "type": [
                     "user"
                 ],

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-chat-message.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-chat-message.json-expected.json
@@ -6,6 +6,9 @@
                 "vendor": "Zoom"
             },
             "@timestamp": "2020-02-11T22:02:11.930Z",
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "zfdgdfgdfgfp8uQ"
@@ -26,7 +29,7 @@
             },
             "event": {
                 "action": "chat_message.sent",
-                "ingested": "2021-04-23T12:57:47.345625538Z",
+                "ingested": "2021-07-30T21:20:17.405374438Z",
                 "type": [
                     "info",
                     "creation"
@@ -46,6 +49,9 @@
                 "vendor": "Zoom"
             },
             "@timestamp": "2020-02-11T23:00:08.594Z",
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "zfdgdfgdfgfp8uQ"
@@ -66,7 +72,7 @@
             },
             "event": {
                 "action": "chat_message.updated",
-                "ingested": "2021-04-23T12:57:47.345628722Z",
+                "ingested": "2021-07-30T21:20:17.405377133Z",
                 "type": [
                     "info",
                     "change"
@@ -86,6 +92,9 @@
                 "vendor": "Zoom"
             },
             "@timestamp": "2020-02-11T23:00:08.594Z",
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "zfdgdfgdfgfp8uQ"
@@ -105,7 +114,7 @@
             },
             "event": {
                 "action": "chat_message.updated",
-                "ingested": "2021-04-23T12:57:47.349214440Z",
+                "ingested": "2021-07-30T21:20:17.405377650Z",
                 "type": [
                     "info",
                     "change"

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-chat-message.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-chat-message.json-expected.json
@@ -29,7 +29,7 @@
             },
             "event": {
                 "action": "chat_message.sent",
-                "ingested": "2021-07-30T21:20:17.405374438Z",
+                "ingested": "2021-08-04T21:21:26.606701291Z",
                 "type": [
                     "info",
                     "creation"
@@ -72,7 +72,7 @@
             },
             "event": {
                 "action": "chat_message.updated",
-                "ingested": "2021-07-30T21:20:17.405377133Z",
+                "ingested": "2021-08-04T21:21:26.606704436Z",
                 "type": [
                     "info",
                     "change"
@@ -114,7 +114,7 @@
             },
             "event": {
                 "action": "chat_message.updated",
-                "ingested": "2021-07-30T21:20:17.405377650Z",
+                "ingested": "2021-08-04T21:21:26.606705627Z",
                 "type": [
                     "info",
                     "change"

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-meeting.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-meeting.json-expected.json
@@ -28,7 +28,7 @@
             "event": {
                 "duration": 3600000000000,
                 "action": "meeting.alert",
-                "ingested": "2021-07-30T21:20:17.481260037Z",
+                "ingested": "2021-08-04T21:21:26.815986286Z",
                 "type": [
                     "error"
                 ],
@@ -70,7 +70,7 @@
             "event": {
                 "duration": 3600000000000,
                 "action": "meeting.created",
-                "ingested": "2021-07-30T21:20:17.481263366Z",
+                "ingested": "2021-08-04T21:21:26.815989225Z",
                 "type": [
                     "info",
                     "creation"
@@ -125,7 +125,7 @@
             "event": {
                 "duration": 7200000000000,
                 "action": "meeting.updated",
-                "ingested": "2021-07-30T21:20:17.481263886Z",
+                "ingested": "2021-08-04T21:21:26.815990479Z",
                 "type": [
                     "info",
                     "change"
@@ -172,7 +172,7 @@
             "event": {
                 "duration": 3600000000000,
                 "action": "meeting.deleted",
-                "ingested": "2021-07-30T21:20:17.481264359Z",
+                "ingested": "2021-08-04T21:21:26.815991619Z",
                 "type": [
                     "info",
                     "deletion"
@@ -213,7 +213,7 @@
             "event": {
                 "duration": 3600000000000,
                 "action": "meeting.started",
-                "ingested": "2021-07-30T21:20:17.481264863Z",
+                "ingested": "2021-08-04T21:21:26.815992721Z",
                 "type": [
                     "info",
                     "start"
@@ -254,7 +254,7 @@
             "event": {
                 "duration": 600000000000,
                 "action": "meeting.ended",
-                "ingested": "2021-07-30T21:20:17.481265312Z",
+                "ingested": "2021-08-04T21:21:26.815993782Z",
                 "type": [
                     "info",
                     "end"
@@ -302,7 +302,7 @@
             "event": {
                 "duration": 7200000000000,
                 "action": "meeting.registration_created",
-                "ingested": "2021-07-30T21:20:17.481265780Z",
+                "ingested": "2021-08-04T21:21:26.815994857Z",
                 "type": [
                     "info",
                     "creation"
@@ -355,7 +355,7 @@
             "event": {
                 "duration": 3600000000000,
                 "action": "meeting.registration_approved",
-                "ingested": "2021-07-30T21:20:17.481266296Z",
+                "ingested": "2021-08-04T21:21:26.815995923Z",
                 "type": [
                     "info",
                     "allowed"
@@ -404,7 +404,7 @@
             "event": {
                 "duration": 7200000000000,
                 "action": "meeting.registration_cancelled",
-                "ingested": "2021-07-30T21:20:17.481266742Z",
+                "ingested": "2021-08-04T21:21:26.815996994Z",
                 "type": [
                     "info"
                 ],
@@ -455,7 +455,7 @@
             "event": {
                 "duration": 3600000000000,
                 "action": "meeting.sharing_started",
-                "ingested": "2021-07-30T21:20:17.481267191Z",
+                "ingested": "2021-08-04T21:21:26.815998064Z",
                 "type": [
                     "info",
                     "start"
@@ -509,7 +509,7 @@
             "event": {
                 "duration": 3600000000000,
                 "action": "meeting.sharing_ended",
-                "ingested": "2021-07-30T21:20:17.481267635Z",
+                "ingested": "2021-08-04T21:21:26.815999156Z",
                 "type": [
                     "info",
                     "end"
@@ -553,7 +553,7 @@
             "event": {
                 "duration": 3600000000000,
                 "action": "meeting.participant_jbh_waiting",
-                "ingested": "2021-07-30T21:20:17.481268264Z",
+                "ingested": "2021-08-04T21:21:26.816000364Z",
                 "type": [
                     "info"
                 ],
@@ -596,7 +596,7 @@
             "event": {
                 "duration": 3600000000000,
                 "action": "meeting.participant_jbh_joined",
-                "ingested": "2021-07-30T21:20:17.481268731Z",
+                "ingested": "2021-08-04T21:21:26.816001451Z",
                 "type": [
                     "info"
                 ],
@@ -643,7 +643,7 @@
             "event": {
                 "duration": 3600000000000,
                 "action": "meeting.participant_joined",
-                "ingested": "2021-07-30T21:20:17.481269196Z",
+                "ingested": "2021-08-04T21:21:26.816002532Z",
                 "type": [
                     "info"
                 ],
@@ -690,7 +690,7 @@
             "event": {
                 "duration": 3600000000000,
                 "action": "meeting.participant_left",
-                "ingested": "2021-07-30T21:20:17.481269640Z",
+                "ingested": "2021-08-04T21:21:26.816003613Z",
                 "type": [
                     "info"
                 ],

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-meeting.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-meeting.json-expected.json
@@ -5,6 +5,9 @@
                 "product": "Webhook",
                 "vendor": "Zoom"
             },
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "z8yCxTTTTSiw02QgCAp8uQ"
@@ -25,7 +28,7 @@
             "event": {
                 "duration": 3600000000000,
                 "action": "meeting.alert",
-                "ingested": "2021-04-23T12:57:47.452552514Z",
+                "ingested": "2021-07-30T21:20:17.481260037Z",
                 "type": [
                     "error"
                 ],
@@ -41,6 +44,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -64,7 +70,7 @@
             "event": {
                 "duration": 3600000000000,
                 "action": "meeting.created",
-                "ingested": "2021-04-23T12:57:47.452556233Z",
+                "ingested": "2021-07-30T21:20:17.481263366Z",
                 "type": [
                     "info",
                     "creation"
@@ -82,6 +88,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -116,7 +125,7 @@
             "event": {
                 "duration": 7200000000000,
                 "action": "meeting.updated",
-                "ingested": "2021-04-23T12:57:47.452557222Z",
+                "ingested": "2021-07-30T21:20:17.481263886Z",
                 "type": [
                     "info",
                     "change"
@@ -137,6 +146,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -160,7 +172,7 @@
             "event": {
                 "duration": 3600000000000,
                 "action": "meeting.deleted",
-                "ingested": "2021-04-23T12:57:47.452558149Z",
+                "ingested": "2021-07-30T21:20:17.481264359Z",
                 "type": [
                     "info",
                     "deletion"
@@ -178,6 +190,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -198,7 +213,7 @@
             "event": {
                 "duration": 3600000000000,
                 "action": "meeting.started",
-                "ingested": "2021-04-23T12:57:47.452559011Z",
+                "ingested": "2021-07-30T21:20:17.481264863Z",
                 "type": [
                     "info",
                     "start"
@@ -215,6 +230,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -236,7 +254,7 @@
             "event": {
                 "duration": 600000000000,
                 "action": "meeting.ended",
-                "ingested": "2021-04-23T12:57:47.452559861Z",
+                "ingested": "2021-07-30T21:20:17.481265312Z",
                 "type": [
                     "info",
                     "end"
@@ -253,6 +271,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -281,7 +302,7 @@
             "event": {
                 "duration": 7200000000000,
                 "action": "meeting.registration_created",
-                "ingested": "2021-04-23T12:57:47.452560733Z",
+                "ingested": "2021-07-30T21:20:17.481265780Z",
                 "type": [
                     "info",
                     "creation"
@@ -301,6 +322,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -331,7 +355,7 @@
             "event": {
                 "duration": 3600000000000,
                 "action": "meeting.registration_approved",
-                "ingested": "2021-04-23T12:57:47.452561610Z",
+                "ingested": "2021-07-30T21:20:17.481266296Z",
                 "type": [
                     "info",
                     "allowed"
@@ -349,6 +373,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -377,7 +404,7 @@
             "event": {
                 "duration": 7200000000000,
                 "action": "meeting.registration_cancelled",
-                "ingested": "2021-04-23T12:57:47.452562465Z",
+                "ingested": "2021-07-30T21:20:17.481266742Z",
                 "type": [
                     "info"
                 ],
@@ -393,6 +420,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -425,7 +455,7 @@
             "event": {
                 "duration": 3600000000000,
                 "action": "meeting.sharing_started",
-                "ingested": "2021-04-23T12:57:47.452563318Z",
+                "ingested": "2021-07-30T21:20:17.481267191Z",
                 "type": [
                     "info",
                     "start"
@@ -443,6 +473,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -476,7 +509,7 @@
             "event": {
                 "duration": 3600000000000,
                 "action": "meeting.sharing_ended",
-                "ingested": "2021-04-23T12:57:47.452564221Z",
+                "ingested": "2021-07-30T21:20:17.481267635Z",
                 "type": [
                     "info",
                     "end"
@@ -494,6 +527,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -517,7 +553,7 @@
             "event": {
                 "duration": 3600000000000,
                 "action": "meeting.participant_jbh_waiting",
-                "ingested": "2021-04-23T12:57:47.452565347Z",
+                "ingested": "2021-07-30T21:20:17.481268264Z",
                 "type": [
                     "info"
                 ],
@@ -534,6 +570,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -557,7 +596,7 @@
             "event": {
                 "duration": 3600000000000,
                 "action": "meeting.participant_jbh_joined",
-                "ingested": "2021-04-23T12:57:47.452566220Z",
+                "ingested": "2021-07-30T21:20:17.481268731Z",
                 "type": [
                     "info"
                 ],
@@ -574,6 +613,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -601,7 +643,7 @@
             "event": {
                 "duration": 3600000000000,
                 "action": "meeting.participant_joined",
-                "ingested": "2021-04-23T12:57:47.452567094Z",
+                "ingested": "2021-07-30T21:20:17.481269196Z",
                 "type": [
                     "info"
                 ],
@@ -618,6 +660,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -645,7 +690,7 @@
             "event": {
                 "duration": 3600000000000,
                 "action": "meeting.participant_left",
-                "ingested": "2021-04-23T12:57:47.452567926Z",
+                "ingested": "2021-07-30T21:20:17.481269640Z",
                 "type": [
                     "info"
                 ],

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-phone.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-phone.json-expected.json
@@ -5,6 +5,9 @@
                 "product": "Webhook",
                 "vendor": "Zoom"
             },
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "cadsd32wA"
@@ -35,7 +38,7 @@
             },
             "event": {
                 "action": "phone.caller_ringing",
-                "ingested": "2021-04-23T12:57:48.066118245Z",
+                "ingested": "2021-07-30T21:20:17.873999193Z",
                 "type": [
                     "info",
                     "creation"
@@ -49,6 +52,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -81,7 +87,7 @@
             },
             "event": {
                 "action": "phone.caller_connected",
-                "ingested": "2021-04-23T12:57:48.066121601Z",
+                "ingested": "2021-07-30T21:20:17.874001548Z",
                 "type": [
                     "info",
                     "start"
@@ -95,6 +101,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -125,7 +134,7 @@
             },
             "event": {
                 "action": "phone.caller_ringing",
-                "ingested": "2021-04-23T12:57:48.066122570Z",
+                "ingested": "2021-07-30T21:20:17.874002008Z",
                 "type": [
                     "info",
                     "creation"
@@ -139,6 +148,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -171,7 +183,7 @@
             },
             "event": {
                 "action": "phone.callee_answered",
-                "ingested": "2021-04-23T12:57:48.066123420Z",
+                "ingested": "2021-07-30T21:20:17.874002386Z",
                 "type": [
                     "info",
                     "start"
@@ -185,6 +197,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -213,7 +228,7 @@
             },
             "event": {
                 "action": "phone.callee_missed",
-                "ingested": "2021-04-23T12:57:48.066124260Z",
+                "ingested": "2021-07-30T21:20:17.874002763Z",
                 "type": [
                     "info",
                     "end"
@@ -227,6 +242,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -256,7 +274,7 @@
             },
             "event": {
                 "duration": 4000000000,
-                "ingested": "2021-04-23T12:57:48.066125114Z",
+                "ingested": "2021-07-30T21:20:17.874003164Z",
                 "kind": [
                     "event"
                 ],
@@ -274,6 +292,9 @@
                 "product": "Webhook",
                 "vendor": "Zoom"
             },
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "z66jfgjdg2QgCfp8uQ"
@@ -302,7 +323,7 @@
             },
             "event": {
                 "duration": 4000000000,
-                "ingested": "2021-04-23T12:57:48.066125956Z",
+                "ingested": "2021-07-30T21:20:17.874003545Z",
                 "kind": [
                     "event"
                 ],
@@ -319,6 +340,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -348,7 +372,7 @@
             },
             "event": {
                 "duration": 6000000000,
-                "ingested": "2021-04-23T12:57:48.066126811Z",
+                "ingested": "2021-07-30T21:20:17.874003932Z",
                 "kind": [
                     "event"
                 ],
@@ -364,6 +388,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -397,7 +424,7 @@
             },
             "event": {
                 "action": "phone.voicemail_received",
-                "ingested": "2021-04-23T12:57:48.066127668Z",
+                "ingested": "2021-07-30T21:20:17.874004330Z",
                 "type": [
                     "info"
                 ],
@@ -414,6 +441,9 @@
                 "product": "Webhook",
                 "vendor": "Zoom"
             },
+            "ecs": {
+                "version": "1.11.0"
+            },
             "zoom": {
                 "phone": {
                     "user_id": "caddsfsdfv_VaHE53wA"
@@ -422,7 +452,7 @@
             },
             "event": {
                 "action": "phone.caller_call_log_completed",
-                "ingested": "2021-04-23T12:57:48.066128518Z",
+                "ingested": "2021-07-30T21:20:17.874004711Z",
                 "type": [
                     "info"
                 ],
@@ -436,6 +466,9 @@
                 "product": "Webhook",
                 "vendor": "Zoom"
             },
+            "ecs": {
+                "version": "1.11.0"
+            },
             "zoom": {
                 "phone": {
                     "user_id": "z8sdfsdfds3uQ"
@@ -444,7 +477,7 @@
             },
             "event": {
                 "action": "phone.callee_call_log_completed",
-                "ingested": "2021-04-23T12:57:48.066129434Z",
+                "ingested": "2021-07-30T21:20:17.874005101Z",
                 "type": [
                     "info"
                 ],

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-phone.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-phone.json-expected.json
@@ -38,7 +38,7 @@
             },
             "event": {
                 "action": "phone.caller_ringing",
-                "ingested": "2021-07-30T21:20:17.873999193Z",
+                "ingested": "2021-08-04T21:21:27.751235151Z",
                 "type": [
                     "info",
                     "creation"
@@ -87,7 +87,7 @@
             },
             "event": {
                 "action": "phone.caller_connected",
-                "ingested": "2021-07-30T21:20:17.874001548Z",
+                "ingested": "2021-08-04T21:21:27.751238183Z",
                 "type": [
                     "info",
                     "start"
@@ -134,7 +134,7 @@
             },
             "event": {
                 "action": "phone.caller_ringing",
-                "ingested": "2021-07-30T21:20:17.874002008Z",
+                "ingested": "2021-08-04T21:21:27.751239382Z",
                 "type": [
                     "info",
                     "creation"
@@ -183,7 +183,7 @@
             },
             "event": {
                 "action": "phone.callee_answered",
-                "ingested": "2021-07-30T21:20:17.874002386Z",
+                "ingested": "2021-08-04T21:21:27.751240528Z",
                 "type": [
                     "info",
                     "start"
@@ -228,7 +228,7 @@
             },
             "event": {
                 "action": "phone.callee_missed",
-                "ingested": "2021-07-30T21:20:17.874002763Z",
+                "ingested": "2021-08-04T21:21:27.751241578Z",
                 "type": [
                     "info",
                     "end"
@@ -274,7 +274,7 @@
             },
             "event": {
                 "duration": 4000000000,
-                "ingested": "2021-07-30T21:20:17.874003164Z",
+                "ingested": "2021-08-04T21:21:27.751242615Z",
                 "kind": [
                     "event"
                 ],
@@ -323,7 +323,7 @@
             },
             "event": {
                 "duration": 4000000000,
-                "ingested": "2021-07-30T21:20:17.874003545Z",
+                "ingested": "2021-08-04T21:21:27.751243655Z",
                 "kind": [
                     "event"
                 ],
@@ -372,7 +372,7 @@
             },
             "event": {
                 "duration": 6000000000,
-                "ingested": "2021-07-30T21:20:17.874003932Z",
+                "ingested": "2021-08-04T21:21:27.751244753Z",
                 "kind": [
                     "event"
                 ],
@@ -424,7 +424,7 @@
             },
             "event": {
                 "action": "phone.voicemail_received",
-                "ingested": "2021-07-30T21:20:17.874004330Z",
+                "ingested": "2021-08-04T21:21:27.751245818Z",
                 "type": [
                     "info"
                 ],
@@ -452,7 +452,7 @@
             },
             "event": {
                 "action": "phone.caller_call_log_completed",
-                "ingested": "2021-07-30T21:20:17.874004711Z",
+                "ingested": "2021-08-04T21:21:27.751246845Z",
                 "type": [
                     "info"
                 ],
@@ -477,7 +477,7 @@
             },
             "event": {
                 "action": "phone.callee_call_log_completed",
-                "ingested": "2021-07-30T21:20:17.874005101Z",
+                "ingested": "2021-08-04T21:21:27.751247901Z",
                 "type": [
                     "info"
                 ],

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-recording.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-recording.json-expected.json
@@ -32,7 +32,7 @@
             "event": {
                 "start": "2019-07-31T22:41:02Z",
                 "action": "recording.started",
-                "ingested": "2021-07-30T21:20:18.183253130Z",
+                "ingested": "2021-08-04T21:21:28.270988202Z",
                 "type": [
                     "info",
                     "start"
@@ -76,7 +76,7 @@
             },
             "event": {
                 "action": "recording.paused",
-                "ingested": "2021-07-30T21:20:18.183255918Z",
+                "ingested": "2021-08-04T21:21:28.271056133Z",
                 "type": [
                     "info",
                     "change"
@@ -120,7 +120,7 @@
             },
             "event": {
                 "action": "recording.resumed",
-                "ingested": "2021-07-30T21:20:18.183256443Z",
+                "ingested": "2021-08-04T21:21:28.271057668Z",
                 "type": [
                     "info",
                     "change"
@@ -165,7 +165,7 @@
             },
             "event": {
                 "action": "recording.stopped",
-                "ingested": "2021-07-30T21:20:18.183256924Z",
+                "ingested": "2021-08-04T21:21:28.271058845Z",
                 "end": "2019-07-31T22:43:29Z",
                 "type": [
                     "info",
@@ -210,7 +210,7 @@
             },
             "event": {
                 "action": "recording.completed",
-                "ingested": "2021-07-30T21:20:18.183257395Z",
+                "ingested": "2021-08-04T21:21:28.271060105Z",
                 "type": [
                     "info",
                     "end"
@@ -259,7 +259,7 @@
             },
             "event": {
                 "action": "recording.renamed",
-                "ingested": "2021-07-30T21:20:18.183257881Z",
+                "ingested": "2021-08-04T21:21:28.271061250Z",
                 "type": [
                     "info",
                     "change"
@@ -303,7 +303,7 @@
             },
             "event": {
                 "action": "recording.trashed",
-                "ingested": "2021-07-30T21:20:18.183258359Z",
+                "ingested": "2021-08-04T21:21:28.271062393Z",
                 "type": [
                     "info",
                     "deletion"
@@ -349,7 +349,7 @@
             },
             "event": {
                 "action": "recording.deleted",
-                "ingested": "2021-07-30T21:20:18.183258820Z",
+                "ingested": "2021-08-04T21:21:28.271077955Z",
                 "type": [
                     "info",
                     "deletion"
@@ -395,7 +395,7 @@
             },
             "event": {
                 "action": "recording.recovered",
-                "ingested": "2021-07-30T21:20:18.183261647Z",
+                "ingested": "2021-08-04T21:21:28.271078951Z",
                 "type": [
                     "info",
                     "change"
@@ -441,7 +441,7 @@
             },
             "event": {
                 "action": "recording.transcript_completed",
-                "ingested": "2021-07-30T21:20:18.183262134Z",
+                "ingested": "2021-08-04T21:21:28.271079949Z",
                 "type": [
                     "info",
                     "end"
@@ -492,7 +492,7 @@
             },
             "event": {
                 "action": "recording.registration_created",
-                "ingested": "2021-07-30T21:20:18.183262577Z",
+                "ingested": "2021-08-04T21:21:28.271080945Z",
                 "type": [
                     "info",
                     "creation"
@@ -542,7 +542,7 @@
             },
             "event": {
                 "action": "recording.registration_approved",
-                "ingested": "2021-07-30T21:20:18.183263204Z",
+                "ingested": "2021-08-04T21:21:28.271082140Z",
                 "type": [
                     "info",
                     "allowed"
@@ -592,7 +592,7 @@
             },
             "event": {
                 "action": "recording.registration_denied",
-                "ingested": "2021-07-30T21:20:18.183263656Z",
+                "ingested": "2021-08-04T21:21:28.271083181Z",
                 "type": [
                     "info",
                     "denied"

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-recording.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-recording.json-expected.json
@@ -5,6 +5,9 @@
                 "product": "Webhook",
                 "vendor": "Zoom"
             },
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "uLobbbbbbbbbb_qQsQ"
@@ -29,7 +32,7 @@
             "event": {
                 "start": "2019-07-31T22:41:02Z",
                 "action": "recording.started",
-                "ingested": "2021-04-23T12:57:48.552238164Z",
+                "ingested": "2021-07-30T21:20:18.183253130Z",
                 "type": [
                     "info",
                     "start"
@@ -46,6 +49,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -70,7 +76,7 @@
             },
             "event": {
                 "action": "recording.paused",
-                "ingested": "2021-04-23T12:57:48.552241652Z",
+                "ingested": "2021-07-30T21:20:18.183255918Z",
                 "type": [
                     "info",
                     "change"
@@ -87,6 +93,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -111,7 +120,7 @@
             },
             "event": {
                 "action": "recording.resumed",
-                "ingested": "2021-04-23T12:57:48.552242725Z",
+                "ingested": "2021-07-30T21:20:18.183256443Z",
                 "type": [
                     "info",
                     "change"
@@ -128,6 +137,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -153,7 +165,7 @@
             },
             "event": {
                 "action": "recording.stopped",
-                "ingested": "2021-04-23T12:57:48.552243609Z",
+                "ingested": "2021-07-30T21:20:18.183256924Z",
                 "end": "2019-07-31T22:43:29Z",
                 "type": [
                     "info",
@@ -171,6 +183,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -195,7 +210,7 @@
             },
             "event": {
                 "action": "recording.completed",
-                "ingested": "2021-04-23T12:57:48.552244534Z",
+                "ingested": "2021-07-30T21:20:18.183257395Z",
                 "type": [
                     "info",
                     "end"
@@ -217,6 +232,9 @@
                 "vendor": "Zoom"
             },
             "@timestamp": "2019-12-04T23:00:57.395Z",
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "zdhghgCfp8uQ"
@@ -241,7 +259,7 @@
             },
             "event": {
                 "action": "recording.renamed",
-                "ingested": "2021-04-23T12:57:48.552245489Z",
+                "ingested": "2021-07-30T21:20:18.183257881Z",
                 "type": [
                     "info",
                     "change"
@@ -259,6 +277,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -282,7 +303,7 @@
             },
             "event": {
                 "action": "recording.trashed",
-                "ingested": "2021-04-23T12:57:48.552246357Z",
+                "ingested": "2021-07-30T21:20:18.183258359Z",
                 "type": [
                     "info",
                     "deletion"
@@ -302,6 +323,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -325,7 +349,7 @@
             },
             "event": {
                 "action": "recording.deleted",
-                "ingested": "2021-04-23T12:57:48.552247201Z",
+                "ingested": "2021-07-30T21:20:18.183258820Z",
                 "type": [
                     "info",
                     "deletion"
@@ -345,6 +369,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -368,7 +395,7 @@
             },
             "event": {
                 "action": "recording.recovered",
-                "ingested": "2021-04-23T12:57:48.552248077Z",
+                "ingested": "2021-07-30T21:20:18.183261647Z",
                 "type": [
                     "info",
                     "change"
@@ -388,6 +415,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -411,7 +441,7 @@
             },
             "event": {
                 "action": "recording.transcript_completed",
-                "ingested": "2021-04-23T12:57:48.552248929Z",
+                "ingested": "2021-07-30T21:20:18.183262134Z",
                 "type": [
                     "info",
                     "end"
@@ -431,6 +461,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -459,7 +492,7 @@
             },
             "event": {
                 "action": "recording.registration_created",
-                "ingested": "2021-04-23T12:57:48.552249794Z",
+                "ingested": "2021-07-30T21:20:18.183262577Z",
                 "type": [
                     "info",
                     "creation"
@@ -478,6 +511,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -506,7 +542,7 @@
             },
             "event": {
                 "action": "recording.registration_approved",
-                "ingested": "2021-04-23T12:57:48.552251029Z",
+                "ingested": "2021-07-30T21:20:18.183263204Z",
                 "type": [
                     "info",
                     "allowed"
@@ -525,6 +561,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -553,7 +592,7 @@
             },
             "event": {
                 "action": "recording.registration_denied",
-                "ingested": "2021-04-23T12:57:48.552251906Z",
+                "ingested": "2021-07-30T21:20:18.183263656Z",
                 "type": [
                     "info",
                     "denied"

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-user.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-user.json-expected.json
@@ -27,7 +27,7 @@
             },
             "event": {
                 "action": "user.created",
-                "ingested": "2021-07-30T21:20:18.524501266Z",
+                "ingested": "2021-08-04T21:21:29.142562232Z",
                 "category": [
                     "iam"
                 ],
@@ -69,7 +69,7 @@
             },
             "event": {
                 "action": "user.invitation_accepted",
-                "ingested": "2021-07-30T21:20:18.524503510Z",
+                "ingested": "2021-08-04T21:21:29.142565206Z",
                 "category": [
                     "iam"
                 ],
@@ -116,7 +116,7 @@
             },
             "event": {
                 "action": "user.updated",
-                "ingested": "2021-07-30T21:20:18.524503999Z",
+                "ingested": "2021-08-04T21:21:29.142566406Z",
                 "category": [
                     "iam"
                 ],
@@ -174,7 +174,7 @@
             },
             "event": {
                 "action": "user.settings_updated",
-                "ingested": "2021-07-30T21:20:18.524504439Z",
+                "ingested": "2021-08-04T21:21:29.142567476Z",
                 "category": [
                     "configuration",
                     "iam"
@@ -229,7 +229,7 @@
             },
             "event": {
                 "action": "user.settings_updated",
-                "ingested": "2021-07-30T21:20:18.524504873Z",
+                "ingested": "2021-08-04T21:21:29.142568474Z",
                 "category": [
                     "configuration",
                     "iam"
@@ -278,7 +278,7 @@
             },
             "event": {
                 "action": "user.deactivated",
-                "ingested": "2021-07-30T21:20:18.524505353Z",
+                "ingested": "2021-08-04T21:21:29.142569493Z",
                 "category": [
                     "iam"
                 ],
@@ -328,7 +328,7 @@
             },
             "event": {
                 "action": "user.activated",
-                "ingested": "2021-07-30T21:20:18.524505793Z",
+                "ingested": "2021-08-04T21:21:29.142570467Z",
                 "category": [
                     "iam"
                 ],
@@ -378,7 +378,7 @@
             },
             "event": {
                 "action": "user.disassociated",
-                "ingested": "2021-07-30T21:20:18.524506306Z",
+                "ingested": "2021-08-04T21:21:29.142571450Z",
                 "category": [
                     "iam"
                 ],
@@ -428,7 +428,7 @@
             },
             "event": {
                 "action": "user.deleted",
-                "ingested": "2021-07-30T21:20:18.524506883Z",
+                "ingested": "2021-08-04T21:21:29.142572427Z",
                 "category": [
                     "iam"
                 ],
@@ -473,7 +473,7 @@
             },
             "event": {
                 "action": "user.presence_status_updated",
-                "ingested": "2021-07-30T21:20:18.524507434Z",
+                "ingested": "2021-08-04T21:21:29.142573451Z",
                 "category": [
                     "iam"
                 ],
@@ -516,7 +516,7 @@
             },
             "event": {
                 "action": "user.personal_notes_updated",
-                "ingested": "2021-07-30T21:20:18.524508072Z",
+                "ingested": "2021-08-04T21:21:29.142574455Z",
                 "category": [
                     "iam"
                 ],
@@ -561,7 +561,7 @@
             },
             "event": {
                 "action": "user.signed_in",
-                "ingested": "2021-07-30T21:20:18.524508870Z",
+                "ingested": "2021-08-04T21:21:29.142575581Z",
                 "category": [
                     "authentication"
                 ],
@@ -602,7 +602,7 @@
             },
             "event": {
                 "action": "user.signed_out",
-                "ingested": "2021-07-30T21:20:18.524509287Z",
+                "ingested": "2021-08-04T21:21:29.142576579Z",
                 "category": [
                     "authentication"
                 ],

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-user.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-user.json-expected.json
@@ -5,6 +5,9 @@
                 "product": "Webhook",
                 "vendor": "Zoom"
             },
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "abcD3ojfdbjfg"
@@ -24,7 +27,7 @@
             },
             "event": {
                 "action": "user.created",
-                "ingested": "2021-04-23T12:57:49.114535763Z",
+                "ingested": "2021-07-30T21:20:18.524501266Z",
                 "category": [
                     "iam"
                 ],
@@ -46,6 +49,9 @@
                 "product": "Webhook",
                 "vendor": "Zoom"
             },
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "sbyjt3ODg"
@@ -63,7 +69,7 @@
             },
             "event": {
                 "action": "user.invitation_accepted",
-                "ingested": "2021-04-23T12:57:49.114539356Z",
+                "ingested": "2021-07-30T21:20:18.524503510Z",
                 "category": [
                     "iam"
                 ],
@@ -86,6 +92,9 @@
                 "vendor": "Zoom"
             },
             "@timestamp": "2019-07-19T18:10:54.861Z",
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "uLobbbbbbbb_qQsQ",
@@ -107,7 +116,7 @@
             },
             "event": {
                 "action": "user.updated",
-                "ingested": "2021-04-23T12:57:49.114540371Z",
+                "ingested": "2021-07-30T21:20:18.524503999Z",
                 "category": [
                     "iam"
                 ],
@@ -133,6 +142,9 @@
                 "vendor": "Zoom"
             },
             "@timestamp": "2019-07-19T21:47:06.929Z",
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "uLoRgfbbTayCX6r2Q_qQsQ",
@@ -162,7 +174,7 @@
             },
             "event": {
                 "action": "user.settings_updated",
-                "ingested": "2021-04-23T12:57:49.114541224Z",
+                "ingested": "2021-07-30T21:20:18.524504439Z",
                 "category": [
                     "configuration",
                     "iam"
@@ -189,6 +201,9 @@
                 "vendor": "Zoom"
             },
             "@timestamp": "2020-06-29T17:32:19.427Z",
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "fdhjfdhsj536274gfd",
@@ -214,7 +229,7 @@
             },
             "event": {
                 "action": "user.settings_updated",
-                "ingested": "2021-04-23T12:57:49.114542074Z",
+                "ingested": "2021-07-30T21:20:18.524504873Z",
                 "category": [
                     "configuration",
                     "iam"
@@ -240,6 +255,9 @@
                 "product": "Webhook",
                 "vendor": "Zoom"
             },
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "z8yCxjabcdEFGHfp8uQ",
@@ -260,7 +278,7 @@
             },
             "event": {
                 "action": "user.deactivated",
-                "ingested": "2021-04-23T12:57:49.114542934Z",
+                "ingested": "2021-07-30T21:20:18.524505353Z",
                 "category": [
                     "iam"
                 ],
@@ -286,6 +304,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -307,7 +328,7 @@
             },
             "event": {
                 "action": "user.activated",
-                "ingested": "2021-04-23T12:57:49.114543780Z",
+                "ingested": "2021-07-30T21:20:18.524505793Z",
                 "category": [
                     "iam"
                 ],
@@ -333,6 +354,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -354,7 +378,7 @@
             },
             "event": {
                 "action": "user.disassociated",
-                "ingested": "2021-04-23T12:57:49.114544626Z",
+                "ingested": "2021-07-30T21:20:18.524506306Z",
                 "category": [
                     "iam"
                 ],
@@ -381,6 +405,9 @@
                 "product": "Webhook",
                 "vendor": "Zoom"
             },
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "z8yCxjabcdEFGHfp8uQ",
@@ -401,7 +428,7 @@
             },
             "event": {
                 "action": "user.deleted",
-                "ingested": "2021-04-23T12:57:49.114545498Z",
+                "ingested": "2021-07-30T21:20:18.524506883Z",
                 "category": [
                     "iam"
                 ],
@@ -428,6 +455,9 @@
                 "product": "Webhook",
                 "vendor": "Zoom"
             },
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "z8ycx1223fq"
@@ -443,7 +473,7 @@
             },
             "event": {
                 "action": "user.presence_status_updated",
-                "ingested": "2021-04-23T12:57:49.114546382Z",
+                "ingested": "2021-07-30T21:20:18.524507434Z",
                 "category": [
                     "iam"
                 ],
@@ -465,6 +495,9 @@
                 "product": "Webhook",
                 "vendor": "Zoom"
             },
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "z8aggp8uq"
@@ -483,7 +516,7 @@
             },
             "event": {
                 "action": "user.personal_notes_updated",
-                "ingested": "2021-04-23T12:57:49.114547216Z",
+                "ingested": "2021-07-30T21:20:18.524508072Z",
                 "category": [
                     "iam"
                 ],
@@ -509,6 +542,9 @@
                 "product": "Webhook",
                 "vendor": "Zoom"
             },
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "djkglfdgkjdflghfdpe"
@@ -525,7 +561,7 @@
             },
             "event": {
                 "action": "user.signed_in",
-                "ingested": "2021-04-23T12:57:49.114548517Z",
+                "ingested": "2021-07-30T21:20:18.524508870Z",
                 "category": [
                     "authentication"
                 ],
@@ -547,6 +583,9 @@
                 "product": "Webhook",
                 "vendor": "Zoom"
             },
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "djkglfdgkjdflghfdpe"
@@ -563,7 +602,7 @@
             },
             "event": {
                 "action": "user.signed_out",
-                "ingested": "2021-04-23T12:57:49.114549402Z",
+                "ingested": "2021-07-30T21:20:18.524509287Z",
                 "category": [
                     "authentication"
                 ],

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-webinar.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-webinar.json-expected.json
@@ -30,7 +30,7 @@
             },
             "event": {
                 "action": "webinar.created",
-                "ingested": "2021-07-30T21:20:18.828060687Z",
+                "ingested": "2021-08-04T21:21:30.188915593Z",
                 "type": [
                     "info",
                     "creation"
@@ -85,7 +85,7 @@
             },
             "event": {
                 "action": "webinar.updated",
-                "ingested": "2021-07-30T21:20:18.828063797Z",
+                "ingested": "2021-08-04T21:21:30.188918281Z",
                 "type": [
                     "info",
                     "change"
@@ -129,7 +129,7 @@
             },
             "event": {
                 "action": "webinar.deleted",
-                "ingested": "2021-07-30T21:20:18.828064310Z",
+                "ingested": "2021-08-04T21:21:30.188919548Z",
                 "type": [
                     "info",
                     "deletion"
@@ -172,7 +172,7 @@
             },
             "event": {
                 "action": "webinar.started",
-                "ingested": "2021-07-30T21:20:18.828064750Z",
+                "ingested": "2021-08-04T21:21:30.188920738Z",
                 "type": [
                     "info",
                     "start"
@@ -214,7 +214,7 @@
             },
             "event": {
                 "action": "webinar.ended",
-                "ingested": "2021-07-30T21:20:18.828065139Z",
+                "ingested": "2021-08-04T21:21:30.188921842Z",
                 "type": [
                     "info",
                     "end"
@@ -255,7 +255,7 @@
             },
             "event": {
                 "action": "webinar.alert",
-                "ingested": "2021-07-30T21:20:18.828065529Z",
+                "ingested": "2021-08-04T21:21:30.188922946Z",
                 "type": [
                     "error"
                 ],
@@ -304,7 +304,7 @@
             },
             "event": {
                 "action": "webinar.sharing_started",
-                "ingested": "2021-07-30T21:20:18.828065927Z",
+                "ingested": "2021-08-04T21:21:30.188924030Z",
                 "type": [
                     "info",
                     "start"
@@ -358,7 +358,7 @@
             },
             "event": {
                 "action": "webinar.sharing_started",
-                "ingested": "2021-07-30T21:20:18.828066308Z",
+                "ingested": "2021-08-04T21:21:30.188925128Z",
                 "type": [
                     "info",
                     "start"
@@ -409,7 +409,7 @@
             },
             "event": {
                 "action": "webinar.registration_created",
-                "ingested": "2021-07-30T21:20:18.828066691Z",
+                "ingested": "2021-08-04T21:21:30.188926258Z",
                 "type": [
                     "info",
                     "creation"
@@ -462,7 +462,7 @@
             },
             "event": {
                 "action": "webinar.registration_approved",
-                "ingested": "2021-07-30T21:20:18.828067097Z",
+                "ingested": "2021-08-04T21:21:30.188927333Z",
                 "type": [
                     "info",
                     "allowed",
@@ -514,7 +514,7 @@
             },
             "event": {
                 "action": "webinar.registration_denied",
-                "ingested": "2021-07-30T21:20:18.828067472Z",
+                "ingested": "2021-08-04T21:21:30.188928430Z",
                 "type": [
                     "info",
                     "denied",
@@ -566,7 +566,7 @@
             },
             "event": {
                 "action": "webinar.registration_cancelled",
-                "ingested": "2021-07-30T21:20:18.828068028Z",
+                "ingested": "2021-08-04T21:21:30.188929683Z",
                 "type": [
                     "info",
                     "change"
@@ -617,7 +617,7 @@
             },
             "event": {
                 "action": "webinar.participant_joined",
-                "ingested": "2021-07-30T21:20:18.828068419Z",
+                "ingested": "2021-08-04T21:21:30.188930767Z",
                 "type": [
                     "info"
                 ],
@@ -666,7 +666,7 @@
             },
             "event": {
                 "action": "webinar.participant_left",
-                "ingested": "2021-07-30T21:20:18.828068813Z",
+                "ingested": "2021-08-04T21:21:30.188931881Z",
                 "type": [
                     "info"
                 ],

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-webinar.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-webinar.json-expected.json
@@ -5,6 +5,9 @@
                 "product": "Webhook",
                 "vendor": "Zoom"
             },
+            "ecs": {
+                "version": "1.11.0"
+            },
             "related": {
                 "user": [
                     "uLoRgfbbTayCX6r2Q_qQsQ"
@@ -27,7 +30,7 @@
             },
             "event": {
                 "action": "webinar.created",
-                "ingested": "2021-04-23T12:57:49.556528981Z",
+                "ingested": "2021-07-30T21:20:18.828060687Z",
                 "type": [
                     "info",
                     "creation"
@@ -45,6 +48,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -79,7 +85,7 @@
             },
             "event": {
                 "action": "webinar.updated",
-                "ingested": "2021-04-23T12:57:49.556532101Z",
+                "ingested": "2021-07-30T21:20:18.828063797Z",
                 "type": [
                     "info",
                     "change"
@@ -97,6 +103,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -120,7 +129,7 @@
             },
             "event": {
                 "action": "webinar.deleted",
-                "ingested": "2021-04-23T12:57:49.556533143Z",
+                "ingested": "2021-07-30T21:20:18.828064310Z",
                 "type": [
                     "info",
                     "deletion"
@@ -138,6 +147,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -160,7 +172,7 @@
             },
             "event": {
                 "action": "webinar.started",
-                "ingested": "2021-04-23T12:57:49.556534041Z",
+                "ingested": "2021-07-30T21:20:18.828064750Z",
                 "type": [
                     "info",
                     "start"
@@ -177,6 +189,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -199,7 +214,7 @@
             },
             "event": {
                 "action": "webinar.ended",
-                "ingested": "2021-04-23T12:57:49.556534900Z",
+                "ingested": "2021-07-30T21:20:18.828065139Z",
                 "type": [
                     "info",
                     "end"
@@ -216,6 +231,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -237,7 +255,7 @@
             },
             "event": {
                 "action": "webinar.alert",
-                "ingested": "2021-04-23T12:57:49.556535762Z",
+                "ingested": "2021-07-30T21:20:18.828065529Z",
                 "type": [
                     "error"
                 ],
@@ -251,56 +269,8 @@
                 "product": "Webhook",
                 "vendor": "Zoom"
             },
-            "related": {
-                "user": [
-                    "z8yCxTTTTSiw02QgCAp8uQ",
-                    "s0AAAASoSE1V8KIFOCYw"
-                ]
-            },
-            "zoom": {
-                "participant": {
-                    "id": "s0AAAASoSE1V8KIFOCYw",
-                    "user_id": "16778000",
-                    "user_name": "Arya Arya",
-                    "sharing_details": {
-                        "link_source": "in_meeting",
-                        "source": "dropbox",
-                        "date_time": "2019-07-16T17:19:11Z",
-                        "content": "application"
-                    }
-                },
-                "account_id": "EPeQtiABC000VYxHMA",
-                "webinar": {
-                    "duration": 60,
-                    "start_time": "2019-07-16T17:14:39Z",
-                    "timezone": "America/Los_Angeles",
-                    "topic": "My Meeting",
-                    "id": "6962400003",
-                    "type": 5,
-                    "uuid": "4118UHIiRCAAAtBlDkcVyw==",
-                    "host_id": "z8yCxTTTTSiw02QgCAp8uQ"
-                }
-            },
-            "event": {
-                "action": "webinar.sharing_started",
-                "ingested": "2021-04-23T12:57:49.556536616Z",
-                "type": [
-                    "info",
-                    "start"
-                ],
-                "kind": [
-                    "event"
-                ]
-            },
-            "user": {
-                "full_name": "Arya Arya",
-                "id": "s0AAAASoSE1V8KIFOCYw"
-            }
-        },
-        {
-            "observer": {
-                "product": "Webhook",
-                "vendor": "Zoom"
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -334,7 +304,7 @@
             },
             "event": {
                 "action": "webinar.sharing_started",
-                "ingested": "2021-04-23T12:57:49.556537457Z",
+                "ingested": "2021-07-30T21:20:18.828065927Z",
                 "type": [
                     "info",
                     "start"
@@ -352,6 +322,63 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
+            },
+            "related": {
+                "user": [
+                    "z8yCxTTTTSiw02QgCAp8uQ",
+                    "s0AAAASoSE1V8KIFOCYw"
+                ]
+            },
+            "zoom": {
+                "participant": {
+                    "id": "s0AAAASoSE1V8KIFOCYw",
+                    "user_id": "16778000",
+                    "user_name": "Arya Arya",
+                    "sharing_details": {
+                        "link_source": "in_meeting",
+                        "source": "dropbox",
+                        "date_time": "2019-07-16T17:19:11Z",
+                        "content": "application"
+                    }
+                },
+                "account_id": "EPeQtiABC000VYxHMA",
+                "webinar": {
+                    "duration": 60,
+                    "start_time": "2019-07-16T17:14:39Z",
+                    "timezone": "America/Los_Angeles",
+                    "topic": "My Meeting",
+                    "id": "6962400003",
+                    "type": 5,
+                    "uuid": "4118UHIiRCAAAtBlDkcVyw==",
+                    "host_id": "z8yCxTTTTSiw02QgCAp8uQ"
+                }
+            },
+            "event": {
+                "action": "webinar.sharing_started",
+                "ingested": "2021-07-30T21:20:18.828066308Z",
+                "type": [
+                    "info",
+                    "start"
+                ],
+                "kind": [
+                    "event"
+                ]
+            },
+            "user": {
+                "full_name": "Arya Arya",
+                "id": "s0AAAASoSE1V8KIFOCYw"
+            }
+        },
+        {
+            "observer": {
+                "product": "Webhook",
+                "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -382,7 +409,7 @@
             },
             "event": {
                 "action": "webinar.registration_created",
-                "ingested": "2021-04-23T12:57:49.556538294Z",
+                "ingested": "2021-07-30T21:20:18.828066691Z",
                 "type": [
                     "info",
                     "creation"
@@ -401,6 +428,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -432,7 +462,7 @@
             },
             "event": {
                 "action": "webinar.registration_approved",
-                "ingested": "2021-04-23T12:57:49.556539164Z",
+                "ingested": "2021-07-30T21:20:18.828067097Z",
                 "type": [
                     "info",
                     "allowed",
@@ -452,6 +482,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -481,7 +514,7 @@
             },
             "event": {
                 "action": "webinar.registration_denied",
-                "ingested": "2021-04-23T12:57:49.556540017Z",
+                "ingested": "2021-07-30T21:20:18.828067472Z",
                 "type": [
                     "info",
                     "denied",
@@ -501,6 +534,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -530,7 +566,7 @@
             },
             "event": {
                 "action": "webinar.registration_cancelled",
-                "ingested": "2021-04-23T12:57:49.556541392Z",
+                "ingested": "2021-07-30T21:20:18.828068028Z",
                 "type": [
                     "info",
                     "change"
@@ -549,6 +585,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -578,7 +617,7 @@
             },
             "event": {
                 "action": "webinar.participant_joined",
-                "ingested": "2021-04-23T12:57:49.556542238Z",
+                "ingested": "2021-07-30T21:20:18.828068419Z",
                 "type": [
                     "info"
                 ],
@@ -595,6 +634,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "related": {
                 "user": [
@@ -624,7 +666,7 @@
             },
             "event": {
                 "action": "webinar.participant_left",
-                "ingested": "2021-04-23T12:57:49.556543080Z",
+                "ingested": "2021-07-30T21:20:18.828068813Z",
                 "type": [
                     "info"
                 ],

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-zoomroom.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-zoomroom.json-expected.json
@@ -23,7 +23,7 @@
             },
             "event": {
                 "action": "zoomroom.alert",
-                "ingested": "2021-07-30T21:20:19.264326886Z",
+                "ingested": "2021-08-04T21:21:31.180905533Z",
                 "kind": [
                     "event"
                 ]
@@ -52,7 +52,7 @@
             },
             "event": {
                 "action": "zoomroom.delayed_alert",
-                "ingested": "2021-07-30T21:20:19.264329088Z",
+                "ingested": "2021-08-04T21:21:31.180953143Z",
                 "kind": [
                     "event"
                 ]
@@ -81,7 +81,7 @@
             },
             "event": {
                 "action": "zoomroom.checked_in",
-                "ingested": "2021-07-30T21:20:19.264329519Z",
+                "ingested": "2021-08-04T21:21:31.180955153Z",
                 "type": [
                     "info",
                     "start"
@@ -114,7 +114,7 @@
             },
             "event": {
                 "action": "zoomroom.checked_in",
-                "ingested": "2021-07-30T21:20:19.264329904Z",
+                "ingested": "2021-08-04T21:21:31.180956373Z",
                 "type": [
                     "info",
                     "start"

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-zoomroom.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-zoomroom.json-expected.json
@@ -5,6 +5,9 @@
                 "product": "Webhook",
                 "vendor": "Zoom"
             },
+            "ecs": {
+                "version": "1.11.0"
+            },
             "zoom": {
                 "zoomroom": {
                     "room_name": "MyFabulousZoomRoom",
@@ -20,7 +23,7 @@
             },
             "event": {
                 "action": "zoomroom.alert",
-                "ingested": "2021-04-23T12:57:50.272413380Z",
+                "ingested": "2021-07-30T21:20:19.264326886Z",
                 "kind": [
                     "event"
                 ]
@@ -30,6 +33,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "zoom": {
                 "zoomroom": {
@@ -46,7 +52,7 @@
             },
             "event": {
                 "action": "zoomroom.delayed_alert",
-                "ingested": "2021-04-23T12:57:50.272416909Z",
+                "ingested": "2021-07-30T21:20:19.264329088Z",
                 "kind": [
                     "event"
                 ]
@@ -56,6 +62,9 @@
             "observer": {
                 "product": "Webhook",
                 "vendor": "Zoom"
+            },
+            "ecs": {
+                "version": "1.11.0"
             },
             "zoom": {
                 "zoomroom": {
@@ -72,7 +81,7 @@
             },
             "event": {
                 "action": "zoomroom.checked_in",
-                "ingested": "2021-04-23T12:57:50.272417894Z",
+                "ingested": "2021-07-30T21:20:19.264329519Z",
                 "type": [
                     "info",
                     "start"
@@ -87,6 +96,9 @@
                 "product": "Webhook",
                 "vendor": "Zoom"
             },
+            "ecs": {
+                "version": "1.11.0"
+            },
             "zoom": {
                 "zoomroom": {
                     "room_name": "Sharks Room",
@@ -102,7 +114,7 @@
             },
             "event": {
                 "action": "zoomroom.checked_in",
-                "ingested": "2021-04-23T12:57:50.272418859Z",
+                "ingested": "2021-07-30T21:20:19.264329904Z",
                 "type": [
                     "info",
                     "start"

--- a/packages/zoom/data_stream/webhook/_dev/test/system/test-webhook-http-config.yml
+++ b/packages/zoom/data_stream/webhook/_dev/test/system/test-webhook-http-config.yml
@@ -7,3 +7,4 @@ data_stream:
     listen_port: 9080
     url: /zoom
     secret_value: abc123
+    preserve_original_event: true

--- a/packages/zoom/data_stream/webhook/_dev/test/system/test-webhook-https-config.yml
+++ b/packages/zoom/data_stream/webhook/_dev/test/system/test-webhook-https-config.yml
@@ -5,6 +5,7 @@ data_stream:
   vars:
     listen_address: 0.0.0.0
     listen_port: 7443
+    preserve_original_event: true
     url: /zoom
     secret_value: abc123
     ssl: |-

--- a/packages/zoom/data_stream/webhook/agent/stream/http_endpoint.yml.hbs
+++ b/packages/zoom/data_stream/webhook/agent/stream/http_endpoint.yml.hbs
@@ -22,7 +22,3 @@ processors:
       fields: [message]
       target: zoom
   - add_locale: ~
-  - add_fields:
-      target: ''
-      fields:
-        ecs.version: 1.9.0

--- a/packages/zoom/data_stream/webhook/agent/stream/http_endpoint.yml.hbs
+++ b/packages/zoom/data_stream/webhook/agent/stream/http_endpoint.yml.hbs
@@ -2,6 +2,9 @@ listen_address: {{listen_address}}
 listen_port: {{listen_port}}
 url: {{url}}
 prefix: zoom
+{{#if preserve_original_event}}
+preserve_original_event: true
+{{/if}}
 # Only set the secret options if a secret.value is set
 {{#if secret_value}}
 secret.header: Authorization
@@ -11,6 +14,9 @@ secret.value: "{{secret_value}}"
 ssl: {{ssl}}
 {{/if}}
 tags:
+{{#if preserve_original_event}}
+ - preserve_original_event
+{{/if}}
 {{#each tags as |tag i|}}
  - {{tag}}
 {{/each}}

--- a/packages/zoom/data_stream/webhook/agent/stream/http_endpoint.yml.hbs
+++ b/packages/zoom/data_stream/webhook/agent/stream/http_endpoint.yml.hbs
@@ -18,7 +18,4 @@ tags:
 publisher_pipeline.disable_host: true
 {{/contains}}
 processors:
-  - decode_json_fields:
-      fields: [message]
-      target: zoom
   - add_locale: ~

--- a/packages/zoom/data_stream/webhook/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zoom/data_stream/webhook/elasticsearch/ingest_pipeline/default.yml
@@ -1,22 +1,22 @@
 ---
 description: Initial pipeline for parsing Zoom webhooks
 processors:
-- set:
-    field: observer.vendor
-    value: Zoom
-- set:
-    field: observer.product
-    value: Webhook
-- set:
-    field: event.ingested
-    value: '{{_ingest.timestamp}}'
-- set:
-    field: ecs.version
-    value: 1.11.0
-- script:
-    description: Drops null/empty values recursively
-    lang: painless
-    source: |
+  - set:
+      field: observer.vendor
+      value: Zoom
+  - set:
+      field: observer.product
+      value: Webhook
+  - set:
+      field: event.ingested
+      value: '{{_ingest.timestamp}}'
+  - set:
+      field: ecs.version
+      value: 1.11.0
+  - script:
+      description: Drops null/empty values recursively
+      lang: painless
+      source: |
         boolean drop(Object o) {
             if (o == null || o == "") {
             return true;
@@ -30,99 +30,99 @@ processors:
             return false;
         }
         drop(ctx);
-- append:
-    field: event.kind
-    value: event
-- rename:
-    field: zoom.event
-    target_field: event.action
-    ignore_missing: true
-- rename:
-    field: zoom.payload
-    target_field: _temp_.payload
-- remove:
-    field: zoom
-- rename:
-    field: _temp_.payload
-    target_field: zoom
-- rename:
-    field: zoom.old_object
-    target_field: zoom.old_values
-    ignore_missing: true
-- rename:
-    field: zoom.object.participant
-    target_field: zoom.participant
-    ignore_missing: true
-- rename:
-    field: zoom.object.settings
-    target_field: zoom.settings
-    ignore_missing: true
-- rename:
-    field: zoom.object.registrant
-    target_field: zoom.registrant
-    ignore_missing: true
-- append:
-    field: related.user
-    value: "{{zoom.operator_id}}"
-    if: "ctx.zoom?.operator_id != null"
-# Set user.id from operator data (user who performs an action).
-- set:
-    field: user.id
-    value: "{{zoom.operator_id}}"
-    if: "ctx.zoom?.operator_id != null"
-# Set user.name from operator data only when user.id also set above.
-- set:
-    field: user.email
-    value: "{{zoom.operator}}"
-    ignore_empty_value: true
-    if: "ctx.zoom?.operator_id != null"
-# Removing some fields that have complex nested arrays that might impact performance
-- remove:
-    field:
-    - message
-    - _temp_
-    - zoom.object.occurrences
-    - zoom.old_values.occurrences
-    - zoom.object.recurrence
-    - zoom.old_values.recurrence
-    - zoom.object.managed_domains
-    - zoom.old_values.managed_domains
-    - zoom.registrant.custom_questions
-    - zoom.old_values.registrant.custom_questions
-    - zoom.object.call_logs
-    - zoom.old_values.call_logs
-    - zoom.object.recording_files
-    - zoom.old_values.recording_files
-    - zoom.object.call_logs
-    ignore_missing: true
-- pipeline:
-    name: '{{ IngestPipeline "meeting" }}'
-    if: "ctx?.event?.action.startsWith('meeting')"
-- pipeline:
-    name: '{{ IngestPipeline "account" }}'
-    if: "ctx?.event?.action.startsWith('account')"
-- pipeline:
-    name: '{{ IngestPipeline "chat_message" }}'
-    if: "ctx?.event?.action.startsWith('chat_message')"
-- pipeline:
-    name: '{{ IngestPipeline "chat_channel" }}'
-    if: "ctx?.event?.action.startsWith('chat_channel')"
-- pipeline:
-    name: '{{ IngestPipeline "phone" }}'
-    if: "ctx?.event?.action.startsWith('phone')"
-- pipeline:
-    name: '{{ IngestPipeline "recording" }}'
-    if: "ctx?.event?.action.startsWith('recording')"
-- pipeline:
-    name: '{{ IngestPipeline "user" }}'
-    if: "ctx?.event?.action.startsWith('user')"
-- pipeline:
-    name: '{{ IngestPipeline "webinar" }}'
-    if: "ctx?.event?.action.startsWith('webinar')"
-- pipeline:
-    name: '{{ IngestPipeline "zoomroom" }}'
-    if: "ctx?.event?.action.startsWith('zoomroom')"
+  - append:
+      field: event.kind
+      value: event
+  - rename:
+      field: zoom.event
+      target_field: event.action
+      ignore_missing: true
+  - rename:
+      field: zoom.payload
+      target_field: _temp_.payload
+  - remove:
+      field: zoom
+  - rename:
+      field: _temp_.payload
+      target_field: zoom
+  - rename:
+      field: zoom.old_object
+      target_field: zoom.old_values
+      ignore_missing: true
+  - rename:
+      field: zoom.object.participant
+      target_field: zoom.participant
+      ignore_missing: true
+  - rename:
+      field: zoom.object.settings
+      target_field: zoom.settings
+      ignore_missing: true
+  - rename:
+      field: zoom.object.registrant
+      target_field: zoom.registrant
+      ignore_missing: true
+  - append:
+      field: related.user
+      value: "{{zoom.operator_id}}"
+      if: "ctx.zoom?.operator_id != null"
+  # Set user.id from operator data (user who performs an action).
+  - set:
+      field: user.id
+      value: "{{zoom.operator_id}}"
+      if: "ctx.zoom?.operator_id != null"
+  # Set user.name from operator data only when user.id also set above.
+  - set:
+      field: user.email
+      value: "{{zoom.operator}}"
+      ignore_empty_value: true
+      if: "ctx.zoom?.operator_id != null"
+  # Removing some fields that have complex nested arrays that might impact performance
+  - remove:
+      field:
+        - message
+        - _temp_
+        - zoom.object.occurrences
+        - zoom.old_values.occurrences
+        - zoom.object.recurrence
+        - zoom.old_values.recurrence
+        - zoom.object.managed_domains
+        - zoom.old_values.managed_domains
+        - zoom.registrant.custom_questions
+        - zoom.old_values.registrant.custom_questions
+        - zoom.object.call_logs
+        - zoom.old_values.call_logs
+        - zoom.object.recording_files
+        - zoom.old_values.recording_files
+        - zoom.object.call_logs
+      ignore_missing: true
+  - pipeline:
+      name: '{{ IngestPipeline "meeting" }}'
+      if: "ctx?.event?.action.startsWith('meeting')"
+  - pipeline:
+      name: '{{ IngestPipeline "account" }}'
+      if: "ctx?.event?.action.startsWith('account')"
+  - pipeline:
+      name: '{{ IngestPipeline "chat_message" }}'
+      if: "ctx?.event?.action.startsWith('chat_message')"
+  - pipeline:
+      name: '{{ IngestPipeline "chat_channel" }}'
+      if: "ctx?.event?.action.startsWith('chat_channel')"
+  - pipeline:
+      name: '{{ IngestPipeline "phone" }}'
+      if: "ctx?.event?.action.startsWith('phone')"
+  - pipeline:
+      name: '{{ IngestPipeline "recording" }}'
+      if: "ctx?.event?.action.startsWith('recording')"
+  - pipeline:
+      name: '{{ IngestPipeline "user" }}'
+      if: "ctx?.event?.action.startsWith('user')"
+  - pipeline:
+      name: '{{ IngestPipeline "webinar" }}'
+      if: "ctx?.event?.action.startsWith('webinar')"
+  - pipeline:
+      name: '{{ IngestPipeline "zoomroom" }}'
+      if: "ctx?.event?.action.startsWith('zoomroom')"
 on_failure:
-- set:
-    field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+  - set:
+      field: error.message
+      value: '{{ _ingest.on_failure_message }}'

--- a/packages/zoom/data_stream/webhook/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zoom/data_stream/webhook/elasticsearch/ingest_pipeline/default.yml
@@ -10,6 +10,9 @@ processors:
 - set:
     field: event.ingested
     value: '{{_ingest.timestamp}}'
+- set:
+    field: ecs.version
+    value: 1.11.0
 - script:
     description: Drops null/empty values recursively
     lang: painless

--- a/packages/zoom/data_stream/webhook/fields/ecs.yml
+++ b/packages/zoom/data_stream/webhook/fields/ecs.yml
@@ -1,199 +1,78 @@
-- description: ECS version this event conforms to.
-  name: ecs.version
-  type: keyword
-- description: Error message.
-  name: error.message
-  type: text
-- description: The action captured by the event.
-  name: event.action
-  type: keyword
-- description: Event category. The second categorization field in the hierarchy.
-  name: event.category
-  type: keyword
-- description: Unique ID to describe the event.
-  name: event.id
-  type: keyword
-- description: Timestamp when an event arrived in the central data store.
-  name: event.ingested
-  type: date
-- description: The kind of the event. The highest categorization field in the hierarchy.
-  name: event.kind
-  type: keyword
-- description: Raw text message of entire event.
-  name: event.original
-  type: keyword
-- description: The outcome of the event. The lowest level categorization field in the hierarchy.
-  name: event.outcome
-  type: keyword
-- description: Event type. The third categorization field in the hierarchy.
-  name: event.type
-  type: keyword
-- description: Log message optimized for viewing in a log viewer.
-  name: message
-  type: text
-- description: All the user names seen on your event.
-  name: related.user
-  type: keyword
-- name: user
-  title: User
-  type: group
-  fields:
-    - name: domain
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the directory the user is a member of.'
-    - name: email
-      type: keyword
-      ignore_above: 1024
-      description: User email address.
-    - name: id
-      type: keyword
-      ignore_above: 1024
-      description: Unique identifier of the user.
-    - name: name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Short name or login of the user.
-    - name: full_name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-      description: User's full name, if available.
-      default_field: false
-    - name: target.domain
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the directory the user is a member of.'
-      default_field: false
-    - name: target.email
-      type: keyword
-      ignore_above: 1024
-      description: User email address.
-      default_field: false
-    - name: target.full_name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-      description: User's full name, if available.
-      default_field: false
-    - name: target.group.domain
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the directory the group is a member of.'
-      default_field: false
-    - name: target.group.id
-      type: keyword
-      ignore_above: 1024
-      description: Unique identifier for the group on the system/platform.
-      default_field: false
-    - name: target.group.name
-      type: keyword
-      ignore_above: 1024
-      description: Name of the group.
-      default_field: false
-    - name: target.id
-      type: keyword
-      ignore_above: 1024
-      description: Unique identifier of the user.
-      default_field: false
-    - name: target.name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-      description: Short name or login of the user.
-      default_field: false
-    - name: changes.domain
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the directory the user is a member of.'
-      default_field: false
-    - name: changes.email
-      type: keyword
-      ignore_above: 1024
-      description: User email address.
-      default_field: false
-    - name: changes.full_name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-      description: User's full name, if available.
-      default_field: false
-    - name: changes.group.domain
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the directory the group is a member of.'
-      default_field: false
-    - name: changes.group.id
-      type: keyword
-      ignore_above: 1024
-      description: Unique identifier for the group on the system/platform.
-      default_field: false
-    - name: changes.group.name
-      type: keyword
-      ignore_above: 1024
-      description: Name of the group.
-      default_field: false
-    - name: changes.id
-      type: keyword
-      ignore_above: 1024
-      description: Unique identifier of the user.
-      default_field: false
-    - name: changes.name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-      description: Short name or login of the user.
-      default_field: false
-- name: observer
-  type: group
-  fields:
-    - name: vendor
-      type: keyword
-      ignore_above: 1024
-      description: Observer vendor.
-    - name: product
-      type: keyword
-      ignore_above: 1024
-      description: The product name of the observer.
-      example: s200
-- name: url
-  title: URL
-  type: group
-  fields:
-    - name: full
-      type: keyword
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: If full URLs are important to your use case, they should be stored in `url.full`, whether this field is reconstructed or present in the event source.
-- description: Unique identifiers of the user.
-  name: source.user.id
-  type: keyword
-- description: Unique identifiers of the user.
+- external: ecs
   name: destination.user.id
-  type: keyword
-- name: tags
-  type: keyword
-  description: List of keywords used to tag each event.
+- external: ecs
+  name: ecs.version
+- external: ecs
+  name: error.message
+- external: ecs
+  name: event.action
+- external: ecs
+  name: event.category
+- external: ecs
+  name: event.id
+- external: ecs
+  name: event.ingested
+- external: ecs
+  name: event.kind
+- external: ecs
+  name: event.original
+- external: ecs
+  name: event.outcome
+- external: ecs
+  name: event.type
+- external: ecs
+  name: message
+- external: ecs
+  name: observer.product
+- external: ecs
+  name: observer.vendor
+- external: ecs
+  name: related.user
+- external: ecs
+  name: source.user.id
+- external: ecs
+  name: tags
+- external: ecs
+  name: url.full
+- external: ecs
+  name: user.changes.domain
+- external: ecs
+  name: user.changes.email
+- external: ecs
+  name: user.changes.full_name
+- external: ecs
+  name: user.changes.group.domain
+- external: ecs
+  name: user.changes.group.id
+- external: ecs
+  name: user.changes.group.name
+- external: ecs
+  name: user.changes.id
+- external: ecs
+  name: user.changes.name
+- external: ecs
+  name: user.domain
+- external: ecs
+  name: user.email
+- external: ecs
+  name: user.full_name
+- external: ecs
+  name: user.id
+- external: ecs
+  name: user.name
+- external: ecs
+  name: user.target.domain
+- external: ecs
+  name: user.target.email
+- external: ecs
+  name: user.target.full_name
+- external: ecs
+  name: user.target.group.domain
+- external: ecs
+  name: user.target.group.id
+- external: ecs
+  name: user.target.group.name
+- external: ecs
+  name: user.target.id
+- external: ecs
+  name: user.target.name

--- a/packages/zoom/data_stream/webhook/manifest.yml
+++ b/packages/zoom/data_stream/webhook/manifest.yml
@@ -57,3 +57,11 @@ streams:
         default:
           - zoom-webhook
           - forwarded
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false

--- a/packages/zoom/docs/README.md
+++ b/packages/zoom/docs/README.md
@@ -39,19 +39,19 @@ This integration is compatible with the Zoom Platform API as of September 2020.
 | dataset.name | Dataset name. | constant_keyword |
 | dataset.namespace | Dataset namespace. | constant_keyword |
 | dataset.type | Dataset type. | constant_keyword |
-| destination.user.id | Unique identifiers of the user. | keyword |
-| ecs.version | ECS version this event conforms to. | keyword |
+| destination.user.id | Unique identifier of the user. | keyword |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
 | error.message | Error message. | text |
-| event.action | The action captured by the event. | keyword |
-| event.category | Event category. The second categorization field in the hierarchy. | keyword |
+| event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
+| event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
 | event.dataset | Event dataset | constant_keyword |
 | event.id | Unique ID to describe the event. | keyword |
-| event.ingested | Timestamp when an event arrived in the central data store. | date |
-| event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
+| event.ingested | Timestamp when an event arrived in the central data store. This is different from `@timestamp`, which is when the event originally occurred.  It's also different from `event.created`, which is meant to capture the first time an agent saw the event. In normal conditions, assuming no tampering, the timestamps should chronologically look like this: `@timestamp` \< `event.created` \< `event.ingested`. | date |
+| event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |
 | event.module | Event module | constant_keyword |
-| event.original | Raw text message of entire event. | keyword |
-| event.outcome | The outcome of the event. The lowest level categorization field in the hierarchy. | keyword |
-| event.type | Event type. The third categorization field in the hierarchy. | keyword |
+| event.original | Raw text message of entire event. Used to demonstrate log integrity or where the full log message (before splitting it up in multiple parts) may be required, e.g. for reindex. This field is not indexed and doc_values are disabled. It cannot be searched, but it can be retrieved from `_source`. If users wish to override this and index this field, please see `Field data types` in the `Elasticsearch Reference`. | keyword |
+| event.outcome | This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy. `event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event. Note that when a single transaction is described in multiple events, each event may populate different values of `event.outcome`, according to their perspective. Also note that in the case of a compound event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer. Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for which an outcome does not make logical sense. | keyword |
+| event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -69,30 +69,30 @@ This integration is compatible with the Zoom Platform API as of September 2020.
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | input.type | Input type. | keyword |
-| message | Log message optimized for viewing in a log viewer. | text |
+| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
 | observer.product | The product name of the observer. | keyword |
-| observer.vendor | Observer vendor. | keyword |
-| related.user | All the user names seen on your event. | keyword |
-| source.user.id | Unique identifiers of the user. | keyword |
+| observer.vendor | Vendor name of the observer. | keyword |
+| related.user | All the user names or other user identifiers seen on the event. | keyword |
+| source.user.id | Unique identifier of the user. | keyword |
 | tags | List of keywords used to tag each event. | keyword |
 | url.full | If full URLs are important to your use case, they should be stored in `url.full`, whether this field is reconstructed or present in the event source. | keyword |
-| user.changes.domain | Name of the directory the user is a member of. | keyword |
+| user.changes.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
 | user.changes.email | User email address. | keyword |
 | user.changes.full_name | User's full name, if available. | keyword |
-| user.changes.group.domain | Name of the directory the group is a member of. | keyword |
+| user.changes.group.domain | Name of the directory the group is a member of. For example, an LDAP or Active Directory domain name. | keyword |
 | user.changes.group.id | Unique identifier for the group on the system/platform. | keyword |
 | user.changes.group.name | Name of the group. | keyword |
 | user.changes.id | Unique identifier of the user. | keyword |
 | user.changes.name | Short name or login of the user. | keyword |
-| user.domain | Name of the directory the user is a member of. | keyword |
+| user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
 | user.email | User email address. | keyword |
 | user.full_name | User's full name, if available. | keyword |
 | user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
-| user.target.domain | Name of the directory the user is a member of. | keyword |
+| user.target.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
 | user.target.email | User email address. | keyword |
 | user.target.full_name | User's full name, if available. | keyword |
-| user.target.group.domain | Name of the directory the group is a member of. | keyword |
+| user.target.group.domain | Name of the directory the group is a member of. For example, an LDAP or Active Directory domain name. | keyword |
 | user.target.group.id | Unique identifier for the group on the system/platform. | keyword |
 | user.target.group.name | Name of the group. | keyword |
 | user.target.id | Unique identifier of the user. | keyword |

--- a/packages/zoom/manifest.yml
+++ b/packages/zoom/manifest.yml
@@ -1,6 +1,6 @@
 name: zoom
 title: Zoom
-version: 0.5.0
+version: 0.5.1
 release: beta
 description: This Elastic integration collects logs from Zoom
 type: integration


### PR DESCRIPTION
## What does this PR do?

- sets `ecs.version` to 1.11.0
- moves setting ecs.version to pipeline for all data sets

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967