### PR TITLE
Move elastic_agent and fleet_server to GA

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0"
+  changes:
+    - description: Make integration GA.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1431
 - version: "0.1.0"
   changes:
     - description: Update integration description

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,14 +1,14 @@
 name: elastic_agent
 title: Elastic Agent
-version: 0.1.0
-release: experimental
+version: 1.0.0
+release: ga
 description: This Elastic integration collects metrics from Elastic Agent
 type: integration
 format_version: 1.0.0
 license: basic
 categories: ["elastic_stack"]
 conditions:
-  kibana.version: "^7.11.0"
+  kibana.version: "^7.14.0"
 owner:
   github: elastic/ingest-management
 icons:

--- a/packages/fleet_server/changelog.yml
+++ b/packages/fleet_server/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0"
+  changes:
+    - description: Make integration GA.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1431
 - version: "0.10.0"
   changes:
     - description: Update integration description

--- a/packages/fleet_server/manifest.yml
+++ b/packages/fleet_server/manifest.yml
@@ -1,14 +1,14 @@
 name: fleet_server
 title: Fleet Server
-version: 0.10.0
-release: beta
+version: 1.0.0
+release: ga
 description: Centrally manage Elastic Agents with the Fleet Server integration
 type: integration
 format_version: 1.0.0
 license: basic
 categories: ["elastic_stack"]
 conditions:
-  kibana.version: "^7.13.0"
+  kibana.version: "^7.14.0"
 owner:
   github: elastic/ingest-management
 #icons:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Move the `elastic_agent` and `fleet-server` packages to GA, changing the version to 1.0.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1329 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
