### PR TITLE
[fortinet] Remove experimental label from manifest

### DIFF
--- a/packages/fortinet/changelog.yml
+++ b/packages/fortinet/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.2"
+  changes:
+    - description: Remove `experimental` label from manifest
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.1.1"
   changes:
     - description: Escape special characters in docs

--- a/packages/fortinet/manifest.yml
+++ b/packages/fortinet/manifest.yml
@@ -1,7 +1,7 @@
 name: fortinet
 title: Fortinet
-version: 1.1.1
-release: experimental
+version: 1.1.2
+release: ga
 description: This Elastic integration collects logs from Fortinet instances
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
## What does this PR do?

Changes experimental label to GA, as the package is already in v1+ and the original intent is for it to be GA.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).
