### PR TITLE
Osquery_manager: Input level settings for platform and version osquery pack constraint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 
 .idea
+.vscode
 /build
 
 dev/packages

--- a/packages/osquery_manager/agent/input/input.yml.hbs
+++ b/packages/osquery_manager/agent/input/input.yml.hbs
@@ -4,3 +4,9 @@ iplatform: {{iplatform}}
 {{#if iversion}}
 iversion: {{iversion}}
 {{/if}}
+{{#if discovery}}
+discovery:
+{{#each discovery as |query i|}}
+ - {{query}}
+{{/each}}
+{{/if}}

--- a/packages/osquery_manager/agent/input/input.yml.hbs
+++ b/packages/osquery_manager/agent/input/input.yml.hbs
@@ -1,0 +1,6 @@
+{{#if iplatform}}
+iplatform: {{iplatform}}
+{{/if}}
+{{#if iversion}}
+iversion: {{iversion}}
+{{/if}}

--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.1"
+  changes:
+    - description: Input level settings for platform and version osquery pack constraint
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "0.5.0"
   changes:
     - description: Update integration description

--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Input level settings for platform and version osquery pack constraint
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/1441
 - version: "0.5.0"
   changes:
     - description: Update integration description

--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "0.5.1"
   changes:
-    - description: Input level settings for platform and version osquery pack constraint
+    - description: Input level settings for platform and version osquery pack constraint and discovery queries
       type: enhancement
       link: https://github.com/elastic/integrations/pull/1441
 - version: "0.5.0"

--- a/packages/osquery_manager/manifest.yml
+++ b/packages/osquery_manager/manifest.yml
@@ -35,5 +35,11 @@ policy_templates:
             type: text
             required: false
             show_user: true
+          - name: discovery
+            type: text
+            title: Discovery queries
+            multi: true
+            required: false
+            show_user: true
 owner:
   github: elastic/integrations

--- a/packages/osquery_manager/manifest.yml
+++ b/packages/osquery_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: osquery_manager
 title: Osquery Manager
-version: 0.5.0
+version: 0.5.1
 license: basic
 description: This Elastic integration lets you centrally manage osquery deployments, run live queries, and schedule recurring queries
 type: integration
@@ -23,7 +23,17 @@ policy_templates:
     description: Send interactive or scheduled queries to the osquery instances executed by the elastic-agent.
     inputs:
       - type: osquery
+        template_path: input.yml.hbs
         title: Send queries to osquery instances
         description: Send interactive or scheduled queries to the osquery instances executed by the elastic-agent.
+        vars:
+          - name: iplatform
+            type: text
+            required: false
+            show_user: true
+          - name: iversion
+            type: text
+            required: false
+            show_user: true
 owner:
   github: elastic/integrations


### PR DESCRIPTION
## What does this PR do?

Introduces the input level settings for platform and version osquery pack constraint. 
The input level settings currently have to have a different name from the stream level settings otherwise they are applied to each stream, thus the names are ```iplatform``` and ```iversion```.

The changes as is break the osquery manager integration configuration on kibana side.
so there are two things to fix on kibana side:
1. kibana needs to be able to create integration configuration with empty vars
2. the configuration page for osquery needs to remove compiled_input from the request payload when updating the streaming configuration via ```/api/fleet/package_policies/``` API. 

Example working request payload:
```
{
    "name": "osquery_manager-1",
    "description": "",
    "policy_id": "548a3940-df4e-11eb-8fdd-b98cebb63257",
    "namespace": "default",
    "inputs": [
        {
            "type": "osquery",
            "enabled": true,
            "streams": [
                {
                    "data_stream": {
                        "type": "logs",
                        "dataset": "osquery_manager.result"
                    },
                    "enabled": true,
                    "id": "osquery-osquery_manager.result-316fbc06-2bd8-470b-bab3-1a566e72bcf1",
                    "vars": {
                        "id": {
                            "type": "text",
                            "value": "users"
                        },
                        "interval": {
                            "type": "integer",
                            "value": 3600
                        },
                        "query": {
                            "type": "text",
                            "value": "select * from users limit 2"
                        },
                        "platform": {
                            "value": "darwin",
                            "type": "text"
                        },
                        "version": {
                            "value": "4.7.0",
                            "type": "text"
                        }
                    }
                }
            ],
            "policy_template": "osquery_manager",
            "vars": {
                "iplatform": {
                    "value": "posix",
                    "type": "text"
                },
                "iversion": {
                    "value": "4.7.0",
                    "type": "text"
                }
            }
        }
    ],
    "enabled": true,
    "output_id": "",
    "package": {
        "name": "osquery_manager",
        "title": "Osquery Manager",
        "version": "0.5.1"
    }
}
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).



## Screenshots
Resulting policy with the version and the platform constraints:
<img width="464" alt="Screen Shot 2021-08-03 at 2 33 07 PM" src="https://user-images.githubusercontent.com/872351/128079491-67a56c11-5088-477d-b1f6-d276318903a4.png">
