### PR TITLE
Azure integration: use ECS fields

### DIFF
--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.8.0"
+  changes:
+    - description: Import ECS field definitions
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1455
 - version: "0.7.0"
   changes:
     - description: Add spring cloud logs

--- a/packages/azure/data_stream/activitylogs/fields/agent.yml
+++ b/packages/azure/data_stream/activitylogs/fields/agent.yml
@@ -1,198 +1,62 @@
-- name: cloud
-  title: Cloud
-  group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
-  type: group
-  fields:
-    - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
-      example: 666777888999
-    - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
-    - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
-    - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
-    - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
-    - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
-    - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
-    - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
-    - name: image.id
-      type: keyword
-      description: Image ID for the cloud instance.
-- name: container
-  title: Container
-  group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
-  type: group
-  fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
-    - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
-    - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
-    - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
-- name: host
-  title: Host
-  group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
-  type: group
-  fields:
-    - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
-    - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
-      example: CONTOSO
-      default_field: false
-    - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
-    - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
-    - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
-    - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
-    - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
-    - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
-    - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
-    - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
-    - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
-    - name: containerized
-      type: boolean
-      description: >
-        If the host is a container.
-
-    - name: os.build
-      type: keyword
-      example: "18D109"
-      description: >
-        OS build information.
-
-    - name: os.codename
-      type: keyword
-      example: "stretch"
-      description: >
-        OS codename, if any.
-
+- name: cloud.account.id
+  external: ecs
+- name: cloud.availability_zone
+  external: ecs
+- name: cloud.instance.id
+  external: ecs
+- name: cloud.instance.name
+  external: ecs
+- name: cloud.machine.type
+  external: ecs
+- name: cloud.provider
+  external: ecs
+- name: cloud.region
+  external: ecs
+- name: cloud.project.id
+  external: ecs
+- name: cloud.image.id
+  type: keyword
+  description: Image ID for the cloud instance.
+- name: container.id
+  external: ecs
+- name: container.image.name
+  external: ecs
+- name: container.labels
+  external: ecs
+- name: container.name
+  external: ecs
+- name: host.architecture
+  external: ecs
+- name: host.domain
+  external: ecs
+- name: host.hostname
+  external: ecs
+- name: host.id
+  external: ecs
+- name: host.ip
+  external: ecs
+- name: host.mac
+  external: ecs
+- name: host.name
+  external: ecs
+- name: host.os.family
+  external: ecs
+- name: host.os.kernel
+  external: ecs
+- name: host.os.name
+  external: ecs
+- name: host.os.platform
+  external: ecs
+- name: host.os.version
+  external: ecs
+- name: host.type
+  external: ecs
+- name: host.containerized
+  type: boolean
+  description: If the host is a container.
+- name: host.os.build
+  type: keyword
+  description: OS build information.
+- name: host.os.codename
+  type: keyword
+  description: OS codename, if any.

--- a/packages/azure/data_stream/activitylogs/fields/ecs.yml
+++ b/packages/azure/data_stream/activitylogs/fields/ecs.yml
@@ -1,249 +1,111 @@
-- description: IP address of the client.
-  name: client.ip
-  type: ip
-- description: Destination network address.
-  ignore_above: 1024
-  name: destination.address
-  type: keyword
-- description: Unique number allocated to the autonomous system.
-  example: 15169
-  name: destination.as.number
-  type: long
-- description: Organization name.
-  example: Google LLC
-  ignore_above: 1024
-  multi_fields:
-    - flat_name: destination.as.organization.name.text
-      name: text
-      norms: false
-      type: text
-  name: destination.as.organization.name
-  type: keyword
-- description: City name.
-  example: Montreal
-  ignore_above: 1024
-  name: destination.geo.city_name
-  type: keyword
-- description: Name of the continent.
-  example: North America
-  ignore_above: 1024
-  name: destination.geo.continent_name
-  type: keyword
-- description: Country ISO code.
-  example: CA
-  ignore_above: 1024
-  name: destination.geo.country_iso_code
-  type: keyword
-- description: Country name.
-  example: Canada
-  ignore_above: 1024
-  name: destination.geo.country_name
-  type: keyword
-- description: Longitude and latitude.
-  example: '{ "lon": -73.614830, "lat": 45.505918 }'
-  name: destination.geo.location
+- name: client.ip
+  external: ecs
+- name: destination.address
+  external: ecs
+- name: destination.as.number
+  external: ecs
+- name: destination.as.organization.name
+  external: ecs
+- name: destination.geo.city_name
+  external: ecs
+- name: destination.geo.continent_name
+  external: ecs
+- name: destination.geo.country_iso_code
+  external: ecs
+- name: destination.geo.country_name
+  external: ecs
+- name: destination.geo.location
   type: geo_point
-- description: User-defined description of a location.
-  example: boston-dc
-  ignore_above: 1024
-  name: destination.geo.name
-  type: keyword
-- description: Region ISO code.
-  example: CA-QC
-  ignore_above: 1024
-  name: destination.geo.region_iso_code
-  type: keyword
-- description: Region name.
-  example: Quebec
-  ignore_above: 1024
-  name: destination.geo.region_name
-  type: keyword
-- description: IP address of the destination.
-  name: destination.ip
-  type: ip
-- description: Port of the destination.
-  name: destination.port
-  type: long
-- description: ECS version this event conforms to.
-  example: 1.0.0
-  ignore_above: 1024
-  name: ecs.version
-  type: keyword
-- description: Error message.
-  name: error.message
-  type: text
-- description: Message.
-  name: message
-  type: text
-- description: The action captured by the event.
-  example: user-password-change
-  ignore_above: 1024
-  name: event.action
-  type: keyword
-- description: Event category. The second categorization field in the hierarchy.
-  example: authentication
-  ignore_above: 1024
-  name: event.category
-  type: keyword
-- description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
-  name: event.created
-  type: date
-- description: Unique ID to describe the event.
-  example: 8a4f500d
-  ignore_above: 1024
-  name: event.id
-  type: keyword
-- description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
-  name: event.ingested
-  type: date
-- description: The kind of the event. The highest categorization field in the hierarchy.
-  example: alert
-  ignore_above: 1024
-  name: event.kind
-  type: keyword
-- description: Event type. The third categorization field in the hierarchy.
-  ignore_above: 1024
-  name: event.type
-  type: keyword
-- description: Media type of file, document, or arrangement of bytes.
-  ignore_above: 1024
-  name: file.mime_type
-  type: keyword
-- description: File size in bytes.
-  example: 16384
-  name: file.size
-  type: long
-- description: A hash of source and destination IPs and ports.
-  example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
-  ignore_above: 1024
-  name: network.community_id
-  type: keyword
-- description: "Host ip addresses."
-  name: host.ip
-  type: ip
-- description: All of the IPs seen on your event.
-  name: related.ip
-  type: ip
-- description: All the user names seen on your event.
-  ignore_above: 1024
-  name: related.user
-  type: keyword
-- description: Source network address.
-  ignore_above: 1024
-  name: source.address
-  type: keyword
-- description: Unique number allocated to the autonomous system.
-  example: 15169
-  name: source.as.number
-  type: long
-- description: Organization name.
-  example: Google LLC
-  ignore_above: 1024
-  multi_fields:
-    - flat_name: source.as.organization.name.text
-      name: text
-      norms: false
-      type: text
-  name: source.as.organization.name
-  type: keyword
-- description: Name of the continent.
-  example: North America
-  ignore_above: 1024
-  name: geo.continent_name
-  type: keyword
-- description: Country ISO code.
-  example: CA
-  ignore_above: 1024
-  name: geo.country_iso_code
-  type: keyword
-- description: Country name.
-  example: Canada
-  ignore_above: 1024
-  name: geo.country_name
-  type: keyword
-- description: Longitude and latitude.
-  example: '{ "lon": -73.614830, "lat": 45.505918 }'
-  name: geo.location
+  description: Longitude and latitude.
+- name: destination.geo.name
+  external: ecs
+- name: destination.geo.region_iso_code
+  external: ecs
+- name: destination.geo.region_name
+  external: ecs
+- name: destination.ip
+  external: ecs
+- name: destination.port
+  external: ecs
+- name: ecs.version
+  external: ecs
+- name: message
+  external: ecs
+- name: event.action
+  external: ecs
+- name: event.category
+  external: ecs
+- name: event.created
+  external: ecs
+- name: event.id
+  external: ecs
+- name: event.ingested
+  external: ecs
+- name: event.kind
+  external: ecs
+- name: event.type
+  external: ecs
+- name: file.mime_type
+  external: ecs
+- name: file.size
+  external: ecs
+- name: network.community_id
+  external: ecs
+- name: host.ip
+  external: ecs
+- name: related.ip
+  external: ecs
+- name: related.user
+  external: ecs
+- name: source.address
+  external: ecs
+- name: source.as.number
+  external: ecs
+- name: source.as.organization.name
+  external: ecs
+- name: geo.continent_name
+  external: ecs
+- name: geo.country_iso_code
+  external: ecs
+- name: geo.country_name
+  external: ecs
+- name: geo.location
   type: geo_point
-- description: City name.
-  example: Montreal
-  ignore_above: 1024
-  name: geo.city_name
-  type: keyword
-- description: Log level of the log event.
-  name: log.level
-  type: keyword
-- description: City name.
-  example: Montreal
-  ignore_above: 1024
-  name: source.geo.city_name
-  type: keyword
-- description: Name of the continent.
-  example: North America
-  ignore_above: 1024
-  name: source.geo.continent_name
-  type: keyword
-- description: Country ISO code.
-  example: CA
-  ignore_above: 1024
-  name: source.geo.country_iso_code
-  type: keyword
-- description: Country name.
-  example: Canada
-  ignore_above: 1024
-  name: source.geo.country_name
-  type: keyword
-- description: Longitude and latitude.
-  example: '{ "lon": -73.614830, "lat": 45.505918 }'
-  name: source.geo.location
+  description: Longitude and latitude.
+- name: geo.city_name
+  external: ecs
+- name: log.level
+  external: ecs
+- name: source.geo.city_name
+  external: ecs
+- name: source.geo.continent_name
+  external: ecs
+- name: source.geo.country_iso_code
+  external: ecs
+- name: source.geo.country_name
+  external: ecs
+- name: source.geo.location
   type: geo_point
-- description: User-defined description of a location.
-  example: boston-dc
-  ignore_above: 1024
-  name: source.geo.name
-  type: keyword
-- description: Region ISO code.
-  example: CA-QC
-  ignore_above: 1024
-  name: source.geo.region_iso_code
-  type: keyword
-- description: Region name.
-  example: Quebec
-  ignore_above: 1024
-  name: source.geo.region_name
-  type: keyword
-- description: IP address of the source.
-  name: source.ip
-  type: ip
-- description: Port of the source.
-  name: source.port
-  type: long
+  description: Longitude and latitude.
+- name: source.geo.name
+  external: ecs
+- name: source.geo.region_iso_code
+  external: ecs
+- name: source.geo.region_name
+  external: ecs
+- name: source.ip
+  external: ecs
+- name: source.port
+  external: ecs
 - name: user.full_name
-  type: keyword
-  description: Full name of the user.
+  external: ecs
 - name: user.domain
-  type: keyword
-  description: Domain of the user.
+  external: ecs
 - name: user.name
-  type: keyword
-  description: Short name or login of the user.
+  external: ecs
 - name: user.id
-  type: keyword
-  description: Unique identifier of the user.
-- description: Short name or login of the user.
-  example: albert
-  ignore_above: 1024
-  multi_fields:
-    - flat_name: user.name.text
-      name: text
-      norms: false
-      type: text
-  name: user.name
-  type: keyword
+  external: ecs
+- name: user.name
+  external: ecs
 - name: tags
-  description: List of keywords used to tag each event.
-  example: '["production", "env2"]'
-  ignore_above: 1024
-  type: keyword
+  external: ecs

--- a/packages/azure/data_stream/auditlogs/fields/agent.yml
+++ b/packages/azure/data_stream/auditlogs/fields/agent.yml
@@ -1,198 +1,62 @@
-- name: cloud
-  title: Cloud
-  group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
-  type: group
-  fields:
-    - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
-      example: 666777888999
-    - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
-    - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
-    - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
-    - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
-    - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
-    - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
-    - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
-    - name: image.id
-      type: keyword
-      description: Image ID for the cloud instance.
-- name: container
-  title: Container
-  group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
-  type: group
-  fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
-    - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
-    - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
-    - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
-- name: host
-  title: Host
-  group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
-  type: group
-  fields:
-    - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
-    - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
-      example: CONTOSO
-      default_field: false
-    - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
-    - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
-    - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
-    - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
-    - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
-    - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
-    - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
-    - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
-    - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
-    - name: containerized
-      type: boolean
-      description: >
-        If the host is a container.
-
-    - name: os.build
-      type: keyword
-      example: "18D109"
-      description: >
-        OS build information.
-
-    - name: os.codename
-      type: keyword
-      example: "stretch"
-      description: >
-        OS codename, if any.
-
+- name: cloud.account.id
+  external: ecs
+- name: cloud.availability_zone
+  external: ecs
+- name: cloud.instance.id
+  external: ecs
+- name: cloud.instance.name
+  external: ecs
+- name: cloud.machine.type
+  external: ecs
+- name: cloud.provider
+  external: ecs
+- name: cloud.region
+  external: ecs
+- name: cloud.project.id
+  external: ecs
+- name: cloud.image.id
+  type: keyword
+  description: Image ID for the cloud instance.
+- name: container.id
+  external: ecs
+- name: container.image.name
+  external: ecs
+- name: container.labels
+  external: ecs
+- name: container.name
+  external: ecs
+- name: host.architecture
+  external: ecs
+- name: host.domain
+  external: ecs
+- name: host.hostname
+  external: ecs
+- name: host.id
+  external: ecs
+- name: host.ip
+  external: ecs
+- name: host.mac
+  external: ecs
+- name: host.name
+  external: ecs
+- name: host.os.family
+  external: ecs
+- name: host.os.kernel
+  external: ecs
+- name: host.os.name
+  external: ecs
+- name: host.os.platform
+  external: ecs
+- name: host.os.version
+  external: ecs
+- name: host.type
+  external: ecs
+- name: host.containerized
+  type: boolean
+  description: If the host is a container.
+- name: host.os.build
+  type: keyword
+  description: OS build information.
+- name: host.os.codename
+  type: keyword
+  description: OS codename, if any.

--- a/packages/azure/data_stream/auditlogs/fields/ecs.yml
+++ b/packages/azure/data_stream/auditlogs/fields/ecs.yml
@@ -1,246 +1,109 @@
-- description: Destination network address.
-  ignore_above: 1024
-  name: destination.address
-  type: keyword
-- description: Unique number allocated to the autonomous system.
-  example: 15169
-  name: destination.as.number
-  type: long
-- description: Organization name.
-  example: Google LLC
-  ignore_above: 1024
-  multi_fields:
-    - flat_name: destination.as.organization.name.text
-      name: text
-      norms: false
-      type: text
-  name: destination.as.organization.name
-  type: keyword
-- description: City name.
-  example: Montreal
-  ignore_above: 1024
-  name: destination.geo.city_name
-  type: keyword
-- description: Name of the continent.
-  example: North America
-  ignore_above: 1024
-  name: destination.geo.continent_name
-  type: keyword
-- description: Country ISO code.
-  example: CA
-  ignore_above: 1024
-  name: destination.geo.country_iso_code
-  type: keyword
-- description: Country name.
-  example: Canada
-  ignore_above: 1024
-  name: destination.geo.country_name
-  type: keyword
-- description: Longitude and latitude.
-  example: '{ "lon": -73.614830, "lat": 45.505918 }'
-  name: destination.geo.location
+- name: destination.address
+  external: ecs
+- name: destination.as.number
+  external: ecs
+- name: destination.as.organization.name
+  external: ecs
+- name: destination.geo.city_name
+  external: ecs
+- name: destination.geo.continent_name
+  external: ecs
+- name: destination.geo.country_iso_code
+  external: ecs
+- name: destination.geo.country_name
+  external: ecs
+- name: destination.geo.location
   type: geo_point
-- description: User-defined description of a location.
-  example: boston-dc
-  ignore_above: 1024
-  name: destination.geo.name
-  type: keyword
-- description: Region ISO code.
-  example: CA-QC
-  ignore_above: 1024
-  name: destination.geo.region_iso_code
-  type: keyword
-- description: Region name.
-  example: Quebec
-  ignore_above: 1024
-  name: destination.geo.region_name
-  type: keyword
-- description: IP address of the destination.
-  name: destination.ip
-  type: ip
-- description: Port of the destination.
-  name: destination.port
-  type: long
-- description: ECS version this event conforms to.
-  example: 1.0.0
-  ignore_above: 1024
-  name: ecs.version
-  type: keyword
-- description: Error message.
-  name: error.message
-  type: text
-- description: Message.
-  name: message
-  type: text
-- description: The action captured by the event.
-  example: user-password-change
-  ignore_above: 1024
-  name: event.action
-  type: keyword
-- description: Event category. The second categorization field in the hierarchy.
-  example: authentication
-  ignore_above: 1024
-  name: event.category
-  type: keyword
-- description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
-  name: event.created
-  type: date
-- description: Unique ID to describe the event.
-  example: 8a4f500d
-  ignore_above: 1024
-  name: event.id
-  type: keyword
-- description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
-  name: event.ingested
-  type: date
-- description: The kind of the event. The highest categorization field in the hierarchy.
-  example: alert
-  ignore_above: 1024
-  name: event.kind
-  type: keyword
-- description: Event type. The third categorization field in the hierarchy.
-  ignore_above: 1024
-  name: event.type
-  type: keyword
-- description: Media type of file, document, or arrangement of bytes.
-  ignore_above: 1024
-  name: file.mime_type
-  type: keyword
-- description: File size in bytes.
-  example: 16384
-  name: file.size
-  type: long
-- description: A hash of source and destination IPs and ports.
-  example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
-  ignore_above: 1024
-  name: network.community_id
-  type: keyword
-- description: "Host ip addresses."
-  name: host.ip
-  type: ip
-- description: All of the IPs seen on your event.
-  name: related.ip
-  type: ip
-- description: All the user names seen on your event.
-  ignore_above: 1024
-  name: related.user
-  type: keyword
-- description: Source network address.
-  ignore_above: 1024
-  name: source.address
-  type: keyword
-- description: Unique number allocated to the autonomous system.
-  example: 15169
-  name: source.as.number
-  type: long
-- description: Organization name.
-  example: Google LLC
-  ignore_above: 1024
-  multi_fields:
-    - flat_name: source.as.organization.name.text
-      name: text
-      norms: false
-      type: text
-  name: source.as.organization.name
-  type: keyword
-- description: Name of the continent.
-  example: North America
-  ignore_above: 1024
-  name: geo.continent_name
-  type: keyword
-- description: Country ISO code.
-  example: CA
-  ignore_above: 1024
-  name: geo.country_iso_code
-  type: keyword
-- description: Country name.
-  example: Canada
-  ignore_above: 1024
-  name: geo.country_name
-  type: keyword
-- description: Longitude and latitude.
-  example: '{ "lon": -73.614830, "lat": 45.505918 }'
-  name: geo.location
+  description: Longitude and latitude.
+- name: destination.geo.name
+  external: ecs
+- name: destination.geo.region_iso_code
+  external: ecs
+- name: destination.geo.region_name
+  external: ecs
+- name: destination.ip
+  external: ecs
+- name: destination.port
+  external: ecs
+- name: ecs.version
+  external: ecs
+- name: message
+  external: ecs
+- name: event.action
+  external: ecs
+- name: event.category
+  external: ecs
+- name: event.created
+  external: ecs
+- name: event.id
+  external: ecs
+- name: event.ingested
+  external: ecs
+- name: event.kind
+  external: ecs
+- name: event.type
+  external: ecs
+- name: file.mime_type
+  external: ecs
+- name: file.size
+  external: ecs
+- name: network.community_id
+  external: ecs
+- name: host.ip
+  external: ecs
+- name: related.ip
+  external: ecs
+- name: related.user
+  external: ecs
+- name: source.address
+  external: ecs
+- name: source.as.number
+  external: ecs
+- name: source.as.organization.name
+  external: ecs
+- name: geo.continent_name
+  external: ecs
+- name: geo.country_iso_code
+  external: ecs
+- name: geo.country_name
+  external: ecs
+- name: geo.location
   type: geo_point
-- description: City name.
-  example: Montreal
-  ignore_above: 1024
-  name: geo.city_name
-  type: keyword
-- description: Log level of the log event.
-  name: log.level
-  type: keyword
-- description: City name.
-  example: Montreal
-  ignore_above: 1024
-  name: source.geo.city_name
-  type: keyword
-- description: Name of the continent.
-  example: North America
-  ignore_above: 1024
-  name: source.geo.continent_name
-  type: keyword
-- description: Country ISO code.
-  example: CA
-  ignore_above: 1024
-  name: source.geo.country_iso_code
-  type: keyword
-- description: Country name.
-  example: Canada
-  ignore_above: 1024
-  name: source.geo.country_name
-  type: keyword
-- description: Longitude and latitude.
-  example: '{ "lon": -73.614830, "lat": 45.505918 }'
-  name: source.geo.location
+  description: Longitude and latitude.
+- name: geo.city_name
+  external: ecs
+- name: log.level
+  external: ecs
+- name: source.geo.city_name
+  external: ecs
+- name: source.geo.continent_name
+  external: ecs
+- name: source.geo.country_iso_code
+  external: ecs
+- name: source.geo.country_name
+  external: ecs
+- name: source.geo.location
   type: geo_point
-- description: User-defined description of a location.
-  example: boston-dc
-  ignore_above: 1024
-  name: source.geo.name
-  type: keyword
-- description: Region ISO code.
-  example: CA-QC
-  ignore_above: 1024
-  name: source.geo.region_iso_code
-  type: keyword
-- description: Region name.
-  example: Quebec
-  ignore_above: 1024
-  name: source.geo.region_name
-  type: keyword
-- description: IP address of the source.
-  name: source.ip
-  type: ip
-- description: Port of the source.
-  name: source.port
-  type: long
+  description: Longitude and latitude.
+- name: source.geo.name
+  external: ecs
+- name: source.geo.region_iso_code
+  external: ecs
+- name: source.geo.region_name
+  external: ecs
+- name: source.ip
+  external: ecs
+- name: source.port
+  external: ecs
 - name: user.full_name
-  type: keyword
-  description: Full name of the user.
+  external: ecs
 - name: user.domain
-  type: keyword
-  description: Domain of the user.
+  external: ecs
 - name: user.name
-  type: keyword
-  description: Short name or login of the user.
+  external: ecs
 - name: user.id
-  type: keyword
-  description: Unique identifier of the user.
-- description: Short name or login of the user.
-  example: albert
-  ignore_above: 1024
-  multi_fields:
-    - flat_name: user.name.text
-      name: text
-      norms: false
-      type: text
-  name: user.name
-  type: keyword
+  external: ecs
+- name: user.name
+  external: ecs
 - name: tags
-  description: List of keywords used to tag each event.
-  example: '["production", "env2"]'
-  ignore_above: 1024
-  type: keyword
+  external: ecs

--- a/packages/azure/data_stream/platformlogs/fields/agent.yml
+++ b/packages/azure/data_stream/platformlogs/fields/agent.yml
@@ -1,198 +1,62 @@
-- name: cloud
-  title: Cloud
-  group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
-  type: group
-  fields:
-    - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
-      example: 666777888999
-    - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
-    - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
-    - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
-    - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
-    - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
-    - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
-    - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
-    - name: image.id
-      type: keyword
-      description: Image ID for the cloud instance.
-- name: container
-  title: Container
-  group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
-  type: group
-  fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
-    - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
-    - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
-    - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
-- name: host
-  title: Host
-  group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
-  type: group
-  fields:
-    - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
-    - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
-      example: CONTOSO
-      default_field: false
-    - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
-    - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
-    - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
-    - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
-    - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
-    - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
-    - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
-    - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
-    - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
-    - name: containerized
-      type: boolean
-      description: >
-        If the host is a container.
-
-    - name: os.build
-      type: keyword
-      example: "18D109"
-      description: >
-        OS build information.
-
-    - name: os.codename
-      type: keyword
-      example: "stretch"
-      description: >
-        OS codename, if any.
-
+- name: cloud.account.id
+  external: ecs
+- name: cloud.availability_zone
+  external: ecs
+- name: cloud.instance.id
+  external: ecs
+- name: cloud.instance.name
+  external: ecs
+- name: cloud.machine.type
+  external: ecs
+- name: cloud.provider
+  external: ecs
+- name: cloud.region
+  external: ecs
+- name: cloud.project.id
+  external: ecs
+- name: cloud.image.id
+  type: keyword
+  description: Image ID for the cloud instance.
+- name: container.id
+  external: ecs
+- name: container.image.name
+  external: ecs
+- name: container.labels
+  external: ecs
+- name: container.name
+  external: ecs
+- name: host.architecture
+  external: ecs
+- name: host.domain
+  external: ecs
+- name: host.hostname
+  external: ecs
+- name: host.id
+  external: ecs
+- name: host.ip
+  external: ecs
+- name: host.mac
+  external: ecs
+- name: host.name
+  external: ecs
+- name: host.os.family
+  external: ecs
+- name: host.os.kernel
+  external: ecs
+- name: host.os.name
+  external: ecs
+- name: host.os.platform
+  external: ecs
+- name: host.os.version
+  external: ecs
+- name: host.type
+  external: ecs
+- name: host.containerized
+  type: boolean
+  description: If the host is a container.
+- name: host.os.build
+  type: keyword
+  description: OS build information.
+- name: host.os.codename
+  type: keyword
+  description: OS codename, if any.

--- a/packages/azure/data_stream/platformlogs/fields/ecs.yml
+++ b/packages/azure/data_stream/platformlogs/fields/ecs.yml
@@ -1,246 +1,109 @@
-- description: Destination network address.
-  ignore_above: 1024
-  name: destination.address
-  type: keyword
-- description: Unique number allocated to the autonomous system.
-  example: 15169
-  name: destination.as.number
-  type: long
-- description: Organization name.
-  example: Google LLC
-  ignore_above: 1024
-  multi_fields:
-    - flat_name: destination.as.organization.name.text
-      name: text
-      norms: false
-      type: text
-  name: destination.as.organization.name
-  type: keyword
-- description: City name.
-  example: Montreal
-  ignore_above: 1024
-  name: destination.geo.city_name
-  type: keyword
-- description: Name of the continent.
-  example: North America
-  ignore_above: 1024
-  name: destination.geo.continent_name
-  type: keyword
-- description: Country ISO code.
-  example: CA
-  ignore_above: 1024
-  name: destination.geo.country_iso_code
-  type: keyword
-- description: Country name.
-  example: Canada
-  ignore_above: 1024
-  name: destination.geo.country_name
-  type: keyword
-- description: Longitude and latitude.
-  example: '{ "lon": -73.614830, "lat": 45.505918 }'
-  name: destination.geo.location
+- name: destination.address
+  external: ecs
+- name: destination.as.number
+  external: ecs
+- name: destination.as.organization.name
+  external: ecs
+- name: destination.geo.city_name
+  external: ecs
+- name: destination.geo.continent_name
+  external: ecs
+- name: destination.geo.country_iso_code
+  external: ecs
+- name: destination.geo.country_name
+  external: ecs
+- name: destination.geo.location
   type: geo_point
-- description: User-defined description of a location.
-  example: boston-dc
-  ignore_above: 1024
-  name: destination.geo.name
-  type: keyword
-- description: Region ISO code.
-  example: CA-QC
-  ignore_above: 1024
-  name: destination.geo.region_iso_code
-  type: keyword
-- description: Region name.
-  example: Quebec
-  ignore_above: 1024
-  name: destination.geo.region_name
-  type: keyword
-- description: IP address of the destination.
-  name: destination.ip
-  type: ip
-- description: Port of the destination.
-  name: destination.port
-  type: long
-- description: ECS version this event conforms to.
-  example: 1.0.0
-  ignore_above: 1024
-  name: ecs.version
-  type: keyword
-- description: Error message.
-  name: error.message
-  type: text
-- description: Message.
-  name: message
-  type: text
-- description: The action captured by the event.
-  example: user-password-change
-  ignore_above: 1024
-  name: event.action
-  type: keyword
-- description: Event category. The second categorization field in the hierarchy.
-  example: authentication
-  ignore_above: 1024
-  name: event.category
-  type: keyword
-- description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
-  name: event.created
-  type: date
-- description: Unique ID to describe the event.
-  example: 8a4f500d
-  ignore_above: 1024
-  name: event.id
-  type: keyword
-- description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
-  name: event.ingested
-  type: date
-- description: The kind of the event. The highest categorization field in the hierarchy.
-  example: alert
-  ignore_above: 1024
-  name: event.kind
-  type: keyword
-- description: Event type. The third categorization field in the hierarchy.
-  ignore_above: 1024
-  name: event.type
-  type: keyword
-- description: Media type of file, document, or arrangement of bytes.
-  ignore_above: 1024
-  name: file.mime_type
-  type: keyword
-- description: File size in bytes.
-  example: 16384
-  name: file.size
-  type: long
-- description: A hash of source and destination IPs and ports.
-  example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
-  ignore_above: 1024
-  name: network.community_id
-  type: keyword
-- description: "Host ip addresses."
-  name: host.ip
-  type: ip
-- description: All of the IPs seen on your event.
-  name: related.ip
-  type: ip
-- description: All the user names seen on your event.
-  ignore_above: 1024
-  name: related.user
-  type: keyword
-- description: Source network address.
-  ignore_above: 1024
-  name: source.address
-  type: keyword
-- description: Unique number allocated to the autonomous system.
-  example: 15169
-  name: source.as.number
-  type: long
-- description: Organization name.
-  example: Google LLC
-  ignore_above: 1024
-  multi_fields:
-    - flat_name: source.as.organization.name.text
-      name: text
-      norms: false
-      type: text
-  name: source.as.organization.name
-  type: keyword
-- description: Name of the continent.
-  example: North America
-  ignore_above: 1024
-  name: geo.continent_name
-  type: keyword
-- description: Country ISO code.
-  example: CA
-  ignore_above: 1024
-  name: geo.country_iso_code
-  type: keyword
-- description: Country name.
-  example: Canada
-  ignore_above: 1024
-  name: geo.country_name
-  type: keyword
-- description: Longitude and latitude.
-  example: '{ "lon": -73.614830, "lat": 45.505918 }'
-  name: geo.location
+  description: Longitude and latitude.
+- name: destination.geo.name
+  external: ecs
+- name: destination.geo.region_iso_code
+  external: ecs
+- name: destination.geo.region_name
+  external: ecs
+- name: destination.ip
+  external: ecs
+- name: destination.port
+  external: ecs
+- name: ecs.version
+  external: ecs
+- name: message
+  external: ecs
+- name: event.action
+  external: ecs
+- name: event.category
+  external: ecs
+- name: event.created
+  external: ecs
+- name: event.id
+  external: ecs
+- name: event.ingested
+  external: ecs
+- name: event.kind
+  external: ecs
+- name: event.type
+  external: ecs
+- name: file.mime_type
+  external: ecs
+- name: file.size
+  external: ecs
+- name: network.community_id
+  external: ecs
+- name: host.ip
+  external: ecs
+- name: related.ip
+  external: ecs
+- name: related.user
+  external: ecs
+- name: source.address
+  external: ecs
+- name: source.as.number
+  external: ecs
+- name: source.as.organization.name
+  external: ecs
+- name: geo.continent_name
+  external: ecs
+- name: geo.country_iso_code
+  external: ecs
+- name: geo.country_name
+  external: ecs
+- name: geo.location
   type: geo_point
-- description: City name.
-  example: Montreal
-  ignore_above: 1024
-  name: geo.city_name
-  type: keyword
-- description: Log level of the log event.
-  name: log.level
-  type: keyword
-- description: City name.
-  example: Montreal
-  ignore_above: 1024
-  name: source.geo.city_name
-  type: keyword
-- description: Name of the continent.
-  example: North America
-  ignore_above: 1024
-  name: source.geo.continent_name
-  type: keyword
-- description: Country ISO code.
-  example: CA
-  ignore_above: 1024
-  name: source.geo.country_iso_code
-  type: keyword
-- description: Country name.
-  example: Canada
-  ignore_above: 1024
-  name: source.geo.country_name
-  type: keyword
-- description: Longitude and latitude.
-  example: '{ "lon": -73.614830, "lat": 45.505918 }'
-  name: source.geo.location
+  description: Longitude and latitude.
+- name: geo.city_name
+  external: ecs
+- name: log.level
+  external: ecs
+- name: source.geo.city_name
+  external: ecs
+- name: source.geo.continent_name
+  external: ecs
+- name: source.geo.country_iso_code
+  external: ecs
+- name: source.geo.country_name
+  external: ecs
+- name: source.geo.location
   type: geo_point
-- description: User-defined description of a location.
-  example: boston-dc
-  ignore_above: 1024
-  name: source.geo.name
-  type: keyword
-- description: Region ISO code.
-  example: CA-QC
-  ignore_above: 1024
-  name: source.geo.region_iso_code
-  type: keyword
-- description: Region name.
-  example: Quebec
-  ignore_above: 1024
-  name: source.geo.region_name
-  type: keyword
-- description: IP address of the source.
-  name: source.ip
-  type: ip
-- description: Port of the source.
-  name: source.port
-  type: long
+  description: Longitude and latitude.
+- name: source.geo.name
+  external: ecs
+- name: source.geo.region_iso_code
+  external: ecs
+- name: source.geo.region_name
+  external: ecs
+- name: source.ip
+  external: ecs
+- name: source.port
+  external: ecs
 - name: user.full_name
-  type: keyword
-  description: Full name of the user.
+  external: ecs
 - name: user.domain
-  type: keyword
-  description: Domain of the user.
+  external: ecs
 - name: user.name
-  type: keyword
-  description: Short name or login of the user.
+  external: ecs
 - name: user.id
-  type: keyword
-  description: Unique identifier of the user.
-- description: Short name or login of the user.
-  example: albert
-  ignore_above: 1024
-  multi_fields:
-    - flat_name: user.name.text
-      name: text
-      norms: false
-      type: text
-  name: user.name
-  type: keyword
+  external: ecs
+- name: user.name
+  external: ecs
 - name: tags
-  description: List of keywords used to tag each event.
-  example: '["production", "env2"]'
-  ignore_above: 1024
-  type: keyword
+  external: ecs

--- a/packages/azure/data_stream/signinlogs/fields/agent.yml
+++ b/packages/azure/data_stream/signinlogs/fields/agent.yml
@@ -1,198 +1,62 @@
-- name: cloud
-  title: Cloud
-  group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
-  type: group
-  fields:
-    - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
-      example: 666777888999
-    - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
-    - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
-    - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
-    - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
-    - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
-    - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
-    - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
-    - name: image.id
-      type: keyword
-      description: Image ID for the cloud instance.
-- name: container
-  title: Container
-  group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
-  type: group
-  fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
-    - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
-    - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
-    - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
-- name: host
-  title: Host
-  group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
-  type: group
-  fields:
-    - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
-    - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
-      example: CONTOSO
-      default_field: false
-    - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
-    - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
-    - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
-    - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
-    - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
-    - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
-    - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
-    - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
-    - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
-    - name: containerized
-      type: boolean
-      description: >
-        If the host is a container.
-
-    - name: os.build
-      type: keyword
-      example: "18D109"
-      description: >
-        OS build information.
-
-    - name: os.codename
-      type: keyword
-      example: "stretch"
-      description: >
-        OS codename, if any.
-
+- name: cloud.account.id
+  external: ecs
+- name: cloud.availability_zone
+  external: ecs
+- name: cloud.instance.id
+  external: ecs
+- name: cloud.instance.name
+  external: ecs
+- name: cloud.machine.type
+  external: ecs
+- name: cloud.provider
+  external: ecs
+- name: cloud.region
+  external: ecs
+- name: cloud.project.id
+  external: ecs
+- name: cloud.image.id
+  type: keyword
+  description: Image ID for the cloud instance.
+- name: container.id
+  external: ecs
+- name: container.image.name
+  external: ecs
+- name: container.labels
+  external: ecs
+- name: container.name
+  external: ecs
+- name: host.architecture
+  external: ecs
+- name: host.domain
+  external: ecs
+- name: host.hostname
+  external: ecs
+- name: host.id
+  external: ecs
+- name: host.ip
+  external: ecs
+- name: host.mac
+  external: ecs
+- name: host.name
+  external: ecs
+- name: host.os.family
+  external: ecs
+- name: host.os.kernel
+  external: ecs
+- name: host.os.name
+  external: ecs
+- name: host.os.platform
+  external: ecs
+- name: host.os.version
+  external: ecs
+- name: host.type
+  external: ecs
+- name: host.containerized
+  type: boolean
+  description: If the host is a container.
+- name: host.os.build
+  type: keyword
+  description: OS build information.
+- name: host.os.codename
+  type: keyword
+  description: OS codename, if any.

--- a/packages/azure/data_stream/signinlogs/fields/ecs.yml
+++ b/packages/azure/data_stream/signinlogs/fields/ecs.yml
@@ -1,249 +1,111 @@
-- description: IP address of the client.
-  name: client.ip
-  type: ip
-- description: Destination network address.
-  ignore_above: 1024
-  name: destination.address
-  type: keyword
-- description: Unique number allocated to the autonomous system.
-  example: 15169
-  name: destination.as.number
-  type: long
-- description: Organization name.
-  example: Google LLC
-  ignore_above: 1024
-  multi_fields:
-    - flat_name: destination.as.organization.name.text
-      name: text
-      norms: false
-      type: text
-  name: destination.as.organization.name
-  type: keyword
-- description: City name.
-  example: Montreal
-  ignore_above: 1024
-  name: destination.geo.city_name
-  type: keyword
-- description: Name of the continent.
-  example: North America
-  ignore_above: 1024
-  name: destination.geo.continent_name
-  type: keyword
-- description: Country ISO code.
-  example: CA
-  ignore_above: 1024
-  name: destination.geo.country_iso_code
-  type: keyword
-- description: Country name.
-  example: Canada
-  ignore_above: 1024
-  name: destination.geo.country_name
-  type: keyword
-- description: Longitude and latitude.
-  example: '{ "lon": -73.614830, "lat": 45.505918 }'
-  name: destination.geo.location
+- name: client.ip
+  external: ecs
+- name: destination.address
+  external: ecs
+- name: destination.as.number
+  external: ecs
+- name: destination.as.organization.name
+  external: ecs
+- name: destination.geo.city_name
+  external: ecs
+- name: destination.geo.continent_name
+  external: ecs
+- name: destination.geo.country_iso_code
+  external: ecs
+- name: destination.geo.country_name
+  external: ecs
+- name: destination.geo.location
   type: geo_point
-- description: User-defined description of a location.
-  example: boston-dc
-  ignore_above: 1024
-  name: destination.geo.name
-  type: keyword
-- description: Region ISO code.
-  example: CA-QC
-  ignore_above: 1024
-  name: destination.geo.region_iso_code
-  type: keyword
-- description: Region name.
-  example: Quebec
-  ignore_above: 1024
-  name: destination.geo.region_name
-  type: keyword
-- description: IP address of the destination.
-  name: destination.ip
-  type: ip
-- description: Port of the destination.
-  name: destination.port
-  type: long
-- description: ECS version this event conforms to.
-  example: 1.0.0
-  ignore_above: 1024
-  name: ecs.version
-  type: keyword
-- description: Error message.
-  name: error.message
-  type: text
-- description: Message.
-  name: message
-  type: text
-- description: The action captured by the event.
-  example: user-password-change
-  ignore_above: 1024
-  name: event.action
-  type: keyword
-- description: Event category. The second categorization field in the hierarchy.
-  example: authentication
-  ignore_above: 1024
-  name: event.category
-  type: keyword
-- description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
-  name: event.created
-  type: date
-- description: Unique ID to describe the event.
-  example: 8a4f500d
-  ignore_above: 1024
-  name: event.id
-  type: keyword
-- description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
-  name: event.ingested
-  type: date
-- description: The kind of the event. The highest categorization field in the hierarchy.
-  example: alert
-  ignore_above: 1024
-  name: event.kind
-  type: keyword
-- description: Event type. The third categorization field in the hierarchy.
-  ignore_above: 1024
-  name: event.type
-  type: keyword
-- description: Media type of file, document, or arrangement of bytes.
-  ignore_above: 1024
-  name: file.mime_type
-  type: keyword
-- description: File size in bytes.
-  example: 16384
-  name: file.size
-  type: long
-- description: A hash of source and destination IPs and ports.
-  example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
-  ignore_above: 1024
-  name: network.community_id
-  type: keyword
-- description: "Host ip addresses."
-  name: host.ip
-  type: ip
-- description: All of the IPs seen on your event.
-  name: related.ip
-  type: ip
-- description: All the user names seen on your event.
-  ignore_above: 1024
-  name: related.user
-  type: keyword
-- description: Source network address.
-  ignore_above: 1024
-  name: source.address
-  type: keyword
-- description: Unique number allocated to the autonomous system.
-  example: 15169
-  name: source.as.number
-  type: long
-- description: Organization name.
-  example: Google LLC
-  ignore_above: 1024
-  multi_fields:
-    - flat_name: source.as.organization.name.text
-      name: text
-      norms: false
-      type: text
-  name: source.as.organization.name
-  type: keyword
-- description: Name of the continent.
-  example: North America
-  ignore_above: 1024
-  name: geo.continent_name
-  type: keyword
-- description: Country ISO code.
-  example: CA
-  ignore_above: 1024
-  name: geo.country_iso_code
-  type: keyword
-- description: Country name.
-  example: Canada
-  ignore_above: 1024
-  name: geo.country_name
-  type: keyword
-- description: Longitude and latitude.
-  example: '{ "lon": -73.614830, "lat": 45.505918 }'
-  name: geo.location
+  description: Longitude and latitude.
+- name: destination.geo.name
+  external: ecs
+- name: destination.geo.region_iso_code
+  external: ecs
+- name: destination.geo.region_name
+  external: ecs
+- name: destination.ip
+  external: ecs
+- name: destination.port
+  external: ecs
+- name: ecs.version
+  external: ecs
+- name: message
+  external: ecs
+- name: event.action
+  external: ecs
+- name: event.category
+  external: ecs
+- name: event.created
+  external: ecs
+- name: event.id
+  external: ecs
+- name: event.ingested
+  external: ecs
+- name: event.kind
+  external: ecs
+- name: event.type
+  external: ecs
+- name: file.mime_type
+  external: ecs
+- name: file.size
+  external: ecs
+- name: network.community_id
+  external: ecs
+- name: host.ip
+  external: ecs
+- name: related.ip
+  external: ecs
+- name: related.user
+  external: ecs
+- name: source.address
+  external: ecs
+- name: source.as.number
+  external: ecs
+- name: source.as.organization.name
+  external: ecs
+- name: geo.continent_name
+  external: ecs
+- name: geo.country_iso_code
+  external: ecs
+- name: geo.country_name
+  external: ecs
+- name: geo.location
   type: geo_point
-- description: City name.
-  example: Montreal
-  ignore_above: 1024
-  name: geo.city_name
-  type: keyword
-- description: Log level of the log event.
-  name: log.level
-  type: keyword
-- description: City name.
-  example: Montreal
-  ignore_above: 1024
-  name: source.geo.city_name
-  type: keyword
-- description: Name of the continent.
-  example: North America
-  ignore_above: 1024
-  name: source.geo.continent_name
-  type: keyword
-- description: Country ISO code.
-  example: CA
-  ignore_above: 1024
-  name: source.geo.country_iso_code
-  type: keyword
-- description: Country name.
-  example: Canada
-  ignore_above: 1024
-  name: source.geo.country_name
-  type: keyword
-- description: Longitude and latitude.
-  example: '{ "lon": -73.614830, "lat": 45.505918 }'
-  name: source.geo.location
+  description: Longitude and latitude.
+- name: geo.city_name
+  external: ecs
+- name: log.level
+  external: ecs
+- name: source.geo.city_name
+  external: ecs
+- name: source.geo.continent_name
+  external: ecs
+- name: source.geo.country_iso_code
+  external: ecs
+- name: source.geo.country_name
+  external: ecs
+- name: source.geo.location
   type: geo_point
-- description: User-defined description of a location.
-  example: boston-dc
-  ignore_above: 1024
-  name: source.geo.name
-  type: keyword
-- description: Region ISO code.
-  example: CA-QC
-  ignore_above: 1024
-  name: source.geo.region_iso_code
-  type: keyword
-- description: Region name.
-  example: Quebec
-  ignore_above: 1024
-  name: source.geo.region_name
-  type: keyword
-- description: IP address of the source.
-  name: source.ip
-  type: ip
-- description: Port of the source.
-  name: source.port
-  type: long
+  description: Longitude and latitude.
+- name: source.geo.name
+  external: ecs
+- name: source.geo.region_iso_code
+  external: ecs
+- name: source.geo.region_name
+  external: ecs
+- name: source.ip
+  external: ecs
+- name: source.port
+  external: ecs
 - name: user.full_name
-  type: keyword
-  description: Full name of the user.
+  external: ecs
 - name: user.domain
-  type: keyword
-  description: Domain of the user.
+  external: ecs
 - name: user.name
-  type: keyword
-  description: Short name or login of the user.
+  external: ecs
 - name: user.id
-  type: keyword
-  description: Unique identifier of the user.
-- description: Short name or login of the user.
-  example: albert
-  ignore_above: 1024
-  multi_fields:
-    - flat_name: user.name.text
-      name: text
-      norms: false
-      type: text
-  name: user.name
-  type: keyword
+  external: ecs
+- name: user.name
+  external: ecs
 - name: tags
-  description: List of keywords used to tag each event.
-  example: '["production", "env2"]'
-  ignore_above: 1024
-  type: keyword
+  external: ecs

--- a/packages/azure/data_stream/springcloudlogs/fields/agent.yml
+++ b/packages/azure/data_stream/springcloudlogs/fields/agent.yml
@@ -1,198 +1,62 @@
-- name: cloud
-  title: Cloud
-  group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
-  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
-  type: group
-  fields:
-    - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
-      example: 666777888999
-    - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
-    - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
-    - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
-    - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
-    - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
-    - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
-    - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
-    - name: image.id
-      type: keyword
-      description: Image ID for the cloud instance.
-- name: container
-  title: Container
-  group: 2
-  description: 'Container fields are used for meta information about the specific container that is the source of information.
-
-    These fields help correlate data based containers from any runtime.'
-  type: group
-  fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
-    - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
-    - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
-    - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
-- name: host
-  title: Host
-  group: 2
-  description: 'A host is defined as a general computing instance.
-
-    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
-  type: group
-  fields:
-    - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
-    - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the domain of which the host is a member.
-
-        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
-      example: CONTOSO
-      default_field: false
-    - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
-    - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
-    - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
-    - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
-    - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
-    - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
-    - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
-    - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
-    - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
-    - name: containerized
-      type: boolean
-      description: >
-        If the host is a container.
-
-    - name: os.build
-      type: keyword
-      example: "18D109"
-      description: >
-        OS build information.
-
-    - name: os.codename
-      type: keyword
-      example: "stretch"
-      description: >
-        OS codename, if any.
-
+- name: cloud.account.id
+  external: ecs
+- name: cloud.availability_zone
+  external: ecs
+- name: cloud.instance.id
+  external: ecs
+- name: cloud.instance.name
+  external: ecs
+- name: cloud.machine.type
+  external: ecs
+- name: cloud.provider
+  external: ecs
+- name: cloud.region
+  external: ecs
+- name: cloud.project.id
+  external: ecs
+- name: cloud.image.id
+  type: keyword
+  description: Image ID for the cloud instance.
+- name: container.id
+  external: ecs
+- name: container.image.name
+  external: ecs
+- name: container.labels
+  external: ecs
+- name: container.name
+  external: ecs
+- name: host.architecture
+  external: ecs
+- name: host.domain
+  external: ecs
+- name: host.hostname
+  external: ecs
+- name: host.id
+  external: ecs
+- name: host.ip
+  external: ecs
+- name: host.mac
+  external: ecs
+- name: host.name
+  external: ecs
+- name: host.os.family
+  external: ecs
+- name: host.os.kernel
+  external: ecs
+- name: host.os.name
+  external: ecs
+- name: host.os.platform
+  external: ecs
+- name: host.os.version
+  external: ecs
+- name: host.type
+  external: ecs
+- name: host.containerized
+  type: boolean
+  description: If the host is a container.
+- name: host.os.build
+  type: keyword
+  description: OS build information.
+- name: host.os.codename
+  type: keyword
+  description: OS codename, if any.

--- a/packages/azure/data_stream/springcloudlogs/fields/ecs.yml
+++ b/packages/azure/data_stream/springcloudlogs/fields/ecs.yml
@@ -1,251 +1,111 @@
-- description: Destination network address.
-  ignore_above: 1024
-  name: destination.address
-  type: keyword
-- description: Unique number allocated to the autonomous system.
-  example: 15169
-  name: destination.as.number
-  type: long
-- description: Organization name.
-  example: Google LLC
-  ignore_above: 1024
-  multi_fields:
-    - flat_name: destination.as.organization.name.text
-      name: text
-      norms: false
-      type: text
-  name: destination.as.organization.name
-  type: keyword
-- description: City name.
-  example: Montreal
-  ignore_above: 1024
-  name: destination.geo.city_name
-  type: keyword
-- description: Name of the continent.
-  example: North America
-  ignore_above: 1024
-  name: destination.geo.continent_name
-  type: keyword
-- description: Country ISO code.
-  example: CA
-  ignore_above: 1024
-  name: destination.geo.country_iso_code
-  type: keyword
-- description: Country name.
-  example: Canada
-  ignore_above: 1024
-  name: destination.geo.country_name
-  type: keyword
-- description: Longitude and latitude.
-  example: '{ "lon": -73.614830, "lat": 45.505918 }'
-  name: destination.geo.location
+- name: destination.address
+  external: ecs
+- name: destination.as.number
+  external: ecs
+- name: destination.as.organization.name
+  external: ecs
+- name: destination.geo.city_name
+  external: ecs
+- name: destination.geo.continent_name
+  external: ecs
+- name: destination.geo.country_iso_code
+  external: ecs
+- name: destination.geo.country_name
+  external: ecs
+- name: destination.geo.location
   type: geo_point
-- description: User-defined description of a location.
-  example: boston-dc
-  ignore_above: 1024
-  name: destination.geo.name
-  type: keyword
-- description: Region ISO code.
-  example: CA-QC
-  ignore_above: 1024
-  name: destination.geo.region_iso_code
-  type: keyword
-- description: Region name.
-  example: Quebec
-  ignore_above: 1024
-  name: destination.geo.region_name
-  type: keyword
-- description: IP address of the destination.
-  name: destination.ip
-  type: ip
-- description: Port of the destination.
-  name: destination.port
-  type: long
-- description: ECS version this event conforms to.
-  example: 1.0.0
-  ignore_above: 1024
-  name: ecs.version
-  type: keyword
-- description: Error message.
-  name: error.message
-  type: text
-- description: Message.
-  name: message
-  type: text
-- description: The action captured by the event.
-  example: user-password-change
-  ignore_above: 1024
-  name: event.action
-  type: keyword
-- description: Event category. The second categorization field in the hierarchy.
-  example: authentication
-  ignore_above: 1024
-  name: event.category
-  type: keyword
-- description: Time when the event was first read by an agent or by your pipeline.
-  example: '2016-05-23T08:05:34.857Z'
-  name: event.created
-  type: date
-- description: Unique ID to describe the event.
-  example: 8a4f500d
-  ignore_above: 1024
-  name: event.id
-  type: keyword
-- description: Timestamp when an event arrived in the central data store.
-  example: '2016-05-23T08:05:35.101Z'
-  name: event.ingested
-  type: date
-- description: The kind of the event. The highest categorization field in the hierarchy.
-  example: alert
-  ignore_above: 1024
-  name: event.kind
-  type: keyword
-- description: Event type. The third categorization field in the hierarchy.
-  ignore_above: 1024
-  name: event.type
-  type: keyword
-- description: Media type of file, document, or arrangement of bytes.
-  ignore_above: 1024
-  name: file.mime_type
-  type: keyword
-- description: File size in bytes.
-  example: 16384
-  name: file.size
-  type: long
-- description: A hash of source and destination IPs and ports.
-  example: 1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
-  ignore_above: 1024
-  name: network.community_id
-  type: keyword
-- description: "Host ip addresses."
-  name: host.ip
-  type: ip
-- description: All of the IPs seen on your event.
-  name: related.ip
-  type: ip
-- description: All the user names seen on your event.
-  ignore_above: 1024
-  name: related.user
-  type: keyword
-- description: Source network address.
-  ignore_above: 1024
-  name: source.address
-  type: keyword
-- description: Unique number allocated to the autonomous system.
-  example: 15169
-  name: source.as.number
-  type: long
-- description: Organization name.
-  example: Google LLC
-  ignore_above: 1024
-  multi_fields:
-    - flat_name: source.as.organization.name.text
-      name: text
-      norms: false
-      type: text
-  name: source.as.organization.name
-  type: keyword
-- description: Name of the continent.
-  example: North America
-  ignore_above: 1024
-  name: geo.continent_name
-  type: keyword
-- description: Country ISO code.
-  example: CA
-  ignore_above: 1024
-  name: geo.country_iso_code
-  type: keyword
-- description: Country name.
-  example: Canada
-  ignore_above: 1024
-  name: geo.country_name
-  type: keyword
-- description: Longitude and latitude.
-  example: '{ "lon": -73.614830, "lat": 45.505918 }'
-  name: geo.location
+  description: Longitude and latitude.
+- name: destination.geo.name
+  external: ecs
+- name: destination.geo.region_iso_code
+  external: ecs
+- name: destination.geo.region_name
+  external: ecs
+- name: destination.ip
+  external: ecs
+- name: destination.port
+  external: ecs
+- name: ecs.version
+  external: ecs
+- name: message
+  external: ecs
+- name: event.action
+  external: ecs
+- name: event.category
+  external: ecs
+- name: event.created
+  external: ecs
+- name: event.id
+  external: ecs
+- name: event.ingested
+  external: ecs
+- name: event.kind
+  external: ecs
+- name: event.type
+  external: ecs
+- name: file.mime_type
+  external: ecs
+- name: file.size
+  external: ecs
+- name: network.community_id
+  external: ecs
+- name: host.ip
+  external: ecs
+- name: related.ip
+  external: ecs
+- name: related.user
+  external: ecs
+- name: source.address
+  external: ecs
+- name: source.as.number
+  external: ecs
+- name: source.as.organization.name
+  external: ecs
+- name: geo.continent_name
+  external: ecs
+- name: geo.country_iso_code
+  external: ecs
+- name: geo.country_name
+  external: ecs
+- name: geo.location
   type: geo_point
-- description: City name.
-  example: Montreal
-  ignore_above: 1024
-  name: geo.city_name
-  type: keyword
-- description: Log level of the log event.
-  name: log.level
-  type: keyword
-- description: City name.
-  example: Montreal
-  ignore_above: 1024
-  name: source.geo.city_name
-  type: keyword
-- description: Name of the continent.
-  example: North America
-  ignore_above: 1024
-  name: source.geo.continent_name
-  type: keyword
-- description: Country ISO code.
-  example: CA
-  ignore_above: 1024
-  name: source.geo.country_iso_code
-  type: keyword
-- description: Country name.
-  example: Canada
-  ignore_above: 1024
-  name: source.geo.country_name
-  type: keyword
-- description: Longitude and latitude.
-  example: '{ "lon": -73.614830, "lat": 45.505918 }'
-  name: source.geo.location
+  description: Longitude and latitude.
+- name: geo.city_name
+  external: ecs
+- name: log.level
+  external: ecs
+- name: source.geo.city_name
+  external: ecs
+- name: source.geo.continent_name
+  external: ecs
+- name: source.geo.country_iso_code
+  external: ecs
+- name: source.geo.country_name
+  external: ecs
+- name: source.geo.location
   type: geo_point
-- description: User-defined description of a location.
-  example: boston-dc
-  ignore_above: 1024
-  name: source.geo.name
-  type: keyword
-- description: Region ISO code.
-  example: CA-QC
-  ignore_above: 1024
-  name: source.geo.region_iso_code
-  type: keyword
-- description: Region name.
-  example: Quebec
-  ignore_above: 1024
-  name: source.geo.region_name
-  type: keyword
-- description: IP address of the source.
-  name: source.ip
-  type: ip
-- description: Port of the source.
-  name: source.port
-  type: long
+  description: Longitude and latitude.
+- name: source.geo.name
+  external: ecs
+- name: source.geo.region_iso_code
+  external: ecs
+- name: source.geo.region_name
+  external: ecs
+- name: source.ip
+  external: ecs
+- name: source.port
+  external: ecs
 - name: user.full_name
-  type: keyword
-  description: Full name of the user.
+  external: ecs
 - name: user.domain
-  type: keyword
-  description: Domain of the user.
+  external: ecs
 - name: user.name
-  type: keyword
-  description: Short name or login of the user.
+  external: ecs
 - name: user.id
-  type: keyword
-  description: Unique identifier of the user.
-- description: Short name or login of the user.
-  example: albert
-  ignore_above: 1024
-  multi_fields:
-    - flat_name: user.name.text
-      name: text
-      norms: false
-      type: text
-  name: user.name
-  type: keyword
+  external: ecs
+- name: user.name
+  external: ecs
 - name: tags
-  description: List of keywords used to tag each event.
-  example: '["production", "env2"]'
-  ignore_above: 1024
-  type: keyword
-- description: User-defined description of a location.
-  example: boston-dc
-  ignore_above: 1024
-  name: geo.name
-  type: keyword
+  external: ecs
+- name: geo.name
+  external: ecs

--- a/packages/azure/docs/README.md
+++ b/packages/azure/docs/README.md
@@ -572,32 +572,31 @@ An example event for `auditlogs` looks as following:
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
-| destination.address | Destination network address. | keyword |
-| destination.as.number | Unique number allocated to the autonomous system. | long |
+| destination.address | Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
+| destination.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | keyword |
+| destination.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
-| destination.ip | IP address of the destination. | ip |
+| destination.ip | IP address of the destination (IPv4 or IPv6). | ip |
 | destination.port | Port of the destination. | long |
-| ecs.version | ECS version this event conforms to. | keyword |
-| error.message | Error message. | text |
-| event.action | The action captured by the event. | keyword |
-| event.category | Event category. The second categorization field in the hierarchy. | keyword |
-| event.created | Time when the event was first read by an agent or by your pipeline. | date |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
+| event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
+| event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
+| event.created | event.created contains the date/time when the event was first read by an agent, or by your pipeline. This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event. In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source. In case the two timestamps are identical, @timestamp should be used. | date |
 | event.dataset | Event dataset | constant_keyword |
 | event.id | Unique ID to describe the event. | keyword |
-| event.ingested | Timestamp when an event arrived in the central data store. | date |
-| event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
+| event.ingested | Timestamp when an event arrived in the central data store. This is different from `@timestamp`, which is when the event originally occurred.  It's also different from `event.created`, which is meant to capture the first time an agent saw the event. In normal conditions, assuming no tampering, the timestamps should chronologically look like this: `@timestamp` \< `event.created` \< `event.ingested`. | date |
+| event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |
 | event.module | Event module | constant_keyword |
-| event.type | Event type. The third categorization field in the hierarchy. | keyword |
-| file.mime_type | Media type of file, document, or arrangement of bytes. | keyword |
-| file.size | File size in bytes. | long |
+| event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |
+| file.mime_type | MIME type should identify the format of the file or stream of bytes using https://www.iana.org/assignments/media-types/media-types.xhtml[IANA official types], where possible. When more than one type is applicable, the most specific type should be used. | keyword |
+| file.size | File size in bytes. Only relevant when `file.type` is "file". | long |
 | geo.city_name | City name. | keyword |
 | geo.continent_name | Name of the continent. | keyword |
 | geo.country_iso_code | Country ISO code. | keyword |
@@ -619,27 +618,27 @@ An example event for `auditlogs` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| log.level | Log level of the log event. | keyword |
-| message | Message. | text |
-| network.community_id | A hash of source and destination IPs and ports. | keyword |
+| log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
+| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
+| network.community_id | A hash of source and destination IPs and ports, as well as the protocol used in a communication. This is a tool-agnostic standard to identify flows. Learn more at https://github.com/corelight/community-id-spec. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
-| related.user | All the user names seen on your event. | keyword |
-| source.address | Source network address. | keyword |
-| source.as.number | Unique number allocated to the autonomous system. | long |
+| related.user | All the user names or other user identifiers seen on the event. | keyword |
+| source.address | Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
+| source.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | keyword |
+| source.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
-| source.ip | IP address of the source. | ip |
+| source.ip | IP address of the source (IPv4 or IPv6). | ip |
 | source.port | Port of the source. | long |
 | tags | List of keywords used to tag each event. | keyword |
-| user.domain | Domain of the user. | keyword |
-| user.full_name | Full name of the user. | keyword |
+| user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.full_name | User's full name, if available. | keyword |
 | user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
 

--- a/packages/azure/docs/README.md
+++ b/packages/azure/docs/README.md
@@ -189,14 +189,14 @@ An example event for `activitylogs` looks as following:
 | azure.tenant_id | tenant ID | keyword |
 | client.ip | IP address of the client. | ip |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
 | cloud.instance.id | Instance ID of the host machine. | keyword |
 | cloud.instance.name | Instance name of the host machine. | keyword |
 | cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
+| cloud.project.id | The cloud project identifier. Examples: Google Cloud Project id, Azure Project id. | keyword |
 | cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |
 | container.id | Unique container id. | keyword |
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |
@@ -241,7 +241,7 @@ An example event for `activitylogs` looks as following:
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
+| host.mac | Host MAC addresses. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |
@@ -372,14 +372,14 @@ An example event for `platformlogs` looks as following:
 | azure.subscription_id | Azure subscription ID | keyword |
 | azure.tenant_id | tenant ID | keyword |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
 | cloud.instance.id | Instance ID of the host machine. | keyword |
 | cloud.instance.name | Instance name of the host machine. | keyword |
 | cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
+| cloud.project.id | The cloud project identifier. Examples: Google Cloud Project id, Azure Project id. | keyword |
 | cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |
 | container.id | Unique container id. | keyword |
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |
@@ -424,7 +424,7 @@ An example event for `platformlogs` looks as following:
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
+| host.mac | Host MAC addresses. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |
@@ -558,14 +558,14 @@ An example event for `auditlogs` looks as following:
 | azure.subscription_id | Azure subscription ID | keyword |
 | azure.tenant_id | tenant ID | keyword |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
 | cloud.instance.id | Instance ID of the host machine. | keyword |
 | cloud.instance.name | Instance name of the host machine. | keyword |
 | cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
+| cloud.project.id | The cloud project identifier. Examples: Google Cloud Project id, Azure Project id. | keyword |
 | cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |
 | container.id | Unique container id. | keyword |
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |
@@ -610,7 +610,7 @@ An example event for `auditlogs` looks as following:
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
+| host.mac | Host MAC addresses. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |
@@ -760,14 +760,14 @@ An example event for `signinlogs` looks as following:
 | azure.tenant_id | tenant ID | keyword |
 | client.ip | IP address of the client. | ip |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
 | cloud.instance.id | Instance ID of the host machine. | keyword |
 | cloud.instance.name | Instance name of the host machine. | keyword |
 | cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
+| cloud.project.id | The cloud project identifier. Examples: Google Cloud Project id, Azure Project id. | keyword |
 | cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |
 | container.id | Unique container id. | keyword |
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |
@@ -812,7 +812,7 @@ An example event for `signinlogs` looks as following:
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
+| host.mac | Host MAC addresses. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |

--- a/packages/azure/docs/README.md
+++ b/packages/azure/docs/README.md
@@ -187,7 +187,7 @@ An example event for `activitylogs` looks as following:
 | azure.resource.provider | Resource type/namespace | keyword |
 | azure.subscription_id | Azure subscription ID | keyword |
 | azure.tenant_id | tenant ID | keyword |
-| client.ip | IP address of the client. | ip |
+| client.ip | IP address of the client (IPv4 or IPv6). | ip |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
 | cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
@@ -204,32 +204,31 @@ An example event for `activitylogs` looks as following:
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
-| destination.address | Destination network address. | keyword |
-| destination.as.number | Unique number allocated to the autonomous system. | long |
+| destination.address | Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
+| destination.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | keyword |
+| destination.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
-| destination.ip | IP address of the destination. | ip |
+| destination.ip | IP address of the destination (IPv4 or IPv6). | ip |
 | destination.port | Port of the destination. | long |
-| ecs.version | ECS version this event conforms to. | keyword |
-| error.message | Error message. | text |
-| event.action | The action captured by the event. | keyword |
-| event.category | Event category. The second categorization field in the hierarchy. | keyword |
-| event.created | Time when the event was first read by an agent or by your pipeline. | date |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
+| event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
+| event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
+| event.created | event.created contains the date/time when the event was first read by an agent, or by your pipeline. This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event. In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source. In case the two timestamps are identical, @timestamp should be used. | date |
 | event.dataset | Event dataset | constant_keyword |
 | event.id | Unique ID to describe the event. | keyword |
-| event.ingested | Timestamp when an event arrived in the central data store. | date |
-| event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
+| event.ingested | Timestamp when an event arrived in the central data store. This is different from `@timestamp`, which is when the event originally occurred.  It's also different from `event.created`, which is meant to capture the first time an agent saw the event. In normal conditions, assuming no tampering, the timestamps should chronologically look like this: `@timestamp` \< `event.created` \< `event.ingested`. | date |
+| event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |
 | event.module | Event module | constant_keyword |
-| event.type | Event type. The third categorization field in the hierarchy. | keyword |
-| file.mime_type | Media type of file, document, or arrangement of bytes. | keyword |
-| file.size | File size in bytes. | long |
+| event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |
+| file.mime_type | MIME type should identify the format of the file or stream of bytes using https://www.iana.org/assignments/media-types/media-types.xhtml[IANA official types], where possible. When more than one type is applicable, the most specific type should be used. | keyword |
+| file.size | File size in bytes. Only relevant when `file.type` is "file". | long |
 | geo.city_name | City name. | keyword |
 | geo.continent_name | Name of the continent. | keyword |
 | geo.country_iso_code | Country ISO code. | keyword |
@@ -251,27 +250,27 @@ An example event for `activitylogs` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| log.level | Log level of the log event. | keyword |
-| message | Message. | text |
-| network.community_id | A hash of source and destination IPs and ports. | keyword |
+| log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
+| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
+| network.community_id | A hash of source and destination IPs and ports, as well as the protocol used in a communication. This is a tool-agnostic standard to identify flows. Learn more at https://github.com/corelight/community-id-spec. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
-| related.user | All the user names seen on your event. | keyword |
-| source.address | Source network address. | keyword |
-| source.as.number | Unique number allocated to the autonomous system. | long |
+| related.user | All the user names or other user identifiers seen on the event. | keyword |
+| source.address | Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
+| source.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | keyword |
+| source.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
-| source.ip | IP address of the source. | ip |
+| source.ip | IP address of the source (IPv4 or IPv6). | ip |
 | source.port | Port of the source. | long |
 | tags | List of keywords used to tag each event. | keyword |
-| user.domain | Domain of the user. | keyword |
-| user.full_name | Full name of the user. | keyword |
+| user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.full_name | User's full name, if available. | keyword |
 | user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
 

--- a/packages/azure/docs/README.md
+++ b/packages/azure/docs/README.md
@@ -755,7 +755,7 @@ An example event for `signinlogs` looks as following:
 | azure.signinlogs.tenant_id | Tenant ID | keyword |
 | azure.subscription_id | Azure subscription ID | keyword |
 | azure.tenant_id | tenant ID | keyword |
-| client.ip | IP address of the client. | ip |
+| client.ip | IP address of the client (IPv4 or IPv6). | ip |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
 | cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
@@ -772,32 +772,31 @@ An example event for `signinlogs` looks as following:
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
-| destination.address | Destination network address. | keyword |
-| destination.as.number | Unique number allocated to the autonomous system. | long |
+| destination.address | Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
+| destination.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | keyword |
+| destination.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
-| destination.ip | IP address of the destination. | ip |
+| destination.ip | IP address of the destination (IPv4 or IPv6). | ip |
 | destination.port | Port of the destination. | long |
-| ecs.version | ECS version this event conforms to. | keyword |
-| error.message | Error message. | text |
-| event.action | The action captured by the event. | keyword |
-| event.category | Event category. The second categorization field in the hierarchy. | keyword |
-| event.created | Time when the event was first read by an agent or by your pipeline. | date |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
+| event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
+| event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
+| event.created | event.created contains the date/time when the event was first read by an agent, or by your pipeline. This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event. In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source. In case the two timestamps are identical, @timestamp should be used. | date |
 | event.dataset | Event dataset | constant_keyword |
 | event.id | Unique ID to describe the event. | keyword |
-| event.ingested | Timestamp when an event arrived in the central data store. | date |
-| event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
+| event.ingested | Timestamp when an event arrived in the central data store. This is different from `@timestamp`, which is when the event originally occurred.  It's also different from `event.created`, which is meant to capture the first time an agent saw the event. In normal conditions, assuming no tampering, the timestamps should chronologically look like this: `@timestamp` \< `event.created` \< `event.ingested`. | date |
+| event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |
 | event.module | Event module | constant_keyword |
-| event.type | Event type. The third categorization field in the hierarchy. | keyword |
-| file.mime_type | Media type of file, document, or arrangement of bytes. | keyword |
-| file.size | File size in bytes. | long |
+| event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |
+| file.mime_type | MIME type should identify the format of the file or stream of bytes using https://www.iana.org/assignments/media-types/media-types.xhtml[IANA official types], where possible. When more than one type is applicable, the most specific type should be used. | keyword |
+| file.size | File size in bytes. Only relevant when `file.type` is "file". | long |
 | geo.city_name | City name. | keyword |
 | geo.continent_name | Name of the continent. | keyword |
 | geo.country_iso_code | Country ISO code. | keyword |
@@ -819,27 +818,27 @@ An example event for `signinlogs` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| log.level | Log level of the log event. | keyword |
-| message | Message. | text |
-| network.community_id | A hash of source and destination IPs and ports. | keyword |
+| log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
+| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
+| network.community_id | A hash of source and destination IPs and ports, as well as the protocol used in a communication. This is a tool-agnostic standard to identify flows. Learn more at https://github.com/corelight/community-id-spec. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
-| related.user | All the user names seen on your event. | keyword |
-| source.address | Source network address. | keyword |
-| source.as.number | Unique number allocated to the autonomous system. | long |
+| related.user | All the user names or other user identifiers seen on the event. | keyword |
+| source.address | Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
+| source.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | keyword |
+| source.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
-| source.ip | IP address of the source. | ip |
+| source.ip | IP address of the source (IPv4 or IPv6). | ip |
 | source.port | Port of the source. | long |
 | tags | List of keywords used to tag each event. | keyword |
-| user.domain | Domain of the user. | keyword |
-| user.full_name | Full name of the user. | keyword |
+| user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.full_name | User's full name, if available. | keyword |
 | user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
 

--- a/packages/azure/docs/README.md
+++ b/packages/azure/docs/README.md
@@ -386,32 +386,31 @@ An example event for `platformlogs` looks as following:
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
-| destination.address | Destination network address. | keyword |
-| destination.as.number | Unique number allocated to the autonomous system. | long |
+| destination.address | Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
+| destination.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | keyword |
+| destination.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
-| destination.ip | IP address of the destination. | ip |
+| destination.ip | IP address of the destination (IPv4 or IPv6). | ip |
 | destination.port | Port of the destination. | long |
-| ecs.version | ECS version this event conforms to. | keyword |
-| error.message | Error message. | text |
-| event.action | The action captured by the event. | keyword |
-| event.category | Event category. The second categorization field in the hierarchy. | keyword |
-| event.created | Time when the event was first read by an agent or by your pipeline. | date |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
+| event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
+| event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
+| event.created | event.created contains the date/time when the event was first read by an agent, or by your pipeline. This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event. In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source. In case the two timestamps are identical, @timestamp should be used. | date |
 | event.dataset | Event dataset | constant_keyword |
 | event.id | Unique ID to describe the event. | keyword |
-| event.ingested | Timestamp when an event arrived in the central data store. | date |
-| event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
+| event.ingested | Timestamp when an event arrived in the central data store. This is different from `@timestamp`, which is when the event originally occurred.  It's also different from `event.created`, which is meant to capture the first time an agent saw the event. In normal conditions, assuming no tampering, the timestamps should chronologically look like this: `@timestamp` \< `event.created` \< `event.ingested`. | date |
+| event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |
 | event.module | Event module | constant_keyword |
-| event.type | Event type. The third categorization field in the hierarchy. | keyword |
-| file.mime_type | Media type of file, document, or arrangement of bytes. | keyword |
-| file.size | File size in bytes. | long |
+| event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |
+| file.mime_type | MIME type should identify the format of the file or stream of bytes using https://www.iana.org/assignments/media-types/media-types.xhtml[IANA official types], where possible. When more than one type is applicable, the most specific type should be used. | keyword |
+| file.size | File size in bytes. Only relevant when `file.type` is "file". | long |
 | geo.city_name | City name. | keyword |
 | geo.continent_name | Name of the continent. | keyword |
 | geo.country_iso_code | Country ISO code. | keyword |
@@ -433,27 +432,27 @@ An example event for `platformlogs` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| log.level | Log level of the log event. | keyword |
-| message | Message. | text |
-| network.community_id | A hash of source and destination IPs and ports. | keyword |
+| log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
+| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
+| network.community_id | A hash of source and destination IPs and ports, as well as the protocol used in a communication. This is a tool-agnostic standard to identify flows. Learn more at https://github.com/corelight/community-id-spec. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
-| related.user | All the user names seen on your event. | keyword |
-| source.address | Source network address. | keyword |
-| source.as.number | Unique number allocated to the autonomous system. | long |
+| related.user | All the user names or other user identifiers seen on the event. | keyword |
+| source.address | Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
+| source.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | keyword |
+| source.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
-| source.ip | IP address of the source. | ip |
+| source.ip | IP address of the source (IPv4 or IPv6). | ip |
 | source.port | Port of the source. | long |
 | tags | List of keywords used to tag each event. | keyword |
-| user.domain | Domain of the user. | keyword |
-| user.full_name | Full name of the user. | keyword |
+| user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.full_name | User's full name, if available. | keyword |
 | user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
 

--- a/packages/azure/docs/activitylogs.md
+++ b/packages/azure/docs/activitylogs.md
@@ -142,7 +142,7 @@ An example event for `activitylogs` looks as following:
 | azure.resource.provider | Resource type/namespace | keyword |
 | azure.subscription_id | Azure subscription ID | keyword |
 | azure.tenant_id | tenant ID | keyword |
-| client.ip | IP address of the client. | ip |
+| client.ip | IP address of the client (IPv4 or IPv6). | ip |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
 | cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
@@ -159,32 +159,31 @@ An example event for `activitylogs` looks as following:
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
-| destination.address | Destination network address. | keyword |
-| destination.as.number | Unique number allocated to the autonomous system. | long |
+| destination.address | Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
+| destination.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | keyword |
+| destination.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
-| destination.ip | IP address of the destination. | ip |
+| destination.ip | IP address of the destination (IPv4 or IPv6). | ip |
 | destination.port | Port of the destination. | long |
-| ecs.version | ECS version this event conforms to. | keyword |
-| error.message | Error message. | text |
-| event.action | The action captured by the event. | keyword |
-| event.category | Event category. The second categorization field in the hierarchy. | keyword |
-| event.created | Time when the event was first read by an agent or by your pipeline. | date |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
+| event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
+| event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
+| event.created | event.created contains the date/time when the event was first read by an agent, or by your pipeline. This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event. In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source. In case the two timestamps are identical, @timestamp should be used. | date |
 | event.dataset | Event dataset | constant_keyword |
 | event.id | Unique ID to describe the event. | keyword |
-| event.ingested | Timestamp when an event arrived in the central data store. | date |
-| event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
+| event.ingested | Timestamp when an event arrived in the central data store. This is different from `@timestamp`, which is when the event originally occurred.  It's also different from `event.created`, which is meant to capture the first time an agent saw the event. In normal conditions, assuming no tampering, the timestamps should chronologically look like this: `@timestamp` \< `event.created` \< `event.ingested`. | date |
+| event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |
 | event.module | Event module | constant_keyword |
-| event.type | Event type. The third categorization field in the hierarchy. | keyword |
-| file.mime_type | Media type of file, document, or arrangement of bytes. | keyword |
-| file.size | File size in bytes. | long |
+| event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |
+| file.mime_type | MIME type should identify the format of the file or stream of bytes using https://www.iana.org/assignments/media-types/media-types.xhtml[IANA official types], where possible. When more than one type is applicable, the most specific type should be used. | keyword |
+| file.size | File size in bytes. Only relevant when `file.type` is "file". | long |
 | geo.city_name | City name. | keyword |
 | geo.continent_name | Name of the continent. | keyword |
 | geo.country_iso_code | Country ISO code. | keyword |
@@ -206,26 +205,26 @@ An example event for `activitylogs` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| log.level | Log level of the log event. | keyword |
-| message | Message. | text |
-| network.community_id | A hash of source and destination IPs and ports. | keyword |
+| log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
+| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
+| network.community_id | A hash of source and destination IPs and ports, as well as the protocol used in a communication. This is a tool-agnostic standard to identify flows. Learn more at https://github.com/corelight/community-id-spec. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
-| related.user | All the user names seen on your event. | keyword |
-| source.address | Source network address. | keyword |
-| source.as.number | Unique number allocated to the autonomous system. | long |
+| related.user | All the user names or other user identifiers seen on the event. | keyword |
+| source.address | Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
+| source.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | keyword |
+| source.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
-| source.ip | IP address of the source. | ip |
+| source.ip | IP address of the source (IPv4 or IPv6). | ip |
 | source.port | Port of the source. | long |
 | tags | List of keywords used to tag each event. | keyword |
-| user.domain | Domain of the user. | keyword |
-| user.full_name | Full name of the user. | keyword |
+| user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.full_name | User's full name, if available. | keyword |
 | user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |

--- a/packages/azure/docs/activitylogs.md
+++ b/packages/azure/docs/activitylogs.md
@@ -144,14 +144,14 @@ An example event for `activitylogs` looks as following:
 | azure.tenant_id | tenant ID | keyword |
 | client.ip | IP address of the client. | ip |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
 | cloud.instance.id | Instance ID of the host machine. | keyword |
 | cloud.instance.name | Instance name of the host machine. | keyword |
 | cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
+| cloud.project.id | The cloud project identifier. Examples: Google Cloud Project id, Azure Project id. | keyword |
 | cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |
 | container.id | Unique container id. | keyword |
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |
@@ -196,7 +196,7 @@ An example event for `activitylogs` looks as following:
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
+| host.mac | Host MAC addresses. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |

--- a/packages/azure/docs/adlogs.md
+++ b/packages/azure/docs/adlogs.md
@@ -320,7 +320,7 @@ An example event for `signinlogs` looks as following:
 | azure.signinlogs.tenant_id | Tenant ID | keyword |
 | azure.subscription_id | Azure subscription ID | keyword |
 | azure.tenant_id | tenant ID | keyword |
-| client.ip | IP address of the client. | ip |
+| client.ip | IP address of the client (IPv4 or IPv6). | ip |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
 | cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
@@ -337,32 +337,31 @@ An example event for `signinlogs` looks as following:
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
-| destination.address | Destination network address. | keyword |
-| destination.as.number | Unique number allocated to the autonomous system. | long |
+| destination.address | Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
+| destination.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | keyword |
+| destination.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
-| destination.ip | IP address of the destination. | ip |
+| destination.ip | IP address of the destination (IPv4 or IPv6). | ip |
 | destination.port | Port of the destination. | long |
-| ecs.version | ECS version this event conforms to. | keyword |
-| error.message | Error message. | text |
-| event.action | The action captured by the event. | keyword |
-| event.category | Event category. The second categorization field in the hierarchy. | keyword |
-| event.created | Time when the event was first read by an agent or by your pipeline. | date |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
+| event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
+| event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
+| event.created | event.created contains the date/time when the event was first read by an agent, or by your pipeline. This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event. In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source. In case the two timestamps are identical, @timestamp should be used. | date |
 | event.dataset | Event dataset | constant_keyword |
 | event.id | Unique ID to describe the event. | keyword |
-| event.ingested | Timestamp when an event arrived in the central data store. | date |
-| event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
+| event.ingested | Timestamp when an event arrived in the central data store. This is different from `@timestamp`, which is when the event originally occurred.  It's also different from `event.created`, which is meant to capture the first time an agent saw the event. In normal conditions, assuming no tampering, the timestamps should chronologically look like this: `@timestamp` \< `event.created` \< `event.ingested`. | date |
+| event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |
 | event.module | Event module | constant_keyword |
-| event.type | Event type. The third categorization field in the hierarchy. | keyword |
-| file.mime_type | Media type of file, document, or arrangement of bytes. | keyword |
-| file.size | File size in bytes. | long |
+| event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |
+| file.mime_type | MIME type should identify the format of the file or stream of bytes using https://www.iana.org/assignments/media-types/media-types.xhtml[IANA official types], where possible. When more than one type is applicable, the most specific type should be used. | keyword |
+| file.size | File size in bytes. Only relevant when `file.type` is "file". | long |
 | geo.city_name | City name. | keyword |
 | geo.continent_name | Name of the continent. | keyword |
 | geo.country_iso_code | Country ISO code. | keyword |
@@ -384,26 +383,26 @@ An example event for `signinlogs` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| log.level | Log level of the log event. | keyword |
-| message | Message. | text |
-| network.community_id | A hash of source and destination IPs and ports. | keyword |
+| log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
+| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
+| network.community_id | A hash of source and destination IPs and ports, as well as the protocol used in a communication. This is a tool-agnostic standard to identify flows. Learn more at https://github.com/corelight/community-id-spec. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
-| related.user | All the user names seen on your event. | keyword |
-| source.address | Source network address. | keyword |
-| source.as.number | Unique number allocated to the autonomous system. | long |
+| related.user | All the user names or other user identifiers seen on the event. | keyword |
+| source.address | Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
+| source.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | keyword |
+| source.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
-| source.ip | IP address of the source. | ip |
+| source.ip | IP address of the source (IPv4 or IPv6). | ip |
 | source.port | Port of the source. | long |
 | tags | List of keywords used to tag each event. | keyword |
-| user.domain | Domain of the user. | keyword |
-| user.full_name | Full name of the user. | keyword |
+| user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.full_name | User's full name, if available. | keyword |
 | user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |

--- a/packages/azure/docs/adlogs.md
+++ b/packages/azure/docs/adlogs.md
@@ -117,14 +117,14 @@ An example event for `auditlogs` looks as following:
 | azure.subscription_id | Azure subscription ID | keyword |
 | azure.tenant_id | tenant ID | keyword |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
 | cloud.instance.id | Instance ID of the host machine. | keyword |
 | cloud.instance.name | Instance name of the host machine. | keyword |
 | cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
+| cloud.project.id | The cloud project identifier. Examples: Google Cloud Project id, Azure Project id. | keyword |
 | cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |
 | container.id | Unique container id. | keyword |
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |
@@ -169,7 +169,7 @@ An example event for `auditlogs` looks as following:
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
+| host.mac | Host MAC addresses. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |
@@ -323,14 +323,14 @@ An example event for `signinlogs` looks as following:
 | azure.tenant_id | tenant ID | keyword |
 | client.ip | IP address of the client. | ip |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
 | cloud.instance.id | Instance ID of the host machine. | keyword |
 | cloud.instance.name | Instance name of the host machine. | keyword |
 | cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
+| cloud.project.id | The cloud project identifier. Examples: Google Cloud Project id, Azure Project id. | keyword |
 | cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |
 | container.id | Unique container id. | keyword |
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |
@@ -375,7 +375,7 @@ An example event for `signinlogs` looks as following:
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
+| host.mac | Host MAC addresses. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |

--- a/packages/azure/docs/adlogs.md
+++ b/packages/azure/docs/adlogs.md
@@ -132,32 +132,31 @@ An example event for `auditlogs` looks as following:
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
-| destination.address | Destination network address. | keyword |
-| destination.as.number | Unique number allocated to the autonomous system. | long |
+| destination.address | Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
+| destination.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | keyword |
+| destination.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
-| destination.ip | IP address of the destination. | ip |
+| destination.ip | IP address of the destination (IPv4 or IPv6). | ip |
 | destination.port | Port of the destination. | long |
-| ecs.version | ECS version this event conforms to. | keyword |
-| error.message | Error message. | text |
-| event.action | The action captured by the event. | keyword |
-| event.category | Event category. The second categorization field in the hierarchy. | keyword |
-| event.created | Time when the event was first read by an agent or by your pipeline. | date |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
+| event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
+| event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
+| event.created | event.created contains the date/time when the event was first read by an agent, or by your pipeline. This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event. In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source. In case the two timestamps are identical, @timestamp should be used. | date |
 | event.dataset | Event dataset | constant_keyword |
 | event.id | Unique ID to describe the event. | keyword |
-| event.ingested | Timestamp when an event arrived in the central data store. | date |
-| event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
+| event.ingested | Timestamp when an event arrived in the central data store. This is different from `@timestamp`, which is when the event originally occurred.  It's also different from `event.created`, which is meant to capture the first time an agent saw the event. In normal conditions, assuming no tampering, the timestamps should chronologically look like this: `@timestamp` \< `event.created` \< `event.ingested`. | date |
+| event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |
 | event.module | Event module | constant_keyword |
-| event.type | Event type. The third categorization field in the hierarchy. | keyword |
-| file.mime_type | Media type of file, document, or arrangement of bytes. | keyword |
-| file.size | File size in bytes. | long |
+| event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |
+| file.mime_type | MIME type should identify the format of the file or stream of bytes using https://www.iana.org/assignments/media-types/media-types.xhtml[IANA official types], where possible. When more than one type is applicable, the most specific type should be used. | keyword |
+| file.size | File size in bytes. Only relevant when `file.type` is "file". | long |
 | geo.city_name | City name. | keyword |
 | geo.continent_name | Name of the continent. | keyword |
 | geo.country_iso_code | Country ISO code. | keyword |
@@ -179,27 +178,27 @@ An example event for `auditlogs` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| log.level | Log level of the log event. | keyword |
-| message | Message. | text |
-| network.community_id | A hash of source and destination IPs and ports. | keyword |
+| log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
+| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
+| network.community_id | A hash of source and destination IPs and ports, as well as the protocol used in a communication. This is a tool-agnostic standard to identify flows. Learn more at https://github.com/corelight/community-id-spec. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
-| related.user | All the user names seen on your event. | keyword |
-| source.address | Source network address. | keyword |
-| source.as.number | Unique number allocated to the autonomous system. | long |
+| related.user | All the user names or other user identifiers seen on the event. | keyword |
+| source.address | Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
+| source.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | keyword |
+| source.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
-| source.ip | IP address of the source. | ip |
+| source.ip | IP address of the source (IPv4 or IPv6). | ip |
 | source.port | Port of the source. | long |
 | tags | List of keywords used to tag each event. | keyword |
-| user.domain | Domain of the user. | keyword |
-| user.full_name | Full name of the user. | keyword |
+| user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.full_name | User's full name, if available. | keyword |
 | user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
 

--- a/packages/azure/docs/platformlogs.md
+++ b/packages/azure/docs/platformlogs.md
@@ -125,32 +125,31 @@ An example event for `platformlogs` looks as following:
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
-| destination.address | Destination network address. | keyword |
-| destination.as.number | Unique number allocated to the autonomous system. | long |
+| destination.address | Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
+| destination.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | keyword |
+| destination.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
-| destination.ip | IP address of the destination. | ip |
+| destination.ip | IP address of the destination (IPv4 or IPv6). | ip |
 | destination.port | Port of the destination. | long |
-| ecs.version | ECS version this event conforms to. | keyword |
-| error.message | Error message. | text |
-| event.action | The action captured by the event. | keyword |
-| event.category | Event category. The second categorization field in the hierarchy. | keyword |
-| event.created | Time when the event was first read by an agent or by your pipeline. | date |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
+| event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
+| event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
+| event.created | event.created contains the date/time when the event was first read by an agent, or by your pipeline. This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event. In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source. In case the two timestamps are identical, @timestamp should be used. | date |
 | event.dataset | Event dataset | constant_keyword |
 | event.id | Unique ID to describe the event. | keyword |
-| event.ingested | Timestamp when an event arrived in the central data store. | date |
-| event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
+| event.ingested | Timestamp when an event arrived in the central data store. This is different from `@timestamp`, which is when the event originally occurred.  It's also different from `event.created`, which is meant to capture the first time an agent saw the event. In normal conditions, assuming no tampering, the timestamps should chronologically look like this: `@timestamp` \< `event.created` \< `event.ingested`. | date |
+| event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |
 | event.module | Event module | constant_keyword |
-| event.type | Event type. The third categorization field in the hierarchy. | keyword |
-| file.mime_type | Media type of file, document, or arrangement of bytes. | keyword |
-| file.size | File size in bytes. | long |
+| event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |
+| file.mime_type | MIME type should identify the format of the file or stream of bytes using https://www.iana.org/assignments/media-types/media-types.xhtml[IANA official types], where possible. When more than one type is applicable, the most specific type should be used. | keyword |
+| file.size | File size in bytes. Only relevant when `file.type` is "file". | long |
 | geo.city_name | City name. | keyword |
 | geo.continent_name | Name of the continent. | keyword |
 | geo.country_iso_code | Country ISO code. | keyword |
@@ -172,26 +171,26 @@ An example event for `platformlogs` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| log.level | Log level of the log event. | keyword |
-| message | Message. | text |
-| network.community_id | A hash of source and destination IPs and ports. | keyword |
+| log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
+| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
+| network.community_id | A hash of source and destination IPs and ports, as well as the protocol used in a communication. This is a tool-agnostic standard to identify flows. Learn more at https://github.com/corelight/community-id-spec. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
-| related.user | All the user names seen on your event. | keyword |
-| source.address | Source network address. | keyword |
-| source.as.number | Unique number allocated to the autonomous system. | long |
+| related.user | All the user names or other user identifiers seen on the event. | keyword |
+| source.address | Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
+| source.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | keyword |
+| source.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
-| source.ip | IP address of the source. | ip |
+| source.ip | IP address of the source (IPv4 or IPv6). | ip |
 | source.port | Port of the source. | long |
 | tags | List of keywords used to tag each event. | keyword |
-| user.domain | Domain of the user. | keyword |
-| user.full_name | Full name of the user. | keyword |
+| user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.full_name | User's full name, if available. | keyword |
 | user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |

--- a/packages/azure/docs/platformlogs.md
+++ b/packages/azure/docs/platformlogs.md
@@ -110,14 +110,14 @@ An example event for `platformlogs` looks as following:
 | azure.subscription_id | Azure subscription ID | keyword |
 | azure.tenant_id | tenant ID | keyword |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
 | cloud.instance.id | Instance ID of the host machine. | keyword |
 | cloud.instance.name | Instance name of the host machine. | keyword |
 | cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
+| cloud.project.id | The cloud project identifier. Examples: Google Cloud Project id, Azure Project id. | keyword |
 | cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |
 | container.id | Unique container id. | keyword |
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |
@@ -162,7 +162,7 @@ An example event for `platformlogs` looks as following:
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
+| host.mac | Host MAC addresses. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |

--- a/packages/azure/docs/springcloudlogs.md
+++ b/packages/azure/docs/springcloudlogs.md
@@ -116,14 +116,14 @@ An example event for `springcloudlogs` looks as following:
 | azure.subscription_id | Azure subscription ID | keyword |
 | azure.tenant_id | tenant ID | keyword |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
 | cloud.instance.id | Instance ID of the host machine. | keyword |
 | cloud.instance.name | Instance name of the host machine. | keyword |
 | cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
+| cloud.project.id | The cloud project identifier. Examples: Google Cloud Project id, Azure Project id. | keyword |
 | cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |
 | container.id | Unique container id. | keyword |
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |
@@ -169,7 +169,7 @@ An example event for `springcloudlogs` looks as following:
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
+| host.mac | Host MAC addresses. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |

--- a/packages/azure/docs/springcloudlogs.md
+++ b/packages/azure/docs/springcloudlogs.md
@@ -131,38 +131,37 @@ An example event for `springcloudlogs` looks as following:
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
-| destination.address | Destination network address. | keyword |
-| destination.as.number | Unique number allocated to the autonomous system. | long |
+| destination.address | Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
+| destination.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | destination.as.organization.name | Organization name. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |
 | destination.geo.country_iso_code | Country ISO code. | keyword |
 | destination.geo.country_name | Country name. | keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
-| destination.geo.name | User-defined description of a location. | keyword |
+| destination.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
-| destination.ip | IP address of the destination. | ip |
+| destination.ip | IP address of the destination (IPv4 or IPv6). | ip |
 | destination.port | Port of the destination. | long |
-| ecs.version | ECS version this event conforms to. | keyword |
-| error.message | Error message. | text |
-| event.action | The action captured by the event. | keyword |
-| event.category | Event category. The second categorization field in the hierarchy. | keyword |
-| event.created | Time when the event was first read by an agent or by your pipeline. | date |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
+| event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
+| event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
+| event.created | event.created contains the date/time when the event was first read by an agent, or by your pipeline. This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event. In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source. In case the two timestamps are identical, @timestamp should be used. | date |
 | event.dataset | Event dataset | constant_keyword |
 | event.id | Unique ID to describe the event. | keyword |
-| event.ingested | Timestamp when an event arrived in the central data store. | date |
-| event.kind | The kind of the event. The highest categorization field in the hierarchy. | keyword |
+| event.ingested | Timestamp when an event arrived in the central data store. This is different from `@timestamp`, which is when the event originally occurred.  It's also different from `event.created`, which is meant to capture the first time an agent saw the event. In normal conditions, assuming no tampering, the timestamps should chronologically look like this: `@timestamp` \< `event.created` \< `event.ingested`. | date |
+| event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |
 | event.module | Event module | constant_keyword |
-| event.type | Event type. The third categorization field in the hierarchy. | keyword |
-| file.mime_type | Media type of file, document, or arrangement of bytes. | keyword |
-| file.size | File size in bytes. | long |
+| event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |
+| file.mime_type | MIME type should identify the format of the file or stream of bytes using https://www.iana.org/assignments/media-types/media-types.xhtml[IANA official types], where possible. When more than one type is applicable, the most specific type should be used. | keyword |
+| file.size | File size in bytes. Only relevant when `file.type` is "file". | long |
 | geo.city_name | City name. | keyword |
 | geo.continent_name | Name of the continent. | keyword |
 | geo.country_iso_code | Country ISO code. | keyword |
 | geo.country_name | Country name. | keyword |
 | geo.location | Longitude and latitude. | geo_point |
-| geo.name | User-defined description of a location. | keyword |
+| geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -179,26 +178,26 @@ An example event for `springcloudlogs` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| log.level | Log level of the log event. | keyword |
-| message | Message. | text |
-| network.community_id | A hash of source and destination IPs and ports. | keyword |
+| log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
+| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
+| network.community_id | A hash of source and destination IPs and ports, as well as the protocol used in a communication. This is a tool-agnostic standard to identify flows. Learn more at https://github.com/corelight/community-id-spec. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
-| related.user | All the user names seen on your event. | keyword |
-| source.address | Source network address. | keyword |
-| source.as.number | Unique number allocated to the autonomous system. | long |
+| related.user | All the user names or other user identifiers seen on the event. | keyword |
+| source.address | Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
+| source.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
 | source.geo.country_name | Country name. | keyword |
 | source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.name | User-defined description of a location. | keyword |
+| source.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
-| source.ip | IP address of the source. | ip |
+| source.ip | IP address of the source (IPv4 or IPv6). | ip |
 | source.port | Port of the source. | long |
 | tags | List of keywords used to tag each event. | keyword |
-| user.domain | Domain of the user. | keyword |
-| user.full_name | Full name of the user. | keyword |
+| user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.full_name | User's full name, if available. | keyword |
 | user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |

--- a/packages/azure/manifest.yml
+++ b/packages/azure/manifest.yml
@@ -1,6 +1,6 @@
 name: azure
 title: Azure Logs
-version: 0.7.0
+version: 0.8.0
 release: beta
 description: This Elastic integration collects logs from Azure
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR modifies field definitions for Azure integration to use ECS fields

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).
