### PR TITLE
Add missing daemonset.name field in pod and container data streams

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add missing field "kubernetes.daemonset.name" field for pod and container data streams
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1413
+      link: https://github.com/elastic/integrations/pull/1459
 - version: "0.12.1"
   changes:
     - description: Add missing cluster filter for "orchestrator.cluster.name" field in [Metrics Kubernetes] Overview dashboard and Dashboard section in the integration overview page

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.12.2"
+  changes:
+    - description: Add missing field "kubernetes.daemonset.name" field for pod and container data streams
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1413
 - version: "0.12.1"
   changes:
     - description: Add missing cluster filter for "orchestrator.cluster.name" field in [Metrics Kubernetes] Overview dashboard and Dashboard section in the integration overview page

--- a/packages/kubernetes/data_stream/container/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/container/fields/base-fields.yml
@@ -74,6 +74,11 @@
       description: >
         Kubernetes deployment name
 
+    - name: daemonset.name
+      type: keyword
+      description: >
+        Kubernetes daemonset name
+
     - name: statefulset.name
       type: keyword
       description: >

--- a/packages/kubernetes/data_stream/pod/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/pod/fields/base-fields.yml
@@ -74,6 +74,11 @@
       description: >
         Kubernetes deployment name
 
+    - name: daemonset.name
+      type: keyword
+      description: >
+        Kubernetes daemonset name
+
     - name: statefulset.name
       type: keyword
       description: >

--- a/packages/kubernetes/docs/kubelet.md
+++ b/packages/kubernetes/docs/kubelet.md
@@ -226,6 +226,7 @@ An example event for `container` looks as following:
 | kubernetes.container.rootfs.inodes.used | Used inodes | long |  | gauge |
 | kubernetes.container.rootfs.used.bytes | Root filesystem total used in bytes | long | byte | gauge |
 | kubernetes.container.start_time | Start time | date |  |  |
+| kubernetes.daemonset.name | Kubernetes daemonset name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |  |
@@ -657,6 +658,7 @@ An example event for `pod` looks as following:
 | kubernetes.annotations.\* | Kubernetes annotations map | object |  |  |
 | kubernetes.container.image | Kubernetes container image | keyword |  |  |
 | kubernetes.container.name | Kubernetes container name | keyword |  |  |
+| kubernetes.daemonset.name | Kubernetes daemonset name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |  |

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 0.12.1
+version: 0.12.2
 license: basic
 description: This Elastic integration collects metrics from Kubernetes clusters
 type: integration


### PR DESCRIPTION
This PR adds missing `daemonset.name` field in pod and container data streams to tune according to elastic/beats#26808.
