### PR TITLE
nginx_ingress_controller generate ecs.yml

### DIFF
--- a/packages/nginx_ingress_controller/_dev/build/build.yml
+++ b/packages/nginx_ingress_controller/_dev/build/build.yml
@@ -1,0 +1,3 @@
+dependencies:
+  ecs:
+    reference: 'git@1.11'

--- a/packages/nginx_ingress_controller/changelog.yml
+++ b/packages/nginx_ingress_controller/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.3.2'
+  changes:
+    - description: Convert to generated ECS fields
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXX
 - version: '0.3.1'
   changes:
     - description: update to ECS 1.11.0

--- a/packages/nginx_ingress_controller/changelog.yml
+++ b/packages/nginx_ingress_controller/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Convert to generated ECS fields
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXX
+      link: https://github.com/elastic/integrations/pull/1517
 - version: '0.3.1'
   changes:
     - description: update to ECS 1.11.0

--- a/packages/nginx_ingress_controller/data_stream/access/fields/agent.yml
+++ b/packages/nginx_ingress_controller/data_stream/access/fields/agent.yml
@@ -196,3 +196,9 @@
       description: >
         OS codename, if any.
 
+- name: input.type
+  type: keyword
+  description: Input type
+- name: log.offset
+  type: long
+  description: Log offset

--- a/packages/nginx_ingress_controller/data_stream/access/fields/ecs.yml
+++ b/packages/nginx_ingress_controller/data_stream/access/fields/ecs.yml
@@ -1,180 +1,62 @@
-- name: http
-  title: HTTP
-  group: 2
-  type: group
-  fields:
-    - name: request.method
-      level: extended
-      type: keyword
-      description: |-
-        HTTP request method.
-        The field value must be normalized to lowercase for querying. See the documentation section "Implementing ECS".
-      ignore_above: 1024
-    - name: request.referrer
-      level: extended
-      type: keyword
-      description: Referrer for this HTTP request.
-      ignore_above: 1024
-    - name: response.body.bytes
-      level: extended
-      type: long
-      format: bytes
-      description: Size in bytes of the response body.
-    - name: response.status_code
-      level: extended
-      type: long
-      format: string
-      description: HTTP response status code.
-    - name: version
-      level: extended
-      type: keyword
-      description: HTTP version.
-      ignore_above: 1024
-- description: "Host ip addresses."
+- external: ecs
+  name: ecs.version
+- external: ecs
   name: host.ip
-  type: ip
-- name: source
-  title: Source
-  group: 2
-  type: group
-  fields:
-    - name: geo.city_name
-      level: core
-      type: keyword
-      description: City name.
-      ignore_above: 1024
-    - name: geo.continent_name
-      level: core
-      type: keyword
-      description: Name of the continent.
-      ignore_above: 1024
-    - name: geo.country_iso_code
-      level: core
-      type: keyword
-      description: Country ISO code.
-      ignore_above: 1024
-    - name: geo.location
-      level: core
-      type: geo_point
-      description: Longitude and latitude.
-    - name: geo.region_iso_code
-      level: core
-      type: keyword
-      description: Region ISO code.
-      ignore_above: 1024
-    - name: geo.region_name
-      level: core
-      type: keyword
-      description: Region name.
-      ignore_above: 1024
-- name: url
-  title: URL
-  group: 2
-  type: group
-  fields:
-    - name: original
-      level: extended
-      type: keyword
-      description: |-
-        Unmodified original url as seen in the event source.
-        Note that in network monitoring, the observed URL may be a full URL, whereas in access logs, the URL is often just represented as a path.
-        This field is meant to represent the URL as it was observed, complete or not.
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-- name: user
-  title: User
-  group: 2
-  type: group
-  fields:
-    - name: name
-      level: core
-      type: keyword
-      description: Short name or login of the user.
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-- name: user_agent
-  title: User agent
-  group: 2
-  type: group
-  fields:
-    - name: device.name
-      level: extended
-      type: keyword
-      description: Name of the device.
-      ignore_above: 1024
-    - name: name
-      level: extended
-      type: keyword
-      description: Name of the user agent.
-      ignore_above: 1024
-    - name: original
-      level: extended
-      type: keyword
-      description: Unparsed user_agent string.
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-    - name: os.name
-      level: extended
-      type: keyword
-      description: Operating system name, without the version.
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-- name: related.ip
-  type: ip
-  description: All of the IPs seen on your event.
-- name: source.address
-  type: keyword
-  description: IP address, domain or unix socket.
-- name: source.ip
-  type: ip
-  description: IP address of the source.
-- name: user_agent.os.full
-  type: keyword
-  description: Operating system name, including the version or code name.
-- name: user_agent.os.version
-  type: keyword
-  description: Operating system version as a raw string.
-- name: user_agent.version
-  type: keyword
-  description: Version of the user agent.
-- name: source.as.organization.name
-  type: keyword
-  description: Organization name.
-- name: source.as.number
-  type: long
-  description: Unique number allocated to the autonomous system.
-- name: source.geo.country_name
-  type: keyword
-  description: Country name.
-- name: ecs.version
-  type: keyword
-  description: ECS version
-- name: input.type
-  type: keyword
-  description: Input type
-- name: log.file.path
-  type: keyword
-  description: Log path
-- name: log.offset
-  type: long
-  description: Log offset
-- name: tags
+- external: ecs
+  name: http.request.method
+- external: ecs
+  name: http.request.referrer
+- external: ecs
+  name: http.response.body.bytes
+- external: ecs
+  name: http.response.status_code
+- external: ecs
+  name: http.version
+- external: ecs
+  name: log.file.path
+- external: ecs
+  name: related.ip
+- external: ecs
+  name: source.address
+- external: ecs
+  name: source.as.number
+- external: ecs
+  name: source.as.organization.name
+- external: ecs
+  name: source.geo.city_name
+- external: ecs
+  name: source.geo.continent_name
+- external: ecs
+  name: source.geo.country_iso_code
+- external: ecs
+  name: source.geo.country_name
+- name: source.geo.location
   level: core
-  type: keyword
-  ignore_above: 1024
-  description: List of keywords used to tag each event.
+  type: geo_point
+  description: Longitude and latitude.
+- external: ecs
+  name: source.geo.region_iso_code
+- external: ecs
+  name: source.geo.region_name
+- external: ecs
+  name: source.ip
+- external: ecs
+  name: tags
+- external: ecs
+  name: url.original
+- external: ecs
+  name: user.name
+- external: ecs
+  name: user_agent.device.name
+- external: ecs
+  name: user_agent.name
+- external: ecs
+  name: user_agent.original
+- external: ecs
+  name: user_agent.os.full
+- external: ecs
+  name: user_agent.os.name
+- external: ecs
+  name: user_agent.os.version
+- external: ecs
+  name: user_agent.version

--- a/packages/nginx_ingress_controller/data_stream/error/fields/agent.yml
+++ b/packages/nginx_ingress_controller/data_stream/error/fields/agent.yml
@@ -196,3 +196,12 @@
       description: >
         OS codename, if any.
 
+- name: input.type
+  type: keyword
+  description: Input type
+- name: log.offset
+  type: long
+  description: Log offset
+- name: log.flags
+  description: Flags for the log file.
+  type: keyword

--- a/packages/nginx_ingress_controller/data_stream/error/fields/ecs.yml
+++ b/packages/nginx_ingress_controller/data_stream/error/fields/ecs.yml
@@ -1,34 +1,10 @@
-- name: message
-  level: core
-  type: text
-  description: |-
-    For log events the message field contains the log message, optimized for viewing in a log viewer.
-    For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event.
-    If multiple messages exist, they can be combined into one message.
-- name: log
-  title: Log
-  type: group
-  fields:
-    - name: level
-      type: keyword
-      description: Original log level of the log event.
-    - name: flags
-      description: Flags for the log file.
-      type: keyword
-- name: input.type
-  type: keyword
-  description: Input type
-- name: log.file.path
-  type: keyword
-  description: Log path
-- name: log.offset
-  type: long
-  description: Log offset
-- name: ecs.version
-  type: keyword
-  description: ECS version
-- name: tags
-  level: core
-  type: keyword
-  ignore_above: 1024
-  description: List of keywords used to tag each event.
+- external: ecs
+  name: ecs.version
+- external: ecs
+  name: log.file.path
+- external: ecs
+  name: log.level
+- external: ecs
+  name: message
+- external: ecs
+  name: tags

--- a/packages/nginx_ingress_controller/docs/README.md
+++ b/packages/nginx_ingress_controller/docs/README.md
@@ -111,7 +111,7 @@ An example event for `access` looks as following:
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version | keyword |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
 | event.created | Date/time when the event was first read by an agent, or by your pipeline. | date |
 | event.dataset | Event dataset | constant_keyword |
 | event.module | Event module | constant_keyword |
@@ -131,13 +131,13 @@ An example event for `access` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| http.request.method | HTTP request method. The field value must be normalized to lowercase for querying. See the documentation section "Implementing ECS". | keyword |
+| http.request.method | HTTP request method. Prior to ECS 1.6.0 the following guidance was provided: "The field value must be normalized to lowercase for querying." As of ECS 1.6.0, the guidance is deprecated because the original case of the method may be useful in anomaly detection.  Original case will be mandated in ECS 2.0.0 | keyword |
 | http.request.referrer | Referrer for this HTTP request. | keyword |
 | http.response.body.bytes | Size in bytes of the response body. | long |
 | http.response.status_code | HTTP response status code. | long |
 | http.version | HTTP version. | keyword |
 | input.type | Input type | keyword |
-| log.file.path | Log path | keyword |
+| log.file.path | Full path to the log file this event came from, including the file name. It should include the drive letter, when appropriate. If the event wasn't read from a log file, do not populate this field. | keyword |
 | log.offset | Log offset | long |
 | nginx_ingress_controller.access.http.request.id | The randomly generated ID of the request | text |
 | nginx_ingress_controller.access.http.request.length | The request length (including request line, header, and request body) | long |
@@ -151,8 +151,8 @@ An example event for `access` looks as following:
 | nginx_ingress_controller.access.upstream.response.status_code | The status code of the response obtained from the upstream server | long |
 | nginx_ingress_controller.access.upstream.response.time | The time spent on receiving the response from the upstream server as seconds with millisecond resolution | double |
 | related.ip | All of the IPs seen on your event. | ip |
-| source.address | IP address, domain or unix socket. | keyword |
-| source.as.number | Unique number allocated to the autonomous system. | long |
+| source.address | Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
+| source.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | source.as.organization.name | Organization name. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
@@ -161,7 +161,7 @@ An example event for `access` looks as following:
 | source.geo.location | Longitude and latitude. | geo_point |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
-| source.ip | IP address of the source. | ip |
+| source.ip | IP address of the source (IPv4 or IPv6). | ip |
 | tags | List of keywords used to tag each event. | keyword |
 | url.original | Unmodified original url as seen in the event source. Note that in network monitoring, the observed URL may be a full URL, whereas in access logs, the URL is often just represented as a path. This field is meant to represent the URL as it was observed, complete or not. | keyword |
 | user.name | Short name or login of the user. | keyword |
@@ -282,7 +282,7 @@ An example event for `error` looks as following:
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version | keyword |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
 | event.dataset | Event dataset | constant_keyword |
 | event.module | Event module | constant_keyword |
 | host.architecture | Operating system architecture. | keyword |
@@ -302,9 +302,9 @@ An example event for `error` looks as following:
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | input.type | Input type | keyword |
-| log.file.path | Log path | keyword |
+| log.file.path | Full path to the log file this event came from, including the file name. It should include the drive letter, when appropriate. If the event wasn't read from a log file, do not populate this field. | keyword |
 | log.flags | Flags for the log file. | keyword |
-| log.level | Original log level of the log event. | keyword |
+| log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
 | log.offset | Log offset | long |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
 | nginx_ingress_controller.error.source.file | Source file | keyword |

--- a/packages/nginx_ingress_controller/manifest.yml
+++ b/packages/nginx_ingress_controller/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: nginx_ingress_controller
 title: Nginx Ingress Controller
-version: 0.3.1
+version: 0.3.2
 license: basic
 description: This Elastic integration collects logs from Nginx Ingress Controller instances
 type: integration


### PR DESCRIPTION
## What does this PR do?

- switches to generated ecs.yml field definitions

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates elastic/beats#26967