### PR TITLE
Fix: import geo_points from ECS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/elastic/elastic-package v0.15.0
+	github.com/elastic/elastic-package v0.16.0
 	github.com/elastic/package-registry v1.0.0
 	github.com/magefile/mage v1.11.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -223,8 +223,8 @@ github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5m
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
-github.com/elastic/elastic-package v0.15.0 h1:+QjhyzM3EzDAQFkG7fqUpaUt7tOKRp5hTLQhAok/1Q4=
-github.com/elastic/elastic-package v0.15.0/go.mod h1:mitxbQTYdWi4xi01ZqDn1ujScfMHFTN684bPksVE/Zs=
+github.com/elastic/elastic-package v0.16.0 h1:SosGVVIG3DCEznYja4qbm7fhCM4rMBNA8tvDJNzU40w=
+github.com/elastic/elastic-package v0.16.0/go.mod h1:c+kFtAcctfsghaQQuuTTYESRIMuqLwHLIHUJ8WBKWr0=
 github.com/elastic/go-elasticsearch/v7 v7.14.0 h1:extp3jos/rwJn3J+lgbaGlwAgs0TVsIHme00GyNAyX4=
 github.com/elastic/go-elasticsearch/v7 v7.14.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/go-licenser v0.3.1 h1:RmRukU/JUmts+rpexAw0Fvt2ly7VVu6mw8z4HrEzObU=
@@ -238,8 +238,8 @@ github.com/elastic/go-windows v1.0.0 h1:qLURgZFkkrYyTTkvYpsZIgf83AUsdIHfvlJaqaZ7
 github.com/elastic/go-windows v1.0.0/go.mod h1:TsU0Nrp7/y3+VwE82FoZF8gC/XFg/Elz6CcloAxnPgU=
 github.com/elastic/package-registry v1.0.0 h1:ooMxpo9QR3BPNnz57l8ka14JwkEJI1wgA17n1RGTWj4=
 github.com/elastic/package-registry v1.0.0/go.mod h1:CUeWMEpYlZ3BrsnuG444EnHm9wGBI/ZkHrSLmbv7WL0=
-github.com/elastic/package-spec/code/go v0.0.0-20210623152222-b358e974b7f9 h1:qvoqy6W/mhBY1t4xxP82oy34VTeF+MEqfVLiIGNBsEs=
-github.com/elastic/package-spec/code/go v0.0.0-20210623152222-b358e974b7f9/go.mod h1:t0uvhLQGg3D4iQ5lSQEQs4YYS53MIIS05v0zm0fIBPM=
+github.com/elastic/package-spec/code/go v0.0.0-20210811110254-a7173524bc76 h1:g6DOxqLEVMVwrwPSNdqmmMD5qSWFSgv0vNGEIrNWbIw=
+github.com/elastic/package-spec/code/go v0.0.0-20210811110254-a7173524bc76/go.mod h1:AwJU57aVd0wHklEPglARwqmi8vaeIoTzzKAPg8HzJl4=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=

--- a/packages/azure/data_stream/activitylogs/fields/ecs.yml
+++ b/packages/azure/data_stream/activitylogs/fields/ecs.yml
@@ -15,8 +15,7 @@
 - name: destination.geo.country_name
   external: ecs
 - name: destination.geo.location
-  type: geo_point
-  description: Longitude and latitude.
+  external: ecs
 - name: destination.geo.name
   external: ecs
 - name: destination.geo.region_iso_code
@@ -70,8 +69,7 @@
 - name: geo.country_name
   external: ecs
 - name: geo.location
-  type: geo_point
-  description: Longitude and latitude.
+  external: ecs
 - name: geo.city_name
   external: ecs
 - name: log.level
@@ -85,8 +83,7 @@
 - name: source.geo.country_name
   external: ecs
 - name: source.geo.location
-  type: geo_point
-  description: Longitude and latitude.
+  external: ecs
 - name: source.geo.name
   external: ecs
 - name: source.geo.region_iso_code

--- a/packages/azure/data_stream/auditlogs/fields/ecs.yml
+++ b/packages/azure/data_stream/auditlogs/fields/ecs.yml
@@ -13,8 +13,7 @@
 - name: destination.geo.country_name
   external: ecs
 - name: destination.geo.location
-  type: geo_point
-  description: Longitude and latitude.
+  external: ecs
 - name: destination.geo.name
   external: ecs
 - name: destination.geo.region_iso_code
@@ -68,8 +67,7 @@
 - name: geo.country_name
   external: ecs
 - name: geo.location
-  type: geo_point
-  description: Longitude and latitude.
+  external: ecs
 - name: geo.city_name
   external: ecs
 - name: log.level
@@ -83,8 +81,7 @@
 - name: source.geo.country_name
   external: ecs
 - name: source.geo.location
-  type: geo_point
-  description: Longitude and latitude.
+  external: ecs
 - name: source.geo.name
   external: ecs
 - name: source.geo.region_iso_code

--- a/packages/azure/data_stream/platformlogs/fields/ecs.yml
+++ b/packages/azure/data_stream/platformlogs/fields/ecs.yml
@@ -13,8 +13,7 @@
 - name: destination.geo.country_name
   external: ecs
 - name: destination.geo.location
-  type: geo_point
-  description: Longitude and latitude.
+  external: ecs
 - name: destination.geo.name
   external: ecs
 - name: destination.geo.region_iso_code
@@ -68,8 +67,7 @@
 - name: geo.country_name
   external: ecs
 - name: geo.location
-  type: geo_point
-  description: Longitude and latitude.
+  external: ecs
 - name: geo.city_name
   external: ecs
 - name: log.level
@@ -83,8 +81,7 @@
 - name: source.geo.country_name
   external: ecs
 - name: source.geo.location
-  type: geo_point
-  description: Longitude and latitude.
+  external: ecs
 - name: source.geo.name
   external: ecs
 - name: source.geo.region_iso_code

--- a/packages/azure/data_stream/signinlogs/fields/ecs.yml
+++ b/packages/azure/data_stream/signinlogs/fields/ecs.yml
@@ -15,8 +15,7 @@
 - name: destination.geo.country_name
   external: ecs
 - name: destination.geo.location
-  type: geo_point
-  description: Longitude and latitude.
+  external: ecs
 - name: destination.geo.name
   external: ecs
 - name: destination.geo.region_iso_code
@@ -70,8 +69,7 @@
 - name: geo.country_name
   external: ecs
 - name: geo.location
-  type: geo_point
-  description: Longitude and latitude.
+  external: ecs
 - name: geo.city_name
   external: ecs
 - name: log.level
@@ -85,8 +83,7 @@
 - name: source.geo.country_name
   external: ecs
 - name: source.geo.location
-  type: geo_point
-  description: Longitude and latitude.
+  external: ecs
 - name: source.geo.name
   external: ecs
 - name: source.geo.region_iso_code

--- a/packages/azure/data_stream/springcloudlogs/fields/ecs.yml
+++ b/packages/azure/data_stream/springcloudlogs/fields/ecs.yml
@@ -13,8 +13,7 @@
 - name: destination.geo.country_name
   external: ecs
 - name: destination.geo.location
-  type: geo_point
-  description: Longitude and latitude.
+  external: ecs
 - name: destination.geo.name
   external: ecs
 - name: destination.geo.region_iso_code
@@ -68,8 +67,7 @@
 - name: geo.country_name
   external: ecs
 - name: geo.location
-  type: geo_point
-  description: Longitude and latitude.
+  external: ecs
 - name: geo.city_name
   external: ecs
 - name: log.level
@@ -83,8 +81,7 @@
 - name: source.geo.country_name
   external: ecs
 - name: source.geo.location
-  type: geo_point
-  description: Longitude and latitude.
+  external: ecs
 - name: source.geo.name
   external: ecs
 - name: source.geo.region_iso_code


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR bumps up dependency on elastic-package to import geo_point definitions from ECS. It also adjusts the Azure integration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ x I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).