### PR TITLE
Fix windows dashboard links

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.5"
+  changes:
+    - description: Fix Windows links
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1525
 - version: "1.1.4"
   changes:
     - description: Fix issue with normalized CPU gauge

--- a/packages/system/kibana/dashboard/system-Windows-Dashboard.json
+++ b/packages/system/kibana/dashboard/system-Windows-Dashboard.json
@@ -90,7 +90,7 @@
         "title": "[System] Windows Overview",
         "version": 1
     },
-    "id": "system-Winlogbeat-dashboard",
+    "id": "system-Windows-Dashboard",
     "migrationVersion": {
         "dashboard": "7.3.0"
     },

--- a/packages/system/kibana/visualization/system-a3c3f350-9b6d-11ea-87e4-49f31ec44891.json
+++ b/packages/system/kibana/visualization/system-a3c3f350-9b6d-11ea-87e4-49f31ec44891.json
@@ -17,7 +17,7 @@
             "aggs": [],
             "params": {
                 "fontSize": 12,
-                "markdown": "[Windows Overview](#/dashboard/Windows-Dashboard) | [User Logon Information](#/dashboard/windows-bae11b00-9bfc-11ea-87e4-49f31ec44891) |  [Logon Failed and Account Lockout](#/dashboard/windows-d401ef40-a7d5-11e9-a422-d144027429da) | [User Management Events](#/dashboard/windows-71f720f0-ff18-11e9-8405-516218e3d268) | [Group Management Events](#/dashboard/windows-bb858830-f412-11e9-8405-516218e3d268)",
+                "markdown": "[Windows Overview](#/dashboard/system-Windows-Dashboard) | [User Logon Information](#/dashboard/system-bae11b00-9bfc-11ea-87e4-49f31ec44891) |  [Logon Failed and Account Lockout](#/dashboard/system-d401ef40-a7d5-11e9-a422-d144027429da) | [User Management Events](#/dashboard/system-71f720f0-ff18-11e9-8405-516218e3d268) | [Group Management Events](#/dashboard/system-bb858830-f412-11e9-8405-516218e3d268)",
                 "openLinksInNewTab": false
             },
             "title": "Dashboard links  [Windows System Security]",

--- a/packages/system/kibana/visualization/system-d770b040-9b35-11ea-87e4-49f31ec44891.json
+++ b/packages/system/kibana/visualization/system-d770b040-9b35-11ea-87e4-49f31ec44891.json
@@ -17,7 +17,7 @@
             "aggs": [],
             "params": {
                 "fontSize": 12,
-                "markdown": "[Windows General Dashboard](#/dashboard/Windows-Dashboard) | [User Logon Information](#/dashboard/windows-035846a0-a249-11e9-a422-d144027429da?) | [Logon failed and Account Lockout](#/dashboard/windows-f49f3170-9ffc-11ea-87e4-49f31ec44891)  | [User Management Events](#/dashboard/windows-8223bed0-b9e9-11e9-b6a2-c9b4015c4baf) | [Group Management Events](#/dashboard/windows-01c54730-fee6-11e9-8405-516218e3d268)",
+                "markdown": "[Windows Overview](#/dashboard/system-Windows-Dashboard) | [User Logon Information](#/dashboard/system-bae11b00-9bfc-11ea-87e4-49f31ec44891) |  [Logon Failed and Account Lockout](#/dashboard/system-d401ef40-a7d5-11e9-a422-d144027429da) | [User Management Events](#/dashboard/system-71f720f0-ff18-11e9-8405-516218e3d268) | [Group Management Events](#/dashboard/system-bb858830-f412-11e9-8405-516218e3d268)",
                 "openLinksInNewTab": false
             },
             "title": "Dashboard links  - Simple [Windows System Security]",

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 1.1.4
+version: 1.1.5
 license: basic
 description: This Elastic integration collects logs and metrics from your servers
 type: integration


### PR DESCRIPTION
See: https://github.com/elastic/integrations/issues/1524

## What does this PR do?

This fixes the dashboard IDs in the windows navigation visualizations. 

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.


## How to test this PR locally

- Pull down a build
- Navigate to the windows Dashboard. Click through the links in the middle-right, make sure they all work.

## Related issues

- Closes #1524

