### PR TITLE
[Synthetics] update categorization to include web and monitoring

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.2"
+  changes:
+    - description: Adjust categories to add web and monitoring
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1531
 - version: "0.2.1"
   changes:
     - description: Adjust category to elastic_stack

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,8 +2,8 @@ format_version: 1.0.0
 name: synthetics
 title: Elastic Synthetics
 description: This Elastic integration allows you to monitor the availability of your services
-version: 0.2.1
-categories: ["elastic_stack"]
+version: 0.2.2
+categories: ["elastic_stack", "monitoring", "web"]
 release: beta
 type: integration
 license: basic


### PR DESCRIPTION
Fixes elastic/integrations#1534

This PR adjusts synthetics categorization to add web and monitoring.

<img width="1287" alt="Screen Shot 2021-08-16 at 9 55 28 AM" src="https://user-images.githubusercontent.com/11356435/129583662-2d04aff3-514e-428e-8012-bc6609dc5f22.png">
<img width="1257" alt="Screen Shot 2021-08-16 at 9 55 19 AM" src="https://user-images.githubusercontent.com/11356435/129583665-462d3e48-3c8f-45f1-b9cf-7dc27ea95b91.png">
<img width="1265" alt="Screen Shot 2021-08-16 at 9 51 19 AM" src="https://user-images.githubusercontent.com/11356435/129583666-1f13fccc-f414-4d65-806c-21a836f59e1e.png">
