### PR TITLE
[Fleet] Fix dataset for elastic_agent logs datastream

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Fix dataset for elastic_agent logs.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/?
 - version: "1.2.0"
   changes:
     - description: Update dashboard to CGroup CPU usage and events rates visualization and add Elastic Agent logo

--- a/packages/elastic_agent/data_stream/elastic_agent_logs/manifest.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_logs/manifest.yml
@@ -1,6 +1,5 @@
 title: Elastic Agent
-# TODO: Why is this?
-dataset: elastic_agent
+dataset: elastic_agent.elastic_agent
 type: logs
 elasticsearch:
   index_template:

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.2.0
+version: 1.2.1
 release: ga
 description: This Elastic integration collects metrics from Elastic Agent
 type: integration


### PR DESCRIPTION
## Description 

Fix the dataset for elastic agent logs datastream.

Tested locally with 7.14 and 8.0 stack agents logs are well shipped. 
