### PR TITLE
Replace localhost with node_name env var to access k8s proxy

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.14.1"
+  changes:
+    - description: Update default host in kubernetes proxy data stream in kubernetes integration
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1565
 - version: "0.14.0"
   changes:
     - description: Add new container logs data stream in kubernetes integration

--- a/packages/kubernetes/data_stream/proxy/manifest.yml
+++ b/packages/kubernetes/data_stream/proxy/manifest.yml
@@ -11,7 +11,7 @@ streams:
         required: true
         show_user: true
         default:
-          - localhost:10249
+          - ${env.NODE_NAME}:10249
       - name: period
         type: text
         title: Period

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 0.14.0
+version: 0.14.1
 license: basic
 description: This Elastic integration collects metrics from Kubernetes clusters
 type: integration


### PR DESCRIPTION
## What does this PR do?

Replaces the default host for proxy data stream in kubernetes package from `localhost:10249` to `${env.NODE_NAME}:10249`.
The proxy metrics can be fetched from the pod by using the k8s node name and proxy port as it is accessible from inside the pod.
This is a step towards getting rid of `hostNetwork:true` setting in agent deployment configuration.
https://github.com/elastic/beats/issues/25739

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).


## Screenshots
<img width="1429" alt="proxy" src="https://user-images.githubusercontent.com/26270880/131648731-57a7fc92-29f4-41eb-bade-042db1d72dc1.png">

