### PR TITLE
Skip system test for aws/ec2_metrics

### DIFF
--- a/packages/aws/data_stream/ec2_metrics/_dev/test/system/test-default-config.yml
+++ b/packages/aws/data_stream/ec2_metrics/_dev/test/system/test-default-config.yml
@@ -1,3 +1,6 @@
+skip:
+  reason: "Test fails"
+  link: https://github.com/elastic/integrations/issues/1566
 vars:
   access_key_id: '{{AWS_ACCESS_KEY_ID}}'
   secret_access_key: '{{AWS_SECRET_ACCESS_KEY}}'


### PR DESCRIPTION
## What does this PR do?

Skips the system test for aws/ec2_metrics as it currently fails.

## Related issues

- Relates #1566