### PR TITLE
[Fleet] Publish a new version of elastic agent package

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Fix dashboard default filter
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1547
 - version: "1.2.0"
   changes:
     - description: Update dashboard to CGroup CPU usage and events rates visualization and add Elastic Agent logo

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
@@ -44,7 +44,7 @@
                                     "label": "Host name",
                                     "options": {
                                         "dynamicOptions": true,
-                                        "multiselect": true,
+                                        "multiselect": false,
                                         "order": "desc",
                                         "size": 5,
                                         "type": "terms"

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.2.0
+version: 1.2.1
 release: ga
 description: This Elastic integration collects metrics from Elastic Agent
 type: integration


### PR DESCRIPTION
## Description

In https://github.com/elastic/integrations/pull/1547 I fixed a bug with the default filter on the agent dashboard

the package has been promoted to production before that fix so we need to publish a new version.