### PR TITLE
gcp: import metrics metricset

### DIFF
--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.0"
+  changes:
+    - description: Add GCP metrics data stream and input
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1570
 - version: "0.3.3"
   changes:
     - description: Convert to generated ECS fields

--- a/packages/gcp/data_stream/metrics/agent/stream/stream.yml.hbs
+++ b/packages/gcp/data_stream/metrics/agent/stream/stream.yml.hbs
@@ -1,0 +1,6 @@
+metricsets: ["metrics"]
+credentials_file_path: {{credentials_file_path}}
+exclude_labels: {{exclude_labels}}
+metrics: {{metrics}}
+period: {{period}}
+project_id: {{project_id}}

--- a/packages/gcp/data_stream/metrics/fields/base-fields.yml
+++ b/packages/gcp/data_stream/metrics/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.
+- name: '@timestamp'
+  type: date
+  description: Event timestamp.

--- a/packages/gcp/data_stream/metrics/fields/fields.yml
+++ b/packages/gcp/data_stream/metrics/fields/fields.yml
@@ -1,4 +1,4 @@
-- name: gcp.
+- name: gcp
   key: metrics
   type: group
   release: beta

--- a/packages/gcp/data_stream/metrics/fields/fields.yml
+++ b/packages/gcp/data_stream/metrics/fields/fields.yml
@@ -1,0 +1,4 @@
+- name: gcp.
+  key: metrics
+  type: group
+  release: beta

--- a/packages/gcp/data_stream/metrics/fields/package-fields.yml
+++ b/packages/gcp/data_stream/metrics/fields/package-fields.yml
@@ -1,0 +1,20 @@
+- name: gcp
+  type: group
+  fields:
+    - name: labels
+      type: object
+      description: |
+        GCP monitoring metrics labels
+      fields:
+        - name: user.*
+          type: object
+        - name: metadata.*
+          type: object
+        - name: metrics.*
+          type: object
+        - name: system.*
+          type: object
+    - name: metrics.*.*.*.*
+      type: object
+      description: |
+        Metrics that returned from Google Cloud API query.

--- a/packages/gcp/data_stream/metrics/manifest.yml
+++ b/packages/gcp/data_stream/metrics/manifest.yml
@@ -46,5 +46,6 @@ streams:
         required: true
         show_user: true
         default: your project id
+    template_path: stream.yml.hbs
     title: Google Cloud Platform metrics metrics
     description: Collect Google Cloud Platform metrics metrics

--- a/packages/gcp/data_stream/metrics/manifest.yml
+++ b/packages/gcp/data_stream/metrics/manifest.yml
@@ -1,0 +1,50 @@
+type: metrics
+title: Google Cloud Platform metrics metrics
+release: experimental
+streams:
+  - input: gcp/metrics
+    vars:
+      - name: credentials_file_path
+        type: text
+        title: Credentials File Path
+        multi: false
+        required: true
+        show_user: true
+        default: your JSON credentials file path
+      - name: exclude_labels
+        type: bool
+        title: Exclude Labels
+        multi: false
+        required: true
+        show_user: true
+        default: false
+      - name: metrics
+        type: yaml
+        title: Metrics
+        multi: false
+        required: true
+        show_user: true
+        default: |
+          - aligner: ALIGN_NONE
+            metric_types:
+            - instance/cpu/reserved_cores
+            - instance/cpu/usage_time
+            - instance/cpu/utilization
+            - instance/uptime
+            service: compute
+      - name: period
+        type: text
+        title: Period
+        multi: false
+        required: true
+        show_user: true
+        default: 1m
+      - name: project_id
+        type: text
+        title: Project Id
+        multi: false
+        required: true
+        show_user: true
+        default: your project id
+    title: Google Cloud Platform metrics metrics
+    description: Collect Google Cloud Platform metrics metrics

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -23,6 +23,14 @@ screenshots:
     title: filebeat gcp audit
     size: 1702x996
     type: image/png
+vars:
+  - name: credentials_file_path
+    type: text
+    title: Credentials File Path
+    multi: false
+    required: true
+    show_user: true
+    default: your JSON credentials file path
 policy_templates:
   - name: gcp
     title: Google Cloud Platform (GCP) logs
@@ -57,20 +65,53 @@ policy_templates:
             show_user: true
         title: "Collect Google Cloud Platform (GCP) audit, firewall and vpcflow logs (input: gcp-pubsub)"
         description: "Collecting audit, firewall and vpcflow logs from Google Cloud Platform (GCP) instances (input: gcp-pubsub)"
-  - name: gcp-metrics
-    title: GCP metrics
-    description: Collect metrics from GCP
+  - name: foo
+    title: Foo
+    description: Do some foo with much bar
     inputs:
-      - type: gcp/metrics
-        title: "Collect Google Cloud Platform billing, compute, gke, loadbalancing, metrics, pubsub and storage metrics"
-        description: "Collecting billing, compute, gke, loadbalancing, metrics, pubsub and storage metrics from Google Cloud Platform instances"
+      - type: gcp-pubsub
         vars:
-          - name: credentials_file_path
+          - name: alternative_host
             type: text
-            title: Credentials File Path
+            title: Alternative host
+            multi: false
+            required: false
+            show_user: false
+          - name: project_id
+            type: text
+            title: Project Id
             multi: false
             required: true
             show_user: true
-            default: your JSON credentials file path
+            default: SET_PROJECT_NAME
+          - name: credentials_file
+            type: text
+            title: Credentials File
+            multi: false
+            required: false
+            show_user: true
+          - name: credentials_json
+            type: text
+            title: Credentials Json
+            multi: false
+            required: false
+            show_user: true
+        title: "Collect Foo with much bar"
+        description: "Collecting so muuuuuch fooo and not letting any bar escape"
+  # - name: gcp-metrics
+  #   title: GCP metrics
+  #   description: Collect metrics from GCP
+  #   inputs:
+  #     - type: gcp/metrics
+  #       title: "Collect Google Cloud Platform billing, compute, gke, loadbalancing, metrics, pubsub and storage metrics"
+  #       description: "Collecting billing, compute, gke, loadbalancing, metrics, pubsub and storage metrics from Google Cloud Platform instances"
+  #       vars:
+  #         - name: credentials_file_path
+  #           type: text
+  #           title: Credentials File Path
+  #           multi: false
+  #           required: true
+  #           show_user: true
+  #           default: your JSON credentials file path
 owner:
   github: elastic/security-external-integrations

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform (GCP)
-version: 0.3.3
+version: 0.4.0
 release: experimental
 description: This Elastic integration collects logs and metrics from Google Cloud Platform (GCP) instances
 type: integration

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -2,7 +2,7 @@ name: gcp
 title: Google Cloud Platform (GCP)
 version: 0.3.3
 release: experimental
-description: This Elastic integration collects logs from Google Cloud Platform (GCP) instances
+description: This Elastic integration collects logs and metrics from Google Cloud Platform (GCP) instances
 type: integration
 icons:
   - src: /img/logo_gcp.svg
@@ -17,7 +17,7 @@ categories:
   - network
   - security
 conditions:
-  kibana.version: ^7.14.0
+  kibana.version: ^7.15.0
 screenshots:
   - src: /img/filebeat-gcp-audit.png
     title: filebeat gcp audit
@@ -57,5 +57,8 @@ policy_templates:
             show_user: true
         title: "Collect Google Cloud Platform (GCP) audit, firewall and vpcflow logs (input: gcp-pubsub)"
         description: "Collecting audit, firewall and vpcflow logs from Google Cloud Platform (GCP) instances (input: gcp-pubsub)"
+      - type: gcp/metrics
+        title: "Collect Google Cloud Platform billing, compute, gke, loadbalancing, metrics, pubsub and storage metrics"
+        description: "Collecting billing, compute, gke, loadbalancing, metrics, pubsub and storage metrics from Google Cloud Platform instances"
 owner:
   github: elastic/security-external-integrations

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -64,6 +64,13 @@ policy_templates:
       - type: gcp/metrics
         title: "Collect Google Cloud Platform billing, compute, gke, loadbalancing, metrics, pubsub and storage metrics"
         description: "Collecting billing, compute, gke, loadbalancing, metrics, pubsub and storage metrics from Google Cloud Platform instances"
-        vars: []
+        vars:
+          - name: credentials_file_path
+            type: text
+            title: Credentials File Path
+            multi: false
+            required: true
+            show_user: true
+            default: your JSON credentials file path
 owner:
   github: elastic/security-external-integrations

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -57,8 +57,13 @@ policy_templates:
             show_user: true
         title: "Collect Google Cloud Platform (GCP) audit, firewall and vpcflow logs (input: gcp-pubsub)"
         description: "Collecting audit, firewall and vpcflow logs from Google Cloud Platform (GCP) instances (input: gcp-pubsub)"
+  - name: gcp-metrics
+    title: GCP metrics
+    description: Collect metrics from GCP
+    inputs:
       - type: gcp/metrics
         title: "Collect Google Cloud Platform billing, compute, gke, loadbalancing, metrics, pubsub and storage metrics"
         description: "Collecting billing, compute, gke, loadbalancing, metrics, pubsub and storage metrics from Google Cloud Platform instances"
+        vars: []
 owner:
   github: elastic/security-external-integrations


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Migrate [GCP `metrics` metricset](https://github.com/elastic/beats/tree/master/x-pack/metricbeat/module/gcp/metrics) to integration.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
