### PR TITLE
Release  Docker as GA

### DIFF
--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0"
+  changes:
+    - description: Release Docker as GA
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1405
 - version: "0.5.1"
   changes:
     - description: Escape special characters in docs

--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Release Docker as GA
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1405
+      link: https://github.com/elastic/integrations/pull/1571
 - version: "0.5.1"
   changes:
     - description: Escape special characters in docs

--- a/packages/docker/data_stream/container/manifest.yml
+++ b/packages/docker/data_stream/container/manifest.yml
@@ -1,6 +1,5 @@
 type: metrics
 title: Docker container metrics
-release: beta
 streams:
   - input: docker/metrics
     vars:

--- a/packages/docker/data_stream/cpu/manifest.yml
+++ b/packages/docker/data_stream/cpu/manifest.yml
@@ -1,6 +1,5 @@
 type: metrics
 title: Docker cpu metrics
-release: beta
 streams:
   - input: docker/metrics
     vars:

--- a/packages/docker/data_stream/diskio/manifest.yml
+++ b/packages/docker/data_stream/diskio/manifest.yml
@@ -1,6 +1,5 @@
 type: metrics
 title: Docker diskio metrics
-release: beta
 streams:
   - input: docker/metrics
     vars:

--- a/packages/docker/data_stream/event/manifest.yml
+++ b/packages/docker/data_stream/event/manifest.yml
@@ -1,6 +1,5 @@
 type: metrics
 title: Docker event metrics
-release: beta
 streams:
   - input: docker/metrics
     vars:

--- a/packages/docker/data_stream/healthcheck/manifest.yml
+++ b/packages/docker/data_stream/healthcheck/manifest.yml
@@ -1,6 +1,5 @@
 type: metrics
 title: Docker healthcheck metrics
-release: beta
 streams:
   - input: docker/metrics
     vars:

--- a/packages/docker/data_stream/image/manifest.yml
+++ b/packages/docker/data_stream/image/manifest.yml
@@ -1,6 +1,5 @@
 type: metrics
 title: Docker image metrics
-release: beta
 streams:
   - input: docker/metrics
     enabled: false

--- a/packages/docker/data_stream/info/manifest.yml
+++ b/packages/docker/data_stream/info/manifest.yml
@@ -1,6 +1,5 @@
 type: metrics
 title: Docker info metrics
-release: beta
 streams:
   - input: docker/metrics
     vars:

--- a/packages/docker/data_stream/memory/manifest.yml
+++ b/packages/docker/data_stream/memory/manifest.yml
@@ -1,6 +1,5 @@
 type: metrics
 title: Docker memory metrics
-release: beta
 streams:
   - input: docker/metrics
     vars:

--- a/packages/docker/data_stream/network/manifest.yml
+++ b/packages/docker/data_stream/network/manifest.yml
@@ -1,6 +1,5 @@
 type: metrics
 title: Docker network metrics
-release: beta
 streams:
   - input: docker/metrics
     vars:

--- a/packages/docker/manifest.yml
+++ b/packages/docker/manifest.yml
@@ -1,7 +1,7 @@
 name: docker
 title: Docker
-version: 0.5.1
-release: beta
+version: 1.0.0
+release: ga
 description: This Elastic integration fetches metrics from Docker instances
 type: integration
 icons:


### PR DESCRIPTION
## What does this PR do?

Release Docker as GA. No breaking changes were introduced. Minimum stack version required: ^7.14

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.14.0`).

## Related issues
- Relates https://github.com/elastic/integrations/issues/1438

## Screenshots

![image](https://user-images.githubusercontent.com/4249331/131991075-52c0d3ca-dd66-46dc-8fd3-4c308a1b0f93.png)
