### PR TITLE
Osquery_manager: Update host.ip field mapping from keyword to ip data type

### DIFF
--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.2"
+  changes:
+    - description: Updates host.ip field mapping from keyword to ip data type
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "0.5.1"
   changes:
     - description: Updates mapping and readme for osquery 4.9.0

--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Updates host.ip field mapping from keyword to ip data type
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/1574
 - version: "0.5.1"
   changes:
     - description: Updates mapping and readme for osquery 4.9.0

--- a/packages/osquery_manager/data_stream/result/fields/ecs.yml
+++ b/packages/osquery_manager/data_stream/result/fields/ecs.yml
@@ -1,0 +1,4 @@
+- name: host.ip
+  type: ip
+  description: |
+    IP of the host.

--- a/packages/osquery_manager/data_stream/result/fields/ecs.yml
+++ b/packages/osquery_manager/data_stream/result/fields/ecs.yml
@@ -1,4 +1,4 @@
 - name: host.ip
   type: ip
-  description: |
+  description: |-
     IP of the host.

--- a/packages/osquery_manager/manifest.yml
+++ b/packages/osquery_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: osquery_manager
 title: Osquery Manager
-version: 0.5.1
+version: 0.5.2
 license: basic
 description: This Elastic integration lets you centrally manage osquery deployments, run live queries, and schedule recurring queries
 type: integration


### PR DESCRIPTION
## What does this PR do?

Updates host.ip field mapping from keyword to ip data type. Addresses https://discuss.elastic.co/t/osquery-manager-integration-mapping-ip-host-ip-as-keyword/283225

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Related issues

- Closes https://github.com/elastic/security-team/issues/1692

## Screenshots

Before the change:
<img width="437" alt="Screen Shot 2021-09-03 at 1 52 38 PM" src="https://user-images.githubusercontent.com/872351/132049568-279c2217-6523-4efe-beef-ddd2be439b83.png">

After the change:
<img width="547" alt="Screen Shot 2021-09-03 at 2 08 04 PM" src="https://user-images.githubusercontent.com/872351/132049620-10d5fb54-1969-47ab-8e03-497fc29cd3d3.png">


