### PR TITLE
Enable system tests for AWS EC2

### DIFF
--- a/packages/aws/data_stream/ec2_metrics/_dev/test/system/test-default-config.yml
+++ b/packages/aws/data_stream/ec2_metrics/_dev/test/system/test-default-config.yml
@@ -1,6 +1,3 @@
-skip:
-  reason: "Test fails"
-  link: https://github.com/elastic/integrations/issues/1566
 vars:
   access_key_id: '{{AWS_ACCESS_KEY_ID}}'
   secret_access_key: '{{AWS_SECRET_ACCESS_KEY}}'


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR enables back system tests for EC2. I suspect that it might be related with machines limit for the AWS account (killed all old machines).

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
~- [ ] I have added an entry to my package's `changelog.yml` file.~
~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- https://github.com/elastic/integrations/issues/1566