### PR TITLE
[Cisco] Deprecate Cisco package in favor of product specific packages

### DIFF
--- a/packages/cisco/changelog.yml
+++ b/packages/cisco/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.11.6"
+  changes:
+    - description: Deprecating Cisco package in favor of new product specific packages
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1541
 - version: "0.11.5"
   changes:
     - description: Requires version 7.14.1 of the stack

--- a/packages/cisco/changelog.yml
+++ b/packages/cisco/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Deprecating Cisco package in favor of new product specific packages
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1541
+      link: https://github.com/elastic/integrations/pull/1589
 - version: "0.11.5"
   changes:
     - description: Requires version 7.14.1 of the stack

--- a/packages/cisco/manifest.yml
+++ b/packages/cisco/manifest.yml
@@ -1,16 +1,16 @@
 format_version: 1.0.0
 name: cisco
-title: Cisco
-version: 0.11.5
+title: Cisco - Deprecated
+version: 0.11.6
 license: basic
-description: This Elastic integration collects logs from Cisco network devices
+description: "Cisco - Deprecated: Use the more specific Cisco packages available"
 type: integration
 categories:
   - network
   - security
 release: experimental
 conditions:
-  kibana.version: "^7.14.1"
+  kibana.version: "^7.16.0"
 screenshots:
   - src: /img/kibana-cisco-asa.png
     title: kibana cisco asa


### PR DESCRIPTION
## What does this PR do?

This simply marks the Cisco package deprecated in title and description, the users should switch to more product specific packages when possible:

https://github.com/elastic/integrations/pull/1582
https://github.com/elastic/integrations/pull/1583
https://github.com/elastic/integrations/pull/1586
https://github.com/elastic/integrations/pull/1587
https://github.com/elastic/integrations/pull/1588

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Related issues

- Relates #343 

