### PR TITLE
GA CEF integration

### DIFF
--- a/packages/cef/changelog.yml
+++ b/packages/cef/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0"
+  changes:
+    - description: make GA
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1604
 - version: "0.5.2"
   changes:
     - description: Convert to generated ECS fields

--- a/packages/cef/data_stream/log/manifest.yml
+++ b/packages/cef/data_stream/log/manifest.yml
@@ -1,6 +1,5 @@
 type: logs
 title: CEF log logs
-release: experimental
 streams:
   - input: logfile
     template_path: log.yml.hbs

--- a/packages/cef/manifest.yml
+++ b/packages/cef/manifest.yml
@@ -1,7 +1,7 @@
 name: cef
 title: CEF
-version: 0.5.2
-release: experimental
+version: 1.0.0
+release: ga
 description: This Elastic integration collects logs in common event format (CEF)
 type: integration
 format_version: 1.0.0
@@ -10,7 +10,7 @@ categories:
   - network
   - security
 conditions:
-  kibana.version: ^7.14.0
+  kibana.version: ^7.16.0
 policy_templates:
   - name: cef
     title: CEF logs


### PR DESCRIPTION
## What does this PR do?

GA CEF integration

- version number to 1.0.0
- release tag to ga
- kibana.version to 7.16.0

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
~~- [ ] I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## Related issues

- Relates #1562