### PR TITLE
Fix aws.billing.EstimatedCharges field name

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,6 +3,7 @@
   changes:
     - description: Fix aws.billing.EstimatedCharges field name
       type: bugfix
+      link: https://github.com/elastic/integrations/pull/1606
 - version: "0.10.5"
   changes:
     - description: Add event.created field

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,8 @@
 # newer versions go on top
+- version: "0.10.6"
+  changes:
+    - description: Fix aws.billing.EstimatedCharges field name
+      type: bugfix
 - version: "0.10.5"
   changes:
     - description: Add event.created field

--- a/packages/aws/data_stream/billing/fields/fields.yml
+++ b/packages/aws/data_stream/billing/fields/fields.yml
@@ -4,7 +4,7 @@
     - name: billing
       type: group
       fields:
-        - name: EstimatedCharges.max
+        - name: EstimatedCharges
           type: long
           description: Maximum estimated charges for AWS acccount.
         - name: Currency

--- a/packages/aws/data_stream/billing/sample_event.json
+++ b/packages/aws/data_stream/billing/sample_event.json
@@ -22,17 +22,29 @@
     },
     "aws": {
         "billing": {
-            "metrics": {
-                "EstimatedCharges": {
-                    "max": 1625.41
-                }
+            "Currency": "USD",
+            "EstimatedCharges": 39.26,
+            "ServiceName": "AmazonEKS",
+            "AmortizedCost": {
+                "amount": 51.6,
+                "unit": "USD"
+            },
+            "BlendedCost": {
+                "amount": 51.6,
+                "unit": "USD"
+            },
+            "NormalizedUsageAmount": {
+                "amount": 672,
+                "unit": "N/A"
+            },
+            "UnblendedCost": {
+                "amount": 51.6,
+                "unit": "USD"
+            },
+            "UsageQuantity": {
+                "amount": 168,
+                "unit": "N/A"
             }
-        },
-        "cloudwatch": {
-            "namespace": "AWS/Billing"
-        },
-        "dimensions": {
-            "Currency": "USD"
         }
     },
     "service": {

--- a/packages/aws/docs/billing.md
+++ b/packages/aws/docs/billing.md
@@ -29,17 +29,29 @@ An example event for `billing` looks as following:
     },
     "aws": {
         "billing": {
-            "metrics": {
-                "EstimatedCharges": {
-                    "max": 1625.41
-                }
+            "Currency": "USD",
+            "EstimatedCharges": 39.26,
+            "ServiceName": "AmazonEKS",
+            "AmortizedCost": {
+                "amount": 51.6,
+                "unit": "USD"
+            },
+            "BlendedCost": {
+                "amount": 51.6,
+                "unit": "USD"
+            },
+            "NormalizedUsageAmount": {
+                "amount": 672,
+                "unit": "N/A"
+            },
+            "UnblendedCost": {
+                "amount": 51.6,
+                "unit": "USD"
+            },
+            "UsageQuantity": {
+                "amount": 168,
+                "unit": "N/A"
             }
-        },
-        "cloudwatch": {
-            "namespace": "AWS/Billing"
-        },
-        "dimensions": {
-            "Currency": "USD"
         }
     },
     "service": {
@@ -66,7 +78,7 @@ An example event for `billing` looks as following:
 | aws.billing.BlendedCost.amount | Blended cost amount. | double |
 | aws.billing.BlendedCost.unit | Blended cost unit. | keyword |
 | aws.billing.Currency | Currency name. | keyword |
-| aws.billing.EstimatedCharges.max | Maximum estimated charges for AWS acccount. | long |
+| aws.billing.EstimatedCharges | Maximum estimated charges for AWS acccount. | long |
 | aws.billing.NormalizedUsageAmount.amount | Normalized usage amount. | double |
 | aws.billing.NormalizedUsageAmount.unit | Normalized usage amount unit. | keyword |
 | aws.billing.ServiceName | AWS service name. | keyword |

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 0.10.5
+version: 0.10.6
 license: basic
 description: This integration collects logs and metrics from Amazon Web Services (AWS)
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
 
This PR is to fix the `aws.billing.EstimatedCharges` field name.

closes: https://github.com/elastic/integrations/issues/1592
