### PR TITLE
GA Cloudflare integration

### DIFF
--- a/packages/cloudflare/changelog.yml
+++ b/packages/cloudflare/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0"
+  changes:
+    - description: make GA
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1628
 - version: "0.2.0"
   changes:
     - description: Update to ECS 1.12.0

--- a/packages/cloudflare/data_stream/logpull/manifest.yml
+++ b/packages/cloudflare/data_stream/logpull/manifest.yml
@@ -1,6 +1,5 @@
 type: logs
 title: Cloudflare Logpull
-release: experimental
 streams:
   - input: httpjson
     vars:

--- a/packages/cloudflare/manifest.yml
+++ b/packages/cloudflare/manifest.yml
@@ -1,14 +1,14 @@
 name: cloudflare
 title: Cloudflare
-version: 0.2.0
-release: experimental
+version: 1.0.0
+release: ga
 description: Cloudflare Integration
 type: integration
 format_version: 1.0.0
 license: basic
 categories: [security, network, web]
 conditions:
-  kibana.version: "^7.15"
+  kibana.version: "^7.16.0"
 icons:
   - src: /img/cf-logo-v.svg
     title: Cloudflare


### PR DESCRIPTION
## What does this PR do?

GA Cloudflare integration

- version number to 1.0.0
- release tag to ga
- kibana.version to 7.16.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
~~- [ ] I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~

## Related issues

- Relates #1562