### PR TITLE
GA crowdstrike integration

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '1.0.0'
+  changes:
+    - description: make GA
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1630
 - version: "0.9.0"
   changes:
     - description: Update to ECS 1.12.0

--- a/packages/crowdstrike/data_stream/falcon/manifest.yml
+++ b/packages/crowdstrike/data_stream/falcon/manifest.yml
@@ -1,6 +1,5 @@
 type: logs
 title: Crowdstrike falcon logs
-release: experimental
 streams:
   - input: logfile
     vars:

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,14 +1,14 @@
 name: crowdstrike
 title: CrowdStrike
-version: 0.9.0
+version: 1.0.0
 description: This Elastic integration collects logs from CrowdStrike products
 type: integration
 format_version: 1.0.0
 license: basic
 categories: [security]
-release: experimental
+release: ga
 conditions:
-  kibana.version: "^7.15.0"
+  kibana.version: "^7.16.0"
 icons:
   - src: /img/logo-integrations-crowdstrike.svg
     title: CrowdStrike


### PR DESCRIPTION
## What does this PR do?

GA crowdstrike integration

- version to 1.0.0
- release to ga
- remove release from falcon data_stream manifest
- kibana version to 7.16.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
~~- [ ] I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~

## Related issues

- Relates #1562