### PR TITLE
GA cyperarkpas integration

### DIFF
--- a/packages/cyberarkpas/changelog.yml
+++ b/packages/cyberarkpas/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.0.0"
+  changes:
+    - description: make GA
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1631
 - version: "1.2.3"
   changes:
     - description: Convert to generated ECS fields

--- a/packages/cyberarkpas/data_stream/audit/manifest.yml
+++ b/packages/cyberarkpas/data_stream/audit/manifest.yml
@@ -1,6 +1,5 @@
 type: logs
 title: CyberArk PAS audit logs
-release: beta
 streams:
   - input: logfile
     enabled: false

--- a/packages/cyberarkpas/manifest.yml
+++ b/packages/cyberarkpas/manifest.yml
@@ -1,14 +1,14 @@
 name: cyberarkpas
 title: CyberArk Privileged Access Security
-version: 1.2.3
-release: beta
+version: 2.0.0
+release: ga
 description: This Elastic integration collects logs from CyberArk
 type: integration
 format_version: 1.0.0
 license: basic
 categories: ["security"]
 conditions:
-  kibana.version: ^7.14.0
+  kibana.version: ^7.16.0
 screenshots:
   - src: /img/filebeat-cyberarkpas-overview.png
     title: filebeat cyberarkpas overview


### PR DESCRIPTION
## What does this PR do?

GA cyperarkpas integration

- version 2.0.0
- release to ga
- remove release from audit data_stream manifest
- kibana version to 7.16.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
~~- [ ] I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~

## Related issues

- Relates #1562