### PR TITLE
0365 Add type assertions to painless scripts

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.4"
+  changes:
+    - description: additional type assertions in painless scripts
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1642
 - version: "1.1.3"
   changes:
     - description: Convert to generated ECS fields

--- a/packages/o365/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/o365/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -189,7 +189,7 @@ processors:
         def list = ctx.o365audit.AlertLinks;
         def links = new ArrayList();
         for (int i = 0; i < list.length; ++i) {
-          if (list[i].containsKey("AlertLinkHref") && list[i]["AlertLinkHref"] != null && list[i]["AlertLinkHref"] instanceof String) {
+          if (list[i] instanceof Map && list[i].containsKey("AlertLinkHref") && list[i]["AlertLinkHref"] != null && list[i]["AlertLinkHref"] instanceof String) {
             links.add(list[i]["AlertLinkHref"]);
           }
         }
@@ -541,7 +541,7 @@ processors:
         }
         ctx.destination.user.email = new ArrayList();
         for (int i = 0; i < fields.length; ++i) {
-          if (ctx.o365audit.ExchangeMetaData.containsKey(fields[i])) {
+          if (ctx.o365audit.ExchangeMetaData instanceof Map && ctx.o365audit.ExchangeMetaData.containsKey(fields[i])) {
             def emails = ctx.o365audit.ExchangeMetaData[fields[i]];
             if (emails instanceof List){
               for (int e = 0; e < emails.length; ++e) {
@@ -592,7 +592,7 @@ processors:
         }
         def maxSeverity = 0;
         def allowed = true;
-        for (int i = 0; i < policies.length; ++i) {
+        for (int i = 0; i < policies.length && policies instanceof List; ++i) {
           def rules = policies[i].Rules;
           if (rules == null) {
             continue;
@@ -770,7 +770,7 @@ processors:
       if: 'ctx.event?.code == "MicrosoftTeams" && ctx.event?.action == "deleted-user-account"'
   - script:
       lang: painless
-      if: 'ctx.event?.code == "MicrosoftTeams" && ctx.o365audit?.Members != null'
+      if: 'ctx.event?.code == "MicrosoftTeams" && ctx.o365audit?.Members != null && ctx.o365audit.Members instanceof List'
       source: >
         def members = ctx.o365audit?.Members;
         if (ctx.related == null) {
@@ -780,7 +780,7 @@ processors:
           ctx.related.user = new ArrayList();
         }
         for (int i = 0; i < members.length; ++i) {
-          if (members[i].containsKey("UPN") && !members[i]["UPN"].isEmpty()) {
+          if (members[i] instanceof Map && members[i].containsKey("UPN") && !members[i]["UPN"].isEmpty()) {
             ctx.related.user.add(members[i]["UPN"]);
           }
         }
@@ -808,7 +808,7 @@ processors:
       if: 'ctx.client?._temp != null && !ctx.client?._temp.isEmpty()'
   - gsub:
       field: server._temp
-      pattern: "\n"
+      pattern: "[\n\r]"
       replacement: ""
       ignore_missing: true
   - grok:
@@ -955,7 +955,7 @@ processors:
       source: >
         def conftenants = ctx._conf.tenants;
         def orgid = ctx.organization.id;
-        if (conftenants.containsKey(orgid)) {
+        if (conftenants instanceof Map && conftenants.containsKey(orgid)) {
           ctx.organization.name = conftenants[orgid];
           ctx.host.name = conftenants[orgid];
         }

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Office 365
-version: 1.1.3
+version: 1.1.4
 release: ga
 description: This Elastic integration collects events from Microsoft Office 365
 type: integration


### PR DESCRIPTION
## What does this PR do?

- Adds type assertion of Map when containsKey() is used
- Adds type assertion of List when accessing as array

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## How to test this PR locally

`elastic-package test`