### PR TITLE
Add Proxy configs for httpjson, aws-s3 inputs and AWS metric sets

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.10.7"
+  changes:
+    - description: Add proxy config
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1648
 - version: "0.10.6"
   changes:
     - description: Fix aws.billing.EstimatedCharges field name

--- a/packages/aws/data_stream/billing/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/billing/agent/stream/stream.yml.hbs
@@ -33,3 +33,6 @@ cost_explorer_config.group_by_tag_keys:
 - {{tag_key}}
 {{/each}}
 {{/if}}
+{{#if proxy_url }}
+proxy_url: {{proxy_url}}
+{{/if}}

--- a/packages/aws/data_stream/cloudtrail/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/cloudtrail/agent/stream/aws-s3.yml.hbs
@@ -42,6 +42,9 @@ role_arn: {{role_arn}}
 {{#if fips_enabled}}
 fips_enabled: {{fips_enabled}}
 {{/if}}
+{{#if proxy_url }}
+proxy_url: {{proxy_url}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/aws/data_stream/cloudwatch_logs/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/cloudwatch_logs/agent/stream/aws-s3.yml.hbs
@@ -29,6 +29,9 @@ role_arn: {{role_arn}}
 {{#if fips_enabled}}
 fips_enabled: {{fips_enabled}}
 {{/if}}
+{{#if proxy_url }}
+proxy_url: {{proxy_url}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/aws/data_stream/cloudwatch_metrics/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/cloudwatch_metrics/agent/stream/stream.yml.hbs
@@ -30,3 +30,6 @@ latency: {{latency}}
 {{#if metrics}}
 metrics: {{metrics}}
 {{/if}}
+{{#if proxy_url }}
+proxy_url: {{proxy_url}}
+{{/if}}

--- a/packages/aws/data_stream/dynamodb/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/dynamodb/agent/stream/stream.yml.hbs
@@ -30,3 +30,6 @@ latency: {{latency}}
 {{#if tags_filter}}
 tags_filter: {{tags_filter}}
 {{/if}}
+{{#if proxy_url }}
+proxy_url: {{proxy_url}}
+{{/if}}

--- a/packages/aws/data_stream/ebs/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/ebs/agent/stream/stream.yml.hbs
@@ -30,3 +30,6 @@ latency: {{latency}}
 {{#if tags_filter}}
 tags_filter: {{tags_filter}}
 {{/if}}
+{{#if proxy_url }}
+proxy_url: {{proxy_url}}
+{{/if}}

--- a/packages/aws/data_stream/ec2_logs/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/ec2_logs/agent/stream/aws-s3.yml.hbs
@@ -29,6 +29,9 @@ role_arn: {{role_arn}}
 {{#if fips_enabled}}
 fips_enabled: {{fips_enabled}}
 {{/if}}
+{{#if proxy_url }}
+proxy_url: {{proxy_url}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/aws/data_stream/ec2_metrics/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/ec2_metrics/agent/stream/stream.yml.hbs
@@ -30,3 +30,6 @@ latency: {{latency}}
 {{#if tags_filter}}
 tags_filter: {{tags_filter}}
 {{/if}}
+{{#if proxy_url }}
+proxy_url: {{proxy_url}}
+{{/if}}

--- a/packages/aws/data_stream/elb_logs/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/elb_logs/agent/stream/aws-s3.yml.hbs
@@ -29,6 +29,9 @@ role_arn: {{role_arn}}
 {{#if fips_enabled}}
 fips_enabled: {{fips_enabled}}
 {{/if}}
+{{#if proxy_url }}
+proxy_url: {{proxy_url}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/aws/data_stream/elb_metrics/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/elb_metrics/agent/stream/stream.yml.hbs
@@ -30,3 +30,6 @@ latency: {{latency}}
 {{#if tags_filter}}
 tags_filter: {{tags_filter}}
 {{/if}}
+{{#if proxy_url }}
+proxy_url: {{proxy_url}}
+{{/if}}

--- a/packages/aws/data_stream/lambda/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/lambda/agent/stream/stream.yml.hbs
@@ -30,3 +30,6 @@ latency: {{latency}}
 {{#if tags_filter}}
 tags_filter: {{tags_filter}}
 {{/if}}
+{{#if proxy_url }}
+proxy_url: {{proxy_url}}
+{{/if}}

--- a/packages/aws/data_stream/natgateway/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/natgateway/agent/stream/stream.yml.hbs
@@ -30,3 +30,6 @@ latency: {{latency}}
 {{#if tags_filter}}
 tags_filter: {{tags_filter}}
 {{/if}}
+{{#if proxy_url }}
+proxy_url: {{proxy_url}}
+{{/if}}

--- a/packages/aws/data_stream/rds/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/rds/agent/stream/stream.yml.hbs
@@ -30,3 +30,6 @@ latency: {{latency}}
 {{#if tags_filter}}
 tags_filter: {{tags_filter}}
 {{/if}}
+{{#if proxy_url }}
+proxy_url: {{proxy_url}}
+{{/if}}

--- a/packages/aws/data_stream/s3_daily_storage/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/s3_daily_storage/agent/stream/stream.yml.hbs
@@ -27,3 +27,6 @@ regions:
 {{#if latency}}
 latency: {{latency}}
 {{/if}}
+{{#if proxy_url }}
+proxy_url: {{proxy_url}}
+{{/if}}

--- a/packages/aws/data_stream/s3_request/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/s3_request/agent/stream/stream.yml.hbs
@@ -27,3 +27,6 @@ regions:
 {{#if latency}}
 latency: {{latency}}
 {{/if}}
+{{#if proxy_url }}
+proxy_url: {{proxy_url}}
+{{/if}}

--- a/packages/aws/data_stream/s3access/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/s3access/agent/stream/aws-s3.yml.hbs
@@ -29,6 +29,9 @@ role_arn: {{role_arn}}
 {{#if fips_enabled}}
 fips_enabled: {{fips_enabled}}
 {{/if}}
+{{#if proxy_url }}
+proxy_url: {{proxy_url}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/aws/data_stream/sns/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/sns/agent/stream/stream.yml.hbs
@@ -30,3 +30,6 @@ latency: {{latency}}
 {{#if tags_filter}}
 tags_filter: {{tags_filter}}
 {{/if}}
+{{#if proxy_url }}
+proxy_url: {{proxy_url}}
+{{/if}}

--- a/packages/aws/data_stream/sqs/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/sqs/agent/stream/stream.yml.hbs
@@ -27,3 +27,6 @@ regions:
 {{#if latency}}
 latency: {{latency}}
 {{/if}}
+{{#if proxy_url }}
+proxy_url: {{proxy_url}}
+{{/if}}

--- a/packages/aws/data_stream/transitgateway/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/transitgateway/agent/stream/stream.yml.hbs
@@ -30,3 +30,6 @@ latency: {{latency}}
 {{#if tags_filter}}
 tags_filter: {{tags_filter}}
 {{/if}}
+{{#if proxy_url }}
+proxy_url: {{proxy_url}}
+{{/if}}

--- a/packages/aws/data_stream/usage/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/usage/agent/stream/stream.yml.hbs
@@ -30,3 +30,6 @@ latency: {{latency}}
 {{#if tags_filter}}
 tags_filter: {{tags_filter}}
 {{/if}}
+{{#if proxy_url }}
+proxy_url: {{proxy_url}}
+{{/if}}

--- a/packages/aws/data_stream/vpcflow/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/vpcflow/agent/stream/aws-s3.yml.hbs
@@ -29,6 +29,9 @@ role_arn: {{role_arn}}
 {{#if fips_enabled}}
 fips_enabled: {{fips_enabled}}
 {{/if}}
+{{#if proxy_url }}
+proxy_url: {{proxy_url}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/aws/data_stream/vpn/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/vpn/agent/stream/stream.yml.hbs
@@ -30,3 +30,6 @@ latency: {{latency}}
 {{#if tags_filter}}
 tags_filter: {{tags_filter}}
 {{/if}}
+{{#if proxy_url }}
+proxy_url: {{proxy_url}}
+{{/if}}

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 0.10.6
+version: 0.10.7
 license: basic
 description: This integration collects logs and metrics from Amazon Web Services (AWS)
 type: integration
@@ -67,6 +67,13 @@ vars:
     show_user: false
     default: "amazonaws.com"
     description: URL of the entry point for an AWS web service
+  - name: proxy_url
+    type: text
+    title: Proxy URL
+    multi: false
+    required: false
+    show_user: false
+    description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port> 
 policy_templates:
   - name: billing
     title: AWS Billing

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -73,7 +73,7 @@ vars:
     multi: false
     required: false
     show_user: false
-    description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port> 
+    description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port>
 policy_templates:
   - name: billing
     title: AWS Billing

--- a/packages/cloudflare/changelog.yml
+++ b/packages/cloudflare/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Add proxy config
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1648
 - version: "0.1.0"
   changes:
     - description: initial release

--- a/packages/cloudflare/data_stream/logpull/agent/stream/httpjson.yml.hbs
+++ b/packages/cloudflare/data_stream/logpull/agent/stream/httpjson.yml.hbs
@@ -8,6 +8,9 @@ request.ssl: {{ssl}}
 {{#if http_client_timeout}}
 request.timeout: {{http_client_timeout}}
 {{/if}}
+{{#if proxy_url }}
+request.proxy_url: {{proxy_url}}
+{{/if}}
 
 request.transforms:
 {{#if auth_token}}

--- a/packages/cloudflare/data_stream/logpull/manifest.yml
+++ b/packages/cloudflare/data_stream/logpull/manifest.yml
@@ -60,6 +60,13 @@ streams:
         multi: false
         required: false
         show_user: false
+      - name: proxy_url
+        type: text
+        title: Proxy URL
+        multi: false
+        required: false
+        show_user: false
+        description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port> 
       - name: tags
         type: text
         title: Tags

--- a/packages/cloudflare/data_stream/logpull/manifest.yml
+++ b/packages/cloudflare/data_stream/logpull/manifest.yml
@@ -66,7 +66,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port> 
+        description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port>
       - name: tags
         type: text
         title: Tags

--- a/packages/cloudflare/manifest.yml
+++ b/packages/cloudflare/manifest.yml
@@ -1,6 +1,6 @@
 name: cloudflare
 title: Cloudflare
-version: 0.1.0
+version: 0.1.1
 release: experimental
 description: Cloudflare Integration
 type: integration

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.8.1"
+  changes:
+    - description: Add proxy config
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1648
 - version: "0.8.0"
   changes:
     - description: Add FDR data stream.

--- a/packages/crowdstrike/data_stream/fdr/agent/stream/aws-s3.yml.hbs
+++ b/packages/crowdstrike/data_stream/fdr/agent/stream/aws-s3.yml.hbs
@@ -29,6 +29,9 @@ role_arn: {{role_arn}}
 {{#if fips_enabled}}
 fips_enabled: {{fips_enabled}}
 {{/if}}
+{{#if proxy_url }}
+proxy_url: {{proxy_url}}
+{{/if}}
 {{#if tags.length}}
 tags:
 {{else}}

--- a/packages/crowdstrike/data_stream/fdr/manifest.yml
+++ b/packages/crowdstrike/data_stream/fdr/manifest.yml
@@ -80,6 +80,13 @@ streams:
         required: false
         show_user: false
         description: Enabling this option changes the service name from `s3` to `s3-fips` for connecting to the correct service endpoint.
+      - name: proxy_url
+        type: text
+        title: Proxy URL
+        multi: false
+        required: false
+        show_user: false
+        description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port> 
       - name: tags
         type: text
         title: Tags

--- a/packages/crowdstrike/data_stream/fdr/manifest.yml
+++ b/packages/crowdstrike/data_stream/fdr/manifest.yml
@@ -86,7 +86,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port> 
+        description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port>
       - name: tags
         type: text
         title: Tags

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: 0.8.0
+version: 0.8.1
 description: This Elastic integration collects logs from CrowdStrike products
 type: integration
 format_version: 1.0.0

--- a/packages/microsoft/changelog.yml
+++ b/packages/microsoft/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.7.5"
+  changes:
+    - description: Add proxy config
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1648
 - version: "0.7.4"
   changes:
     - description: Requires version 7.14.1 of the stack

--- a/packages/microsoft/data_stream/defender_atp/agent/stream/httpjson.yml.hbs
+++ b/packages/microsoft/data_stream/defender_atp/agent/stream/httpjson.yml.hbs
@@ -7,6 +7,9 @@ auth.oauth2.provider: azure
 auth.oauth2.azure.resource: https://api.securitycenter.windows.com/
 request.url: "https://api.securitycenter.windows.com/api/alerts"
 request.method: GET
+{{#if proxy_url }}
+request.proxy_url: {{proxy_url}}
+{{/if}}
 request.transforms:
   - set:
       target: "header.User-Agent"

--- a/packages/microsoft/data_stream/defender_atp/manifest.yml
+++ b/packages/microsoft/data_stream/defender_atp/manifest.yml
@@ -33,6 +33,13 @@ streams:
         show_user: true
         default: 5m
         description: The interval between requests to the HTTP API.
+      - name: proxy_url
+        type: text
+        title: Proxy URL
+        multi: false
+        required: false
+        show_user: false
+        description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port> 
       - name: tags
         type: text
         title: Tags

--- a/packages/microsoft/data_stream/defender_atp/manifest.yml
+++ b/packages/microsoft/data_stream/defender_atp/manifest.yml
@@ -39,7 +39,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port> 
+        description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port>
       - name: tags
         type: text
         title: Tags

--- a/packages/microsoft/manifest.yml
+++ b/packages/microsoft/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft
 title: Microsoft
-version: 0.7.4
+version: 0.7.5
 description: This Elastic integration collects logs from Microsoft products
 categories:
   - "network"

--- a/packages/okta/changelog.yml
+++ b/packages/okta/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.3"
+  changes:
+    - description: Add proxy config
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1648
 - version: "1.1.2"
   changes:
     - description: Convert to generated ECS fields

--- a/packages/okta/data_stream/system/agent/stream/httpjson.yml.hbs
+++ b/packages/okta/data_stream/system/agent/stream/httpjson.yml.hbs
@@ -11,6 +11,9 @@ request.ssl: {{ssl}}
 {{#if http_client_timeout}}
 request.timeout: {{http_client_timeout}}
 {{/if}}
+{{#if proxy_url }}
+request.proxy_url: {{proxy_url}}
+{{/if}}
 
 request.rate_limit:
   limit: '[[.last_response.header.Get "X-Rate-Limit-Limit"]]'

--- a/packages/okta/manifest.yml
+++ b/packages/okta/manifest.yml
@@ -69,8 +69,8 @@ policy_templates:
             title: Proxy URL
             multi: false
             required: false
-            show_user: 
-            description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port> 
+            show_user: false
+            description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port>
         title: "Collect Okta logs via API"
         description: "Collecting logs from Okta via API"
 owner:

--- a/packages/okta/manifest.yml
+++ b/packages/okta/manifest.yml
@@ -1,6 +1,6 @@
 name: okta
 title: Okta
-version: 1.1.2
+version: 1.1.3
 release: ga
 description: This Elastic integration collects events from Okta
 type: integration
@@ -64,6 +64,13 @@ policy_templates:
             multi: false
             required: false
             show_user: true
+          - name: proxy_url
+            type: text
+            title: Proxy URL
+            multi: false
+            required: false
+            show_user: 
+            description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port> 
         title: "Collect Okta logs via API"
         description: "Collecting logs from Okta via API"
 owner:


### PR DESCRIPTION
## What does this PR do?

Add Proxy config option for packages with the httpjson, aws-s3 inputs and AWS metric sets

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Author's Checklist

- [ ]

## How to test this PR locally


## Related issues

- #1647 

## Screenshots
![image](https://user-images.githubusercontent.com/13125104/133010283-42fdde5a-3161-4c1d-8a93-3363ceed7c91.png)
