### PR TITLE
Osquery_manager: Update integration manifest to allow free-form osquery configuration, limit to one integration

### DIFF
--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.0"
+  changes:
+    - description: Change the package to adopt the native osquery configuration better.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1715
 - version: "0.5.3"
   changes:
     - description: Updates readme and adds link to Kibana docs

--- a/packages/osquery_manager/manifest.yml
+++ b/packages/osquery_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: osquery_manager
 title: Osquery Manager
-version: 0.5.3
+version: 0.6.0
 license: basic
 description: This Elastic integration lets you centrally manage osquery deployments, run live queries, and schedule recurring queries
 type: integration
@@ -11,7 +11,7 @@ categories:
   - os_system
   - config_management
 conditions:
-  kibana.version: '^7.15.0'
+  kibana.version: '^7.16.0'
 icons:
   - src: /img/logo_osquery.svg
     title: logo osquery
@@ -21,9 +21,6 @@ policy_templates:
   - name: osquery_manager
     title: Osquery Manager
     description: Send interactive or scheduled queries to the osquery instances executed by the elastic-agent.
-    inputs:
-      - type: osquery
-        title: Send queries to osquery instances
-        description: Send interactive or scheduled queries to the osquery instances executed by the elastic-agent.
+    multiple: false
 owner:
   github: elastic/integrations


### PR DESCRIPTION
## What does this PR do?

Update integration manifest to allow free-form osquery configuration, limit to one integration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## How to test this PR locally

Example of the new configuration payload, specifically the ```streams``` array is empty and the osquery configuration is under ```config``` ```osquery``` ```value``` property on updating the configuration:
```
{
    "name": "osquery_manager-1",
    "description": "",
    "policy_id": "dc5c1ad0-0b47-11ec-9743-91c25b5c7a9b",
    "namespace": "default",
    "inputs": [
        {
            "type": "osquery",
            "enabled": true,
            "streams": [],
            "policy_template": "osquery_manager",
            "config": {
                "osquery": {
                    "value": {
                        "schedule": {
                            "macos_uptime": {
                                "query": "SELECT * FROM uptime",
                                "interval": 60
                            }
                        },
                        "options": {
                            "disable_tables": "users"
                        },
                        "packs": {
                            "internal_stuff": {
                                "queries": {
                                    "users": {
                                        "query": "SELECT * FROM users limit 5",
                                        "interval": 90
                                    }
                                }
                            }
                        }
                    }
                }
            }
        }
    ],
    "enabled": true,
    "output_id": "",
    "package": {
        "name": "osquery_manager",
        "title": "Osquery Manager",
        "version": "0.5.2"
    }
}
```

## Related issues

The osquerybeat change PR in order to support the new configuration format
- Relates https://github.com/elastic/beats/pull/27900


