### PR TITLE
GA winlog integration

### DIFF
--- a/packages/winlog/_dev/build/build.yml
+++ b/packages/winlog/_dev/build/build.yml
@@ -1,0 +1,3 @@
+dependencies:
+  ecs:
+    reference: git@1.11

--- a/packages/winlog/_dev/deploy/docker/docker-compose.yml
+++ b/packages/winlog/_dev/deploy/docker/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '2.3'
+services:
+  splunk-mock:
+    image: docker.elastic.co/observability/stream:v0.5.0
+    ports:
+      - 8080
+    volumes:
+      - ./http-mock-config.yml:/config.yml
+    environment:
+      PORT: 8080
+    command:
+      - http-server
+      - --addr=:8080
+      - --config=/config.yml

--- a/packages/winlog/_dev/deploy/docker/http-mock-config.yml
+++ b/packages/winlog/_dev/deploy/docker/http-mock-config.yml
@@ -1,0 +1,21 @@
+rules:
+  - path: /services/search/jobs/export
+    user: test
+    password: test
+    methods:
+      - POST
+    query_params:
+      index_earliest: "{index_earliest:[0-9]+}"
+      index_latest: "{index_latest:[0-9]+}"
+      output_mode: json
+      search: 'search sourcetype="XmlWinEventLog:ChannelName" | streamstats max(_indextime) AS max_indextime'
+    request_headers:
+      Content-Type:
+        - "application/x-www-form-urlencoded"
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"preview":false,"offset":0,"result":{"_bkt":"main~1~EA9FB697-F3E3-47FD-BC1C-F3BD8B764D6E","_cd":"1:40398","_indextime":"1631280904","_raw":"<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Service Control Manager' Guid='{555908d1-a6d7-4695-8e1e-26931d2012f4}' EventSourceName='Service Control Manager'/><EventID Qualifiers='16384'>7036<\/EventID><Version>0<\/Version><Level>4<\/Level><Task>0<\/Task><Opcode>0<\/Opcode><Keywords>0x8080000000000000<\/Keywords><TimeCreated SystemTime='2021-09-10T13:35:03.573766300Z'/><EventRecordID>5700<\/EventRecordID><Correlation/><Execution ProcessID='688' ThreadID='5452'/><Channel>System<\/Channel><Computer>vagrant<\/Computer><Security/><\/System><EventData><Data Name='param1'>Software Protection<\/Data><Data Name='param2'>stopped<\/Data><Binary>7300700070007300760063002F0031000000<\/Binary><\/EventData><\/Event>","_serial":"0","_si":["2485e2d68f96","main"],"_sourcetype":"XmlWinEventLog:System","_time":"2021-09-10 13:35:03.000 UTC","host":"VAGRANT","index":"main","last_indextime":"1631282356","linecount":"1","max_indextime":"1631280904","source":"WinEventLog:System","sourcetype":"XmlWinEventLog:System","splunk_server":"2485e2d68f96"}}

--- a/packages/winlog/changelog.yml
+++ b/packages/winlog/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0"
+  changes:
+    - description: make GA
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1716
 - version: "0.4.0"
   changes:
     - description: Update integration description

--- a/packages/winlog/data_stream/winlog/_dev/test/system/test-splunk-config.yml
+++ b/packages/winlog/data_stream/winlog/_dev/test/system/test-splunk-config.yml
@@ -1,0 +1,8 @@
+input: httpjson
+service: splunk-mock
+vars:
+  url: http://{{Hostname}}:{{Port}}
+  username: test
+  password: test
+numeric_keyword_fields:
+  - winlog.record_id

--- a/packages/winlog/data_stream/winlog/fields/beats.yml
+++ b/packages/winlog/data_stream/winlog/fields/beats.yml
@@ -1,0 +1,6 @@
+- name: input.type
+  description: Type of Filebeat input.
+  type: keyword
+- name: tags
+  type: keyword
+  description: User defined tags

--- a/packages/winlog/data_stream/winlog/fields/ecs.yml
+++ b/packages/winlog/data_stream/winlog/fields/ecs.yml
@@ -1,0 +1,4 @@
+- name: ecs.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/winlog/data_stream/winlog/fields/winlog.yml
+++ b/packages/winlog/data_stream/winlog/fields/winlog.yml
@@ -18,12 +18,30 @@
       description: >
         A globally unique identifier that identifies the current activity. The events that are published with this identifier are part of the same activity.
 
+    - name: channel
+      type: keyword
+      required: true
+      description: >
+        The name of the channel from which this record was read. This value is one of the names from the `event_logs` collection in the configuration.
+
     - name: computer_name
       type: keyword
       required: true
       description: >
         The name of the computer that generated the record. When using Windows event forwarding, this name can differ from `agent.hostname`.
 
+    - name: computerObject
+      type: group
+      description: >
+        computer Object data
+
+      fields:
+        - name: domain
+          type: keyword
+        - name: id
+          type: keyword
+        - name: name
+          type: keyword
     - name: event_data
       type: object
       object_type: keyword
@@ -37,6 +55,24 @@
         This is a non-exhaustive list of parameters that are used in Windows events. By having these fields defined in the template they can be used in dashboards and machine-learning jobs.
 
       fields:
+        - name: AccessGranted
+          type: keyword
+        - name: AccessRemoved
+          type: keyword
+        - name: AccountDomain
+          type: keyword
+        - name: AccountExpires
+          type: keyword
+        - name: AccountName
+          type: keyword
+        - name: AllowedToDelegateTo
+          type: keyword
+        - name: AuditPolicyChanges
+          type: keyword
+        - name: AuditPolicyChangesDescription
+          type: keyword
+        - name: AuditSourceName
+          type: keyword
         - name: AuthenticationPackageName
           type: keyword
         - name: Binary
@@ -49,9 +85,25 @@
           type: keyword
         - name: BuildVersion
           type: keyword
+        - name: CallerProcessId
+          type: keyword
+        - name: CallerProcessName
+          type: keyword
+        - name: Category
+          type: keyword
+        - name: CategoryId
+          type: keyword
+        - name: ClientAddress
+          type: keyword
+        - name: ClientName
+          type: keyword
+        - name: CommandLine
+          type: keyword
         - name: Company
           type: keyword
         - name: CorruptionActionState
+          type: keyword
+        - name: CrashOnAuditFailValue
           type: keyword
         - name: CreationUtcTime
           type: keyword
@@ -69,15 +121,29 @@
           type: keyword
         - name: DeviceVersionMinor
           type: keyword
+        - name: DisplayName
+          type: keyword
+        - name: DomainBehaviorVersion
+          type: keyword
+        - name: DomainName
+          type: keyword
+        - name: DomainPolicyChanged
+          type: keyword
+        - name: DomainSid
+          type: keyword
         - name: DriveName
           type: keyword
         - name: DriverName
           type: keyword
         - name: DriverNameLength
           type: keyword
+        - name: Dummy
+          type: keyword
         - name: DwordVal
           type: keyword
         - name: EntryCount
+          type: keyword
+        - name: EventSourceId
           type: keyword
         - name: ExtraInfo
           type: keyword
@@ -85,11 +151,21 @@
           type: keyword
         - name: FailureNameLength
           type: keyword
+        - name: FailureReason
+          type: keyword
         - name: FileVersion
           type: keyword
         - name: FinalStatus
           type: keyword
         - name: Group
+          type: keyword
+        - name: GroupTypeChange
+          type: keyword
+        - name: HandleId
+          type: keyword
+        - name: HomeDirectory
+          type: keyword
+        - name: HomePath
           type: keyword
         - name: IdleImplementation
           type: keyword
@@ -103,6 +179,8 @@
           type: keyword
         - name: IpPort
           type: keyword
+        - name: KerberosPolicyChange
+          type: keyword
         - name: KeyLength
           type: keyword
         - name: LastBootGood
@@ -113,13 +191,21 @@
           type: keyword
         - name: LogonGuid
           type: keyword
+        - name: LogonHours
+          type: keyword
         - name: LogonId
+          type: keyword
+        - name: LogonID
           type: keyword
         - name: LogonProcessName
           type: keyword
         - name: LogonType
           type: keyword
+        - name: MachineAccountQuota
+          type: keyword
         - name: MajorVersion
+          type: keyword
+        - name: MandatoryLabel
           type: keyword
         - name: MaximumPerformancePercent
           type: keyword
@@ -133,31 +219,91 @@
           type: keyword
         - name: MinorVersion
           type: keyword
+        - name: MixedDomainMode
+          type: keyword
         - name: NewProcessId
           type: keyword
         - name: NewProcessName
           type: keyword
         - name: NewSchemeGuid
           type: keyword
+        - name: NewSd
+          type: keyword
+        - name: NewSdDacl0
+          type: keyword
+        - name: NewSdDacl1
+          type: keyword
+        - name: NewSdDacl2
+          type: keyword
+        - name: NewSdSacl0
+          type: keyword
+        - name: NewSdSacl1
+          type: keyword
+        - name: NewSdSacl2
+          type: keyword
+        - name: NewTargetUserName
+          type: keyword
         - name: NewTime
+          type: keyword
+        - name: NewUACList
+          type: keyword
+        - name: NewUacValue
           type: keyword
         - name: NominalFrequency
           type: keyword
         - name: Number
           type: keyword
+        - name: ObjectName
+          type: keyword
+        - name: ObjectServer
+          type: keyword
+        - name: ObjectType
+          type: keyword
+        - name: OemInformation
+          type: keyword
         - name: OldSchemeGuid
+          type: keyword
+        - name: OldSd
+          type: keyword
+        - name: OldSdDacl0
+          type: keyword
+        - name: OldSdDacl1
+          type: keyword
+        - name: OldSdDacl2
+          type: keyword
+        - name: OldSdSacl0
+          type: keyword
+        - name: OldSdSacl1
+          type: keyword
+        - name: OldSdSacl2
+          type: keyword
+        - name: OldTargetUserName
           type: keyword
         - name: OldTime
           type: keyword
+        - name: OldUacValue
+          type: keyword
         - name: OriginalFileName
           type: keyword
+        - name: PackageName
+          type: keyword
+        - name: PasswordLastSet
+          type: keyword
+        - name: PasswordHistoryLength
+          type: keyword
         - name: Path
+          type: keyword
+        - name: ParentProcessName
           type: keyword
         - name: PerformanceImplementation
           type: keyword
         - name: PreviousCreationUtcTime
           type: keyword
+        - name: PreAuthType
+          type: keyword
         - name: PreviousTime
+          type: keyword
+        - name: PrimaryGroupId
           type: keyword
         - name: PrivilegeList
           type: keyword
@@ -171,6 +317,8 @@
           type: keyword
         - name: Product
           type: keyword
+        - name: ProfilePath
+          type: keyword
         - name: PuaCount
           type: keyword
         - name: PuaPolicyId
@@ -179,19 +327,41 @@
           type: keyword
         - name: Reason
           type: keyword
+        - name: SamAccountName
+          type: keyword
         - name: SchemaVersion
+          type: keyword
+        - name: ScriptPath
+          type: keyword
+        - name: SidHistory
           type: keyword
         - name: ScriptBlockText
           type: keyword
+        - name: Service
+          type: keyword
+        - name: ServiceAccount
+          type: keyword
+        - name: ServiceFileName
+          type: keyword
         - name: ServiceName
           type: keyword
+        - name: ServiceSid
+          type: keyword
+        - name: ServiceStartType
+          type: keyword
+        - name: ServiceType
+          type: keyword
         - name: ServiceVersion
+          type: keyword
+        - name: SessionName
           type: keyword
         - name: ShutdownActionType
           type: keyword
         - name: ShutdownEventCode
           type: keyword
         - name: ShutdownReason
+          type: keyword
+        - name: SidFilteringEnabled
           type: keyword
         - name: Signature
           type: keyword
@@ -205,7 +375,19 @@
           type: keyword
         - name: Status
           type: keyword
+        - name: StatusDescription
+          type: keyword
         - name: StopTime
+          type: keyword
+        - name: SubCategory
+          type: keyword
+        - name: SubCategoryGuid
+          type: keyword
+        - name: SubcategoryGuid
+          type: keyword
+        - name: SubCategoryId
+          type: keyword
+        - name: SubcategoryId
           type: keyword
         - name: SubjectDomainName
           type: keyword
@@ -214,6 +396,8 @@
         - name: SubjectUserName
           type: keyword
         - name: SubjectUserSid
+          type: keyword
+        - name: SubStatus
           type: keyword
         - name: TSId
           type: keyword
@@ -227,25 +411,47 @@
           type: keyword
         - name: TargetServerName
           type: keyword
+        - name: TargetSid
+          type: keyword
         - name: TargetUserName
-          type: keyword
-        - name: NewTargetUserName
-          type: keyword
-        - name: OldTargetUserName
           type: keyword
         - name: TargetUserSid
           type: keyword
+        - name: TdoAttributes
+          type: keyword
+        - name: TdoDirection
+          type: keyword
+        - name: TdoType
+          type: keyword
         - name: TerminalSessionId
+          type: keyword
+        - name: TicketEncryptionType
+          type: keyword
+        - name: TicketEncryptionTypeDescription
+          type: keyword
+        - name: TicketOptions
+          type: keyword
+        - name: TicketOptionsDescription
           type: keyword
         - name: TokenElevationType
           type: keyword
         - name: TransmittedServices
           type: keyword
+        - name: UserAccountControl
+          type: keyword
+        - name: UserParameters
+          type: keyword
+        - name: UserPrincipalName
+          type: keyword
         - name: UserSid
+          type: keyword
+        - name: UserWorkstations
           type: keyword
         - name: Version
           type: keyword
         - name: Workstation
+          type: keyword
+        - name: WorkstationName
           type: keyword
         - name: param1
           type: keyword
@@ -275,11 +481,17 @@
       description: >
         The keywords are used to classify an event.
 
-    - name: channel
+    - name: level
       type: keyword
-      required: true
+      required: false
       description: >
-        The name of the channel from which this record was read. This value is one of the names from the `event_logs` collection in the configuration.
+        The event severity.  Levels are Critical, Error, Warning and Information, Verbose
+
+    - name: outcome
+      type: keyword
+      required: false
+      description: >
+        Success or Failure of the event.
 
     - name: record_id
       type: keyword
@@ -292,12 +504,6 @@
       required: false
       description: >
         A globally unique identifier that identifies the activity to which control was transferred to. The related events would then have this identifier as their `activity_id` identifier.
-
-    - name: time_created
-      type: date
-      required: false
-      description: >
-        The event creation time.
 
     - name: opcode
       type: keyword
@@ -329,6 +535,21 @@
       description: >
         The task defined in the event. Task and opcode are typically used to identify the location in the application from where the event was logged. The category used by the Event Logging API (on pre Windows Vista operating systems) is written to this field.
 
+    - name: time_created
+      type: keyword
+      required: false
+      description: >
+        Time event was created
+
+    - name: trustAttribute
+      type: keyword
+      required: false
+    - name: trustDirection
+      type: keyword
+      required: false
+    - name: trustType
+      type: keyword
+      required: false
     - name: process.thread.id
       type: long
       required: false
@@ -339,6 +560,26 @@
       description: >
         The event specific data. This field is mutually exclusive with `event_data`.
 
+    - name: user_data
+      type: group
+      description: >
+        The event specific data. This field is mutually exclusive with `event_data`.
+
+      fields:
+        - name: BackupPath
+          type: keyword
+        - name: Channel
+          type: keyword
+        - name: SubjectDomainName
+          type: keyword
+        - name: SubjectLogonId
+          type: keyword
+        - name: SubjectUserName
+          type: keyword
+        - name: SubjectUserSid
+          type: keyword
+        - name: xml_name
+          type: keyword
     - name: user.identifier
       type: keyword
       required: false

--- a/packages/winlog/data_stream/winlog/manifest.yml
+++ b/packages/winlog/data_stream/winlog/manifest.yml
@@ -17,7 +17,7 @@ streams:
         title: Dataset name
         description: >-
           Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-        default: windows_custom
+        default: winlog.winlog
         required: true
         show_user: true
       - name: tags
@@ -64,7 +64,7 @@ streams:
         title: Dataset name
         description: >-
           Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-        default: windows_custom
+        default: winlog.winlog
         required: true
         show_user: true
       - name: tags

--- a/packages/winlog/docs/README.md
+++ b/packages/winlog/docs/README.md
@@ -21,21 +21,45 @@ To configure Splunk Enterprise to be able to pull events from it, please visit
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
 | event.dataset | Event dataset | constant_keyword |
 | event.module | Event module | constant_keyword |
+| input.type | Type of Filebeat input. | keyword |
+| log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
+| tags | User defined tags | keyword |
 | winlog.activity_id | A globally unique identifier that identifies the current activity. The events that are published with this identifier are part of the same activity. | keyword |
 | winlog.api | The event log API type used to read the record. The possible values are "wineventlog" for the Windows Event Log API or "eventlogging" for the Event Logging API. The Event Logging API was designed for Windows Server 2003 or Windows 2000 operating systems. In Windows Vista, the event logging infrastructure was redesigned. On Windows Vista or later operating systems, the Windows Event Log API is used. Winlogbeat automatically detects which API to use for reading event logs. | keyword |
 | winlog.channel | The name of the channel from which this record was read. This value is one of the names from the `event_logs` collection in the configuration. | keyword |
+| winlog.computerObject.domain |  | keyword |
+| winlog.computerObject.id |  | keyword |
+| winlog.computerObject.name |  | keyword |
 | winlog.computer_name | The name of the computer that generated the record. When using Windows event forwarding, this name can differ from `agent.hostname`. | keyword |
 | winlog.event_data | The event-specific data. This field is mutually exclusive with `user_data`. If you are capturing event data on versions prior to Windows Vista, the parameters in `event_data` are named `param1`, `param2`, and so on, because event log parameters are unnamed in earlier versions of Windows. | object |
+| winlog.event_data.AccessGranted |  | keyword |
+| winlog.event_data.AccessRemoved |  | keyword |
+| winlog.event_data.AccountDomain |  | keyword |
+| winlog.event_data.AccountExpires |  | keyword |
+| winlog.event_data.AccountName |  | keyword |
+| winlog.event_data.AllowedToDelegateTo |  | keyword |
+| winlog.event_data.AuditPolicyChanges |  | keyword |
+| winlog.event_data.AuditPolicyChangesDescription |  | keyword |
+| winlog.event_data.AuditSourceName |  | keyword |
 | winlog.event_data.AuthenticationPackageName |  | keyword |
 | winlog.event_data.Binary |  | keyword |
 | winlog.event_data.BitlockerUserInputTime |  | keyword |
 | winlog.event_data.BootMode |  | keyword |
 | winlog.event_data.BootType |  | keyword |
 | winlog.event_data.BuildVersion |  | keyword |
+| winlog.event_data.CallerProcessId |  | keyword |
+| winlog.event_data.CallerProcessName |  | keyword |
+| winlog.event_data.Category |  | keyword |
+| winlog.event_data.CategoryId |  | keyword |
+| winlog.event_data.ClientAddress |  | keyword |
+| winlog.event_data.ClientName |  | keyword |
+| winlog.event_data.CommandLine |  | keyword |
 | winlog.event_data.Company |  | keyword |
 | winlog.event_data.CorruptionActionState |  | keyword |
+| winlog.event_data.CrashOnAuditFailValue |  | keyword |
 | winlog.event_data.CreationUtcTime |  | keyword |
 | winlog.event_data.Description |  | keyword |
 | winlog.event_data.Detail |  | keyword |
@@ -44,77 +68,141 @@ To configure Splunk Enterprise to be able to pull events from it, please visit
 | winlog.event_data.DeviceTime |  | keyword |
 | winlog.event_data.DeviceVersionMajor |  | keyword |
 | winlog.event_data.DeviceVersionMinor |  | keyword |
+| winlog.event_data.DisplayName |  | keyword |
+| winlog.event_data.DomainBehaviorVersion |  | keyword |
+| winlog.event_data.DomainName |  | keyword |
+| winlog.event_data.DomainPolicyChanged |  | keyword |
+| winlog.event_data.DomainSid |  | keyword |
 | winlog.event_data.DriveName |  | keyword |
 | winlog.event_data.DriverName |  | keyword |
 | winlog.event_data.DriverNameLength |  | keyword |
+| winlog.event_data.Dummy |  | keyword |
 | winlog.event_data.DwordVal |  | keyword |
 | winlog.event_data.EntryCount |  | keyword |
+| winlog.event_data.EventSourceId |  | keyword |
 | winlog.event_data.ExtraInfo |  | keyword |
 | winlog.event_data.FailureName |  | keyword |
 | winlog.event_data.FailureNameLength |  | keyword |
+| winlog.event_data.FailureReason |  | keyword |
 | winlog.event_data.FileVersion |  | keyword |
 | winlog.event_data.FinalStatus |  | keyword |
 | winlog.event_data.Group |  | keyword |
+| winlog.event_data.GroupTypeChange |  | keyword |
+| winlog.event_data.HandleId |  | keyword |
+| winlog.event_data.HomeDirectory |  | keyword |
+| winlog.event_data.HomePath |  | keyword |
 | winlog.event_data.IdleImplementation |  | keyword |
 | winlog.event_data.IdleStateCount |  | keyword |
 | winlog.event_data.ImpersonationLevel |  | keyword |
 | winlog.event_data.IntegrityLevel |  | keyword |
 | winlog.event_data.IpAddress |  | keyword |
 | winlog.event_data.IpPort |  | keyword |
+| winlog.event_data.KerberosPolicyChange |  | keyword |
 | winlog.event_data.KeyLength |  | keyword |
 | winlog.event_data.LastBootGood |  | keyword |
 | winlog.event_data.LastShutdownGood |  | keyword |
 | winlog.event_data.LmPackageName |  | keyword |
 | winlog.event_data.LogonGuid |  | keyword |
+| winlog.event_data.LogonHours |  | keyword |
+| winlog.event_data.LogonID |  | keyword |
 | winlog.event_data.LogonId |  | keyword |
 | winlog.event_data.LogonProcessName |  | keyword |
 | winlog.event_data.LogonType |  | keyword |
+| winlog.event_data.MachineAccountQuota |  | keyword |
 | winlog.event_data.MajorVersion |  | keyword |
+| winlog.event_data.MandatoryLabel |  | keyword |
 | winlog.event_data.MaximumPerformancePercent |  | keyword |
 | winlog.event_data.MemberName |  | keyword |
 | winlog.event_data.MemberSid |  | keyword |
 | winlog.event_data.MinimumPerformancePercent |  | keyword |
 | winlog.event_data.MinimumThrottlePercent |  | keyword |
 | winlog.event_data.MinorVersion |  | keyword |
+| winlog.event_data.MixedDomainMode |  | keyword |
 | winlog.event_data.NewProcessId |  | keyword |
 | winlog.event_data.NewProcessName |  | keyword |
 | winlog.event_data.NewSchemeGuid |  | keyword |
+| winlog.event_data.NewSd |  | keyword |
+| winlog.event_data.NewSdDacl0 |  | keyword |
+| winlog.event_data.NewSdDacl1 |  | keyword |
+| winlog.event_data.NewSdDacl2 |  | keyword |
+| winlog.event_data.NewSdSacl0 |  | keyword |
+| winlog.event_data.NewSdSacl1 |  | keyword |
+| winlog.event_data.NewSdSacl2 |  | keyword |
 | winlog.event_data.NewTargetUserName |  | keyword |
 | winlog.event_data.NewTime |  | keyword |
+| winlog.event_data.NewUACList |  | keyword |
+| winlog.event_data.NewUacValue |  | keyword |
 | winlog.event_data.NominalFrequency |  | keyword |
 | winlog.event_data.Number |  | keyword |
+| winlog.event_data.ObjectName |  | keyword |
+| winlog.event_data.ObjectServer |  | keyword |
+| winlog.event_data.ObjectType |  | keyword |
+| winlog.event_data.OemInformation |  | keyword |
 | winlog.event_data.OldSchemeGuid |  | keyword |
+| winlog.event_data.OldSd |  | keyword |
+| winlog.event_data.OldSdDacl0 |  | keyword |
+| winlog.event_data.OldSdDacl1 |  | keyword |
+| winlog.event_data.OldSdDacl2 |  | keyword |
+| winlog.event_data.OldSdSacl0 |  | keyword |
+| winlog.event_data.OldSdSacl1 |  | keyword |
+| winlog.event_data.OldSdSacl2 |  | keyword |
 | winlog.event_data.OldTargetUserName |  | keyword |
 | winlog.event_data.OldTime |  | keyword |
+| winlog.event_data.OldUacValue |  | keyword |
 | winlog.event_data.OriginalFileName |  | keyword |
+| winlog.event_data.PackageName |  | keyword |
+| winlog.event_data.ParentProcessName |  | keyword |
+| winlog.event_data.PasswordHistoryLength |  | keyword |
+| winlog.event_data.PasswordLastSet |  | keyword |
 | winlog.event_data.Path |  | keyword |
 | winlog.event_data.PerformanceImplementation |  | keyword |
+| winlog.event_data.PreAuthType |  | keyword |
 | winlog.event_data.PreviousCreationUtcTime |  | keyword |
 | winlog.event_data.PreviousTime |  | keyword |
+| winlog.event_data.PrimaryGroupId |  | keyword |
 | winlog.event_data.PrivilegeList |  | keyword |
 | winlog.event_data.ProcessId |  | keyword |
 | winlog.event_data.ProcessName |  | keyword |
 | winlog.event_data.ProcessPath |  | keyword |
 | winlog.event_data.ProcessPid |  | keyword |
 | winlog.event_data.Product |  | keyword |
+| winlog.event_data.ProfilePath |  | keyword |
 | winlog.event_data.PuaCount |  | keyword |
 | winlog.event_data.PuaPolicyId |  | keyword |
 | winlog.event_data.QfeVersion |  | keyword |
 | winlog.event_data.Reason |  | keyword |
+| winlog.event_data.SamAccountName |  | keyword |
 | winlog.event_data.SchemaVersion |  | keyword |
 | winlog.event_data.ScriptBlockText |  | keyword |
+| winlog.event_data.ScriptPath |  | keyword |
+| winlog.event_data.Service |  | keyword |
+| winlog.event_data.ServiceAccount |  | keyword |
+| winlog.event_data.ServiceFileName |  | keyword |
 | winlog.event_data.ServiceName |  | keyword |
+| winlog.event_data.ServiceSid |  | keyword |
+| winlog.event_data.ServiceStartType |  | keyword |
+| winlog.event_data.ServiceType |  | keyword |
 | winlog.event_data.ServiceVersion |  | keyword |
+| winlog.event_data.SessionName |  | keyword |
 | winlog.event_data.ShutdownActionType |  | keyword |
 | winlog.event_data.ShutdownEventCode |  | keyword |
 | winlog.event_data.ShutdownReason |  | keyword |
+| winlog.event_data.SidFilteringEnabled |  | keyword |
+| winlog.event_data.SidHistory |  | keyword |
 | winlog.event_data.Signature |  | keyword |
 | winlog.event_data.SignatureStatus |  | keyword |
 | winlog.event_data.Signed |  | keyword |
 | winlog.event_data.StartTime |  | keyword |
 | winlog.event_data.State |  | keyword |
 | winlog.event_data.Status |  | keyword |
+| winlog.event_data.StatusDescription |  | keyword |
 | winlog.event_data.StopTime |  | keyword |
+| winlog.event_data.SubCategory |  | keyword |
+| winlog.event_data.SubCategoryGuid |  | keyword |
+| winlog.event_data.SubCategoryId |  | keyword |
+| winlog.event_data.SubStatus |  | keyword |
+| winlog.event_data.SubcategoryGuid |  | keyword |
+| winlog.event_data.SubcategoryId |  | keyword |
 | winlog.event_data.SubjectDomainName |  | keyword |
 | winlog.event_data.SubjectLogonId |  | keyword |
 | winlog.event_data.SubjectUserName |  | keyword |
@@ -125,14 +213,27 @@ To configure Splunk Enterprise to be able to pull events from it, please visit
 | winlog.event_data.TargetLogonGuid |  | keyword |
 | winlog.event_data.TargetLogonId |  | keyword |
 | winlog.event_data.TargetServerName |  | keyword |
+| winlog.event_data.TargetSid |  | keyword |
 | winlog.event_data.TargetUserName |  | keyword |
 | winlog.event_data.TargetUserSid |  | keyword |
+| winlog.event_data.TdoAttributes |  | keyword |
+| winlog.event_data.TdoDirection |  | keyword |
+| winlog.event_data.TdoType |  | keyword |
 | winlog.event_data.TerminalSessionId |  | keyword |
+| winlog.event_data.TicketEncryptionType |  | keyword |
+| winlog.event_data.TicketEncryptionTypeDescription |  | keyword |
+| winlog.event_data.TicketOptions |  | keyword |
+| winlog.event_data.TicketOptionsDescription |  | keyword |
 | winlog.event_data.TokenElevationType |  | keyword |
 | winlog.event_data.TransmittedServices |  | keyword |
+| winlog.event_data.UserAccountControl |  | keyword |
+| winlog.event_data.UserParameters |  | keyword |
+| winlog.event_data.UserPrincipalName |  | keyword |
 | winlog.event_data.UserSid |  | keyword |
+| winlog.event_data.UserWorkstations |  | keyword |
 | winlog.event_data.Version |  | keyword |
 | winlog.event_data.Workstation |  | keyword |
+| winlog.event_data.WorkstationName |  | keyword |
 | winlog.event_data.param1 |  | keyword |
 | winlog.event_data.param2 |  | keyword |
 | winlog.event_data.param3 |  | keyword |
@@ -143,7 +244,9 @@ To configure Splunk Enterprise to be able to pull events from it, please visit
 | winlog.event_data.param8 |  | keyword |
 | winlog.event_id | The event identifier. The value is specific to the source of the event. | keyword |
 | winlog.keywords | The keywords are used to classify an event. | keyword |
+| winlog.level | The event severity.  Levels are Critical, Error, Warning and Information, Verbose | keyword |
 | winlog.opcode | The opcode defined in the event. Task and opcode are typically used to identify the location in the application from where the event was logged. | keyword |
+| winlog.outcome | Success or Failure of the event. | keyword |
 | winlog.process.pid | The process_id of the Client Server Runtime Process. | long |
 | winlog.process.thread.id |  | long |
 | winlog.provider_guid | A globally unique identifier that identifies the provider that logged the event. | keyword |
@@ -151,11 +254,21 @@ To configure Splunk Enterprise to be able to pull events from it, please visit
 | winlog.record_id | The record ID of the event log record. The first record written to an event log is record number 1, and other records are numbered sequentially. If the record number reaches the maximum value (2^32^ for the Event Logging API and 2^64^ for the Windows Event Log API), the next record number will be 0. | keyword |
 | winlog.related_activity_id | A globally unique identifier that identifies the activity to which control was transferred to. The related events would then have this identifier as their `activity_id` identifier. | keyword |
 | winlog.task | The task defined in the event. Task and opcode are typically used to identify the location in the application from where the event was logged. The category used by the Event Logging API (on pre Windows Vista operating systems) is written to this field. | keyword |
-| winlog.time_created | The event creation time. | date |
+| winlog.time_created | Time event was created | keyword |
+| winlog.trustAttribute |  | keyword |
+| winlog.trustDirection |  | keyword |
+| winlog.trustType |  | keyword |
 | winlog.user.domain | The domain that the account associated with this event is a member of. | keyword |
 | winlog.user.identifier | The Windows security identifier (SID) of the account associated with this event. If Winlogbeat cannot resolve the SID to a name, then the `user.name`, `user.domain`, and `user.type` fields will be omitted from the event. If you discover Winlogbeat not resolving SIDs, review the log for clues as to what the problem may be. | keyword |
 | winlog.user.name | Name of the user associated with this event. | keyword |
 | winlog.user.type | The type of account associated with this event. | keyword |
 | winlog.user_data | The event specific data. This field is mutually exclusive with `event_data`. | object |
+| winlog.user_data.BackupPath |  | keyword |
+| winlog.user_data.Channel |  | keyword |
+| winlog.user_data.SubjectDomainName |  | keyword |
+| winlog.user_data.SubjectLogonId |  | keyword |
+| winlog.user_data.SubjectUserName |  | keyword |
+| winlog.user_data.SubjectUserSid |  | keyword |
+| winlog.user_data.xml_name |  | keyword |
 | winlog.version | The version number of the event's definition. | long |
 

--- a/packages/winlog/manifest.yml
+++ b/packages/winlog/manifest.yml
@@ -4,10 +4,10 @@ title: Custom Windows event logs
 description: |-
   This Elastic integration collects custom Windows event logs
 type: integration
-version: 0.4.0
-release: experimental
+version: 1.0.0
+release: ga
 conditions:
-  kibana.version: '^7.14.0'
+  kibana.version: '^7.16.0'
 license: basic
 categories:
   - custom


### PR DESCRIPTION
## What does this PR do?

GA winlog integration

- release to ga
- version to 1.0.0
- kibana.version to 7.16.0
- ecs external definitions
- add missing field definitions
- sync winlog.yml with system/security integration
- add system test for httpjson input
- change default datastream.dataset to winlog.winlog

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~


## How to test this PR locally

``` bash
elastic-package test system
```

## Related issues

- Relates #1562