### PR TITLE
GA gcp integrations

### DIFF
--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -4,6 +4,9 @@
     - description: Move from experimental to GA
       type: enhancement
       link: https://github.com/elastic/integrations/pull/1568
+    - description: remove experimental from data_sets
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1717
 - version: "0.3.3"
   changes:
     - description: Convert to generated ECS fields

--- a/packages/gcp/data_stream/audit/manifest.yml
+++ b/packages/gcp/data_stream/audit/manifest.yml
@@ -1,6 +1,5 @@
 type: logs
 title: Google Cloud Platform (GCP) audit logs
-release: experimental
 streams:
   - input: gcp-pubsub
     vars:

--- a/packages/gcp/data_stream/firewall/manifest.yml
+++ b/packages/gcp/data_stream/firewall/manifest.yml
@@ -1,6 +1,5 @@
 type: logs
 title: Google Cloud Platform (GCP) firewall logs
-release: experimental
 streams:
   - input: gcp-pubsub
     vars:

--- a/packages/gcp/data_stream/vpcflow/manifest.yml
+++ b/packages/gcp/data_stream/vpcflow/manifest.yml
@@ -1,6 +1,5 @@
 type: logs
 title: Google Cloud Platform (GCP) vpcflow logs
-release: experimental
 streams:
   - input: gcp-pubsub
     vars:

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -17,7 +17,7 @@ categories:
   - network
   - security
 conditions:
-  kibana.version: ^7.16.0
+  kibana.version: ^7.15.0
 screenshots:
   - src: /img/filebeat-gcp-audit.png
     title: filebeat gcp audit

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -17,7 +17,7 @@ categories:
   - network
   - security
 conditions:
-  kibana.version: ^7.14.0
+  kibana.version: ^7.16.0
 screenshots:
   - src: /img/filebeat-gcp-audit.png
     title: filebeat gcp audit


### PR DESCRIPTION
## What does this PR do?

GA gcp integrations

- version to 1.0.0
- release to ga
- kibana.version to 7.16.0
- remove release from data_stream manifests

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
~~- [ ] I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~

## Related issues

- Relates #1562