### PR TITLE
[santa] ga santa integration

### DIFF
--- a/packages/santa/changelog.yml
+++ b/packages/santa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0"
+  changes:
+    - description: make GA
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1718
 - version: "0.4.0"
   changes:
     - description: Update to ECS 1.12.0

--- a/packages/santa/data_stream/log/manifest.yml
+++ b/packages/santa/data_stream/log/manifest.yml
@@ -1,6 +1,5 @@
 type: logs
 title: Google Santa log logs
-release: experimental
 streams:
   - input: logfile
     vars:

--- a/packages/santa/manifest.yml
+++ b/packages/santa/manifest.yml
@@ -1,7 +1,7 @@
 name: santa
 title: Google Santa
-version: 0.4.0
-release: experimental
+version: 1.0.0
+release: ga
 description: This Elastic integration collects logs from Google Santa instances
 type: integration
 icons:
@@ -14,7 +14,7 @@ categories:
   - security
   - os_system
 conditions:
-  kibana.version: ^7.14.0
+  kibana.version: ^7.16.0
 screenshots:
   - src: /img/kibana-santa-log-overview.png
     title: kibana santa log overview


### PR DESCRIPTION
## What does this PR do?

ga santa integration

- version to 1.0.0
- release to ga
- kibana.version to 7.16.0
- remove release from data_stream

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
~~- [ ] I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~

## Related issues

- Relates #1562