### PR TITLE
[google_workspace] ga google_workspace integration

### DIFF
--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0"
+  changes:
+    - description: make GA
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1719
 - version: "0.7.3"
   changes:
     - description: Convert to generated ECS fields

--- a/packages/google_workspace/data_stream/admin/manifest.yml
+++ b/packages/google_workspace/data_stream/admin/manifest.yml
@@ -1,6 +1,5 @@
 type: logs
 title: Admin logs
-release: experimental
 streams:
   - input: httpjson
     template_path: httpjson.yml.hbs

--- a/packages/google_workspace/data_stream/drive/manifest.yml
+++ b/packages/google_workspace/data_stream/drive/manifest.yml
@@ -1,6 +1,5 @@
 type: logs
 title: Drive logs
-release: experimental
 streams:
   - input: httpjson
     template_path: httpjson.yml.hbs

--- a/packages/google_workspace/data_stream/groups/manifest.yml
+++ b/packages/google_workspace/data_stream/groups/manifest.yml
@@ -1,6 +1,5 @@
 type: logs
 title: Groups logs
-release: experimental
 streams:
   - input: httpjson
     template_path: httpjson.yml.hbs

--- a/packages/google_workspace/data_stream/login/manifest.yml
+++ b/packages/google_workspace/data_stream/login/manifest.yml
@@ -1,6 +1,5 @@
 type: logs
 title: Login logs
-release: experimental
 streams:
   - input: httpjson
     template_path: httpjson.yml.hbs

--- a/packages/google_workspace/data_stream/saml/manifest.yml
+++ b/packages/google_workspace/data_stream/saml/manifest.yml
@@ -1,6 +1,5 @@
 type: logs
 title: SAML logs
-release: experimental
 streams:
   - input: httpjson
     template_path: httpjson.yml.hbs

--- a/packages/google_workspace/data_stream/user_accounts/manifest.yml
+++ b/packages/google_workspace/data_stream/user_accounts/manifest.yml
@@ -1,6 +1,5 @@
 type: logs
 title: User accounts logs
-release: experimental
 streams:
   - input: httpjson
     template_path: httpjson.yml.hbs

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,7 +1,7 @@
 name: google_workspace
 title: Google Workspace
-version: 0.7.3
-release: experimental
+version: 1.0.0
+release: ga
 description: This Elastic integration collects logs from Google Workspace APIs
 type: integration
 format_version: 1.0.0
@@ -14,7 +14,7 @@ icons:
 categories:
   - security
 conditions:
-  kibana.version: ^7.14.0
+  kibana.version: ^7.16.0
 policy_templates:
   - name: google_workspace
     title: Google Workspace logs


### PR DESCRIPTION
## What does this PR do?

ga google_workspace integration

- version to 1.0.0
- release to ga
- kibana.version to 7.16.0
- remove release from data_stream manifests

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
~~- [ ] I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~

## Related issues

- Relates #1562