### PR TITLE
Fix Cisco Umbrella & Cloudflare changelog

### DIFF
--- a/packages/cisco_umbrella/changelog.yml
+++ b/packages/cisco_umbrella/changelog.yml
@@ -3,4 +3,4 @@
   changes:
     - description: Initial migration from Filebeat Module
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXX
+      link: https://github.com/elastic/integrations/pull/1646

--- a/packages/cloudflare/changelog.yml
+++ b/packages/cloudflare/changelog.yml
@@ -3,4 +3,4 @@
   changes:
     - description: initial release
       type: enhancement # can be one of: enhancement, bugfix, breaking-change
-      link: https://github.com/elastic/integrations/pull/1646
+      link: https://github.com/elastic/integrations/pull/984


### PR DESCRIPTION
## What does this PR do?

Fixes the changelog entries for Cisco Umbrella and Cloudflare.  When Cisco Umbrella was merged, I accidently updated the Cloudflare changelog.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Author's Checklist

- [ ]

## How to test this PR locally



## Related issues

- Relates #1646 

## Screenshots

