### PR TITLE
ga hashicorp vault integration

### DIFF
--- a/packages/hashicorp_vault/changelog.yml
+++ b/packages/hashicorp_vault/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0"
+  changes:
+    - description: make GA
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1735
 - version: "0.0.1"
   changes:
     - description: Initial package with audit, log, and metrics.

--- a/packages/hashicorp_vault/manifest.yml
+++ b/packages/hashicorp_vault/manifest.yml
@@ -1,15 +1,15 @@
 format_version: 1.0.0
 name: hashicorp_vault
 title: "Hashicorp Vault"
-version: 0.0.1
+version: 1.0.0
 license: basic
 description: "Collect logs and monitor Hashicorp Vault."
 type: integration
 categories:
   - security
-release: experimental
+release: ga
 conditions:
-  kibana.version: "^7.15.0"
+  kibana.version: "^7.16.0"
 screenshots:
   - src: /img/hashicorp_vault-audit-dashboard.png
     title: Audit Log Dashboard


### PR DESCRIPTION
## What does this PR do?

ga hashicorp vault integration

- version to 1.0.0
- release to GA
- kibana.version to 7.16.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
~~- [ ] I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~

## Related issues

- Relates #1562