### PR TITLE
[CI] use obltGitHubComments

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger('(?i)(.*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*|/test)')
+    issueCommentTrigger("${obltGitHubComments()}")
   }
   parameters {
     string(name: 'stackVersion', defaultValue: '', description: 'Version of the stack to use for testing.')


### PR DESCRIPTION
## What does this PR do?

Use https://github.com/elastic/apm-pipeline-library/blob/master/vars/obltGitHubComments.txt

## Why is it important?

Avoid hardcoded strings and easy to normalise the GitHub comments in all the oblt projects