### PR TITLE
Workaround: use Ubuntu 18 as worker node for Kubernetes

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -62,7 +62,11 @@ pipeline {
             findFiles()?.findAll{ !it.name.endsWith('@tmp') }?.collect{ it.name }?.sort()?.each {
               if (isPrAffected(it)) {
                 integrations[it] = {
-                  withNode(labels: 'ubuntu-20 && immutable', sleepMin: 10, sleepMax: 100) {
+                  def workerNode = "ubuntu-20"
+                  if (it == "kubernetes") {
+                    workerNode = "ubuntu-18"
+                  }
+                  withNode(labels: "${workerNode} && immutable", sleepMin: 10, sleepMax: 100) {
                     stage("${it}: check") {
                       deleteDir()
                       unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -62,6 +62,7 @@ pipeline {
             findFiles()?.findAll{ !it.name.endsWith('@tmp') }?.collect{ it.name }?.sort()?.each {
               if (isPrAffected(it)) {
                 integrations[it] = {
+                  // Workaround: https://github.com/elastic/integrations/pull/1754
                   def workerNode = "ubuntu-20"
                   if (it == "kubernetes") {
                     workerNode = "ubuntu-18"


### PR DESCRIPTION
This PR checks if it's fine to temporarily switch to Ubuntu 18 workerNode for Kubernetes integration, as in Ubuntu 20 there are issues with `kind`.