### PR TITLE
Zerofox: Release version 1.0.0 as GA

### DIFF
--- a/packages/zerofox/_dev/deploy/docker/docker-compose.yml
+++ b/packages/zerofox/_dev/deploy/docker/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '2.3'
+services:
+  zerofox-http:
+    image: docker.elastic.co/observability/stream:v0.5.0
+    ports:
+      - 8080
+    volumes:
+      - ./files:/files:ro
+    environment:
+      PORT: 8080
+    command:
+      - http-server
+      - --addr=:8080
+      - --config=/files/config.yml

--- a/packages/zerofox/_dev/deploy/docker/files/config.yml
+++ b/packages/zerofox/_dev/deploy/docker/files/config.yml
@@ -1,0 +1,286 @@
+rules:
+  - path: /1.0/alerts/
+    methods: ["GET"]
+    request_headers:
+      authorization: "Token testing"
+    query_params:
+      min_timestamp: "{min_timestamp:.*}"
+    responses:
+      - status_code: 200
+        body: |-
+          {
+            "alerts": [
+              {
+                "alert_type": "search query",
+                "logs": [
+                  {
+                    "id": 205171631,
+                    "timestamp": "2021-04-29T18:56:52+00:00",
+                    "actor": "ZeroFox Platform Specialist",
+                    "subject": "",
+                    "action": "modify tags"
+                  },
+                  {
+                    "id": 205171630,
+                    "timestamp": "2021-04-29T18:56:51+00:00",
+                    "actor": "",
+                    "subject": "",
+                    "action": "open"
+                  }
+                ],
+                "offending_content_url": "hxxp://abc.biz?entity=123456",
+                "asset_term": "",
+                "assignee": "",
+                "entity": {
+                  "id": 123456,
+                  "name": "abc.com",
+                  "image": "https://cdn.zerofox.com/media/entityimages/1.jpg",
+                  "labels": [
+                    {
+                      "id": 17700,
+                      "name": "Brand"
+                    }
+                  ],
+                  "entity_group": {
+                    "id": 2857,
+                    "name": "Default"
+                  }
+                },
+                "entity_term": "",
+                "content_created_at": "2017-01-10T11:00:00+00:00",
+                "id": 123456789,
+                "protected_account": "",
+                "severity": 4,
+                "perpetrator": {
+                  "name": "Concealed",
+                  "display_name": "Concealed",
+                  "id": 123456789,
+                  "url": "hxxp://abc.biz?entity=123456",
+                  "content": "Variation of protected domain abc.com found: abc.biz",
+                  "type": "page",
+                  "timestamp": "2017-01-10T11:00:00+00:00",
+                  "network": "domains"
+                },
+                "rule_group_id": 457,
+                "metadata": "{}",
+                "status": "Open",
+                "timestamp": "2021-04-29T18:56:51+00:00",
+                "rule_name": "Advanced Domain Analysis - Typosquat Match",
+                "last_modified": "2021-04-29T18:56:52Z",
+                "protected_locations": "",
+                "darkweb_term": "",
+                "business_network": "",
+                "reviewed": false,
+                "escalated": false,
+                "network": "domains",
+                "protected_social_object": "",
+                "notes": "",
+                "reviews": [],
+                "content_actions": [],
+                "rule_id": 38160,
+                "entity_account": "",
+                "entity_email_receiver_id": "",
+                "tags": [],
+                "asset": {
+                  "id": 123456,
+                  "name": "abc.com",
+                  "image": "https://cdn.zerofox.com/media/entityimages/1.jpg",
+                  "labels": [
+                    {
+                      "id": 17700,
+                      "name": "Brand"
+                    }
+                  ],
+                  "entity_group": {
+                    "id": 2857,
+                    "name": "Default"
+                  }
+                }
+              },
+              {
+                "alert_type": "search query",
+                "logs": [
+                  {
+                    "id": 206587078,
+                    "timestamp": "2021-05-06T13:50:48+00:00",
+                    "actor": "",
+                    "subject": "",
+                    "action": "open"
+                  }
+                ],
+                "offending_content_url": "https://twitter.com/NOWMG/status/1390297659475365894",
+                "asset_term": {
+                  "id": 673804,
+                  "name": "#darksocial",
+                  "deleted": false
+                },
+                "assignee": "",
+                "entity": {
+                  "id": 1181330,
+                  "name": "Dark Social",
+                  "image": "https://cdn.zerofox.com/media/entityimages/1bkyslxoujpytdallxdghafmkhpar5r58jqzsoojgjc9gs917au8uo7dehsfyrii.png",
+                  "labels": [
+                    {
+                      "id": 2048750,
+                      "name": "brand"
+                    }
+                  ],
+                  "entity_group": {
+                    "id": 6444,
+                    "name": "Default"
+                  }
+                },
+                "entity_term": {
+                  "id": 673804,
+                  "name": "#darksocial",
+                  "deleted": false
+                },
+                "content_created_at": "2021-05-06T13:29:27+00:00",
+                "id": 137814029,
+                "protected_account": null,
+                "severity": 1,
+                "perpetrator": {
+                  "id": 6830162495,
+                  "username": "NOWMG",
+                  "display_name": "NOW Marketing Group",
+                  "account_number": "178236715",
+                  "destination_account_number": "178236715",
+                  "parent_post_number": null,
+                  "parent_post_url": null,
+                  "parent_post_account_number": null,
+                  "post_number": "1390297659475365894",
+                  "network": "twitter",
+                  "image": "https://pbs.twimg.com/profile_images/1356266220065009667/dTlGFDCM.jpg",
+                  "url": "https://twitter.com/NOWMG/status/1390297659475365894",
+                  "type": "post",
+                  "post_type": "post",
+                  "timestamp": "2021-05-06T13:29:27+00:00"
+                },
+                "rule_group_id": null,
+                "asset": {
+                  "id": 1181330,
+                  "name": "Dark Social",
+                  "image": "https://cdn.zerofox.com/media/entityimages/1bkyslxoujpytdallxdghafmkhpar5r58jqzsoojgjc9gs917au8uo7dehsfyrii.png",
+                  "labels": [
+                    {
+                      "id": 2048750,
+                      "name": "brand"
+                    }
+                  ],
+                  "entity_group": {
+                    "id": 6444,
+                    "name": "Default"
+                  }
+                },
+                "entered_by": "",
+                "metadata": "",
+                "status": "Open",
+                "timestamp": "2021-05-06T13:50:48+00:00",
+                "rule_name": "Mentions",
+                "last_modified": "2021-05-06T13:50:48Z",
+                "protected_locations": null,
+                "darkweb_term": null,
+                "business_network": null,
+                "reviewed": false,
+                "escalated": false,
+                "network": "twitter",
+                "protected_social_object": "#darksocial",
+                "notes": "",
+                "reviews": [],
+                "content_actions": [],
+                "rule_id": 40816,
+                "entity_account": null,
+                "entity_email_receiver_id": null,
+                "tags": []
+              },
+              {
+                "alert_type": "impersonating account",
+                "logs": [
+                  {
+                    "id": 206433935,
+                    "timestamp": "2021-05-05T19:36:38+00:00",
+                    "actor": "jedmunds@zerofox.com",
+                    "subject": "",
+                    "action": "review"
+                  },
+                  {
+                    "id": 206431230,
+                    "timestamp": "2021-05-05T19:22:00+00:00",
+                    "actor": "jedmunds@zerofox.com",
+                    "subject": "",
+                    "action": "open"
+                  }
+                ],
+                "offending_content_url": "https://twitter.com/TheDarkSocial",
+                "asset_term": null,
+                "assignee": "",
+                "entity": {
+                  "id": 1181330,
+                  "name": "Dark Social",
+                  "image": "https://cdn.zerofox.com/media/entityimages/1bkyslxoujpytdallxdghafmkhpar5r58jqzsoojgjc9gs917au8uo7dehsfyrii.png",
+                  "labels": [
+                    {
+                      "id": 2048750,
+                      "name": "brand"
+                    }
+                  ],
+                  "entity_group": {
+                    "id": 6444,
+                    "name": "Default"
+                  }
+                },
+                "entity_term": null,
+                "content_created_at": "2014-08-09T16:00:16+00:00",
+                "id": 137731395,
+                "protected_account": null,
+                "severity": 1,
+                "perpetrator": {
+                  "id": 958871039,
+                  "username": "TheDarkSocial",
+                  "display_name": "Dark Social",
+                  "account_number": "2719621658",
+                  "image": "https://pbs.twimg.com/profile_images/498137972940603392/45HEzP-B.jpeg",
+                  "network": "twitter",
+                  "url": "https://twitter.com/TheDarkSocial",
+                  "type": "account",
+                  "timestamp": "2014-08-09T16:00:16+00:00"
+                },
+                "rule_group_id": 4,
+                "asset": {
+                  "id": 1181330,
+                  "name": "Dark Social",
+                  "image": "https://cdn.zerofox.com/media/entityimages/1bkyslxoujpytdallxdghafmkhpar5r58jqzsoojgjc9gs917au8uo7dehsfyrii.png",
+                  "labels": [
+                    {
+                      "id": 2048750,
+                      "name": "brand"
+                    }
+                  ],
+                  "entity_group": {
+                    "id": 6444,
+                    "name": "Default"
+                  }
+                },
+                "entered_by": "jedmunds@zerofox.com",
+                "metadata": "",
+                "status": "Open",
+                "timestamp": "2021-05-05T19:22:00+00:00",
+                "rule_name": "Impersonation - Name",
+                "last_modified": "2021-05-05T19:36:38Z",
+                "protected_locations": null,
+                "darkweb_term": null,
+                "business_network": null,
+                "reviewed": true,
+                "escalated": false,
+                "network": "twitter",
+                "protected_social_object": null,
+                "notes": "",
+                "reviews": [],
+                "content_actions": [],
+                "rule_id": 32,
+                "entity_account": null,
+                "entity_email_receiver_id": null,
+                "tags": []
+              }
+            ]
+          }

--- a/packages/zerofox/changelog.yml
+++ b/packages/zerofox/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0"
+  changes:
+    - description: GA package
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1757
 - version: "0.2.0"
   changes:
     - description: Update to ECS 1.12.0

--- a/packages/zerofox/data_stream/alerts/_dev/test/system/test-default-config.yml
+++ b/packages/zerofox/data_stream/alerts/_dev/test/system/test-default-config.yml
@@ -1,0 +1,8 @@
+input: httpjson
+service: zerofox-http
+vars:
+  url: http://{{Hostname}}:{{Port}}/1.0/alerts/
+  zerofox_api_token: testing
+data_stream:
+  vars:
+    preserve_original_event: true

--- a/packages/zerofox/data_stream/alerts/fields/beats.yml
+++ b/packages/zerofox/data_stream/alerts/fields/beats.yml
@@ -1,0 +1,3 @@
+- name: input.type
+  type: keyword
+  description: Type of Filebeat input.

--- a/packages/zerofox/data_stream/alerts/manifest.yml
+++ b/packages/zerofox/data_stream/alerts/manifest.yml
@@ -1,6 +1,5 @@
 type: logs
 title: Alerts
-release: experimental
 streams:
   - input: httpjson
     template_path: httpjson.yml.hbs

--- a/packages/zerofox/docs/README.md
+++ b/packages/zerofox/docs/README.md
@@ -61,6 +61,7 @@ Contains alert data received from the ZeroFox Cloud Platform
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| input.type | Type of Filebeat input. | keyword |
 | network.name | Name given by operators to sections of their network. | keyword |
 | rule.category | A categorization value keyword used by the entity using the rule for detection of this event. | keyword |
 | rule.id | A rule ID that is unique within the scope of an agent, observer, or other entity using the rule for detection of this event. | keyword |

--- a/packages/zerofox/manifest.yml
+++ b/packages/zerofox/manifest.yml
@@ -1,7 +1,7 @@
 name: zerofox
 title: ZeroFox
-version: 0.2.0
-release: experimental
+version: 1.0.0
+release: ga
 description: ZeroFox Cloud Platform
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
## What does this PR do?

Updates the zerofox package to GA:
- Adds system tests.
- Fixes missing input.type field.
- Updates version to 1.0.0.
- Marked as GA.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Related issues

https://github.com/elastic/integrations/issues/1562
