### PR TITLE
osquery: GA package as version 1.0.0

### DIFF
--- a/packages/osquery/changelog.yml
+++ b/packages/osquery/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0"
+  changes:
+    - description: GA package
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1758
 - version: "0.6.0"
   changes:
     - description: Update to ECS 1.12.0

--- a/packages/osquery/data_stream/result/manifest.yml
+++ b/packages/osquery/data_stream/result/manifest.yml
@@ -1,6 +1,5 @@
 type: logs
 title: Osquery result logs
-release: experimental
 streams:
   - input: logfile
     vars:

--- a/packages/osquery/manifest.yml
+++ b/packages/osquery/manifest.yml
@@ -1,7 +1,7 @@
 name: osquery
 title: Osquery Log Collection
-version: 0.6.0
-release: experimental
+version: 1.0.0
+release: ga
 description: This Elastic integration collects logs from Osquery instances
 type: integration
 icons:


### PR DESCRIPTION
## What does this PR do?

Updates the osquery package to GA:

- Updates version to 1.0.0.
- Marked as GA.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Related issues

https://github.com/elastic/integrations/issues/1562
