### PR TITLE
[network_traffic] Set title to Network Packet Capture

### DIFF
--- a/packages/network_traffic/_dev/build/docs/README.md
+++ b/packages/network_traffic/_dev/build/docs/README.md
@@ -1,4 +1,4 @@
-# Network Traffic Integration
+# Network Packet Capture Integration
 
 This integration sniffs network packets on a host and dissects
 known protocols.

--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Change title to Network Packet Capture. Added timeout/period config to flows data stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "0.2.2"
   changes:
     - description: Requires version 7.14.1 of the stack

--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Change title to Network Packet Capture. Added timeout/period config to flows data stream.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/1764
 - version: "0.2.2"
   changes:
     - description: Requires version 7.14.1 of the stack

--- a/packages/network_traffic/data_stream/flow/agent/stream/flow.yml.hbs
+++ b/packages/network_traffic/data_stream/flow/agent/stream/flow.yml.hbs
@@ -1,4 +1,10 @@
 type: flow
+{{#if timeout}}
+flows.timeout: '{{timeout}}'
+{{/if}}
+{{#if period}}
+flows.period: '{{period}}'
+{{/if}}
 {{#if processes}}
 procs:
   enabled: true

--- a/packages/network_traffic/data_stream/flow/manifest.yml
+++ b/packages/network_traffic/data_stream/flow/manifest.yml
@@ -6,3 +6,18 @@ streams:
     title: Flows
     description: Track Network Flows
     template_path: flow.yml.hbs
+    vars:
+      - name: period
+        type: text
+        title: Period
+        required: false
+        show_user: false
+        description: Configure the reporting interval. All flows are reported at the very same point in time. Periodical reporting can be disabled by setting the value to -1. If disabled, flows are still reported once being timed out.
+        default: '10s'
+      - name: timeout
+        type: text
+        title: Flow timeout
+        description: Timeout configures the lifetime of a flow. If no packets have been received for a flow within the timeout time window, the flow is killed and reported.
+        required: false
+        show_user: false
+        default: '30s'

--- a/packages/network_traffic/docs/README.md
+++ b/packages/network_traffic/docs/README.md
@@ -1,4 +1,4 @@
-# Network Traffic Integration
+# Network Packet Capture Integration
 
 This integration sniffs network packets on a host and dissects
 known protocols.

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -1,9 +1,9 @@
 format_version: 1.0.0
 name: network_traffic
-title: Network Traffic
-version: 0.2.2
+title: Network Packet Capture
+version: 0.3.0
 license: basic
-description: This Elastic integration sniffs Network Traffic
+description: This Elastic integration captures and analyzes network traffic.
 type: integration
 categories:
   - web
@@ -12,11 +12,11 @@ conditions:
   kibana.version: "^7.14.1"
 policy_templates:
   - name: network
-    title: Network Traffic
-    description: Collect network traffic
+    title: Network Packet Capture
+    description: Capture network traffic
     inputs:
       - type: packet
-        title: Collect network traffic
+        title: Capture network traffic
         description: Collecting network traffic
         vars:
           - name: interface


### PR DESCRIPTION
## What does this PR do?

Set the title of the integration to "Network Packet Capture".

Also add config options for `timeout` and `period` to the `flow` data stream.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.

## Screenshots

<img width="285" alt="Screen Shot 2021-09-27 at 10 23 32 AM" src="https://user-images.githubusercontent.com/4565752/134927678-9d3e2232-da01-4fff-9751-fc0004a06ad5.png">


<img width="644" alt="Screen Shot 2021-09-27 at 10 17 54 AM" src="https://user-images.githubusercontent.com/4565752/134927478-6e729755-d442-471c-9bff-b32db71735fb.png">

