### PR TITLE
Revert "Workaround: use Ubuntu 18 as worker node for Kubernetes (#1754)"

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -62,12 +62,7 @@ pipeline {
             findFiles()?.findAll{ !it.name.endsWith('@tmp') }?.collect{ it.name }?.sort()?.each {
               if (isPrAffected(it)) {
                 integrations[it] = {
-                  // Workaround: https://github.com/elastic/integrations/pull/1754
-                  def workerNode = "ubuntu-20"
-                  if (it == "kubernetes") {
-                    workerNode = "ubuntu-18"
-                  }
-                  withNode(labels: "${workerNode} && immutable", sleepMin: 10, sleepMax: 100) {
+                  withNode(labels: 'ubuntu-20 && immutable', sleepMin: 10, sleepMax: 100) {
                     stage("${it}: check") {
                       deleteDir()
                       unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")


### PR DESCRIPTION
This reverts commit aba53e6b70147d7c505d2c58bb9e43757e7b19a7 (https://github.com/elastic/integrations/pull/1754)

