### PR TITLE
Flaky: skip system tests for EC2

### DIFF
--- a/packages/aws/data_stream/ec2_metrics/_dev/test/system/test-default-config.yml
+++ b/packages/aws/data_stream/ec2_metrics/_dev/test/system/test-default-config.yml
@@ -1,3 +1,6 @@
+skip:
+  reason: "EC2 tests are flaky due to machine not being ready in time, we will improve it"
+  link: https://github.com/elastic/integrations/issues/1761
 vars:
   access_key_id: '{{AWS_ACCESS_KEY_ID}}'
   secret_access_key: '{{AWS_SECRET_ACCESS_KEY}}'


### PR DESCRIPTION
Skip flaky tests: https://github.com/elastic/integrations/issues/1761