### PR TITLE
ga juniper integration

### DIFF
--- a/packages/juniper/changelog.yml
+++ b/packages/juniper/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0"
+  changes:
+    - description: make GA
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1744
 - version: "0.9.0"
   changes:
     - description: Update to ECS 1.12.0

--- a/packages/juniper/data_stream/srx/fields/fields.yml
+++ b/packages/juniper/data_stream/srx/fields/fields.yml
@@ -1,6 +1,6 @@
 - name: juniper.srx
   type: group
-  release: beta
+  release: ga
   fields:
     - name: reason
       type: keyword

--- a/packages/juniper/data_stream/srx/manifest.yml
+++ b/packages/juniper/data_stream/srx/manifest.yml
@@ -1,6 +1,5 @@
 type: logs
 title: Juniper SRX logs
-release: experimental
 streams:
   - input: tcp
     vars:

--- a/packages/juniper/manifest.yml
+++ b/packages/juniper/manifest.yml
@@ -1,10 +1,10 @@
 format_version: 1.0.0
 name: juniper
 title: Juniper
-version: 0.9.0
+version: 1.0.0
 description: This Elastic integration collects logs from Juniper
 categories: ["network", "security"]
-release: experimental
+release: ga
 license: basic
 type: integration
 conditions:


### PR DESCRIPTION
## What does this PR do?

ga juniper integration

- release to ga
- remove release from srx data_stream
- release experimental for junos & netscreen data_streams
- version 1.0.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
~~- [ ] I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~

## How to test this PR locally

``` bash
elastic-package test
```

## Related issues

- Relates #1562