### PR TITLE
ga sophos xg

### DIFF
--- a/packages/sophos/changelog.yml
+++ b/packages/sophos/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0"
+  changes:
+    - description: make GA
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1775
 - version: "0.6.0"
   changes:
     - description: Update to ECS 1.12.0

--- a/packages/sophos/data_stream/xg/fields/fields.yml
+++ b/packages/sophos/data_stream/xg/fields/fields.yml
@@ -3,7 +3,6 @@
   fields:
     - name: xg
       type: group
-      release: beta
       fields:
         - name: device
           type: keyword

--- a/packages/sophos/data_stream/xg/manifest.yml
+++ b/packages/sophos/data_stream/xg/manifest.yml
@@ -1,6 +1,5 @@
 type: logs
 title: Sophos XG logs
-release: experimental
 streams:
   - input: tcp
     vars:

--- a/packages/sophos/manifest.yml
+++ b/packages/sophos/manifest.yml
@@ -1,10 +1,10 @@
 format_version: 1.0.0
 name: sophos
 title: Sophos
-version: 0.6.0
+version: 1.0.0
 description: This Elastic integration collects logs from Sophos
 categories: ["security"]
-release: experimental
+release: ga
 license: basic
 type: integration
 conditions:


### PR DESCRIPTION
## What does this PR do?

ga sophos xg

- version to 1.0.0
- release to ga
- remove release from xg data_stream
- utm is still experimental

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
~~- [ ] I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~

## How to test this PR locally

``` bash
elastic-package test
```

## Related issues

- Relates #1562