### PR TITLE
synthetics - add new ssl and filter params for browser monitors

### DIFF
--- a/packages/synthetics/data_stream/browser/agent/stream/browser.yml.hbs
+++ b/packages/synthetics/data_stream/browser/agent/stream/browser.yml.hbs
@@ -32,8 +32,32 @@ screenshots: {{screenshots}}
 {{#if synthetics_args}}
 synthetics_args: {{synthetics_args}}
 {{/if}}
+{{#if filter_journeys.match}}
+filter_journeys.match: {{filter_journeys.match}}
+{{/if}}
+{{#if filter_journeys.tags}}
+filter_journeys.tags: {{filter_journeys.tags}}
+{{/if}}
 {{#if ignore_https_errors}}
 ignore_https_errors: {{ignore_https_errors}}
+{{/if}}
+{{#if ssl.certificate}}
+ssl.certificate: {{ssl.certificate}}
+{{/if}}
+{{#if ssl.certificate_authorities}}
+ssl.certificate_authorities: {{ssl.certificate_authorities}}
+{{/if}}
+{{#if ssl.key}}
+ssl.key: {{ssl.key}}
+{{/if}}
+{{#if ssl.key_passphrase}}
+ssl.key_passphrase: {{ssl.key_passphrase}}
+{{/if}}
+{{#if ssl.verification_mode}}
+ssl.verification_mode: {{ssl.verification_mode}}
+{{/if}}
+{{#if ssl.supported_protocols}}
+ssl.supported_protocols: {{ssl.supported_protocols}}
 {{/if}}
 processors:
   - add_observer_metadata:

--- a/packages/synthetics/data_stream/browser/manifest.yml
+++ b/packages/synthetics/data_stream/browser/manifest.yml
@@ -100,3 +100,51 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: filter_journeys.tags
+        type: text
+        title: run only journeys with the given tag(s), or globs
+        multi: true
+        required: false
+        show_user: true
+      - name: filter_journeys.match
+        type: text
+        title: run only journeys with a name or tags that matches the configured glob
+        multi: false
+        required: false
+        show_user: true
+      - name: ssl.certificate_authorities
+        type: yaml
+        title: Certificate authorities
+        multi: false
+        required: false
+        show_user: true
+      - name: ssl.certificate
+        type: yaml
+        title: Certificate
+        multi: false
+        required: false
+        show_user: true
+      - name: ssl.key
+        type: yaml
+        title: Certificate private key
+        multi: false
+        required: false
+        show_user: true
+      - name: ssl.key_passphrase
+        type: text
+        title: Private key passphrase
+        multi: false
+        required: false
+        show_user: true
+      - name: ssl.verification_mode
+        type: text
+        title: SSL Verification mode
+        multi: false
+        required: false
+        show_user: true
+      - name: ssl.supported_protocols
+        type: yaml
+        title: Supported protocols
+        multi: false
+        required: false
+        show_user: true


### PR DESCRIPTION
This PR contains 3 new fields for the `synthetics.browser` input

- `filter_journeys.tags`
- `ssl.certificate_authorities`
- `ssl.certificate`
- `ssl.key`
- `ssl.key_passphrase`
- `ssl.verification_mode`
- `ssl.supported_protocols`
      