### PR TITLE
Update kubernetes namespace field. breaking change

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Update Kubernetes namespace field
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1696
 - version: "1.1.0"
   changes:
     - description: Update to ECS 1.12.0

--- a/packages/kubernetes/data_stream/container/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/container/fields/base-fields.yml
@@ -29,9 +29,31 @@
         Kubernetes pod IP
 
     - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: >
+            Kubernetes namespace name
+
+        - name: uuid
+          type: keyword
+          description: >
+            Kubernetes namespace uuid
+
+        - name: labels.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace labels map
+
+        - name: annotations.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace annotations map
 
     - name: node.name
       type: keyword

--- a/packages/kubernetes/data_stream/container_logs/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/container_logs/fields/base-fields.yml
@@ -29,9 +29,31 @@
         Kubernetes pod IP
 
     - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: >
+            Kubernetes namespace name
+
+        - name: uuid
+          type: keyword
+          description: >
+            Kubernetes namespace uuid
+
+        - name: labels.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace labels map
+
+        - name: annotations.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace annotations map
 
     - name: node.name
       type: keyword

--- a/packages/kubernetes/data_stream/controllermanager/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/controllermanager/fields/base-fields.yml
@@ -29,9 +29,31 @@
         Kubernetes pod IP
 
     - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: >
+            Kubernetes namespace name
+
+        - name: uuid
+          type: keyword
+          description: >
+            Kubernetes namespace uuid
+
+        - name: labels.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace labels map
+
+        - name: annotations.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace annotations map
 
     - name: node.name
       type: keyword

--- a/packages/kubernetes/data_stream/event/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/event/fields/base-fields.yml
@@ -29,9 +29,31 @@
         Kubernetes pod IP
 
     - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: >
+            Kubernetes namespace name
+
+        - name: uuid
+          type: keyword
+          description: >
+            Kubernetes namespace uuid
+
+        - name: labels.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace labels map
+
+        - name: annotations.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace annotations map
 
     - name: node.name
       type: keyword

--- a/packages/kubernetes/data_stream/node/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/node/fields/base-fields.yml
@@ -29,9 +29,31 @@
         Kubernetes pod IP
 
     - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: >
+            Kubernetes namespace name
+
+        - name: uuid
+          type: keyword
+          description: >
+            Kubernetes namespace uuid
+
+        - name: labels.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace labels map
+
+        - name: annotations.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace annotations map
 
     - name: node.name
       type: keyword

--- a/packages/kubernetes/data_stream/pod/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/pod/fields/base-fields.yml
@@ -29,9 +29,31 @@
         Kubernetes pod IP
 
     - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: >
+            Kubernetes namespace name
+
+        - name: uuid
+          type: keyword
+          description: >
+            Kubernetes namespace uuid
+
+        - name: labels.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace labels map
+
+        - name: annotations.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace annotations map
 
     - name: node.name
       type: keyword

--- a/packages/kubernetes/data_stream/scheduler/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/scheduler/fields/base-fields.yml
@@ -29,9 +29,31 @@
         Kubernetes pod IP
 
     - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: >
+            Kubernetes namespace name
+
+        - name: uuid
+          type: keyword
+          description: >
+            Kubernetes namespace uuid
+
+        - name: labels.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace labels map
+
+        - name: annotations.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace annotations map
 
     - name: node.name
       type: keyword

--- a/packages/kubernetes/data_stream/state_container/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_container/fields/base-fields.yml
@@ -29,9 +29,31 @@
         Kubernetes pod IP
 
     - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: >
+            Kubernetes namespace name
+
+        - name: uuid
+          type: keyword
+          description: >
+            Kubernetes namespace uuid
+
+        - name: labels.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace labels map
+
+        - name: annotations.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace annotations map
 
     - name: node.name
       type: keyword

--- a/packages/kubernetes/data_stream/state_cronjob/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_cronjob/fields/base-fields.yml
@@ -29,9 +29,31 @@
         Kubernetes pod IP
 
     - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: >
+            Kubernetes namespace name
+
+        - name: uuid
+          type: keyword
+          description: >
+            Kubernetes namespace uuid
+
+        - name: labels.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace labels map
+
+        - name: annotations.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace annotations map
 
     - name: node.name
       type: keyword

--- a/packages/kubernetes/data_stream/state_daemonset/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_daemonset/fields/base-fields.yml
@@ -29,9 +29,31 @@
         Kubernetes pod IP
 
     - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: >
+            Kubernetes namespace name
+
+        - name: uuid
+          type: keyword
+          description: >
+            Kubernetes namespace uuid
+
+        - name: labels.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace labels map
+
+        - name: annotations.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace annotations map
 
     - name: node.name
       type: keyword

--- a/packages/kubernetes/data_stream/state_deployment/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_deployment/fields/base-fields.yml
@@ -29,9 +29,31 @@
         Kubernetes pod IP
 
     - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: >
+            Kubernetes namespace name
+
+        - name: uuid
+          type: keyword
+          description: >
+            Kubernetes namespace uuid
+
+        - name: labels.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace labels map
+
+        - name: annotations.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace annotations map
 
     - name: node.name
       type: keyword

--- a/packages/kubernetes/data_stream/state_job/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_job/fields/base-fields.yml
@@ -29,9 +29,31 @@
         Kubernetes pod IP
 
     - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: >
+            Kubernetes namespace name
+
+        - name: uuid
+          type: keyword
+          description: >
+            Kubernetes namespace uuid
+
+        - name: labels.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace labels map
+
+        - name: annotations.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace annotations map
 
     - name: node.name
       type: keyword

--- a/packages/kubernetes/data_stream/state_node/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_node/fields/base-fields.yml
@@ -29,9 +29,31 @@
         Kubernetes pod IP
 
     - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: >
+            Kubernetes namespace name
+
+        - name: uuid
+          type: keyword
+          description: >
+            Kubernetes namespace uuid
+
+        - name: labels.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace labels map
+
+        - name: annotations.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace annotations map
 
     - name: node.name
       type: keyword

--- a/packages/kubernetes/data_stream/state_persistentvolume/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolume/fields/base-fields.yml
@@ -29,9 +29,31 @@
         Kubernetes pod IP
 
     - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: >
+            Kubernetes namespace name
+
+        - name: uuid
+          type: keyword
+          description: >
+            Kubernetes namespace uuid
+
+        - name: labels.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace labels map
+
+        - name: annotations.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace annotations map
 
     - name: node.name
       type: keyword

--- a/packages/kubernetes/data_stream/state_persistentvolumeclaim/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolumeclaim/fields/base-fields.yml
@@ -29,9 +29,31 @@
         Kubernetes pod IP
 
     - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: >
+            Kubernetes namespace name
+
+        - name: uuid
+          type: keyword
+          description: >
+            Kubernetes namespace uuid
+
+        - name: labels.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace labels map
+
+        - name: annotations.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace annotations map
 
     - name: node.name
       type: keyword

--- a/packages/kubernetes/data_stream/state_pod/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_pod/fields/base-fields.yml
@@ -29,9 +29,31 @@
         Kubernetes pod IP
 
     - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: >
+            Kubernetes namespace name
+
+        - name: uuid
+          type: keyword
+          description: >
+            Kubernetes namespace uuid
+
+        - name: labels.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace labels map
+
+        - name: annotations.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace annotations map
 
     - name: node.name
       type: keyword

--- a/packages/kubernetes/data_stream/state_replicaset/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_replicaset/fields/base-fields.yml
@@ -29,9 +29,31 @@
         Kubernetes pod IP
 
     - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: >
+            Kubernetes namespace name
+
+        - name: uuid
+          type: keyword
+          description: >
+            Kubernetes namespace uuid
+
+        - name: labels.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace labels map
+
+        - name: annotations.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace annotations map
 
     - name: node.name
       type: keyword

--- a/packages/kubernetes/data_stream/state_resourcequota/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_resourcequota/fields/base-fields.yml
@@ -29,9 +29,31 @@
         Kubernetes pod IP
 
     - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: >
+            Kubernetes namespace name
+
+        - name: uuid
+          type: keyword
+          description: >
+            Kubernetes namespace uuid
+
+        - name: labels.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace labels map
+
+        - name: annotations.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace annotations map
 
     - name: node.name
       type: keyword

--- a/packages/kubernetes/data_stream/state_service/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_service/fields/base-fields.yml
@@ -29,9 +29,31 @@
         Kubernetes pod IP
 
     - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: >
+            Kubernetes namespace name
+
+        - name: uuid
+          type: keyword
+          description: >
+            Kubernetes namespace uuid
+
+        - name: labels.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace labels map
+
+        - name: annotations.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace annotations map
 
     - name: node.name
       type: keyword

--- a/packages/kubernetes/data_stream/state_statefulset/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_statefulset/fields/base-fields.yml
@@ -29,9 +29,31 @@
         Kubernetes pod IP
 
     - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: >
+            Kubernetes namespace name
+
+        - name: uuid
+          type: keyword
+          description: >
+            Kubernetes namespace uuid
+
+        - name: labels.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace labels map
+
+        - name: annotations.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace annotations map
 
     - name: node.name
       type: keyword

--- a/packages/kubernetes/data_stream/state_storageclass/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_storageclass/fields/base-fields.yml
@@ -29,9 +29,31 @@
         Kubernetes pod IP
 
     - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: >
+            Kubernetes namespace name
+
+        - name: uuid
+          type: keyword
+          description: >
+            Kubernetes namespace uuid
+
+        - name: labels.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace labels map
+
+        - name: annotations.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace annotations map
 
     - name: node.name
       type: keyword

--- a/packages/kubernetes/data_stream/system/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/system/fields/base-fields.yml
@@ -29,9 +29,31 @@
         Kubernetes pod IP
 
     - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: >
+            Kubernetes namespace name
+
+        - name: uuid
+          type: keyword
+          description: >
+            Kubernetes namespace uuid
+
+        - name: labels.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace labels map
+
+        - name: annotations.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace annotations map
 
     - name: node.name
       type: keyword

--- a/packages/kubernetes/data_stream/volume/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/volume/fields/base-fields.yml
@@ -29,9 +29,31 @@
         Kubernetes pod IP
 
     - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: >
+            Kubernetes namespace name
+
+        - name: uuid
+          type: keyword
+          description: >
+            Kubernetes namespace uuid
+
+        - name: labels.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace labels map
+
+        - name: annotations.*
+          type: object
+          object_type: keyword
+          object_type_mapping_type: "*"
+          description: >
+            Kubernetes namespace annotations map
 
     - name: node.name
       type: keyword

--- a/packages/kubernetes/docs/events.md
+++ b/packages/kubernetes/docs/events.md
@@ -157,7 +157,10 @@ An example event for `event` looks as following:
 | kubernetes.event.timestamp.last_occurrence | Timestamp of last occurrence of event | date |  |
 | kubernetes.event.type | Type of the given event | keyword |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |
-| kubernetes.namespace | Kubernetes namespace | keyword |  |
+| kubernetes.namespace.annotations.\* | Kubernetes namespace annotations map | object |  |
+| kubernetes.namespace.labels.\* | Kubernetes namespace labels map | object |  |
+| kubernetes.namespace.name | Kubernetes namespace name | keyword |  |
+| kubernetes.namespace.uuid | Kubernetes namespace uuid | keyword |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |
 | kubernetes.pod.ip | Kubernetes pod IP | ip |  |

--- a/packages/kubernetes/docs/kube-controller-manager.md
+++ b/packages/kubernetes/docs/kube-controller-manager.md
@@ -180,7 +180,10 @@ An example event for `controllermanager` looks as following:
 | kubernetes.controllermanager.zone | Infrastructure zone | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |  |
-| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.namespace.annotations.\* | Kubernetes namespace annotations map | object |  |  |
+| kubernetes.namespace.labels.\* | Kubernetes namespace labels map | object |  |  |
+| kubernetes.namespace.name | Kubernetes namespace name | keyword |  |  |
+| kubernetes.namespace.uuid | Kubernetes namespace uuid | keyword |  |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |
 | kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |

--- a/packages/kubernetes/docs/kube-scheduler.md
+++ b/packages/kubernetes/docs/kube-scheduler.md
@@ -134,7 +134,10 @@ An example event for `scheduler` looks as following:
 | kubernetes.container.name | Kubernetes container name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |  |
-| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.namespace.annotations.\* | Kubernetes namespace annotations map | object |  |  |
+| kubernetes.namespace.labels.\* | Kubernetes namespace labels map | object |  |  |
+| kubernetes.namespace.name | Kubernetes namespace name | keyword |  |  |
+| kubernetes.namespace.uuid | Kubernetes namespace uuid | keyword |  |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |
 | kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |

--- a/packages/kubernetes/docs/kube-state-metrics.md
+++ b/packages/kubernetes/docs/kube-state-metrics.md
@@ -152,7 +152,10 @@ An example event for `state_container` looks as following:
 | kubernetes.daemonset.name | Kubernetes daemonset name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |  |
-| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.namespace.annotations.\* | Kubernetes namespace annotations map | object |  |  |
+| kubernetes.namespace.labels.\* | Kubernetes namespace labels map | object |  |  |
+| kubernetes.namespace.name | Kubernetes namespace name | keyword |  |  |
+| kubernetes.namespace.uuid | Kubernetes namespace uuid | keyword |  |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |
 | kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
@@ -295,7 +298,10 @@ An example event for `state_cronjob` looks as following:
 | kubernetes.cronjob.schedule | Cronjob schedule | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |  |
-| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.namespace.annotations.\* | Kubernetes namespace annotations map | object |  |  |
+| kubernetes.namespace.labels.\* | Kubernetes namespace labels map | object |  |  |
+| kubernetes.namespace.name | Kubernetes namespace name | keyword |  |  |
+| kubernetes.namespace.uuid | Kubernetes namespace uuid | keyword |  |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |
 | kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
@@ -430,7 +436,10 @@ An example event for `state_daemonset` looks as following:
 | kubernetes.daemonset.replicas.unavailable | The number of unavailable replicas per DaemonSet | long | gauge |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |
-| kubernetes.namespace | Kubernetes namespace | keyword |  |
+| kubernetes.namespace.annotations.\* | Kubernetes namespace annotations map | object |  |
+| kubernetes.namespace.labels.\* | Kubernetes namespace labels map | object |  |
+| kubernetes.namespace.name | Kubernetes namespace name | keyword |  |
+| kubernetes.namespace.uuid | Kubernetes namespace uuid | keyword |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |
 | kubernetes.pod.ip | Kubernetes pod IP | ip |  |
@@ -566,7 +575,10 @@ An example event for `state_deployment` looks as following:
 | kubernetes.deployment.replicas.unavailable | Deployment unavailable replicas | integer | gauge |
 | kubernetes.deployment.replicas.updated | Deployment updated replicas | integer | gauge |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |
-| kubernetes.namespace | Kubernetes namespace | keyword |  |
+| kubernetes.namespace.annotations.\* | Kubernetes namespace annotations map | object |  |
+| kubernetes.namespace.labels.\* | Kubernetes namespace labels map | object |  |
+| kubernetes.namespace.name | Kubernetes namespace name | keyword |  |
+| kubernetes.namespace.uuid | Kubernetes namespace uuid | keyword |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |
 | kubernetes.pod.ip | Kubernetes pod IP | ip |  |
@@ -719,7 +731,10 @@ An example event for `state_job` looks as following:
 | kubernetes.job.time.completed | The time at which the job completed | date |  |
 | kubernetes.job.time.created | The time at which the job was created | date |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |
-| kubernetes.namespace | Kubernetes namespace | keyword |  |
+| kubernetes.namespace.annotations.\* | Kubernetes namespace annotations map | object |  |
+| kubernetes.namespace.labels.\* | Kubernetes namespace labels map | object |  |
+| kubernetes.namespace.name | Kubernetes namespace name | keyword |  |
+| kubernetes.namespace.uuid | Kubernetes namespace uuid | keyword |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |
 | kubernetes.pod.ip | Kubernetes pod IP | ip |  |
@@ -875,7 +890,10 @@ An example event for `state_node` looks as following:
 | kubernetes.container.name | Kubernetes container name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |  |
-| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.namespace.annotations.\* | Kubernetes namespace annotations map | object |  |  |
+| kubernetes.namespace.labels.\* | Kubernetes namespace labels map | object |  |  |
+| kubernetes.namespace.name | Kubernetes namespace name | keyword |  |  |
+| kubernetes.namespace.uuid | Kubernetes namespace uuid | keyword |  |  |
 | kubernetes.node.cpu.allocatable.cores | Node CPU allocatable cores | float |  | gauge |
 | kubernetes.node.cpu.capacity.cores | Node CPU capacity cores | long |  | gauge |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
@@ -1015,7 +1033,10 @@ An example event for `state_persistentvolume` looks as following:
 | kubernetes.container.name | Kubernetes container name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |  |
-| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.namespace.annotations.\* | Kubernetes namespace annotations map | object |  |  |
+| kubernetes.namespace.labels.\* | Kubernetes namespace labels map | object |  |  |
+| kubernetes.namespace.name | Kubernetes namespace name | keyword |  |  |
+| kubernetes.namespace.uuid | Kubernetes namespace uuid | keyword |  |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |
 | kubernetes.persistentvolume.capacity.bytes | Volume capacity | long | byte | gauge |
@@ -1147,7 +1168,10 @@ An example event for `state_persistentvolumeclaim` looks as following:
 | kubernetes.container.name | Kubernetes container name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |  |
-| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.namespace.annotations.\* | Kubernetes namespace annotations map | object |  |  |
+| kubernetes.namespace.labels.\* | Kubernetes namespace labels map | object |  |  |
+| kubernetes.namespace.name | Kubernetes namespace name | keyword |  |  |
+| kubernetes.namespace.uuid | Kubernetes namespace uuid | keyword |  |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |
 | kubernetes.persistentvolumeclaim.access_mode | Access mode. | keyword |  |  |
@@ -1292,7 +1316,10 @@ An example event for `state_pod` looks as following:
 | kubernetes.daemonset.name | Kubernetes daemonset name | keyword |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |
 | kubernetes.labels.\* | Kubernetes labels map | object |
-| kubernetes.namespace | Kubernetes namespace | keyword |
+| kubernetes.namespace.annotations.\* | Kubernetes namespace annotations map | object |
+| kubernetes.namespace.labels.\* | Kubernetes namespace labels map | object |
+| kubernetes.namespace.name | Kubernetes namespace name | keyword |
+| kubernetes.namespace.uuid | Kubernetes namespace uuid | keyword |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
 | kubernetes.node.name | Kubernetes node name | keyword |
 | kubernetes.pod.host_ip | Kubernetes pod host IP | ip |
@@ -1433,7 +1460,10 @@ An example event for `state_replicaset` looks as following:
 | kubernetes.container.name | Kubernetes container name | keyword |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |
-| kubernetes.namespace | Kubernetes namespace | keyword |  |
+| kubernetes.namespace.annotations.\* | Kubernetes namespace annotations map | object |  |
+| kubernetes.namespace.labels.\* | Kubernetes namespace labels map | object |  |
+| kubernetes.namespace.name | Kubernetes namespace name | keyword |  |
+| kubernetes.namespace.uuid | Kubernetes namespace uuid | keyword |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |
 | kubernetes.pod.ip | Kubernetes pod IP | ip |  |
@@ -1562,7 +1592,10 @@ An example event for `state_resourcequota` looks as following:
 | kubernetes.container.name | Kubernetes container name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |  |
-| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.namespace.annotations.\* | Kubernetes namespace annotations map | object |  |  |
+| kubernetes.namespace.labels.\* | Kubernetes namespace labels map | object |  |  |
+| kubernetes.namespace.name | Kubernetes namespace name | keyword |  |  |
+| kubernetes.namespace.uuid | Kubernetes namespace uuid | keyword |  |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |
 | kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
@@ -1697,7 +1730,10 @@ An example event for `state_service` looks as following:
 | kubernetes.container.name | Kubernetes container name | keyword |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |
 | kubernetes.labels.\* | Kubernetes labels map | object |
-| kubernetes.namespace | Kubernetes namespace | keyword |
+| kubernetes.namespace.annotations.\* | Kubernetes namespace annotations map | object |
+| kubernetes.namespace.labels.\* | Kubernetes namespace labels map | object |
+| kubernetes.namespace.name | Kubernetes namespace name | keyword |
+| kubernetes.namespace.uuid | Kubernetes namespace uuid | keyword |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
 | kubernetes.node.name | Kubernetes node name | keyword |
 | kubernetes.pod.ip | Kubernetes pod IP | ip |
@@ -1835,7 +1871,10 @@ An example event for `state_statefulset` looks as following:
 | kubernetes.container.name | Kubernetes container name | keyword |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |
-| kubernetes.namespace | Kubernetes namespace | keyword |  |
+| kubernetes.namespace.annotations.\* | Kubernetes namespace annotations map | object |  |
+| kubernetes.namespace.labels.\* | Kubernetes namespace labels map | object |  |
+| kubernetes.namespace.name | Kubernetes namespace name | keyword |  |
+| kubernetes.namespace.uuid | Kubernetes namespace uuid | keyword |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |
 | kubernetes.pod.ip | Kubernetes pod IP | ip |  |
@@ -1968,7 +2007,10 @@ An example event for `state_storageclass` looks as following:
 | kubernetes.container.name | Kubernetes container name | keyword |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |
 | kubernetes.labels.\* | Kubernetes labels map | object |
-| kubernetes.namespace | Kubernetes namespace | keyword |
+| kubernetes.namespace.annotations.\* | Kubernetes namespace annotations map | object |
+| kubernetes.namespace.labels.\* | Kubernetes namespace labels map | object |
+| kubernetes.namespace.name | Kubernetes namespace name | keyword |
+| kubernetes.namespace.uuid | Kubernetes namespace uuid | keyword |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
 | kubernetes.node.name | Kubernetes node name | keyword |
 | kubernetes.pod.ip | Kubernetes pod IP | ip |

--- a/packages/kubernetes/docs/kubelet.md
+++ b/packages/kubernetes/docs/kubelet.md
@@ -229,7 +229,10 @@ An example event for `container` looks as following:
 | kubernetes.daemonset.name | Kubernetes daemonset name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |  |
-| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.namespace.annotations.\* | Kubernetes namespace annotations map | object |  |  |
+| kubernetes.namespace.labels.\* | Kubernetes namespace labels map | object |  |  |
+| kubernetes.namespace.name | Kubernetes namespace name | keyword |  |  |
+| kubernetes.namespace.uuid | Kubernetes namespace uuid | keyword |  |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |
 | kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
@@ -445,7 +448,10 @@ An example event for `node` looks as following:
 | kubernetes.container.name | Kubernetes container name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |  |
-| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.namespace.annotations.\* | Kubernetes namespace annotations map | object |  |  |
+| kubernetes.namespace.labels.\* | Kubernetes namespace labels map | object |  |  |
+| kubernetes.namespace.name | Kubernetes namespace name | keyword |  |  |
+| kubernetes.namespace.uuid | Kubernetes namespace uuid | keyword |  |  |
 | kubernetes.node.cpu.usage.core.ns | Node CPU Core usage nanoseconds | long |  | gauge |
 | kubernetes.node.cpu.usage.nanocores | CPU used nanocores | long |  | gauge |
 | kubernetes.node.fs.available.bytes | Filesystem total available in bytes | long | byte | gauge |
@@ -661,7 +667,10 @@ An example event for `pod` looks as following:
 | kubernetes.daemonset.name | Kubernetes daemonset name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |  |
-| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.namespace.annotations.\* | Kubernetes namespace annotations map | object |  |  |
+| kubernetes.namespace.labels.\* | Kubernetes namespace labels map | object |  |  |
+| kubernetes.namespace.name | Kubernetes namespace name | keyword |  |  |
+| kubernetes.namespace.uuid | Kubernetes namespace uuid | keyword |  |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |
 | kubernetes.pod.cpu.usage.limit.pct | CPU usage as a percentage of the defined limit for the pod containers (or total node CPU if one or more containers of the pod are unlimited) | scaled_float | percent | gauge |
@@ -846,7 +855,10 @@ An example event for `system` looks as following:
 | kubernetes.container.name | Kubernetes container name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |  |
-| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.namespace.annotations.\* | Kubernetes namespace annotations map | object |  |  |
+| kubernetes.namespace.labels.\* | Kubernetes namespace labels map | object |  |  |
+| kubernetes.namespace.name | Kubernetes namespace name | keyword |  |  |
+| kubernetes.namespace.uuid | Kubernetes namespace uuid | keyword |  |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |
 | kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
@@ -1022,7 +1034,10 @@ An example event for `volume` looks as following:
 | kubernetes.container.name | Kubernetes container name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |  |
-| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
+| kubernetes.namespace.annotations.\* | Kubernetes namespace annotations map | object |  |  |
+| kubernetes.namespace.labels.\* | Kubernetes namespace labels map | object |  |  |
+| kubernetes.namespace.name | Kubernetes namespace name | keyword |  |  |
+| kubernetes.namespace.uuid | Kubernetes namespace uuid | keyword |  |  |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |
 | kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.1.0
+version: 1.2.0
 license: basic
 description: This Elastic integration collects metrics from Kubernetes clusters
 type: integration
@@ -10,7 +10,7 @@ categories:
   - kubernetes
 release: ga
 conditions:
-  kibana.version: "^7.15.0"
+  kibana.version: "^8.0.0"
 screenshots:
   - src: /img/metricbeat_kubernetes_overview.png
     title: Metricbeat Kubernetes Overview


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This is a breaking change for 8.0 release.

As part of https://github.com/elastic/beats/issues/16483 and after merging of https://github.com/elastic/beats/pull/27917 which 
- Updates `kubernetes.namespace` from keyword to group field. 
-  Moves `kubernetes.namespace` which was the name of the namespace to `kubernetes.namespace.name` field.
- Renames `namespace_labels` and `namespace_annotations` metadata  to `namespace.labels` and `namespace.annotations`

kubernetes integration must also be updated.
In this PR `Kubernetes namespace` field gets updated from keyword to group type and `name`,`labels`,`annotations` are added as fields under it.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

