### PR TITLE
[windows] prevent pipeline script error

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.2"
+  changes:
+    - description: Prevent pipeline script error
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1872
 - version: "1.2.1"
   changes:
     - description: Fix logic that checks for the 'forwarded' tag

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security.yml
@@ -744,7 +744,7 @@ processors:
             - end
           action: windows-firewall-driver-error
       source: |-
-        if (ctx?.event?.code == null) {
+        if (ctx?.event?.code == null || params.get(ctx.event.code) == null) {
           return;
         }
         def hm = new HashMap(params.get(ctx.event.code));
@@ -3178,4 +3178,5 @@ processors:
 on_failure:
   - set:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: |-
+        Processor "{{ _ingest.on_failure_processor_type }}" with tag "{{ _ingest.on_failure_processor_tag }}" in pipeline "{{ _ingest.on_failure_pipeline }}" failed with message "{{ _ingest.on_failure_message }}"

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/sysmon_operational.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/sysmon_operational.yml
@@ -146,8 +146,11 @@ processors:
             - process
           type:
             - change
-      if: ctx?.event?.code != null
+      tag: Set ECS categorization fields
       source: |-
+        if (ctx?.event?.code == null || params.get(ctx.event.code) == null) {
+          return;
+        }
         def hm = new HashMap(params[ctx.event.code]);
         hm.forEach((k, v) -> ctx.event[k] = v);
   - convert:
@@ -1245,4 +1248,5 @@ processors:
 on_failure:
   - set:
       field: "error.message"
-      value: "{{ _ingest.on_failure_message }}"
+      value: |-
+        Processor "{{ _ingest.on_failure_processor_type }}" with tag "{{ _ingest.on_failure_processor_tag }}" in pipeline "{{ _ingest.on_failure_pipeline }}" failed with message "{{ _ingest.on_failure_message }}"

--- a/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
@@ -146,8 +146,11 @@ processors:
             - process
           type:
             - change
-      if: ctx?.event?.code != null
+      tag: Add ECS categorization fields
       source: |-
+        if (ctx?.event?.code == null || params.get(ctx.event.code) == null) {
+          return;
+        }
         def hm = new HashMap(params[ctx.event.code]);
         hm.forEach((k, v) -> ctx.event[k] = v);
   - convert:
@@ -1246,4 +1249,5 @@ processors:
 on_failure:
   - set:
       field: "error.message"
-      value: "{{ _ingest.on_failure_message }}"
+      value: |-
+        Processor "{{ _ingest.on_failure_processor_type }}" with tag "{{ _ingest.on_failure_processor_tag }}" in pipeline "{{ _ingest.on_failure_pipeline }}" failed with message "{{ _ingest.on_failure_message }}"

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.2.1
+version: 1.2.2
 description: This Elastic integration collects logs and metrics from Windows
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

Prevents pipeline script error in windows integration

- prevent creating new HashMap with null
- improve error.message


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~

## How to test this PR locally

``` bash
elastic-package test pipeline
```

## Related issues

- Relates #1789