### PR TITLE
[Synthetics integration] add metadata key for brower data stream

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Add metadata key to synthetics browser type
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1875
 - version: "0.3.0"
   changes:
     - description: Add browser data streams

--- a/packages/synthetics/data_stream/browser/agent/stream/browser.yml.hbs
+++ b/packages/synthetics/data_stream/browser/agent/stream/browser.yml.hbs
@@ -1,3 +1,4 @@
+metadata: {{metadata}}
 type: {{type}}
 name: {{name}}
 {{#if service.name}}

--- a/packages/synthetics/data_stream/browser/manifest.yml
+++ b/packages/synthetics/data_stream/browser/manifest.yml
@@ -9,6 +9,12 @@ streams:
     template_path: browser.yml.hbs
     enabled: true
     vars:
+      - name: metadata
+        type: yaml
+        title: metadata about the package
+        multi: false
+        required: true
+        show_user: false
       - name: type
         type: text
         title: Monitor type

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: synthetics
 title: Elastic Synthetics
 description: This Elastic integration allows you to monitor the availability of your services
-version: 0.3.0
+version: 0.3.1
 categories: ["elastic_stack", "monitoring", "web"]
 release: beta
 type: integration
@@ -25,7 +25,7 @@ policy_templates:
         title: Browser
         description: Perform an Browser check
 conditions:
-  kibana.version: "^7.13.0"
+  kibana.version: "^7.16.0"
 icons:
   - src: /img/uptime-logo-color-64px.svg
     size: 16x16


### PR DESCRIPTION
Relates to @elastic/uptime#371

This PR adds metadata key to the browser data stream, to store arbitrary metadata about the browser monitor.