### PR TITLE
Remove deprecated lines from kubernetes package readme

### DIFF
--- a/packages/kubernetes/_dev/build/docs/README.md
+++ b/packages/kubernetes/_dev/build/docs/README.md
@@ -16,9 +16,6 @@ Some of the previous components are running on each of the Kubernetes nodes (lik
 a single cluster-wide endpoint. This is important to determine the optimal configuration and running strategy
 for the different datasets included in the integration.
 
-For a complete reference on how to configure and run this package on Kubernetes as part of a `DaemonSet` and a `Deployment`,
-there's a complete [example manifest](https://github.com/elastic/beats/blob/master/deploy/kubernetes/elastic-agent-kubernetes.yaml)
-available.
 
 #### Kubernetes endpoints and metricsets
 

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.1"
+  changes:
+    - description: Update Kubernetes integration Readme
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1696
 - version: "1.1.0"
   changes:
     - description: Update to ECS 1.12.0

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update Kubernetes integration Readme
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1696
+      link: https://github.com/elastic/integrations/pull/1890
 - version: "1.1.0"
   changes:
     - description: Update to ECS 1.12.0

--- a/packages/kubernetes/docs/README.md
+++ b/packages/kubernetes/docs/README.md
@@ -16,9 +16,6 @@ Some of the previous components are running on each of the Kubernetes nodes (lik
 a single cluster-wide endpoint. This is important to determine the optimal configuration and running strategy
 for the different datasets included in the integration.
 
-For a complete reference on how to configure and run this package on Kubernetes as part of a `DaemonSet` and a `Deployment`,
-there's a complete [example manifest](https://github.com/elastic/beats/blob/master/deploy/kubernetes/elastic-agent-kubernetes.yaml)
-available.
 
 #### Kubernetes endpoints and metricsets
 

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.1.0
+version: 1.1.1
 license: basic
 description: This Elastic integration collects metrics from Kubernetes clusters
 type: integration


### PR DESCRIPTION
## What does this PR do?

This PR resolves https://github.com/elastic/integrations/issues/1780.

In [Kubernetes integration Readme](https://github.com/elastic/integrations/blob/master/packages/kubernetes/_dev/build/docs/README.md) which is the text that appears in the k8s integration Fleet UI, an example manifest is mentioned pointing to a non-existing doc.

These lines are deprecated and are removed completely.




## Related issues

- Closes https://github.com/elastic/integrations/issues/1780


