### PR TITLE
[Cisco ASA] Loosen time parsing and add group and session type capture

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Relax time parsing and capture group and session type in Cisco ASA module
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1891
 - version: "1.2.0"
   changes:
     - description: Add support for Cisco ASA SIP events

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -64,7 +64,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252114Z",
+                "ingested": "2021-10-11T11:44:17.554978200Z",
                 "original": "May  5 17:51:17 dev01: %FTD-6-302013: Built inbound TCP connection 111111111 for net:10.10.10.10/53500 (8.8.8.8/53500) to fw111:192.168.2.2/53500 (8.8.5.4/53500)",
                 "code": "302013",
                 "kind": "event",
@@ -152,7 +152,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252122600Z",
+                "ingested": "2021-10-11T11:44:17.554989100Z",
                 "original": "May  5 17:51:17 dev01: %FTD-6-302015: Built inbound UDP connection 111111111 for net:10.10.10.10/53500 (8.8.8.8/53500) to fw111:192.168.2.2/53500 (8.8.5.4/53500)",
                 "code": "302015",
                 "kind": "event",
@@ -223,7 +223,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252213500Z",
+                "ingested": "2021-10-11T11:44:17.555012900Z",
                 "original": "May  5 17:51:17 dev01: %FTD-6-302020: Built inbound ICMP connection for faddr 10.10.10.10/0 gaddr 8.8.8.8/0 laddr 192.168.2.2/0 type 3 code 3",
                 "code": "302020",
                 "kind": "event",
@@ -284,7 +284,7 @@
             "event": {
                 "severity": 7,
                 "duration": 0,
-                "ingested": "2021-10-06T20:54:48.252217Z",
+                "ingested": "2021-10-11T11:44:17.555020700Z",
                 "original": "May  5 17:51:17 dev01: %FTD-7-609002: Teardown local-host net:192.168.2.2 duration 0:00:00",
                 "code": "609002",
                 "kind": "event",
@@ -344,7 +344,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-10-06T20:54:48.252222800Z",
+                "ingested": "2021-10-11T11:44:17.555024900Z",
                 "original": "May  5 17:51:17 dev01: %FTD-7-609001: Built local-host net:192.168.2.2",
                 "code": "609001",
                 "kind": "event",
@@ -410,7 +410,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252226900Z",
+                "ingested": "2021-10-11T11:44:17.555028700Z",
                 "original": "May  5 17:51:17 dev01: %FTD-6-302020: Built inbound ICMP connection for faddr 10.10.10.10/0 gaddr 8.8.8.8/0 laddr 192.168.2.2/0 type 3 code 1",
                 "code": "302020",
                 "kind": "event",
@@ -493,7 +493,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252230700Z",
+                "ingested": "2021-10-11T11:44:17.555034100Z",
                 "original": "May  5 17:51:17 dev01: %FTD-6-805001: Offloaded TCP Flow for connection 111111111 from fw111:10.10.10.10/111 (8.8.8.8/111) to fw111:192.168.2.2/111 (8.8.5.4/111)",
                 "code": "805001",
                 "kind": "event",
@@ -572,7 +572,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252235800Z",
+                "ingested": "2021-10-11T11:44:17.555040600Z",
                 "original": "May  5 17:51:17 dev01: %FTD-6-805002: TCP Flow is no longer offloaded for connection 941243214 from net:10.192.18.4/51261 (10.192.18.4/51261) to fw109:10.192.70.66/443 (10.192.70.66/443)",
                 "code": "805002",
                 "kind": "event",
@@ -646,7 +646,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-10-06T20:54:48.252243Z",
+                "ingested": "2021-10-11T11:44:17.555047Z",
                 "original": "May  5 17:51:17 dev01: %FTD-7-710005: UDP request discarded from 192.168.2.2/68 to fw111:10.10.10.10/67",
                 "code": "710005",
                 "kind": "event",
@@ -728,7 +728,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252265500Z",
+                "ingested": "2021-10-11T11:44:17.555051200Z",
                 "original": "May  5 17:51:17 dev01: %FTD-6-303002: FTP connection from net:192.168.2.2/63656 to fw111:10.192.18.4/21, user testuser Stored file /export/home/sysm/ftproot/sdsdsds/tmp.log",
                 "code": "303002",
                 "kind": "event",
@@ -771,7 +771,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-10-06T20:54:48.252270800Z",
+                "ingested": "2021-10-11T11:44:17.555089800Z",
                 "original": "May  5 17:51:17 dev01: %FTD-7-710006: VRRP request discarded from 192.168.2.2 to fw111:192.18.4",
                 "code": "710006",
                 "kind": "event",
@@ -826,7 +826,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-10-06T20:54:48.252300300Z",
+                "ingested": "2021-10-11T11:44:17.555096600Z",
                 "original": "May  5 17:51:17 dev01: %FTD-4-313005: No matching connection for ICMP error message: icmp src fw111:10.192.33.100 dst fw111:192.18.4 (type 3, code 3) on fw111 interface. Original IP payload: udp src 192.18.4/53 dst 8.8.8.8/10872.",
                 "code": "313005",
                 "kind": "event",
@@ -891,7 +891,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252308700Z",
+                "ingested": "2021-10-11T11:44:17.555102900Z",
                 "original": "May  5 18:16:21 dev01: %ASA-6-302021: Teardown ICMP connection for faddr 192.168.2.2/0 gaddr 8.8.8.8/2 laddr 10.10.10.10/2 type 8 code 0",
                 "code": "302021",
                 "kind": "event",
@@ -951,7 +951,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-10-06T20:54:48.252314300Z",
+                "ingested": "2021-10-11T11:44:17.555108500Z",
                 "original": "May  5 18:22:35 dev01: %ASA-7-609001: Built local-host net:10.10.10.10",
                 "code": "609001",
                 "kind": "event",
@@ -1010,7 +1010,7 @@
             "event": {
                 "severity": 7,
                 "duration": 0,
-                "ingested": "2021-10-06T20:54:48.252318700Z",
+                "ingested": "2021-10-11T11:44:17.555114Z",
                 "original": "May  5 18:24:31 dev01: %ASA-7-609002: Teardown local-host identity:10.10.10.10 duration 0:00:00",
                 "code": "609002",
                 "kind": "event",
@@ -1078,7 +1078,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252323200Z",
+                "ingested": "2021-10-11T11:44:17.555121800Z",
                 "original": "May  5 18:29:32 dev01: %ASA-6-302020: Built inbound ICMP connection for faddr 10.10.10.10/0 gaddr 8.8.8.8/0 laddr 10.192.46.90/0",
                 "code": "302020",
                 "kind": "event",
@@ -1144,7 +1144,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252326700Z",
+                "ingested": "2021-10-11T11:44:17.555129600Z",
                 "original": "May  5 18:29:32 dev01: %ASA-6-302020: Built outbound ICMP connection for faddr 10.10.10.10/0 gaddr 8.8.8.8/0 laddr 192.168.2.2/0 type 3 code 3",
                 "code": "302020",
                 "kind": "event",
@@ -1223,7 +1223,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "TCP Reset-I",
-                "ingested": "2021-10-06T20:54:48.252331700Z",
+                "ingested": "2021-10-11T11:44:17.555137100Z",
                 "original": "May  5 18:29:32 dev01: %ASA-6-302014: Teardown TCP connection 2960892904 for out111:10.10.10.10/443 to fw111:192.168.2.2/55225 duration 0:00:00 bytes 0 TCP Reset-I",
                 "code": "302014",
                 "kind": "event",
@@ -1309,7 +1309,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252355700Z",
+                "ingested": "2021-10-11T11:44:17.555144600Z",
                 "original": "May  5 18:29:32 dev01: %ASA-6-302013: Built outbound TCP connection 1588662 for intfacename:192.168.2.2/80 (8.8.8.8/80) to net:10.10.10.10/54839 (8.8.8.8/54839)",
                 "code": "302013",
                 "kind": "event",
@@ -1389,7 +1389,7 @@
             "event": {
                 "severity": 6,
                 "duration": 0,
-                "ingested": "2021-10-06T20:54:48.252361Z",
+                "ingested": "2021-10-11T11:44:17.555152100Z",
                 "original": "May  5 18:29:32 dev01: %ASA-6-302012: Teardown dynamic UDP translation from fw111:10.10.10.10/54230 to out111:192.168.2.2/54230 duration 0:00:00",
                 "code": "302012",
                 "kind": "event",
@@ -1459,7 +1459,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-10-06T20:54:48.252386700Z",
+                "ingested": "2021-10-11T11:44:17.555159600Z",
                 "original": "May  5 18:40:50 dev01: %ASA-4-313004: Denied ICMP type=0, from laddr 10.10.10.10 on interface fw502 to 192.168.2.2: no matching session",
                 "code": "313004",
                 "kind": "event",
@@ -1535,7 +1535,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252391900Z",
+                "ingested": "2021-10-11T11:44:17.555167200Z",
                 "original": "May  5 18:40:50 dev01: %ASA-6-305011: Built dynamic TCP translation from fw111:10.10.10.10/57006 to out111:192.168.2.2/57006",
                 "code": "305011",
                 "kind": "event",
@@ -1605,7 +1605,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-10-06T20:54:48.252398900Z",
+                "ingested": "2021-10-11T11:44:17.555174900Z",
                 "original": "May  5 18:40:50 dev01: %ASA-2-106001: Inbound TCP connection denied from 192.168.2.2/43803 to 10.10.10.10/14322 flags SYN  on interface out111",
                 "code": "106001",
                 "kind": "event",
@@ -1700,7 +1700,7 @@
             "event": {
                 "severity": 2,
                 "duration": 124000000000,
-                "ingested": "2021-10-06T20:54:48.252405900Z",
+                "ingested": "2021-10-11T11:44:17.555182800Z",
                 "original": "May  5 18:40:50 dev01: %ASA-2-302016: Teardown UDP connection 1671727 for intfacename:10.10.10.10/161 to net:192.186.2.2/53356 duration 0:02:04 bytes 64585",
                 "code": "302016",
                 "kind": "event",
@@ -1787,7 +1787,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-10-06T20:54:48.252413700Z",
+                "ingested": "2021-10-11T11:44:17.555187800Z",
                 "original": "May  5 18:40:50 dev01: %ASA-2-302015: Built outbound UDP connection 1743372 for intfacename:10.10.10.10/161 (8.8.8.4/161) to net:192.168.2.2/22638 (8.8.8.8/22638)",
                 "code": "302015",
                 "kind": "event",
@@ -1875,7 +1875,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-10-06T20:54:48.252417Z",
+                "ingested": "2021-10-11T11:44:17.555193600Z",
                 "original": "May  5 18:40:50 dev01: %ASA-2-302015: Built outbound UDP connection 1743372 for intfacename:10.10.10.10/161 (8.8.8.4/161) to net:192.168.2.2/22638 (8.8.8.8/22638)",
                 "code": "302015",
                 "kind": "event",
@@ -1954,7 +1954,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-10-06T20:54:48.252422200Z",
+                "ingested": "2021-10-11T11:44:17.555200300Z",
                 "original": "May  5 18:40:50 dev01: %ASA-4-106023: Deny tcp src fw111:10.10.10.10/64388 dst out111:192.168.2.2/443 by access-group \"out1111_access_out\" [0x47e21ef4, 0x47e21ef4]",
                 "code": "106023",
                 "kind": "event",
@@ -2024,7 +2024,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-10-06T20:54:48.252427500Z",
+                "ingested": "2021-10-11T11:44:17.555206900Z",
                 "original": "May  5 18:40:50 dev01: %ASA-4-106021: Deny TCP reverse path check from 192.168.2.2 to 10.10.10.10 on interface fw111",
                 "code": "106021",
                 "kind": "event",
@@ -2095,7 +2095,7 @@
             },
             "event": {
                 "severity": 2,
-                "ingested": "2021-10-06T20:54:48.252450700Z",
+                "ingested": "2021-10-11T11:44:17.555214800Z",
                 "original": "May  5 19:02:58 dev01: %ASA-2-106006: Deny inbound UDP from 192.168.2.2/65020 to 10.10.10.10/65020 on interface fw111",
                 "code": "106006",
                 "kind": "event",
@@ -2165,7 +2165,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252454200Z",
+                "ingested": "2021-10-11T11:44:17.555219200Z",
                 "original": "May  5 19:02:58 dev01: %ASA-6-106015: Deny TCP (no connection) from 192.168.2.2/53089 to 10.10.10.10/443 flags FIN PSH ACK  on interface out111",
                 "code": "106015",
                 "kind": "event",
@@ -2235,7 +2235,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252459Z",
+                "ingested": "2021-10-11T11:44:17.555224800Z",
                 "original": "May  5 19:02:58 dev01: %ASA-6-106015: Deny TCP (no connection) from 192.168.2.2/17127 to 10.10.10.10/443 flags PSH ACK  on interface out111",
                 "code": "106015",
                 "kind": "event",
@@ -2305,7 +2305,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252465800Z",
+                "ingested": "2021-10-11T11:44:17.555232700Z",
                 "original": "May  5 19:02:58 dev01: %ASA-6-106015: Deny TCP (no connection) from 192.168.2.2/24223 to 10.10.10.10/443 flags RST  on interface fw111",
                 "code": "106015",
                 "kind": "event",
@@ -2380,7 +2380,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252470300Z",
+                "ingested": "2021-10-11T11:44:17.555237500Z",
                 "original": "May  5 19:02:58 dev01: %ASA-6-302022: Built director stub TCP connection for fw1111:10.10.10.10/38540 (8.8.8.5/38540) to net:192.168.2.2/10051 (8.8.8.8/10051)",
                 "code": "302022",
                 "kind": "event",
@@ -2454,7 +2454,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252474Z",
+                "ingested": "2021-10-11T11:44:17.555242100Z",
                 "original": "May  5 19:02:58 dev01: %ASA-6-302022: Built forwarder  stub TCP connection for fw111:10.10.10.10/38540 (8.8.8.5/38540) to net:192.168.2.2/10051 (8.8.8.8/10051)",
                 "code": "302022",
                 "kind": "event",
@@ -2528,7 +2528,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252499800Z",
+                "ingested": "2021-10-11T11:44:17.555245800Z",
                 "original": "May  5 19:02:58 dev01: %ASA-6-302022: Built backup  stub TCP connection for fw111:10.10.10.10/38540 (8.8.8.5/38540) to net:192.1682.2.2/10051 (8.8.8.8/10051)",
                 "code": "302022",
                 "kind": "event",
@@ -2605,7 +2605,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "Cluster flow with CLU closed on owner",
-                "ingested": "2021-10-06T20:54:48.252503300Z",
+                "ingested": "2021-10-11T11:44:17.555251200Z",
                 "original": "May  5 19:02:58 dev01: %ASA-6-302023: Teardown stub TCP connection for fw111:10.10.10.10/39210 to net:192.168.2.2/10051 duration 0:00:00 forwarded bytes 0 Cluster flow with CLU closed on owner",
                 "code": "302023",
                 "kind": "event",
@@ -2684,7 +2684,7 @@
                 "severity": 6,
                 "duration": 0,
                 "reason": "Forwarding or redirect flow removed to create director or backup flow",
-                "ingested": "2021-10-06T20:54:48.252508400Z",
+                "ingested": "2021-10-11T11:44:17.555257500Z",
                 "original": "May  5 19:02:58 dev01: %ASA-6-302023: Teardown stub TCP connection for net:10.10.10.10/10051 to unknown:192.168.2.2/39222 duration 0:00:00 forwarded bytes 0 Forwarding or redirect flow removed to create director or backup flow",
                 "code": "302023",
                 "kind": "event",
@@ -2735,7 +2735,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-10-06T20:54:48.252513800Z",
+                "ingested": "2021-10-11T11:44:17.555264100Z",
                 "original": "May  5 19:03:27 dev01: %ASA-7-111009: User 'aaaa' executed cmd: show access-list fw211111_access_out brief",
                 "code": "111009",
                 "kind": "event",
@@ -2786,7 +2786,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-10-06T20:54:48.252519900Z",
+                "ingested": "2021-10-11T11:44:17.555271900Z",
                 "original": "May  5 19:02:26 dev01: %ASA-7-111009: User 'aaaa' executed cmd: show access-list aaa_out brief",
                 "code": "111009",
                 "kind": "event",
@@ -2862,7 +2862,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252526700Z",
+                "ingested": "2021-10-11T11:44:17.555279500Z",
                 "original": "May  5 19:02:26 dev01: %ASA-6-106100: access-list fw111_out permitted tcp ptaaac/192.168.2.2(62157) -\u003e fw111/10.10.10.10(3452) hit-cnt 1 first hit [0x38ff326b, 0x00000000]",
                 "code": "106100",
                 "kind": "event",
@@ -2939,7 +2939,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252533500Z",
+                "ingested": "2021-10-11T11:44:17.555287200Z",
                 "original": "May  5 19:02:26 dev01: %ASA-6-106100: access-list fw111_out permitted tcp net/192.168.2.2(49033) -\u003e fw111/10.10.10.10(6007) hit-cnt 2 300-second interval [0x38ff326b, 0x00000000]",
                 "code": "106100",
                 "kind": "event",
@@ -2985,7 +2985,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252540400Z",
+                "ingested": "2021-10-11T11:44:17.555294700Z",
                 "original": "May  5 19:02:26 dev01: %ASA-6-302027: Teardown stub ICMP connection for fw1111:10.10.10.10/6426 to net:192.168.2.2/0 duration 1:00:04 forwarded bytes 56 Cluster flow with CLU closed on owner",
                 "code": "302027",
                 "kind": "event",
@@ -3028,7 +3028,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252547200Z",
+                "ingested": "2021-10-11T11:44:17.555302200Z",
                 "original": "May  5 19:02:26 dev01: %ASA-6-302026: Built director stub ICMP connection for fw111:10.10.10.10/32004 (8.8.8.5) to net:192.168.2.2/0 (8.8.8.8)",
                 "code": "302026",
                 "kind": "event",
@@ -3097,7 +3097,7 @@
             },
             "event": {
                 "severity": 7,
-                "ingested": "2021-10-06T20:54:48.252554Z",
+                "ingested": "2021-10-11T11:44:17.555309700Z",
                 "original": "May  5 19:02:26 dev01: %ASA-7-710005: UDP request discarded from 10.10.10.10/1985 to net:192.168.2.2/1985",
                 "code": "710005",
                 "kind": "event",
@@ -3141,7 +3141,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252560900Z",
+                "ingested": "2021-10-11T11:44:17.555317400Z",
                 "original": "May  5 19:02:26 dev01: %ASA-6-302025: Teardown stub UDP connection for net:192.168.2.2/123 to unknown:10.10.10.10/123 duration 0:01:00 forwarded bytes 48 Cluster flow with CLU removed from due to idle timeout",
                 "code": "302025",
                 "kind": "event",
@@ -3184,7 +3184,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252567700Z",
+                "ingested": "2021-10-11T11:44:17.555324900Z",
                 "original": "May  5 19:02:26 dev01: %ASA-6-302024: Built backup stub UDP connection for net:192.168.2.2/9051 (8.8.8.5(19051) to fw111:10.10.10.10/123 (8.8.8.8/123)",
                 "code": "302024",
                 "kind": "event",
@@ -3256,7 +3256,7 @@
             },
             "event": {
                 "severity": 3,
-                "ingested": "2021-10-06T20:54:48.252574400Z",
+                "ingested": "2021-10-11T11:44:17.555332500Z",
                 "original": "May  5 19:02:26 dev01: %ASA-3-106014: Deny inbound icmp src fw111:10.10.10.10 dst fw111:10.10.10.10(type 8, code 0)",
                 "code": "106014",
                 "kind": "event",
@@ -3301,7 +3301,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-10-06T20:54:48.252581200Z",
+                "ingested": "2021-10-11T11:44:17.555340Z",
                 "original": "May  5 19:02:25 dev01: %ASA-4-733100: [192.168.2.2] drop rate-1 exceeded. Current burst rate is 0 per second, max configured rate is -4; Current average rate is 7 per second, max configured rate is -4; Cumulative total count is 9063",
                 "code": "733100",
                 "kind": "event",
@@ -3384,7 +3384,7 @@
             },
             "event": {
                 "severity": 3,
-                "ingested": "2021-10-06T20:54:48.252588Z",
+                "ingested": "2021-10-11T11:44:17.555345600Z",
                 "original": "May  5 19:02:25 dev01: %ASA-3-106010: Deny inbound sctp src fw111:10.10.10.10/5114 dst fw111:10.10.10.10/2",
                 "code": "106010",
                 "kind": "event",
@@ -3460,7 +3460,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-10-06T20:54:48.252594700Z",
+                "ingested": "2021-10-11T11:44:17.555349200Z",
                 "original": "May  5 19:02:25 dev01: %ASA-4-507003: tcp flow from fw111:10.10.10.10/49574 to out111:192.168.2.2/80 terminated by inspection engine, reason - disconnected, dropped packet.",
                 "code": "507003",
                 "kind": "event",
@@ -3523,7 +3523,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-10-06T20:54:48.252602600Z",
+                "ingested": "2021-10-11T11:44:17.555354900Z",
                 "original": "Apr 27 04:18:49 dev01: %ASA-5-304001: 10.20.30.40 Accessed URL 10.20.30.40:http://10.20.30.40/",
                 "code": "304001",
                 "kind": "event",
@@ -3585,7 +3585,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-10-06T20:54:48.252605900Z",
+                "ingested": "2021-10-11T11:44:17.555360400Z",
                 "original": "Apr 27 04:18:49 dev01: %ASA-5-304001: 10.20.30.40 Accessed URL someuser@10.20.30.40:http://10.20.30.40/IOFUHSIU98[0]",
                 "code": "304001",
                 "kind": "event",
@@ -3647,7 +3647,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-10-06T20:54:48.252611Z",
+                "ingested": "2021-10-11T11:44:17.555366700Z",
                 "original": "Apr 27 17:54:52 dev01: %ASA-5-304001: 10.20.30.40 Accessed JAVA URL 10.20.30.40:http://10.20.30.40/some/longer/url-asd-er9789870[0]_=23",
                 "code": "304001",
                 "kind": "event",
@@ -3709,7 +3709,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-10-06T20:54:48.252616Z",
+                "ingested": "2021-10-11T11:44:17.555370900Z",
                 "original": "Apr 27 04:18:49 dev01: %ASA-5-304001: 10.20.30.40 Accessed JAVA URL someuser@10.20.30.40:http://10.20.30.40/",
                 "code": "304001",
                 "kind": "event",
@@ -3815,7 +3815,7 @@
                 "severity": 6,
                 "duration": 3602000000000,
                 "reason": "Connection timeout",
-                "ingested": "2021-10-06T20:54:48.252636900Z",
+                "ingested": "2021-10-11T11:44:17.555376400Z",
                 "original": "Apr 27 04:12:23 dev01: %ASA-6-302304: Teardown TCP state-bypass connection 2751765169 from server.deflan:1.2.3.4/54242 to server.deflan:2.3.4.5/9101 duration 1:00:02 bytes 245 Connection timeout",
                 "code": "302304",
                 "kind": "event",
@@ -3893,7 +3893,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-10-06T20:54:48.252644200Z",
+                "ingested": "2021-10-11T11:44:17.555382500Z",
                 "original": "Apr 27 02:02:02 dev01: %ASA-4-106023: Deny tcp src outside:10.10.10.2/56444 dst srv:192.168.2.2/51635(testhostname.domain) by access-group \"global_access_1\"",
                 "code": "106023",
                 "kind": "event",
@@ -3988,7 +3988,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-10-06T20:54:48.252650800Z",
+                "ingested": "2021-10-11T11:44:17.555386600Z",
                 "original": "Oct 20 2019 15:15:15 dev01: %ASA-5-106100: access-list testrulename denied tcp insideintf/somedomainname.local(27218) -\u003e OUTSIDE/195.122.12.242(53) hit-cnt 1 first hit [0x16847359, 0x00000000]",
                 "code": "106100",
                 "kind": "event",
@@ -4042,7 +4042,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-10-06T20:54:48.252654700Z",
+                "ingested": "2021-10-11T11:44:17.555391Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-5-111004: console end configuration: OK",
                 "code": "111004",
                 "kind": "event",
@@ -4100,7 +4100,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-10-06T20:54:48.252658200Z",
+                "ingested": "2021-10-11T11:44:17.555394600Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-5-111010: User 'enable_15', running 'CLI' from IP 10.10.0.87, executed 'clear'",
                 "code": "111010",
                 "kind": "event",
@@ -4148,7 +4148,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-10-06T20:54:48.252678Z",
+                "ingested": "2021-10-11T11:44:17.555399900Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-5-502103: User priv level changed: Uname: enable_15 From: 1 To: 15",
                 "code": "502103",
                 "kind": "event",
@@ -4226,7 +4226,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252681500Z",
+                "ingested": "2021-10-11T11:44:17.555405500Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-6-605004: Login denied from 10.10.1.212/51923 to FCD-FS-LAN:10.10.1.254/https for user \"*****\"",
                 "code": "605004",
                 "kind": "event",
@@ -4286,7 +4286,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252686500Z",
+                "ingested": "2021-10-11T11:44:17.555411900Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-6-611102: User authentication failed: IP address: 10.10.0.87, Uname: admin",
                 "code": "611102",
                 "kind": "event",
@@ -4357,7 +4357,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252691800Z",
+                "ingested": "2021-10-11T11:44:17.555419600Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-6-605005: Login permitted from 10.10.0.87/6651 to FCD-FS-LAN:10.10.1.254/ssh for user \"admin\"",
                 "code": "605005",
                 "kind": "event",
@@ -4417,7 +4417,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252697900Z",
+                "ingested": "2021-10-11T11:44:17.555427200Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-6-611101: User authentication succeeded: IP address: 10.10.0.87, Uname: admin",
                 "code": "611101",
                 "kind": "event",
@@ -4486,7 +4486,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-10-06T20:54:48.252727200Z",
+                "ingested": "2021-10-11T11:44:17.555434800Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-5-713049: Group = 91.240.17.178, IP = 91.240.17.178, Security negotiation complete for LAN-to-LAN Group (91.240.17.178) Responder, Inbound SPI = 0x276b1da2, Outbound SPI = 0x0e1a581d",
                 "code": "713049",
                 "kind": "event",
@@ -4531,7 +4531,10 @@
             },
             "source": {
                 "user": {
-                    "name": "91.240.17.178"
+                    "name": "91.240.17.178",
+                    "group": {
+                        "name": "91.240.17.178"
+                    }
                 },
                 "bytes": 297103
             },
@@ -4564,12 +4567,13 @@
             },
             "event": {
                 "severity": 4,
-                "duration": 0,
-                "ingested": "2021-10-06T20:54:48.252752300Z",
+                "duration": 1936000000000,
+                "reason": "User Requested",
+                "ingested": "2021-10-11T11:44:17.555442400Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-4-113019: Group = 91.240.17.178, Username = 91.240.17.178, IP = 91.240.17.178, Session disconnected. Session Type: LAN-to-LAN, Duration: 0h:32m:16s, Bytes xmt: 297103, Bytes rcv: 1216163, Reason: User Requested",
                 "code": "113019",
                 "kind": "event",
-                "start": "2021-04-27T02:03:03.000Z",
+                "start": "2021-04-27T01:30:47.000Z",
                 "action": "firewall-rule",
                 "end": "2021-04-27T02:03:03.000Z",
                 "category": [
@@ -4580,7 +4584,9 @@
                 ]
             },
             "cisco": {
-                "asa": {}
+                "asa": {
+                    "session_type": "LAN-to-LAN"
+                }
             }
         },
         {
@@ -4623,7 +4629,7 @@
             },
             "event": {
                 "severity": 4,
-                "ingested": "2021-10-06T20:54:48.252760100Z",
+                "ingested": "2021-10-11T11:44:17.555450Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-4-722051: Group \u003cVPN5Policy\u003e User \u003cjohn\u003e IP \u003c192.168.50.3\u003e IPv4 Address \u003c192.168.50.5\u003e IPv6 address \u003c::\u003e assigned to session",
                 "code": "722051",
                 "kind": "event",
@@ -4700,7 +4706,7 @@
             "event": {
                 "severity": 6,
                 "reason": "User Requested",
-                "ingested": "2021-10-06T20:54:48.252828300Z",
+                "ingested": "2021-10-11T11:44:17.555457500Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-6-716002: Group another-policy User testuser IP 8.8.8.8 WebVPN session terminated: User Requested.",
                 "code": "716002",
                 "kind": "event",
@@ -4761,7 +4767,7 @@
             "event": {
                 "severity": 6,
                 "reason": "Idle timeout",
-                "ingested": "2021-10-06T20:54:48.252836800Z",
+                "ingested": "2021-10-11T11:44:17.555465300Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-6-716002: Group another-policy User alice IP 192.168.50.1 WebVPN session terminated: Idle timeout.",
                 "code": "716002",
                 "kind": "event",
@@ -4867,7 +4873,7 @@
             },
             "event": {
                 "severity": 3,
-                "ingested": "2021-10-06T20:54:48.252844Z",
+                "ingested": "2021-10-11T11:44:17.555473100Z",
                 "original": "Apr 27 02:03:03 dev01: %ASA-3-710003: TCP access denied by ACL from 104.46.88.19/6370 to outside:195.74.114.34/23",
                 "code": "710003",
                 "kind": "event",
@@ -4959,7 +4965,7 @@
             },
             "event": {
                 "severity": 5,
-                "ingested": "2021-10-06T20:54:48.252847700Z",
+                "ingested": "2021-10-11T11:44:17.555480800Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-5-434004: SFR requested ASA to bypass further packet redirection and process TCP flow from sourceInterfaceName:91.240.17.178/8888 to destinationInterfaceName:192.168.2.2/123123 locally",
                 "code": "434004",
                 "kind": "event",
@@ -5053,7 +5059,7 @@
             "event": {
                 "severity": 4,
                 "action": "drop",
-                "ingested": "2021-10-06T20:54:48.252851500Z",
+                "ingested": "2021-10-11T11:44:17.555488500Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-4-434002: SFR requested to drop TCP packet from sourceInterfaceName:91.240.17.138/8888 to destinationInterfaceName:192.168.2.2/514514",
                 "code": "434002",
                 "outcome": "unknown"
@@ -5133,7 +5139,7 @@
             "event": {
                 "severity": 6,
                 "reason": "Failed to locate egress interface",
-                "ingested": "2021-10-06T20:54:48.252878200Z",
+                "ingested": "2021-10-11T11:44:17.555492700Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-6-110002: Failed to locate egress interface for TCP from sourceInterfaceName:91.240.17.178/7777 to 192.168.2.2/123412",
                 "code": "110002",
                 "kind": "event",
@@ -5226,7 +5232,7 @@
             "event": {
                 "severity": 4,
                 "reason": "Duplicate TCP SYN with different initial sequence number",
-                "ingested": "2021-10-06T20:54:48.252881800Z",
+                "ingested": "2021-10-11T11:44:17.555496400Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-4-419002: Duplicate TCP SYN from sourceInterfaceName:91.240.17.178/7777 to destinationInterfaceName:192.168.2.2/514514 with different initial sequence number",
                 "code": "419002",
                 "kind": "event",
@@ -5311,7 +5317,7 @@
             "event": {
                 "severity": 6,
                 "action": "created",
-                "ingested": "2021-10-06T20:54:48.252887400Z",
+                "ingested": "2021-10-11T11:44:17.555502Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-6-602303: IPSEC: An outbound LAN-to-LAN SA (SPI= 0xF81283) between 91.240.17.178 and 192.168.2.2 (user= admin) has been created.",
                 "code": "602303",
                 "outcome": "success"
@@ -5388,7 +5394,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252892400Z",
+                "ingested": "2021-10-11T11:44:17.555507600Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-6-602304: IPSEC: An outbound LAN-to-LAN SA (SPI= 0xF81283) between 91.240.17.178 and 192.168.2.2 (user= admin) has been deleted.",
                 "code": "602304",
                 "kind": "event",
@@ -5474,7 +5480,7 @@
             "event": {
                 "severity": 5,
                 "reason": "Received a IKE_INIT_SA request",
-                "ingested": "2021-10-06T20:54:48.252898800Z",
+                "ingested": "2021-10-11T11:44:17.555513800Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-5-750002: Local:91.240.17.178:7777 Remote:192.168.2.2:7777 Username:admin Received a IKE_INIT_SA request",
                 "code": "750002",
                 "kind": "event",
@@ -5557,7 +5563,7 @@
             "event": {
                 "severity": 4,
                 "reason": "Negotiation aborted due to Failed to locate an item in the database",
-                "ingested": "2021-10-06T20:54:48.252923900Z",
+                "ingested": "2021-10-11T11:44:17.555518Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-4-750003: Local:91.240.17.178:7777 Remote:192.168.2.2:7777 Username:admin Negotiation aborted due to ERROR: Failed to locate an item in the database",
                 "code": "750003",
                 "kind": "event",
@@ -5620,7 +5626,7 @@
             "event": {
                 "severity": 5,
                 "reason": "PHASE 2 COMPLETED",
-                "ingested": "2021-10-06T20:54:48.252953700Z",
+                "ingested": "2021-10-11T11:44:17.555524Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-5-713120: Group = 100.60.140.10, IP = 192.128.1.1, PHASE 2 COMPLETED (msgid=bbe383e88)",
                 "code": "713120",
                 "kind": "event",
@@ -5683,7 +5689,7 @@
             "event": {
                 "severity": 5,
                 "reason": "Duplicate first packet detected",
-                "ingested": "2021-10-06T20:54:48.252960900Z",
+                "ingested": "2021-10-11T11:44:17.555529500Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-5-713202: IP = 192.64.157.61, Duplicate first packet detected. Ignoring packet.",
                 "code": "713202",
                 "kind": "event",
@@ -5743,7 +5749,7 @@
             "event": {
                 "severity": 6,
                 "reason": "All IPSec SA proposals found unacceptable!",
-                "ingested": "2021-10-06T20:54:48.252968100Z",
+                "ingested": "2021-10-11T11:44:17.555533700Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-6-713905: Group = 100.60.140.10, IP = 192.128.1.1, All IPSec SA proposals found unacceptable!",
                 "code": "713905",
                 "kind": "event",
@@ -5786,7 +5792,7 @@
             "event": {
                 "severity": 6,
                 "reason": "All IPSec SA proposals found unacceptable!",
-                "ingested": "2021-10-06T20:54:48.252975200Z",
+                "ingested": "2021-10-11T11:44:17.555538Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-6-713904: All IPSec SA proposals found unacceptable!",
                 "code": "713904",
                 "kind": "event",
@@ -5831,7 +5837,7 @@
             },
             "event": {
                 "severity": 6,
-                "ingested": "2021-10-06T20:54:48.252996400Z",
+                "ingested": "2021-10-11T11:44:17.555541600Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-6-713903: IP = 192.128.1.1, All IPSec SA proposals found unacceptable!",
                 "code": "713903",
                 "kind": "event",
@@ -5875,7 +5881,7 @@
             "event": {
                 "severity": 6,
                 "reason": "All IPSec SA proposals found unacceptable!",
-                "ingested": "2021-10-06T20:54:48.252999700Z",
+                "ingested": "2021-10-11T11:44:17.555546900Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-6-713902: Group = 100.60.140.10, All IPSec SA proposals found unacceptable!",
                 "code": "713902",
                 "kind": "event",
@@ -5940,7 +5946,7 @@
             "event": {
                 "severity": 6,
                 "reason": "All IPSec SA proposals found unacceptable!",
-                "ingested": "2021-10-06T20:54:48.253004700Z",
+                "ingested": "2021-10-11T11:44:17.555552500Z",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-6-713901: Group = 100.60.140.10, IP = 192.128.1.1, All IPSec SA proposals found unacceptable!",
                 "code": "713901",
                 "kind": "event",

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-missing-groups.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-missing-groups.log
@@ -1,0 +1,5 @@
+Jun 08 2020 12:59:57: %ASA-4-113019: Group = TheBeatles, Username = Ringo, IP = 234.56.12.87, Session disconnected. Session Type: AnyConnect-Parent, Duration: 0h:01m:52s, Bytes xmt: 32452, Bytes rcv: 0, Reason: User Requested
+Oct 20 2019 15:42:53: %ASA-4-113019: Group = TheBeatles, Username = John, IP = 234.28.45.42, Session disconnected. Session Type: SSL, Duration: 2h:27m:34s, Bytes xmt: 45323434, Bytes rcv: 43252324, Reason: Idle Timeout
+Oct 20 2019 15:42:54: %ASA-4-722037: Group <GroupPolicy_TheBeatles> User <Paul> IP <83.212.241.149> SVC closing connection: DPD failure.
+Aug  6 2020 11:01:37: %ASA-4-722037: Group <GroupPolicy_TheBeatles> User <Brian> IP <234.63.56.32> SVC closing connection: Transport closing.
+Aug  6 2020 11:01:38: %ASA-4-722051: Group <GroupPolicy_TheBeatles> User <George> IP <234.24.156.94> IPv4 Address <234.56.47.98> IPv6 address <::> assigned to session

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-missing-groups.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-missing-groups.log-expected.json
@@ -1,0 +1,250 @@
+{
+    "expected": [
+        {
+            "log": {
+                "level": "warning"
+            },
+            "destination": {
+                "bytes": 0,
+                "address": "234.56.12.87",
+                "ip": "234.56.12.87"
+            },
+            "source": {
+                "user": {
+                    "name": "Ringo",
+                    "group": {
+                        "name": "TheBeatles"
+                    }
+                },
+                "bytes": 32452
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "observer": {
+                "type": "firewall",
+                "product": "asa",
+                "vendor": "Cisco"
+            },
+            "@timestamp": "2020-06-08T12:59:57.000Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "related": {
+                "user": [
+                    "Ringo"
+                ],
+                "ip": [
+                    "234.56.12.87"
+                ]
+            },
+            "event": {
+                "severity": 4,
+                "duration": 112000000000,
+                "reason": "User Requested",
+                "ingested": "2021-10-11T11:16:23.841932100Z",
+                "original": "Jun 08 2020 12:59:57: %ASA-4-113019: Group = TheBeatles, Username = Ringo, IP = 234.56.12.87, Session disconnected. Session Type: AnyConnect-Parent, Duration: 0h:01m:52s, Bytes xmt: 32452, Bytes rcv: 0, Reason: User Requested",
+                "code": "113019",
+                "kind": "event",
+                "start": "2020-06-08T12:58:05.000Z",
+                "action": "firewall-rule",
+                "end": "2020-06-08T12:59:57.000Z",
+                "category": [
+                    "network"
+                ],
+                "type": [
+                    "info"
+                ]
+            },
+            "cisco": {
+                "asa": {
+                    "session_type": "AnyConnect-Parent"
+                }
+            }
+        },
+        {
+            "log": {
+                "level": "warning"
+            },
+            "destination": {
+                "bytes": 43252324,
+                "address": "234.28.45.42",
+                "ip": "234.28.45.42"
+            },
+            "source": {
+                "user": {
+                    "name": "John",
+                    "group": {
+                        "name": "TheBeatles"
+                    }
+                },
+                "bytes": 45323434
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "observer": {
+                "type": "firewall",
+                "product": "asa",
+                "vendor": "Cisco"
+            },
+            "@timestamp": "2019-10-20T15:42:53.000Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "related": {
+                "user": [
+                    "John"
+                ],
+                "ip": [
+                    "234.28.45.42"
+                ]
+            },
+            "event": {
+                "severity": 4,
+                "duration": 8854000000000,
+                "reason": "Idle Timeout",
+                "ingested": "2021-10-11T11:16:23.841946100Z",
+                "original": "Oct 20 2019 15:42:53: %ASA-4-113019: Group = TheBeatles, Username = John, IP = 234.28.45.42, Session disconnected. Session Type: SSL, Duration: 2h:27m:34s, Bytes xmt: 45323434, Bytes rcv: 43252324, Reason: Idle Timeout",
+                "code": "113019",
+                "kind": "event",
+                "start": "2019-10-20T13:15:19.000Z",
+                "action": "firewall-rule",
+                "end": "2019-10-20T15:42:53.000Z",
+                "category": [
+                    "network"
+                ],
+                "type": [
+                    "info"
+                ]
+            },
+            "cisco": {
+                "asa": {
+                    "session_type": "SSL"
+                }
+            }
+        },
+        {
+            "observer": {
+                "type": "firewall",
+                "product": "asa",
+                "vendor": "Cisco"
+            },
+            "@timestamp": "2019-10-20T15:42:54.000Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "warning"
+            },
+            "event": {
+                "severity": 4,
+                "ingested": "2021-10-11T11:16:23.841954400Z",
+                "original": "Oct 20 2019 15:42:54: %ASA-4-722037: Group \u003cGroupPolicy_TheBeatles\u003e User \u003cPaul\u003e IP \u003c83.212.241.149\u003e SVC closing connection: DPD failure.",
+                "code": "722037",
+                "kind": "event",
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "type": [
+                    "info"
+                ]
+            },
+            "cisco": {
+                "asa": {}
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "observer": {
+                "type": "firewall",
+                "product": "asa",
+                "vendor": "Cisco"
+            },
+            "@timestamp": "2020-08-06T11:01:37.000Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "warning"
+            },
+            "event": {
+                "severity": 4,
+                "ingested": "2021-10-11T11:16:23.841961900Z",
+                "original": "Aug  6 2020 11:01:37: %ASA-4-722037: Group \u003cGroupPolicy_TheBeatles\u003e User \u003cBrian\u003e IP \u003c234.63.56.32\u003e SVC closing connection: Transport closing.",
+                "code": "722037",
+                "kind": "event",
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "type": [
+                    "info"
+                ]
+            },
+            "cisco": {
+                "asa": {}
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "observer": {
+                "type": "firewall",
+                "product": "asa",
+                "vendor": "Cisco"
+            },
+            "@timestamp": "2020-08-06T11:01:38.000Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "related": {
+                "user": [
+                    "George"
+                ],
+                "ip": [
+                    "234.24.156.94"
+                ]
+            },
+            "log": {
+                "level": "warning"
+            },
+            "source": {
+                "user": {
+                    "name": "George"
+                },
+                "address": "234.24.156.94",
+                "ip": "234.24.156.94"
+            },
+            "event": {
+                "severity": 4,
+                "ingested": "2021-10-11T11:16:23.841969400Z",
+                "original": "Aug  6 2020 11:01:38: %ASA-4-722051: Group \u003cGroupPolicy_TheBeatles\u003e User \u003cGeorge\u003e IP \u003c234.24.156.94\u003e IPv4 Address \u003c234.56.47.98\u003e IPv6 address \u003c::\u003e assigned to session",
+                "code": "722051",
+                "kind": "event",
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "type": [
+                    "info"
+                ]
+            },
+            "cisco": {
+                "asa": {
+                    "webvpn": {
+                        "group_name": "GroupPolicy_TheBeatles"
+                    },
+                    "assigned_ip": "234.56.47.98"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        }
+    ]
+}

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -322,7 +322,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '113019'"
       field: "message"
       description: "113019"
-      pattern: "Group = %{}, Username = %{source.user.name}, IP = %{destination.address}, Session disconnected. Session Type: %{}, Duration: %{_temp_.duration_hms}, Bytes xmt: %{source.bytes}, Bytes rcv: %{destination.bytes}, Reason: %{message}"
+      pattern: "Group = %{source.user.group.name}, Username = %{source.user.name}, IP = %{destination.address}, Session disconnected. Session Type: %{_temp_.cisco.session_type}, Duration: %{_temp_.duration_hms}, Bytes xmt: %{source.bytes}, Bytes rcv: %{destination.bytes}, Reason: %{event.reason}"
   - grok:
       if: '["302013", "302015"].contains(ctx._temp_.cisco.message_id)'
       field: "message"
@@ -1321,7 +1321,7 @@ processors:
                 } else if (c == (char)':') {
                     total = (total + cur) * 60;
                     cur = 0;
-                } else {
+                } else if (c != (char)'h' && c == (char)'m' && c == (char)'s') {
                     return 0;
                 }
             }

--- a/packages/cisco_asa/data_stream/log/fields/ecs.yml
+++ b/packages/cisco_asa/data_stream/log/fields/ecs.yml
@@ -167,6 +167,8 @@
 - external: ecs
   name: source.user.name
 - external: ecs
+  name: source.user.group.name
+- external: ecs
   name: tags
 - external: ecs
   name: url.domain

--- a/packages/cisco_asa/data_stream/log/fields/fields.yml
+++ b/packages/cisco_asa/data_stream/log/fields/fields.yml
@@ -86,6 +86,12 @@
       description: >
         The VPN connection type
 
+    - name: session_type
+      type: keyword
+      default_field: false
+      description: >
+        Session type (for example, IPsec or UDP).
+
     - name: dap_records
       type: keyword
       description: >

--- a/packages/cisco_asa/docs/README.md
+++ b/packages/cisco_asa/docs/README.md
@@ -158,6 +158,7 @@ An example event for `log` looks as following:
 | cisco.asa.privilege.old | When a users privilege is changed this is the old value | keyword |
 | cisco.asa.rule_name | Name of the Access Control List rule that matched this event. | keyword |
 | cisco.asa.security | Cisco FTD security event fields. | flattened |
+| cisco.asa.session_type | Session type (for example, IPsec or UDP). | keyword |
 | cisco.asa.source_interface | Source interface for the flow or event. | keyword |
 | cisco.asa.source_username | Name of the user that is the source for this event. | keyword |
 | cisco.asa.suffix | Optional suffix after %ASA identifier. | keyword |
@@ -289,6 +290,7 @@ An example event for `log` looks as following:
 | source.nat.ip | Translated ip of source based NAT sessions (e.g. internal client to internet) Typically connections traversing load balancers, firewalls, or routers. | ip |
 | source.nat.port | Translated port of source based NAT sessions. (e.g. internal client to internet) Typically used with load balancers, firewalls, or routers. | long |
 | source.port | Port of the source. | long |
+| source.user.group.name | Name of the group. | keyword |
 | source.user.name | Short name or login of the user. | keyword |
 | syslog.facility.code | Syslog numeric facility of the event. | long |
 | syslog.priority | Syslog priority of the event. | long |

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_asa
 title: Cisco ASA
-version: 1.2.0
+version: 1.2.1
 license: basic
 description: This Elastic integration collects logs from Cisco ASA network devices
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This change reflects the changes to beats Cisco ASA module in elastic/beats#28325.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Confirm this matches elastic/beats#28325

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
elastic-package test pipeline
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates elastic/beats#28325

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->

N/A