### PR TITLE
Re-enable AWS tests for debugging purposes

### DIFF
--- a/packages/aws/data_stream/ec2_metrics/_dev/test/system/test-default-config.yml
+++ b/packages/aws/data_stream/ec2_metrics/_dev/test/system/test-default-config.yml
@@ -1,6 +1,3 @@
-skip:
-  reason: "EC2 tests are flaky due to machine not being ready in time, we will improve it"
-  link: https://github.com/elastic/integrations/issues/1761
 vars:
   access_key_id: '{{AWS_ACCESS_KEY_ID}}'
   secret_access_key: '{{AWS_SECRET_ACCESS_KEY}}'


### PR DESCRIPTION
Issue: https://github.com/elastic/integrations/issues/1761

We enabled extra feature to collect service container logs including the Terraform service deployer (AWS orchestrator).