### PR TITLE
Fix build

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -2,6 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build mage
 // +build mage
 
 package main

--- a/tools.go
+++ b/tools.go
@@ -2,6 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build tools
 // +build tools
 
 package main


### PR DESCRIPTION
## What does this PR do?

Fixes the broken build. The `goimports` fixes up the build tags for `magefile.go` and `tools.go`. This leads to build failures due to unclean git state.