### PR TITLE
Flaky: skip EC2 system tests

### DIFF
--- a/packages/aws/data_stream/ec2_metrics/_dev/test/system/test-default-config.yml
+++ b/packages/aws/data_stream/ec2_metrics/_dev/test/system/test-default-config.yml
@@ -1,5 +1,5 @@
 skip:
-  reason: "EC2 tests are flaky due to delay in metrics delivery in CloudWatch"
+  reason: "EC2 tests are flaky due to delay in metrics delivery to CloudWatch"
   link: https://github.com/elastic/integrations/issues/1566
 vars:
   access_key_id: '{{AWS_ACCESS_KEY_ID}}'


### PR DESCRIPTION
Issue: https://github.com/elastic/integrations/issues/1566

Let's skip this one more time as it's flaky.

We will enable it once https://github.com/elastic/elastic-package/issues/540 is delivered.

