### PR TITLE
packages/windows/data_stream/powershell_operations: don't split tokens on hyphen

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Don't split hyphenated tokens for PowerShell scripts
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/1931
 - version: "1.3.3"
   changes:
     - description: Uniform with guidelines

--- a/packages/windows/data_stream/forwarded/fields/fields.yml
+++ b/packages/windows/data_stream/forwarded/fields/fields.yml
@@ -144,6 +144,8 @@
       example: "50d2dbda-7361-4926-a94d-d9eadfdb43fa"
     - name: script_block_text
       type: text
+      analyzer: powershell_script_analyzer
+      search_analyzer: powershell_script_analyzer
       description: >
         Text of the executed script block.
 

--- a/packages/windows/data_stream/forwarded/manifest.yml
+++ b/packages/windows/data_stream/forwarded/manifest.yml
@@ -1,5 +1,13 @@
 type: logs
 title: Windows forwarded events
+elasticsearch:
+  index_template:
+    settings:
+      analysis:
+        analyzer:
+          powershell_script_analyzer:
+            type: pattern
+            pattern: '[\W&&[^-]]+'
 streams:
   - input: winlog
     template_path: winlog.yml.hbs

--- a/packages/windows/data_stream/powershell/fields/fields.yml
+++ b/packages/windows/data_stream/powershell/fields/fields.yml
@@ -104,6 +104,8 @@
       description: Id of the executed script block.
       example: "50d2dbda-7361-4926-a94d-d9eadfdb43fa"
     - name: script_block_text
+      analyzer: powershell_script_analyzer
+      search_analyzer: powershell_script_analyzer
       type: text
       description: >
         Text of the executed script block.

--- a/packages/windows/data_stream/powershell/manifest.yml
+++ b/packages/windows/data_stream/powershell/manifest.yml
@@ -1,5 +1,13 @@
 type: logs
 title: Windows Powershell logs
+elasticsearch:
+  index_template:
+    settings:
+      analysis:
+        analyzer:
+          powershell_script_analyzer:
+            type: pattern
+            pattern: '[\W&&[^-]]+'
 streams:
   - input: winlog
     template_path: winlog.yml.hbs

--- a/packages/windows/data_stream/powershell_operational/fields/fields.yml
+++ b/packages/windows/data_stream/powershell_operational/fields/fields.yml
@@ -105,6 +105,7 @@
       example: "50d2dbda-7361-4926-a94d-d9eadfdb43fa"
     - name: script_block_text
       type: text
+      analyzer: powershell_script_analyzer
       description: >
         Text of the executed script block.
 

--- a/packages/windows/data_stream/powershell_operational/manifest.yml
+++ b/packages/windows/data_stream/powershell_operational/manifest.yml
@@ -1,5 +1,13 @@
 type: logs
 title: Windows Powershell/Operational logs
+elasticsearch:
+  index_template:
+    settings:
+      analysis:
+        analyzer:
+          powershell_script_analyzer:
+            type: pattern
+            pattern: '[\W&&[^-]]+'
 streams:
   - input: winlog
     template_path: winlog.yml.hbs

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.3.3
+version: 1.4.0
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

The change replaces the simple tokenizer with a custom tokenizer that splits on word boundaries that do not include hyphen.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Confirm that this generates the correct output template.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #1776.

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
