### PR TITLE
Update title and description of Security integrations for consistency

### DIFF
--- a/packages/1password/changelog.yml
+++ b/packages/1password/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Update Title and Description.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1997
 - version: "0.1.0"
   changes:
     - description: Initial draft of the package

--- a/packages/1password/manifest.yml
+++ b/packages/1password/manifest.yml
@@ -1,9 +1,9 @@
 format_version: 1.0.0
 name: 1password
 title: "1Password Events Reporting"
-version: 0.1.0
+version: 0.1.1
 license: basic
-description: "This Elastic integration collects events from 1Password Events Reporting."
+description: Collect events from 1Password Events API with Elastic Agent.
 type: integration
 categories:
   - security

--- a/packages/cisco/changelog.yml
+++ b/packages/cisco/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.12.3"
+  changes:
+    - description: Update Title and Description.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1997
 - version: "0.12.2"
   changes:
     - description: Fixed a bug that prevents the package from working in 7.16.

--- a/packages/cisco/manifest.yml
+++ b/packages/cisco/manifest.yml
@@ -1,9 +1,9 @@
 format_version: 1.0.0
 name: cisco
-title: Cisco - Deprecated
-version: 0.12.2
+title: Cisco
+version: 0.12.3
 license: basic
-description: "Cisco - Deprecated: Use the more specific Cisco packages available"
+description: Deprecated. Use a specific Cisco package instead.
 type: integration
 categories:
   - network

--- a/packages/cyberark/changelog.yml
+++ b/packages/cyberark/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.3"
+  changes:
+    - description: Update title and description.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1997
 - version: "0.4.2"
   changes:
     - description: Fixed a bug that prevents the package from working in 7.16.

--- a/packages/cyberark/manifest.yml
+++ b/packages/cyberark/manifest.yml
@@ -1,8 +1,8 @@
 format_version: 1.0.0
 name: cyberark
-title: Cyber-Ark - Deprecated
-version: 0.4.2
-description: "Cyber-Ark Integration - Deprecated: Use 'CyberArk Privileged Access Security' instead."
+title: Cyber-Ark
+version: 0.4.3
+description: Deprecated. Use CyberArk Privileged Access Security instead.
 categories: ["security"]
 release: experimental
 license: basic

--- a/packages/fortinet/changelog.yml
+++ b/packages/fortinet/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.3"
+  changes:
+    - description: Update title and description.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1997
 - version: "1.2.2"
   changes:
     - description: Fixed a bug that prevents the package from working in 7.16.

--- a/packages/fortinet/manifest.yml
+++ b/packages/fortinet/manifest.yml
@@ -1,8 +1,8 @@
 name: fortinet
 title: Fortinet
-version: 1.2.2
+version: 1.2.3
 release: ga
-description: This Elastic integration collects logs from Fortinet instances
+description: Collect logs from Fortinet software with Elastic Agent.
 type: integration
 format_version: 1.0.0
 license: basic

--- a/packages/github/changelog.yml
+++ b/packages/github/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Update Title and Description.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1997
 - version: "0.1.0"
   changes:
     - description: initial release

--- a/packages/github/manifest.yml
+++ b/packages/github/manifest.yml
@@ -1,8 +1,8 @@
 name: github
 title: GitHub
-version: 0.1.0
+version: 0.1.1
 release: experimental
-description: GitHub Integration
+description: Collect events from GitHub with Elastic Agent.
 type: integration
 format_version: 1.0.0
 license: basic

--- a/packages/juniper/changelog.yml
+++ b/packages/juniper/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.3"
+  changes:
+    - description: Update title and description.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1997
 - version: "1.0.2"
   changes:
     - description: Fixed a bug that prevents the package from working in 7.16.

--- a/packages/juniper/manifest.yml
+++ b/packages/juniper/manifest.yml
@@ -1,8 +1,8 @@
 format_version: 1.0.0
 name: juniper
 title: Juniper
-version: 1.0.2
-description: This Elastic integration collects logs from Juniper
+version: 1.0.3
+description: Collect logs from Juniper devices with Elastic Agent.
 categories: ["network", "security"]
 release: ga
 license: basic

--- a/packages/microsoft/changelog.yml
+++ b/packages/microsoft/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.8.3"
+  changes:
+    - description: Update title and description. Mark as deprecated in description.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1997
 - version: "0.8.2"
   changes:
     - description: Fixed a bug that prevents the package from working in 7.16.

--- a/packages/microsoft/manifest.yml
+++ b/packages/microsoft/manifest.yml
@@ -1,8 +1,8 @@
 format_version: 1.0.0
 name: microsoft
 title: Microsoft
-version: 0.8.2
-description: This Elastic integration collects logs from Microsoft products
+version: 0.8.3
+description: Deprecated. Use a specific Microsoft package instead.
 categories:
   - "network"
   - "security"

--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -1,6 +1,9 @@
 # newer versions go on top
 - version: "0.4.1"
   changes:
+    - description: Update Description.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1997
     - description: Update Title and Description.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/1975

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -3,7 +3,7 @@ name: network_traffic
 title: Network Packet Capture
 version: 0.4.1
 license: basic
-description: Collect logs from Network Packet Capture with Elastic Agent.
+description: Collect packets from network interfaces with Elastic Agent.
 type: integration
 categories:
   - web

--- a/packages/ti_abusech/changelog.yml
+++ b/packages/ti_abusech/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.2"
+  changes:
+    - description: Update title and description.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1997
 - version: "1.0.1"
   changes:
     - description: Fix invisible package icon

--- a/packages/ti_abusech/manifest.yml
+++ b/packages/ti_abusech/manifest.yml
@@ -1,8 +1,8 @@
 name: ti_abusech
-title: AbuseCH API
-version: 1.0.1
+title: AbuseCH
+version: 1.0.2
 release: ga
-description: This Elastic integration collects threat intelligence from AbuseCH API endpoints
+description: Collect threat intelligence from AbuseCH API with Elastic Agent.
 type: integration
 format_version: 1.0.0
 license: basic

--- a/packages/ti_anomali/changelog.yml
+++ b/packages/ti_anomali/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: Update title and description.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1997
 - version: "1.0.0"
   changes:
     - description: Initial release

--- a/packages/ti_anomali/manifest.yml
+++ b/packages/ti_anomali/manifest.yml
@@ -1,8 +1,8 @@
 name: ti_anomali
 title: Anomali
-version: 1.0.0
+version: 1.0.1
 release: ga
-description: This Elastic integration collects events from Anomali
+description: Collect threat intelligence from Anomali APIs with Elastic Agent.
 type: integration
 format_version: 1.0.0
 license: basic

--- a/packages/ti_otx/changelog.yml
+++ b/packages/ti_otx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: Update title and description.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1997
 - version: "1.0.0"
   changes:
     - description: Initial release

--- a/packages/ti_otx/manifest.yml
+++ b/packages/ti_otx/manifest.yml
@@ -1,8 +1,8 @@
 name: ti_otx
-title: Alienvault OTX
-version: 1.0.0
+title: AlienVault OTX
+version: 1.0.1
 release: ga
-description: This Elastic integration collects threat intelligence from Alienvault OTX API endpoints
+description: Collect threat intelligence from AlienVault OTX with Elastic Agent.
 type: integration
 format_version: 1.0.0
 license: basic


### PR DESCRIPTION
## What does this PR do?

This updates the titles and descriptions as per #1900. Specifically:

- Change Cisco and Cyber-Ark to the deprecated format in https://github.com/elastic/integrations/issues/1900#issuecomment-945889319.
- Make Microsoft deprecated using the same format. Relates #1937.
- Change description for `network_traffic`.
- Update the packages that were missed in the previous update.

Relates: #1900

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Related issues

- Relates: #1900
