### PR TITLE
Fix: AWS EC2 system test uses latency option

### DIFF
--- a/packages/aws/data_stream/ec2_metrics/_dev/test/system/test-default-config.yml
+++ b/packages/aws/data_stream/ec2_metrics/_dev/test/system/test-default-config.yml
@@ -5,7 +5,8 @@ vars:
   session_token: '{{AWS_SESSION_TOKEN}}'
 data_stream:
   vars:
-    period: 60s
+    period: 5m
+    latency: 10m
     tags_filter: |-
       - key: Name
         value: "elastic-package-test-{{TEST_RUN_ID}}"


### PR DESCRIPTION
Issue: https://github.com/elastic/integrations/issues/1566

This PR modifies the system test definition for AWS EC2 to use "latency" config. This is the last possible option we can adopt to make system tests bulletproof. If it doesn't work, we can assume that metrics delivery in CloudWatch is so deterministic that we can't depend on it. 