### PR TITLE
[Synthetics] update mappings

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.1"
+  changes:
+    - description: Update mappings for synthetics step
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/2027
 - version: "0.4.0"
   changes:
     - description: Add new synthetics/browser input params

--- a/packages/synthetics/data_stream/browser/fields/synthetics.yml
+++ b/packages/synthetics/data_stream/browser/fields/synthetics.yml
@@ -27,6 +27,9 @@
       fields:
         - name: name
           type: text
+          multi_fields:
+            - name: keyword
+              type: keyword
         - name: index
           type: integer
         - name: status

--- a/packages/synthetics/data_stream/browser_network/fields/synthetics.yml
+++ b/packages/synthetics/data_stream/browser_network/fields/synthetics.yml
@@ -27,6 +27,9 @@
       fields:
         - name: name
           type: text
+          multi_fields:
+            - name: keyword
+              type: keyword
         - name: index
           type: integer
         - name: status

--- a/packages/synthetics/data_stream/browser_screenshot/fields/synthetics.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/fields/synthetics.yml
@@ -27,6 +27,9 @@
       fields:
         - name: name
           type: text
+          multi_fields:
+            - name: keyword
+              type: keyword
         - name: index
           type: integer
         - name: status

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: synthetics
 title: Elastic Synthetics
 description: This Elastic integration allows you to monitor the availability of your services
-version: 0.4.0
+version: 0.4.1
 categories: ["elastic_stack", "monitoring", "web"]
 release: beta
 type: integration


### PR DESCRIPTION
Fixes #1925
Relates to elastic/beats#28409

Type of change
- Enhancement

## What does this PR do?

Updates the `browser`, `browser.network`, and `browser.screenshot` mappings to include keyword mapping, keeping in step with heartbeat.
