### PR TITLE
Skip nats system tests since can be flaky

### DIFF
--- a/packages/nats/data_stream/log/_dev/test/pipeline/test-log-sample.log
+++ b/packages/nats/data_stream/log/_dev/test/pipeline/test-log-sample.log
@@ -9,6 +9,7 @@
 [1] 2019/02/06 07:20:08.512153 [TRC] 172.18.0.1:38630 - cid:1 - <<- [PONG]
 [1] 2019/02/04 15:40:02.717819 [TRC] 50.39.246.116:62388 - cid:3 - ->> [PUB aiuser.platinum1.pingpeer _INBOX.e3hAUbP4r5wbjw3Hudw42r.udigGiHn 20]
 [1] 2019/02/04 15:40:02.717825 [TRC] 50.39.246.116:62388 - cid:3 - ->> MSG_PAYLOAD: [peer, are you alive?]
+[1] 2019/02/04 15:40:02.717825 [TRC] 50.39.246.116:62388 - cid:3 - <<- MSG_PAYLOAD: [\"\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\"]
 [1] 2019/02/04 15:40:02.717832 [TRC] 192.168.176.11:36262 - cid:4 - <<- [MSG aiuser.platinum1.pingpeer 1 _INBOX.e3hAUbP4r5wbjw3Hudw42r.udigGiHn 20]
 [1] 2019/02/04 15:40:02.718007 [TRC] 192.168.176.11:36262 - cid:4 - ->> [PUB _INBOX.e3hAUbP4r5wbjw3Hudw42r.udigGiHn 17]
 [1] 2019/02/04 15:40:02.718023 [TRC] 192.168.176.11:36262 - cid:4 - ->> MSG_PAYLOAD: [I am fine, agent!]

--- a/packages/nats/data_stream/log/_dev/test/pipeline/test-log-sample.log-expected.json
+++ b/packages/nats/data_stream/log/_dev/test/pipeline/test-log-sample.log-expected.json
@@ -17,7 +17,7 @@
                 "level": "info"
             },
             "event": {
-                "ingested": "2021-06-09T12:07:01.961493300Z",
+                "ingested": "2021-10-27T10:26:49.197765249Z",
                 "original": "[1] 2019/02/06 07:19:40.624334 [INF] Starting nats-server version 1.3.0",
                 "type": [
                     "info"
@@ -47,7 +47,7 @@
                 "level": "info"
             },
             "event": {
-                "ingested": "2021-06-09T12:07:01.961517200Z",
+                "ingested": "2021-10-27T10:26:49.197769348Z",
                 "original": "[1] 2019/02/06 07:19:40.624547 [INF] Git commit [eed4fbc]",
                 "type": [
                     "info"
@@ -77,7 +77,7 @@
                 "level": "info"
             },
             "event": {
-                "ingested": "2021-06-09T12:07:01.961527100Z",
+                "ingested": "2021-10-27T10:26:49.197771417Z",
                 "original": "[1] 2019/02/06 07:19:40.624674 [INF] Listening for client connections on 0.0.0.0:4222",
                 "type": [
                     "info"
@@ -107,7 +107,7 @@
                 "level": "info"
             },
             "event": {
-                "ingested": "2021-06-09T12:07:01.961570100Z",
+                "ingested": "2021-10-27T10:26:49.197773209Z",
                 "original": "[1] 2019/02/06 07:19:40.624690 [INF] Server is ready",
                 "type": [
                     "info"
@@ -153,7 +153,7 @@
                 "ip": "172.18.0.1"
             },
             "event": {
-                "ingested": "2021-06-09T12:07:01.961576800Z",
+                "ingested": "2021-10-27T10:26:49.197775006Z",
                 "original": "[1] 2019/02/06 07:20:08.508891 [DBG] 172.18.0.1:38630 - cid:1 - Client connection created",
                 "type": [
                     "info"
@@ -200,7 +200,7 @@
                 "ip": "172.18.0.1"
             },
             "event": {
-                "ingested": "2021-06-09T12:07:01.961583100Z",
+                "ingested": "2021-10-27T10:26:49.197776708Z",
                 "original": "[1] 2019/02/06 07:20:08.510296 [TRC] 172.18.0.1:38630 - cid:1 - -\u003e\u003e [CONNECT {\"verbose\":false,\"pedantic\":false,\"tls_required\":false,\"name\":\"NATS Benchmark\",\"lang\":\"go\",\"version\":\"1.7.0\",\"protocol\":1,\"echo\":true}]",
                 "type": [
                     "info"
@@ -248,7 +248,7 @@
                 "ip": "172.18.0.1"
             },
             "event": {
-                "ingested": "2021-06-09T12:07:01.961588800Z",
+                "ingested": "2021-10-27T10:26:49.197778387Z",
                 "original": "[1] 2019/02/06 07:20:08.512052 [TRC] 172.18.0.1:38630 - cid:1 - -\u003e\u003e [SUB foo  1]",
                 "type": [
                     "info"
@@ -294,7 +294,7 @@
                 "ip": "172.18.0.1"
             },
             "event": {
-                "ingested": "2021-06-09T12:07:01.961593400Z",
+                "ingested": "2021-10-27T10:26:49.197780020Z",
                 "original": "[1] 2019/02/06 07:20:08.512128 [TRC] 172.18.0.1:38630 - cid:1 - -\u003e\u003e [PING]",
                 "type": [
                     "info"
@@ -340,7 +340,7 @@
                 "ip": "172.18.0.1"
             },
             "event": {
-                "ingested": "2021-06-09T12:07:01.961599200Z",
+                "ingested": "2021-10-27T10:26:49.197781703Z",
                 "original": "[1] 2019/02/06 07:20:08.512153 [TRC] 172.18.0.1:38630 - cid:1 - \u003c\u003c- [PONG]",
                 "type": [
                     "info"
@@ -389,7 +389,7 @@
                 "ip": "50.39.246.116"
             },
             "event": {
-                "ingested": "2021-06-09T12:07:01.961605200Z",
+                "ingested": "2021-10-27T10:26:49.197783401Z",
                 "original": "[1] 2019/02/04 15:40:02.717819 [TRC] 50.39.246.116:62388 - cid:3 - -\u003e\u003e [PUB aiuser.platinum1.pingpeer _INBOX.e3hAUbP4r5wbjw3Hudw42r.udigGiHn 20]",
                 "type": [
                     "info"
@@ -435,8 +435,54 @@
                 "ip": "50.39.246.116"
             },
             "event": {
-                "ingested": "2021-06-09T12:07:01.961622700Z",
+                "ingested": "2021-10-27T10:26:49.197785054Z",
                 "original": "[1] 2019/02/04 15:40:02.717825 [TRC] 50.39.246.116:62388 - cid:3 - -\u003e\u003e MSG_PAYLOAD: [peer, are you alive?]",
+                "type": [
+                    "info"
+                ],
+                "created": "2020-04-28T11:07:58.223Z",
+                "kind": "event"
+            }
+        },
+        {
+            "nats": {
+                "log": {
+                    "msg": {
+                        "type": "payload"
+                    },
+                    "client": {
+                        "id": "3"
+                    }
+                }
+            },
+            "process": {
+                "pid": 1
+            },
+            "log": {
+                "level": "trace"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "direction": "inbound"
+            },
+            "@timestamp": "2019-02-04T15:40:02.717Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "related": {
+                "ip": [
+                    "50.39.246.116"
+                ]
+            },
+            "client": {
+                "port": 62388,
+                "ip": "50.39.246.116"
+            },
+            "event": {
+                "ingested": "2021-10-27T10:26:49.197786896Z",
+                "original": "[1] 2019/02/04 15:40:02.717825 [TRC] 50.39.246.116:62388 - cid:3 - \u003c\u003c- MSG_PAYLOAD: [\\\"\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\"]",
                 "type": [
                     "info"
                 ],
@@ -485,7 +531,7 @@
                 "ip": "192.168.176.11"
             },
             "event": {
-                "ingested": "2021-06-09T12:07:01.961630600Z",
+                "ingested": "2021-10-27T10:26:49.197788580Z",
                 "original": "[1] 2019/02/04 15:40:02.717832 [TRC] 192.168.176.11:36262 - cid:4 - \u003c\u003c- [MSG aiuser.platinum1.pingpeer 1 _INBOX.e3hAUbP4r5wbjw3Hudw42r.udigGiHn 20]",
                 "type": [
                     "info"
@@ -533,7 +579,7 @@
                 "ip": "192.168.176.11"
             },
             "event": {
-                "ingested": "2021-06-09T12:07:01.961636900Z",
+                "ingested": "2021-10-27T10:26:49.197790211Z",
                 "original": "[1] 2019/02/04 15:40:02.718007 [TRC] 192.168.176.11:36262 - cid:4 - -\u003e\u003e [PUB _INBOX.e3hAUbP4r5wbjw3Hudw42r.udigGiHn 17]",
                 "type": [
                     "info"
@@ -579,7 +625,7 @@
                 "ip": "192.168.176.11"
             },
             "event": {
-                "ingested": "2021-06-09T12:07:01.961642100Z",
+                "ingested": "2021-10-27T10:26:49.197791877Z",
                 "original": "[1] 2019/02/04 15:40:02.718023 [TRC] 192.168.176.11:36262 - cid:4 - -\u003e\u003e MSG_PAYLOAD: [I am fine, agent!]",
                 "type": [
                     "info"
@@ -628,7 +674,7 @@
                 "ip": "50.39.246.116"
             },
             "event": {
-                "ingested": "2021-06-09T12:07:01.961647100Z",
+                "ingested": "2021-10-27T10:26:49.197793541Z",
                 "original": "[1] 2019/02/04 15:40:02.718044 [TRC] 50.39.246.116:62388 - cid:3 - \u003c\u003c- [MSG _INBOX.e3hAUbP4r5wbjw3Hudw42r.udigGiHn 11 17]",
                 "type": [
                     "info"
@@ -676,7 +722,7 @@
                 "ip": "50.39.246.116"
             },
             "event": {
-                "ingested": "2021-06-09T12:07:01.961652500Z",
+                "ingested": "2021-10-27T10:26:49.197795278Z",
                 "original": "[1] 2019/02/04 15:40:02.717600 [TRC] 50.39.246.116:62388 - cid:3 - -\u003e\u003e [PUB aiuser.platinum1.appstats 1583]",
                 "type": [
                     "info"
@@ -725,7 +771,7 @@
                 "ip": "192.168.176.11"
             },
             "event": {
-                "ingested": "2021-06-09T12:07:01.961663200Z",
+                "ingested": "2021-10-27T10:26:49.197796956Z",
                 "original": "[1] 2019/02/04 15:40:02.717811 [TRC] 192.168.176.11:36262 - cid:4 - \u003c\u003c- [MSG aiuser.platinum1.appstats 6 1583]",
                 "type": [
                     "info"
@@ -771,7 +817,7 @@
                 "ip": "172.18.0.1"
             },
             "event": {
-                "ingested": "2021-06-09T12:07:01.961668200Z",
+                "ingested": "2021-10-27T10:26:49.197798598Z",
                 "original": "[1] 2019/02/16 07:20:08.512153 [TRC] 172.18.0.1:38630 - cid:1 - \u003c\u003c- [OK]",
                 "type": [
                     "info"

--- a/packages/nats/data_stream/log/_dev/test/system/test-default-config.yml
+++ b/packages/nats/data_stream/log/_dev/test/system/test-default-config.yml
@@ -1,3 +1,6 @@
+skip:
+  reason: Test is skipped for now since it has been reported as flaky. We can rely on pipeline tests for now.
+  link: https://github.com/elastic/integrations/issues/1576
 vars: ~
 data_stream:
   vars:


### PR DESCRIPTION
## What does this PR do?
Skips nats system tests since can be flaky as reported at https://github.com/elastic/integrations/issues/1576.
Tried to investigate the flakyness but it seems really weird since the problematic log line is not failing if I add it explicitly in the pipeline test. I’m gonna skip this for now since we can rely on pipeline test without an issue. 