### PR TITLE
[AbuseCH] Bump min version

### DIFF
--- a/packages/ti_abusech/changelog.yml
+++ b/packages/ti_abusech/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.4"
+  changes:
+    - description: Bump minimum version in manifest
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/2072
 - version: "1.0.3"
   changes:
     - description: Bump minimum version

--- a/packages/ti_abusech/manifest.yml
+++ b/packages/ti_abusech/manifest.yml
@@ -8,7 +8,7 @@ format_version: 1.0.0
 license: basic
 categories: [security]
 conditions:
-  kibana.version: "^7.16.0"
+  kibana.version: "^8.0.0"
 icons:
   - src: /img/abusech2.svg
     title: AbuseCH

--- a/packages/ti_abusech/manifest.yml
+++ b/packages/ti_abusech/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_abusech
 title: AbuseCH
-version: 1.0.3
+version: 1.0.4
 release: ga
 description: Collect threat intelligence from AbuseCH API with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Bumping min version, it was supposed to be done with https://github.com/elastic/integrations/pull/2063 but seems to have not been included.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

