### PR TITLE
Fix processors configuration in windows and o365 packages

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.3"
+  changes:
+    - description: Fix processors key.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/TODO
 - version: "1.2.2"
   changes:
     - description: Update Title and Description.

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "1.2.3"
   changes:
-    - description: Fix processors key.
+    - description: Fix processors configuration
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/TODO
+      link: https://github.com/elastic/integrations/pull/2113
 - version: "1.2.2"
   changes:
     - description: Update Title and Description.

--- a/packages/o365/data_stream/audit/agent/stream/o365audit.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/o365audit.yml.hbs
@@ -27,13 +27,13 @@ api.preserve_original_event: true
 publisher_pipeline.disable_host: true
 {{/contains}}
 processors:
- - add_fields:
-    target: "_conf"
-    fields:
-      tenants:
-        {{#each tenant_names}}
-          {{this}}
-        {{/each}}
+- add_fields:
+   target: "_conf"
+   fields:
+     tenants:
+       {{#each tenant_names}}
+         {{this}}
+       {{/each}}
 {{#if processors}}
- {{processors}}
+{{processors}}
 {{/if}}

--- a/packages/o365/data_stream/audit/manifest.yml
+++ b/packages/o365/data_stream/audit/manifest.yml
@@ -92,6 +92,11 @@ streams:
         multi: false
         required: false
         show_user: false
+        default: |-
+          #- add_fields:
+          #    target: foo
+          #    fields:
+          #      bar: baz
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Office 365
-version: 1.2.2
+version: 1.2.3
 release: ga
 description: Collect logs from Office 365 with Elastic Agent.
 type: integration

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.2"
+  changes:
+    - description: Fix processors configuration
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/NNN
 - version: "1.3.1"
   changes:
     - description: Update Splunk input description

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix processors configuration
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/NNN
+      link: https://github.com/elastic/integrations/pull/2113
 - version: "1.3.1"
   changes:
     - description: Update Splunk input description

--- a/packages/windows/data_stream/forwarded/agent/stream/httpjson.yml.hbs
+++ b/packages/windows/data_stream/forwarded/agent/stream/httpjson.yml.hbs
@@ -59,43 +59,43 @@ tags:
 publisher_pipeline.disable_host: true
 {{/contains}}
 processors:
-  - decode_json_fields:
-      fields: message
-      target: json
-      add_error_key: true
-  - drop_event:
-      when:
-        not:
-          has_fields: ['json.result']
-  - fingerprint:
-      fields:
-        - json.result._cd
-        - json.result._indextime
-        - json.result._raw
-        - json.result._time
-        - json.result.host
-        - json.result.source
-      target_field: "@metadata._id"
-  - drop_fields:
-      fields: message
-  - rename:
-      fields:
-        - from: json.result._raw
-          to: event.original
-        - from: json.result.host
-          to: host.name
-        - from: json.result.source
-          to: event.provider
-      ignore_missing: true
-      fail_on_error: false
-  - drop_fields:
-      fields: json
-  - decode_xml_wineventlog:
-      field: event.original
-      target_field: winlog
-      ignore_missing: true
-      ignore_failure: true
-      map_ecs_fields: true
+- decode_json_fields:
+    fields: message
+    target: json
+    add_error_key: true
+- drop_event:
+    when:
+      not:
+        has_fields: ['json.result']
+- fingerprint:
+    fields:
+      - json.result._cd
+      - json.result._indextime
+      - json.result._raw
+      - json.result._time
+      - json.result.host
+      - json.result.source
+    target_field: "@metadata._id"
+- drop_fields:
+    fields: message
+- rename:
+    fields:
+      - from: json.result._raw
+        to: event.original
+      - from: json.result.host
+        to: host.name
+      - from: json.result.source
+        to: event.provider
+    ignore_missing: true
+    fail_on_error: false
+- drop_fields:
+    fields: json
+- decode_xml_wineventlog:
+    field: event.original
+    target_field: winlog
+    ignore_missing: true
+    ignore_failure: true
+    map_ecs_fields: true
 {{#if processors.length}}
-  {{processors}}
+{{processors}}
 {{/if}}

--- a/packages/windows/data_stream/forwarded/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/forwarded/agent/stream/winlog.yml.hbs
@@ -16,5 +16,5 @@ publisher_pipeline.disable_host: true
 {{/contains}}
 {{#if processors.length}}
 processors:
-  {{processors}}
+{{processors}}
 {{/if}}

--- a/packages/windows/data_stream/powershell/agent/stream/httpjson.yml.hbs
+++ b/packages/windows/data_stream/powershell/agent/stream/httpjson.yml.hbs
@@ -59,43 +59,43 @@ tags:
 publisher_pipeline.disable_host: true
 {{/contains}}
 processors:
-  - decode_json_fields:
-      fields: message
-      target: json
-      add_error_key: true
-  - drop_event:
-      when:
-        not:
-          has_fields: ['json.result']
-  - fingerprint:
-      fields:
-        - json.result._cd
-        - json.result._indextime
-        - json.result._raw
-        - json.result._time
-        - json.result.host
-        - json.result.source
-      target_field: "@metadata._id"
-  - drop_fields:
-      fields: message
-  - rename:
-      fields:
-        - from: json.result._raw
-          to: event.original
-        - from: json.result.host
-          to: host.name
-        - from: json.result.source
-          to: event.provider
-      ignore_missing: true
-      fail_on_error: false
-  - drop_fields:
-      fields: json
-  - decode_xml_wineventlog:
-      field: event.original
-      target_field: winlog
-      ignore_missing: true
-      ignore_failure: true
-      map_ecs_fields: true
+- decode_json_fields:
+    fields: message
+    target: json
+    add_error_key: true
+- drop_event:
+    when:
+      not:
+        has_fields: ['json.result']
+- fingerprint:
+    fields:
+      - json.result._cd
+      - json.result._indextime
+      - json.result._raw
+      - json.result._time
+      - json.result.host
+      - json.result.source
+    target_field: "@metadata._id"
+- drop_fields:
+    fields: message
+- rename:
+    fields:
+      - from: json.result._raw
+        to: event.original
+      - from: json.result.host
+        to: host.name
+      - from: json.result.source
+        to: event.provider
+    ignore_missing: true
+    fail_on_error: false
+- drop_fields:
+    fields: json
+- decode_xml_wineventlog:
+    field: event.original
+    target_field: winlog
+    ignore_missing: true
+    ignore_failure: true
+    map_ecs_fields: true
 {{#if processors.length}}
-  {{processors}}
+{{processors}}
 {{/if}}

--- a/packages/windows/data_stream/powershell/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/powershell/agent/stream/winlog.yml.hbs
@@ -14,5 +14,5 @@ tags:
 {{/if}}
 {{#if processors.length}}
 processors:
-  {{processors}}
+{{processors}}
 {{/if}}

--- a/packages/windows/data_stream/powershell_operational/agent/stream/httpjson.yml.hbs
+++ b/packages/windows/data_stream/powershell_operational/agent/stream/httpjson.yml.hbs
@@ -59,43 +59,43 @@ tags:
 publisher_pipeline.disable_host: true
 {{/contains}}
 processors:
-  - decode_json_fields:
-      fields: message
-      target: json
-      add_error_key: true
-  - drop_event:
-      when:
-        not:
-          has_fields: ['json.result']
-  - fingerprint:
-      fields:
-        - json.result._cd
-        - json.result._indextime
-        - json.result._raw
-        - json.result._time
-        - json.result.host
-        - json.result.source
-      target_field: "@metadata._id"
-  - drop_fields:
-      fields: message
-  - rename:
-      fields:
-        - from: json.result._raw
-          to: event.original
-        - from: json.result.host
-          to: host.name
-        - from: json.result.source
-          to: event.provider
-      ignore_missing: true
-      fail_on_error: false
-  - drop_fields:
-      fields: json
-  - decode_xml_wineventlog:
-      field: event.original
-      target_field: winlog
-      ignore_missing: true
-      ignore_failure: true
-      map_ecs_fields: true
+- decode_json_fields:
+    fields: message
+    target: json
+    add_error_key: true
+- drop_event:
+    when:
+      not:
+        has_fields: ['json.result']
+- fingerprint:
+    fields:
+      - json.result._cd
+      - json.result._indextime
+      - json.result._raw
+      - json.result._time
+      - json.result.host
+      - json.result.source
+    target_field: "@metadata._id"
+- drop_fields:
+    fields: message
+- rename:
+    fields:
+      - from: json.result._raw
+        to: event.original
+      - from: json.result.host
+        to: host.name
+      - from: json.result.source
+        to: event.provider
+    ignore_missing: true
+    fail_on_error: false
+- drop_fields:
+    fields: json
+- decode_xml_wineventlog:
+    field: event.original
+    target_field: winlog
+    ignore_missing: true
+    ignore_failure: true
+    map_ecs_fields: true
 {{#if processors.length}}
-  {{processors}}
+{{processors}}
 {{/if}}

--- a/packages/windows/data_stream/powershell_operational/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/powershell_operational/agent/stream/winlog.yml.hbs
@@ -14,5 +14,5 @@ tags:
 {{/if}}
 {{#if processors.length}}
 processors:
-  {{processors}}
+{{processors}}
 {{/if}}

--- a/packages/windows/data_stream/sysmon_operational/agent/stream/httpjson.yml.hbs
+++ b/packages/windows/data_stream/sysmon_operational/agent/stream/httpjson.yml.hbs
@@ -59,44 +59,43 @@ tags:
 publisher_pipeline.disable_host: true
 {{/contains}}
 processors:
-  - decode_json_fields:
-      fields: message
-      target: json
-      add_error_key: true
-  - drop_event:
-      when:
-        not:
-          has_fields: ['json.result']
-  - fingerprint:
-      fields:
-        - json.result._cd
-        - json.result._indextime
-        - json.result._raw
-        - json.result._time
-        - json.result.host
-        - json.result.source
-      target_field: "@metadata._id"
-  - drop_fields:
-      fields: message
-  - rename:
-      fields:
-        - from: json.result._raw
-          to: event.original
-        - from: json.result.host
-          to: host.name
-        - from: json.result.source
-          to: event.provider
-      ignore_missing: true
-      fail_on_error: false
-  - drop_fields:
-      fields: json
-  - decode_xml_wineventlog:
-      field: event.original
-      target_field: winlog
-      ignore_missing: true
-      ignore_failure: true
-      map_ecs_fields: true
+- decode_json_fields:
+    fields: message
+    target: json
+    add_error_key: true
+- drop_event:
+    when:
+      not:
+        has_fields: ['json.result']
+- fingerprint:
+    fields:
+      - json.result._cd
+      - json.result._indextime
+      - json.result._raw
+      - json.result._time
+      - json.result.host
+      - json.result.source
+    target_field: "@metadata._id"
+- drop_fields:
+    fields: message
+- rename:
+    fields:
+      - from: json.result._raw
+        to: event.original
+      - from: json.result.host
+        to: host.name
+      - from: json.result.source
+        to: event.provider
+    ignore_missing: true
+    fail_on_error: false
+- drop_fields:
+    fields: json
+- decode_xml_wineventlog:
+    field: event.original
+    target_field: winlog
+    ignore_missing: true
+    ignore_failure: true
+    map_ecs_fields: true
 {{#if processors.length}}
-processors:
-  {{processors}}
+{{processors}}
 {{/if}}

--- a/packages/windows/data_stream/sysmon_operational/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/sysmon_operational/agent/stream/winlog.yml.hbs
@@ -13,5 +13,5 @@ tags:
 {{/if}}
 {{#if processors.length}}
 processors:
-  {{processors}}
+{{processors}}
 {{/if}}

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.3.1
+version: 1.3.2
 description: This Elastic integration collects logs and metrics from Windows
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

Fixes the _processors_ configuration option for `windows` and `o365` packages.

Before this change, trying to add custom processors to any of their data streams resulted in the following error:

![image](https://user-images.githubusercontent.com/15056957/139923795-21b98378-e3c4-431d-8d96-fcb0f9a899d0.png)


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- ~~[ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).~~
