### PR TITLE
Set kube proxy default hosts to localhost

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.2"
+  changes:
+    - description: Set default host for proxy to localhost
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/2057
 - version: "1.3.1"
   changes:
     - description: Uniform with guidelines

--- a/packages/kubernetes/data_stream/proxy/_dev/test/system/test-default-config.yml
+++ b/packages/kubernetes/data_stream/proxy/_dev/test/system/test-default-config.yml
@@ -3,4 +3,4 @@ data_stream:
   vars:
     period: 5s
     hosts:
-      - http://{{Hostname}}:10249
+      - http://localhost:10249

--- a/packages/kubernetes/data_stream/proxy/manifest.yml
+++ b/packages/kubernetes/data_stream/proxy/manifest.yml
@@ -10,7 +10,7 @@ streams:
         required: true
         show_user: true
         default:
-          - ${env.NODE_NAME}:10249
+          - localhost:10249
       - name: period
         type: text
         title: Period

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.3.1
+version: 1.3.2
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

This PR sets the default host for `proxy` data_stream of `kubernetes` integration to `localhost` instead of `env.NODE_NAME` in order to resolve https://github.com/elastic/integrations/issues/2029

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
