### PR TITLE
Release Apache for Kibana 8

### DIFF
--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Support Kibana 8.0
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/2122
 - version: "1.2.0"
   changes:
     - description: Uniform with guidelines

--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.0"
+  changes:
+    - description: Support Kibana 8.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.2.0"
   changes:
     - description: Uniform with guidelines

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: apache
 title: Apache HTTP Server
-version: 1.2.0
+version: 1.3.0
 license: basic
 description: Collect logs and metrics from Apache servers with Elastic Agent.
 type: integration
@@ -9,7 +9,7 @@ categories:
   - web
 release: ga
 conditions:
-  kibana.version: "^7.14.0"
+  kibana.version: "^7.14.0 || ^8.0.0"
 screenshots:
   - src: /img/apache-metrics-overview.png
     title: Apache metrics overview


### PR DESCRIPTION
## What does this PR do?

Release a version of the Apache package compatible with the 8 version of the stack.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- https://github.com/elastic/elastic-package/pull/571