### PR TITLE
Osquery_manager: Update to GA. Reduce the number of explicitly mapped text/keyword osquery fields.

### DIFF
--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.7.4"
+  changes:
+    - description: Update fields and readme with host_users, host_groups, host_processes tables.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "0.7.3"
   changes:
     - description: Update team owner.

--- a/packages/osquery_manager/data_stream/result/fields/ecs.yml
+++ b/packages/osquery_manager/data_stream/result/fields/ecs.yml
@@ -2,33 +2,97 @@
 # To regenerate use:
 # osqgen --schema "./schema/ecs/fields.ecs_1.12.yml" ecs > ecs.yml
 - external: ecs
+  name: as.number
+- external: ecs
+  name: client.as.number
+- external: ecs
+  name: client.bytes
+- external: ecs
   name: client.ip
 - external: ecs
   name: client.nat.ip
 - external: ecs
+  name: client.nat.port
+- external: ecs
+  name: client.packets
+- external: ecs
+  name: client.port
+- external: ecs
+  name: code_signature.exists
+- external: ecs
   name: code_signature.timestamp
+- external: ecs
+  name: code_signature.trusted
+- external: ecs
+  name: code_signature.valid
+- external: ecs
+  name: destination.as.number
+- external: ecs
+  name: destination.bytes
 - external: ecs
   name: destination.ip
 - external: ecs
   name: destination.nat.ip
 - external: ecs
+  name: destination.nat.port
+- external: ecs
+  name: destination.packets
+- external: ecs
+  name: destination.port
+- external: ecs
+  name: dll.code_signature.exists
+- external: ecs
   name: dll.code_signature.timestamp
+- external: ecs
+  name: dll.code_signature.trusted
+- external: ecs
+  name: dll.code_signature.valid
+- external: ecs
+  name: dns.answers.ttl
 - external: ecs
   name: dns.resolved_ip
 - external: ecs
   name: elf.creation_date
 - external: ecs
+  name: elf.header.entrypoint
+- external: ecs
+  name: elf.sections.chi2
+- external: ecs
+  name: elf.sections.entropy
+- external: ecs
+  name: elf.sections.physical_size
+- external: ecs
+  name: elf.sections.virtual_address
+- external: ecs
+  name: elf.sections.virtual_size
+- external: ecs
   name: event.created
+- external: ecs
+  name: event.duration
 - external: ecs
   name: event.end
 - external: ecs
   name: event.ingested
 - external: ecs
+  name: event.risk_score
+- external: ecs
+  name: event.risk_score_norm
+- external: ecs
+  name: event.sequence
+- external: ecs
+  name: event.severity
+- external: ecs
   name: event.start
 - external: ecs
   name: file.accessed
 - external: ecs
+  name: file.code_signature.exists
+- external: ecs
   name: file.code_signature.timestamp
+- external: ecs
+  name: file.code_signature.trusted
+- external: ecs
+  name: file.code_signature.valid
 - external: ecs
   name: file.created
 - external: ecs
@@ -36,49 +100,195 @@
 - external: ecs
   name: file.elf.creation_date
 - external: ecs
+  name: file.elf.header.entrypoint
+- external: ecs
+  name: file.elf.sections.chi2
+- external: ecs
+  name: file.elf.sections.entropy
+- external: ecs
+  name: file.elf.sections.physical_size
+- external: ecs
+  name: file.elf.sections.virtual_address
+- external: ecs
+  name: file.elf.sections.virtual_size
+- external: ecs
   name: file.mtime
+- external: ecs
+  name: file.size
 - external: ecs
   name: file.x509.not_after
 - external: ecs
   name: file.x509.not_before
 - external: ecs
+  name: file.x509.public_key_exponent
+- external: ecs
+  name: file.x509.public_key_size
+- external: ecs
+  name: host.disk.read.bytes
+- external: ecs
+  name: host.disk.write.bytes
+- external: ecs
   name: host.ip
 - external: ecs
+  name: host.network.egress.bytes
+- external: ecs
+  name: host.network.egress.packets
+- external: ecs
+  name: host.network.ingress.bytes
+- external: ecs
+  name: host.network.ingress.packets
+- external: ecs
+  name: host.uptime
+- external: ecs
+  name: http.request.body.bytes
+- external: ecs
+  name: http.request.bytes
+- external: ecs
+  name: http.response.body.bytes
+- external: ecs
+  name: http.response.bytes
+- external: ecs
+  name: http.response.status_code
+- external: ecs
+  name: log.syslog.facility.code
+- external: ecs
+  name: log.syslog.priority
+- external: ecs
+  name: log.syslog.severity.code
+- external: ecs
+  name: network.bytes
+- external: ecs
   name: network.forwarded_ip
+- external: ecs
+  name: network.packets
 - external: ecs
   name: observer.ip
 - external: ecs
   name: package.installed
 - external: ecs
+  name: package.size
+- external: ecs
+  name: process.args_count
+- external: ecs
+  name: process.code_signature.exists
+- external: ecs
   name: process.code_signature.timestamp
+- external: ecs
+  name: process.code_signature.trusted
+- external: ecs
+  name: process.code_signature.valid
 - external: ecs
   name: process.elf.creation_date
 - external: ecs
+  name: process.elf.header.entrypoint
+- external: ecs
+  name: process.elf.sections.chi2
+- external: ecs
+  name: process.elf.sections.entropy
+- external: ecs
+  name: process.elf.sections.physical_size
+- external: ecs
+  name: process.elf.sections.virtual_address
+- external: ecs
+  name: process.elf.sections.virtual_size
+- external: ecs
   name: process.end
+- external: ecs
+  name: process.exit_code
+- external: ecs
+  name: process.parent.args_count
+- external: ecs
+  name: process.parent.code_signature.exists
 - external: ecs
   name: process.parent.code_signature.timestamp
 - external: ecs
+  name: process.parent.code_signature.trusted
+- external: ecs
+  name: process.parent.code_signature.valid
+- external: ecs
   name: process.parent.elf.creation_date
+- external: ecs
+  name: process.parent.elf.header.entrypoint
+- external: ecs
+  name: process.parent.elf.sections.chi2
+- external: ecs
+  name: process.parent.elf.sections.entropy
+- external: ecs
+  name: process.parent.elf.sections.physical_size
+- external: ecs
+  name: process.parent.elf.sections.virtual_address
+- external: ecs
+  name: process.parent.elf.sections.virtual_size
 - external: ecs
   name: process.parent.end
 - external: ecs
+  name: process.parent.exit_code
+- external: ecs
+  name: process.parent.pgid
+- external: ecs
+  name: process.parent.pid
+- external: ecs
+  name: process.parent.ppid
+- external: ecs
   name: process.parent.start
+- external: ecs
+  name: process.parent.thread.id
+- external: ecs
+  name: process.parent.uptime
+- external: ecs
+  name: process.pgid
+- external: ecs
+  name: process.pid
+- external: ecs
+  name: process.ppid
 - external: ecs
   name: process.start
 - external: ecs
+  name: process.thread.id
+- external: ecs
+  name: process.uptime
+- external: ecs
   name: related.ip
+- external: ecs
+  name: server.as.number
+- external: ecs
+  name: server.bytes
 - external: ecs
   name: server.ip
 - external: ecs
   name: server.nat.ip
 - external: ecs
+  name: server.nat.port
+- external: ecs
+  name: server.packets
+- external: ecs
+  name: server.port
+- external: ecs
+  name: source.as.number
+- external: ecs
+  name: source.bytes
+- external: ecs
   name: source.ip
 - external: ecs
   name: source.nat.ip
 - external: ecs
+  name: source.nat.port
+- external: ecs
+  name: source.packets
+- external: ecs
+  name: source.port
+- external: ecs
+  name: threat.enrichments.indicator.as.number
+- external: ecs
   name: threat.enrichments.indicator.file.accessed
 - external: ecs
+  name: threat.enrichments.indicator.file.code_signature.exists
+- external: ecs
   name: threat.enrichments.indicator.file.code_signature.timestamp
+- external: ecs
+  name: threat.enrichments.indicator.file.code_signature.trusted
+- external: ecs
+  name: threat.enrichments.indicator.file.code_signature.valid
 - external: ecs
   name: threat.enrichments.indicator.file.created
 - external: ecs
@@ -86,11 +296,29 @@
 - external: ecs
   name: threat.enrichments.indicator.file.elf.creation_date
 - external: ecs
+  name: threat.enrichments.indicator.file.elf.header.entrypoint
+- external: ecs
+  name: threat.enrichments.indicator.file.elf.sections.chi2
+- external: ecs
+  name: threat.enrichments.indicator.file.elf.sections.entropy
+- external: ecs
+  name: threat.enrichments.indicator.file.elf.sections.physical_size
+- external: ecs
+  name: threat.enrichments.indicator.file.elf.sections.virtual_address
+- external: ecs
+  name: threat.enrichments.indicator.file.elf.sections.virtual_size
+- external: ecs
   name: threat.enrichments.indicator.file.mtime
+- external: ecs
+  name: threat.enrichments.indicator.file.size
 - external: ecs
   name: threat.enrichments.indicator.file.x509.not_after
 - external: ecs
   name: threat.enrichments.indicator.file.x509.not_before
+- external: ecs
+  name: threat.enrichments.indicator.file.x509.public_key_exponent
+- external: ecs
+  name: threat.enrichments.indicator.file.x509.public_key_size
 - external: ecs
   name: threat.enrichments.indicator.first_seen
 - external: ecs
@@ -100,13 +328,33 @@
 - external: ecs
   name: threat.enrichments.indicator.modified_at
 - external: ecs
+  name: threat.enrichments.indicator.port
+- external: ecs
+  name: threat.enrichments.indicator.scanner_stats
+- external: ecs
+  name: threat.enrichments.indicator.sightings
+- external: ecs
+  name: threat.enrichments.indicator.url.port
+- external: ecs
   name: threat.enrichments.indicator.x509.not_after
 - external: ecs
   name: threat.enrichments.indicator.x509.not_before
 - external: ecs
+  name: threat.enrichments.indicator.x509.public_key_exponent
+- external: ecs
+  name: threat.enrichments.indicator.x509.public_key_size
+- external: ecs
+  name: threat.indicator.as.number
+- external: ecs
   name: threat.indicator.file.accessed
 - external: ecs
+  name: threat.indicator.file.code_signature.exists
+- external: ecs
   name: threat.indicator.file.code_signature.timestamp
+- external: ecs
+  name: threat.indicator.file.code_signature.trusted
+- external: ecs
+  name: threat.indicator.file.code_signature.valid
 - external: ecs
   name: threat.indicator.file.created
 - external: ecs
@@ -114,11 +362,29 @@
 - external: ecs
   name: threat.indicator.file.elf.creation_date
 - external: ecs
+  name: threat.indicator.file.elf.header.entrypoint
+- external: ecs
+  name: threat.indicator.file.elf.sections.chi2
+- external: ecs
+  name: threat.indicator.file.elf.sections.entropy
+- external: ecs
+  name: threat.indicator.file.elf.sections.physical_size
+- external: ecs
+  name: threat.indicator.file.elf.sections.virtual_address
+- external: ecs
+  name: threat.indicator.file.elf.sections.virtual_size
+- external: ecs
   name: threat.indicator.file.mtime
+- external: ecs
+  name: threat.indicator.file.size
 - external: ecs
   name: threat.indicator.file.x509.not_after
 - external: ecs
   name: threat.indicator.file.x509.not_before
+- external: ecs
+  name: threat.indicator.file.x509.public_key_exponent
+- external: ecs
+  name: threat.indicator.file.x509.public_key_size
 - external: ecs
   name: threat.indicator.first_seen
 - external: ecs
@@ -128,9 +394,21 @@
 - external: ecs
   name: threat.indicator.modified_at
 - external: ecs
+  name: threat.indicator.port
+- external: ecs
+  name: threat.indicator.scanner_stats
+- external: ecs
+  name: threat.indicator.sightings
+- external: ecs
+  name: threat.indicator.url.port
+- external: ecs
   name: threat.indicator.x509.not_after
 - external: ecs
   name: threat.indicator.x509.not_before
+- external: ecs
+  name: threat.indicator.x509.public_key_exponent
+- external: ecs
+  name: threat.indicator.x509.public_key_size
 - external: ecs
   name: tls.client.not_after
 - external: ecs
@@ -140,6 +418,14 @@
 - external: ecs
   name: tls.client.x509.not_before
 - external: ecs
+  name: tls.client.x509.public_key_exponent
+- external: ecs
+  name: tls.client.x509.public_key_size
+- external: ecs
+  name: tls.established
+- external: ecs
+  name: tls.resumed
+- external: ecs
   name: tls.server.not_after
 - external: ecs
   name: tls.server.not_before
@@ -148,6 +434,22 @@
 - external: ecs
   name: tls.server.x509.not_before
 - external: ecs
+  name: tls.server.x509.public_key_exponent
+- external: ecs
+  name: tls.server.x509.public_key_size
+- external: ecs
+  name: url.port
+- external: ecs
+  name: vulnerability.score.base
+- external: ecs
+  name: vulnerability.score.environmental
+- external: ecs
+  name: vulnerability.score.temporal
+- external: ecs
   name: x509.not_after
 - external: ecs
   name: x509.not_before
+- external: ecs
+  name: x509.public_key_exponent
+- external: ecs
+  name: x509.public_key_size

--- a/packages/osquery_manager/data_stream/result/fields/osquery.yml
+++ b/packages/osquery_manager/data_stream/result/fields/osquery.yml
@@ -3,24 +3,6 @@
   description: Fields related to the Osquery result
   type: group
   fields:
-    - name: UUID
-      description: system_extensions.UUID - Extension unique id
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: abi
-      description: elf_info.abi - Section type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: abi_version
       description: elf_info.abi_version - Section virtual address in memory
       type: keyword
@@ -29,24 +11,6 @@
         - name: number
           type: long
           default_field: false
-    - name: access
-      description: ntfs_acl_permissions.access - Specific permissions that indicate the rights described by the ACE.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: accessed_directories
-      description: prefetch.accessed_directories - Directories accessed by application within ten seconds of launch.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: accessed_directories_count
       description: prefetch.accessed_directories_count - Number of directories accessed.
       type: keyword
@@ -54,15 +18,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: accessed_files
-      description: prefetch.accessed_files - Files accessed by application within ten seconds of launch.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: accessed_files_count
       description: prefetch.accessed_files_count - Number of files accessed.
@@ -79,32 +34,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: account_id
-      description: ec2_instance_metadata.account_id - AWS account ID which owns this EC2 instance
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: action
-      description: |-
-        disk_events.action - Appear or disappear
-        example.action - Action performed in generation
-        file_events.action - Change action (UPDATE, REMOVE, etc)
-        hardware_events.action - Remove, insert, change properties, etc
-        ntfs_journal_events.action - Change action (Write, Delete, etc)
-        scheduled_tasks.action - Actions executed by the scheduled task
-        socket_events.action - The socket action (bind, listen, close)
-        yara_events.action - Change action (UPDATE, REMOVE, etc)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: activated
       description: tpm_info.activated - TPM is activated
@@ -136,15 +65,6 @@
         - name: number
           type: long
           default_field: false
-    - name: active_state
-      description: systemd_units.active_state - The high-level unit activation state, i.e. generalization of SUB
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: actual
       description: fan_speed_sensors.actual - Actual speed
       type: keyword
@@ -153,15 +73,6 @@
         - name: number
           type: long
           default_field: false
-    - name: additional_product_id
-      description: smart_drive_info.additional_product_id - An additional drive identifier if any
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: addr
       description: elf_symbols.addr - Symbol address (value)
       type: keyword
@@ -169,64 +80,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: address
-      description: |-
-        arp_cache.address - IPv4 address target
-        dns_resolvers.address - Resolver IP/IPv6 address
-        etc_hosts.address - IP address mapping
-        fbsd_kmods.address - Kernel module address
-        interface_addresses.address - Specific address for interface
-        kernel_modules.address - Kernel module address
-        listening_ports.address - Specific address for bind
-        platform_info.address - Relative address of firmware mapping
-        user_events.address - The Internet protocol address or family ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: address_width
-      description: cpu_info.address_width - The width of the CPU address bus.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: algorithm
-      description: authorized_keys.algorithm - algorithm of key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: alias
-      description: |-
-        etc_protocols.alias - Protocol alias
-        time_machine_destinations.alias - Human readable name of drive
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: aliases
-      description: |-
-        etc_services.aliases - Optional space separated list of other names for a service
-        lxd_images.aliases - Comma-separated list of image aliases
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: align
       description: |-
@@ -246,15 +99,6 @@
         - name: number
           type: long
           default_field: false
-    - name: allow_root
-      description: authorizations.allow_root - Label top-level key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: allow_signed_enabled
       description: alf.allow_signed_enabled - 1 If allow signed mode is enabled else 0
       type: keyword
@@ -262,15 +106,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: ami_id
-      description: ec2_instance_metadata.ami_id - AMI ID used to launch this EC2 instance
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: amperage
       description: battery.amperage - The battery's current amperage in mA
@@ -288,125 +123,6 @@
         - name: number
           type: long
           default_field: false
-    - name: antispyware
-      description: windows_security_center.antispyware - The health of the monitored Antispyware solution (see windows_security_products)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: antivirus
-      description: windows_security_center.antivirus - The health of the monitored Antivirus solution (see windows_security_products)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: api_version
-      description: docker_version.api_version - API version
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: apparmor
-      description: apparmor_events.apparmor - Apparmor Status like ALLOWED, DENIED etc.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: applescript_enabled
-      description: apps.applescript_enabled - Info properties NSAppleScriptEnabled label
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: application
-      description: office_mru.application - Associated Office application
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: arch
-      description: |-
-        deb_packages.arch - Package architecture
-        docker_version.arch - Hardware architecture
-        os_version.arch - OS Architecture
-        pkg_packages.arch - Architecture(s) supported
-        rpm_packages.arch - Architecture(s) supported
-        seccomp_events.arch - Information about the CPU architecture
-        signature.arch - If applicable, the arch of the signed code
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: architecture
-      description: |-
-        docker_info.architecture - Hardware architecture
-        ec2_instance_metadata.architecture - Hardware architecture of this EC2 instance
-        lxd_images.architecture - Target architecture for the image
-        lxd_instances.architecture - Instance architecture
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: architectures
-      description: apt_sources.architectures - Repository architectures
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: args
-      description: startup_items.args - Arguments provided to startup executable
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: arguments
-      description: kernel_info.arguments - Kernel arguments
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: array_handle
-      description: memory_devices.array_handle - The memory array that the device is attached to
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: assessments_enabled
       description: gatekeeper.assessments_enabled - 1 If a Gatekeeper is enabled else 0
       type: keyword
@@ -414,24 +130,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: asset_tag
-      description: memory_devices.asset_tag - Manufacturer specific asset tag of memory device
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ata_version
-      description: smart_drive_info.ata_version - ATA version of drive
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: atime
       description: |-
@@ -446,15 +144,6 @@
         - name: number
           type: long
           default_field: false
-    - name: attach
-      description: apparmor_profiles.attach - Which executable(s) a profile will attach to.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: attached
       description: shared_memory.attached - Number of attached processes
       type: keyword
@@ -462,24 +151,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: attributes
-      description: "file.attributes - File attrib string. See: https://ss64.com/nt/attrib.html"
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: audible_alarm
-      description: chassis_info.audible_alarm - If TRUE, the frame is equipped with an audible alarm.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: auid
       description: |-
@@ -490,74 +161,6 @@
         user_events.auid - Audit User ID
       type: keyword
       ignore_above: 1024
-    - name: authenticate_user
-      description: authorizations.authenticate_user - Label top-level key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: authentication_package
-      description: logon_sessions.authentication_package - The authentication package used to authenticate the owner of the logon session.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: author
-      description: |-
-        chocolatey_packages.author - Optional package author
-        chrome_extensions.author - Optional extension author
-        npm_packages.author - Package author name
-        python_packages.author - Optional package author
-        safari_extensions.author - Optional extension author
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: authority
-      description: signature.authority - Certificate Common Name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: authority_key_id
-      description: certificates.authority_key_id - AKID an optionally included SHA1
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: authority_key_identifier
-      description: curl_certificate.authority_key_identifier - Authority Key Identifier
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: authorizations
-      description: keychain_acls.authorizations - A space delimited set of authorization attributes
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: auto_login
       description: wifi_networks.auto_login - 1 if auto login is enabled, 0 otherwise
       type: keyword
@@ -580,33 +183,6 @@
         windows_security_center.autoupdate - The health of the Windows Autoupdate feature
       type: keyword
       ignore_above: 1024
-    - name: availability
-      description: cpu_info.availability - The availability and status of the CPU.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: availability_zone
-      description: ec2_instance_metadata.availability_zone - Availability zone in which this instance launched
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: average
-      description: load_average.average - Load average over the specified period.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: average_memory
       description: osquery_schedule.average_memory - Average private memory left after executing
       type: keyword
@@ -671,15 +247,6 @@
         - name: number
           type: long
           default_field: false
-    - name: bank_locator
-      description: memory_devices.bank_locator - String number of the string that identifies the physically-labeled bank where the memory device is located
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: base64
       description: extended_attributes.base64 - 1 if the value is base64 encoded else 0
       type: keyword
@@ -688,42 +255,6 @@
         - name: number
           type: long
           default_field: false
-    - name: base_image
-      description: lxd_instances.base_image - ID of image used to launch this instance
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: base_uri
-      description: apt_sources.base_uri - Repository base URI
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: baseurl
-      description: yum_sources.baseurl - Repository base URL
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: basic_constraint
-      description: curl_certificate.basic_constraint - Basic Constraints
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: binary_queue
       description: carbon_black_info.binary_queue - Size in bytes of binaries waiting to be sent to Carbon Black server
       type: keyword
@@ -731,51 +262,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: binding
-      description: elf_symbols.binding - Binding type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: bitmap_chunk_size
-      description: md_devices.bitmap_chunk_size - Bitmap chunk size
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: bitmap_external_file
-      description: md_devices.bitmap_external_file - External referenced bitmap file
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: bitmap_on_mem
-      description: md_devices.bitmap_on_mem - Pages allocated in in-memory bitmap, if enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: block
-      description: ssh_configs.block - The host or match block
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: block_size
       description: |-
@@ -832,42 +318,6 @@
         - name: number
           type: long
           default_field: false
-    - name: board_model
-      description: system_info.board_model - Board model
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: board_serial
-      description: system_info.board_serial - Board serial number
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: board_vendor
-      description: system_info.board_vendor - Board vendor
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: board_version
-      description: system_info.board_version - Board version
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: boot_partition
       description: logical_drives.boot_partition - True if Windows booted from this drive.
       type: keyword
@@ -875,15 +325,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: boot_uuid
-      description: ibridge_info.boot_uuid - Boot UUID of the iBridge controller
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: bp_microcode_disabled
       description: kva_speculative_info.bp_microcode_disabled - Branch Predictions are disabled due to lack of microcode update.
@@ -909,15 +350,6 @@
         - name: number
           type: long
           default_field: false
-    - name: breach_description
-      description: chassis_info.breach_description - If provided, gives a more detailed description of a detected security breach.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: bridge_nf_ip6tables
       description: docker_info.bridge_nf_ip6tables - 1 if bridge netfilter ip6tables is enabled. 0 otherwise
       type: keyword
@@ -933,46 +365,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: broadcast
-      description: interface_addresses.broadcast - Broadcast address for the interface
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: browser_type
-      description: |-
-        chrome_extension_content_scripts.browser_type - The browser type (Valid values: chrome, chromium, opera, yandex, brave)
-        chrome_extensions.browser_type - The browser type (Valid values: chrome, chromium, opera, yandex, brave, edge, edge_beta)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: bsd_flags
-      description: "file.bsd_flags - The BSD file flags (chflags). Possible values: NODUMP, UF_IMMUTABLE, UF_APPEND, OPAQUE, HIDDEN, ARCHIVED, SF_IMMUTABLE, SF_APPEND"
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: bssid
-      description: |-
-        wifi_status.bssid - The current basic service set identifier
-        wifi_survey.bssid - The current basic service set identifier
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: btime
       description: |-
@@ -992,33 +384,6 @@
         - name: number
           type: long
           default_field: false
-    - name: build
-      description: os_version.build - Optional build-specific or variant string
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: build_distro
-      description: osquery_info.build_distro - osquery toolkit platform distribution name (os version)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: build_id
-      description: sandboxes.build_id - Sandbox-specific identifier
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: build_number
       description: windows_crashes.build_number - Windows build number of the crashing machine
       type: keyword
@@ -1026,93 +391,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: build_platform
-      description: osquery_info.build_platform - osquery toolkit build platform
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: build_time
-      description: |-
-        docker_version.build_time - Build time
-        portage_packages.build_time - Unix time when package was built
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: bundle_executable
-      description: apps.bundle_executable - Info properties CFBundleExecutable label
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: bundle_identifier
-      description: |-
-        apps.bundle_identifier - Info properties CFBundleIdentifier label
-        running_apps.bundle_identifier - The bundle identifier of the application
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: bundle_name
-      description: apps.bundle_name - Info properties CFBundleName label
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: bundle_package_type
-      description: apps.bundle_package_type - Info properties CFBundlePackageType label
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: bundle_path
-      description: |-
-        sandboxes.bundle_path - Application bundle used by the sandbox
-        system_extensions.bundle_path - System extension bundle path
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: bundle_short_version
-      description: apps.bundle_short_version - Info properties CFBundleShortVersionString label
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: bundle_version
-      description: apps.bundle_version - Info properties CFBundleVersion label
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: busy_state
       description: |-
@@ -1174,15 +452,6 @@
         - name: number
           type: long
           default_field: false
-    - name: cache_path
-      description: quicklook_cache.cache_path - Path to cache data
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: cached
       description: |-
         lxd_images.cached - Whether image is cached (1) or not (0)
@@ -1201,26 +470,6 @@
         - name: number
           type: long
           default_field: false
-    - name: capname
-      description: apparmor_events.capname - Capability requested by the process
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: caption
-      description: |-
-        patches.caption - Short description of the patch.
-        windows_optional_features.caption - Caption of feature in settings UI
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: captive_portal
       description: wifi_networks.captive_portal - 1 if this network has a captive portal, 0 otherwise
       type: keyword
@@ -1237,41 +486,6 @@
         - name: number
           type: long
           default_field: false
-    - name: carve_guid
-      description: carves.carve_guid - Identifying value of the carve session
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: category
-      description: |-
-        apps.category - The UTI that categorizes the app for the App Store
-        file_events.category - The category of the file defined in the config
-        ntfs_journal_events.category - The category that the event originated from
-        power_sensors.category - The sensor category: currents, voltage, wattage
-        system_extensions.category - System extension category
-        yara_events.category - The category of the file
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: cdhash
-      description: |-
-        es_process_events.cdhash - Codesigning hash of the process
-        signature.cdhash - Hash of the application Code Directory
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: celsius
       description: temperature_sensors.celsius - Temperature in Celsius
       type: keyword
@@ -1279,53 +493,6 @@
       multi_fields:
         - name: number
           type: double
-          default_field: false
-    - name: certificate
-      description: lxd_certificates.certificate - Certificate content
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: cgroup_driver
-      description: docker_info.cgroup_driver - Control groups driver
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: cgroup_namespace
-      description: |-
-        docker_containers.cgroup_namespace - cgroup namespace
-        process_namespaces.cgroup_namespace - cgroup namespace inode
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: chain
-      description: iptables.chain - Size of module content.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: change_type
-      description: "docker_container_fs_changes.change_type - Type of change: C:Modified, A:Added, D:Deleted"
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: channel
       description: |-
@@ -1402,33 +569,6 @@
         - name: number
           type: long
           default_field: false
-    - name: chassis_id
-      description: lldp_neighbors.chassis_id - Neighbor chassis ID value
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: chassis_id_type
-      description: lldp_neighbors.chassis_id_type - Neighbor chassis ID type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: chassis_mgmt_ips
-      description: lldp_neighbors.chassis_mgmt_ips - Comma delimited list of chassis management IPS
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: chassis_other_capability_available
       description: lldp_neighbors.chassis_other_capability_available - Chassis other capability availability
       type: keyword
@@ -1501,15 +641,6 @@
         - name: number
           type: long
           default_field: false
-    - name: chassis_sysname
-      description: lldp_neighbors.chassis_sysname - CPU brand string, contains vendor and model
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: chassis_tel_capability_available
       description: lldp_neighbors.chassis_tel_capability_available - Chassis telephone capability availability
       type: keyword
@@ -1526,15 +657,6 @@
         - name: number
           type: long
           default_field: false
-    - name: chassis_types
-      description: chassis_info.chassis_types - A comma-separated list of chassis types, such as Desktop or Laptop.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: chassis_wlan_capability_available
       description: lldp_neighbors.chassis_wlan_capability_available - Chassis wlan capability availability
       type: keyword
@@ -1550,42 +672,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: check_array_finish
-      description: md_devices.check_array_finish - Estimated duration of the check array activity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: check_array_progress
-      description: md_devices.check_array_progress - Progress of the check array activity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: check_array_speed
-      description: md_devices.check_array_speed - Speed of the check array activity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: checksum
-      description: disk_events.checksum - UDIF Master checksum if available (CRC32)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: child_pid
       description: es_process_events.child_pid - Process ID of a child process in case of a fork event
@@ -1613,49 +699,6 @@
         - name: number
           type: long
           default_field: false
-    - name: class
-      description: |-
-        authorizations.class - Label top-level key
-        drivers.class - Device/driver class name
-        elf_dynamic.class - Class (32 or 64)
-        elf_info.class - Class type, 32 or 64bit
-        iokit_devicetree.class - Best matching device class (most-specific category)
-        iokit_registry.class - Best matching device class (most-specific category)
-        usb_devices.class - USB Device class
-        wmi_cli_event_consumers.class - The name of the class.
-        wmi_event_filters.class - The name of the class.
-        wmi_filter_consumer_binding.class - The name of the class.
-        wmi_script_event_consumers.class - The name of the class.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: client_site_name
-      description: ntdomains.client_site_name - The name of the site where the domain controller is configured.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: cmdline
-      description: |-
-        bpf_process_events.cmdline - Command line arguments
-        docker_container_processes.cmdline - Complete argv
-        es_process_events.cmdline - Command line arguments (argv)
-        process_events.cmdline - Command line arguments (argv)
-        processes.cmdline - Complete argv
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: cmdline_count
       description: es_process_events.cmdline_count - Number of command line arguments
       type: keyword
@@ -1671,33 +714,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: code
-      description: seccomp_events.code - The seccomp action
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: code_integrity_policy_enforcement_status
-      description: hvci_status.code_integrity_policy_enforcement_status - The status of the code integrity policy enforcement settings. Returns UNKNOWN if an error is encountered.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: codename
-      description: os_version.codename - OS version codename
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: collect_cross_processes
       description: carbon_black_info.collect_cross_processes - If the sensor is configured to cross process events
@@ -1811,91 +827,6 @@
         - name: number
           type: long
           default_field: false
-    - name: comm
-      description: |-
-        apparmor_events.comm - Command-line name of the command that was used to invoke the analyzed process
-        seccomp_events.comm - Command-line name of the command that was used to invoke the analyzed process
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: command
-      description: |-
-        crontab.command - Raw command string
-        docker_containers.command - Command with arguments
-        shell_history.command - Unparsed date/line/command history line
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: command_args
-      description: shortcut_files.command_args - Command args passed to lnk file.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: command_line
-      description: windows_crashes.command_line - Command-line string passed to the crashed process
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: command_line_template
-      description: wmi_cli_event_consumers.command_line_template - Standard string template that specifies the process to be started. This property can be NULL, and the ExecutablePath property is used as the command line.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: comment
-      description: |-
-        authorizations.comment - Label top-level key
-        docker_image_history.comment - Instruction comment
-        etc_protocols.comment - Comment with protocol description
-        etc_services.comment - Optional comment for a service.
-        groups.comment - Remarks or comments associated with the group
-        keychain_items.comment - Optional keychain comment
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: common_name
-      description: |-
-        certificates.common_name - Certificate CommonName
-        curl_certificate.common_name - Common name of company issued to
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: common_path
-      description: shortcut_files.common_path - Common system path to target file.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: compat
       description: seccomp_events.compat - Is system call in compatibility mode
       type: keyword
@@ -1904,15 +835,6 @@
         - name: number
           type: long
           default_field: false
-    - name: compiler
-      description: apps.compiler - Info properties DTCompiler label
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: completed_time
       description: cups_jobs.completed_time - When the job completed printing
       type: keyword
@@ -1920,15 +842,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: components
-      description: apt_sources.components - Repository components
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: compressed
       description: virtual_memory_info.compressed - The total number of pages that have been compressed by the VM compressor.
@@ -1946,63 +859,6 @@
         - name: number
           type: long
           default_field: false
-    - name: computer_name
-      description: |-
-        system_info.computer_name - Friendly computer name (optional)
-        windows_eventlog.computer_name - Hostname of system where event was generated
-        windows_events.computer_name - Hostname of system where event was generated
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: condition
-      description: 'battery.condition - One of the following: "Normal" indicates the condition of the battery is within normal tolerances, "Service Needed" indicates that the battery should be checked out by a licensed Mac repair service, "Permanent Failure" indicates the battery needs replacement'
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: config_entrypoint
-      description: docker_containers.config_entrypoint - Container entrypoint(s)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: config_flag
-      description: sip_config.config_flag - The System Integrity Protection config flag
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: config_hash
-      description: osquery_info.config_hash - Hash of the working configuration state
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: config_name
-      description: carbon_black_info.config_name - Sensor group
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: config_valid
       description: osquery_info.config_valid - 1 if the config was loaded and considered valid, else 0
       type: keyword
@@ -2010,15 +866,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: config_value
-      description: system_controls.config_value - The MIB value set in /etc/sysctl.conf
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: configured_clock_speed
       description: memory_devices.configured_clock_speed - Configured speed of memory device in megatransfers per second (MT/s)
@@ -2036,24 +883,6 @@
         - name: number
           type: long
           default_field: false
-    - name: connection_id
-      description: interface_details.connection_id - Name of the network connection as it appears in the Network Connections Control Panel program.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: connection_status
-      description: interface_details.connection_status - State of the network adapter connection to the network.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: consistency_scan_date
       description: time_machine_destinations.consistency_scan_date - Consistency scan date
       type: keyword
@@ -2061,15 +890,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: consumer
-      description: wmi_filter_consumer_binding.consumer - Reference to an instance of __EventConsumer that represents the object path to a logical consumer, the recipient of an event.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: containers
       description: docker_info.containers - Total number of containers
@@ -2103,15 +923,6 @@
         - name: number
           type: long
           default_field: false
-    - name: content
-      description: disk_events.content - Disk event content
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: content_caching
       description: sharing_preferences.content_caching - 1 If content caching is enabled else 0
       type: keyword
@@ -2119,15 +930,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: content_type
-      description: package_install_history.content_type - Package content_type (optional)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: conversion_status
       description: bitlocker_info.conversion_status - The bitlocker conversion status of the drive.
@@ -2137,15 +939,6 @@
         - name: number
           type: long
           default_field: false
-    - name: coprocessor_version
-      description: ibridge_info.coprocessor_version - The manufacturer and chip version
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: copy
       description: virtual_memory_info.copy - Total number of copy-on-write pages.
       type: keyword
@@ -2153,15 +946,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: copyright
-      description: apps.copyright - Info properties NSHumanReadableCopyright label
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: core
       description: cpu_time.core - Name of the cpu (core)
@@ -2190,17 +974,6 @@
         - name: number
           type: long
           default_field: false
-    - name: country_code
-      description: |-
-        wifi_status.country_code - The country code (ISO/IEC 3166-1:1997) for the network
-        wifi_survey.country_code - The country code (ISO/IEC 3166-1:1997) for the network
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: cpu
       description: docker_container_processes.cpu - CPU utilization as percentage
       type: keyword
@@ -2208,15 +981,6 @@
       multi_fields:
         - name: number
           type: double
-          default_field: false
-    - name: cpu_brand
-      description: system_info.cpu_brand - CPU brand string, contains vendor and model
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: cpu_cfs_period
       description: docker_info.cpu_cfs_period - 1 if CPU Completely Fair Scheduler (CFS) period support is enabled. 0 otherwise
@@ -2249,15 +1013,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: cpu_microcode
-      description: system_info.cpu_microcode - Microcode version
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: cpu_physical_cores
       description: system_info.cpu_physical_cores - Number of physical CPU cores in to the system
@@ -2343,17 +1098,6 @@
         - name: number
           type: long
           default_field: false
-    - name: crash_path
-      description: |-
-        crashes.crash_path - Location of log file
-        windows_crashes.crash_path - Path of the log file
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: crashed_thread
       description: crashes.crashed_thread - Thread ID which crashed
       type: keyword
@@ -2361,41 +1105,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: created
-      description: |-
-        authorizations.created - Label top-level key
-        docker_containers.created - Time of creation as UNIX time
-        docker_image_history.created - Time of creation as UNIX time
-        docker_images.created - Time of creation as UNIX time
-        docker_networks.created - Time of creation as UNIX time
-        keychain_items.created - Data item was created
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: created_at
-      description: |-
-        lxd_images.created_at - ISO time of image creation
-        lxd_instances.created_at - ISO time of creation
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: created_by
-      description: docker_image_history.created_by - Created by instruction
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: created_time
       description: shellbags.created_time - Directory Created time.
@@ -2411,15 +1120,6 @@
         cups_jobs.creation_time - When the print request was initiated
       type: keyword
       ignore_above: 1024
-    - name: creator
-      description: firefox_addons.creator - Addon-supported creator string
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: creator_pid
       description: shared_memory.creator_pid - Process ID that created the segment
       type: keyword
@@ -2435,15 +1135,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: csname
-      description: patches.csname - The name of the host the patch is installed on.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: ctime
       description: |-
@@ -2471,15 +1162,6 @@
         - name: number
           type: long
           default_field: false
-    - name: current_directory
-      description: windows_crashes.current_directory - Current working directory of the crashed process
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: current_disk_queue_length
       description: physical_disk_performance.current_disk_queue_length - Number of requests outstanding on the disk at the time the performance data is collected
       type: keyword
@@ -2488,38 +1170,6 @@
         - name: number
           type: long
           default_field: false
-    - name: current_locale
-      description: chrome_extensions.current_locale - Current locale supported by extension
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: current_value
-      description: system_controls.current_value - Value of setting
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: cwd
-      description: |-
-        bpf_process_events.cwd - Current working directory
-        es_process_events.cwd - The process current working directory
-        process_events.cwd - The process current working directory
-        process_file_events.cwd - The current working directory of the process
-        processes.cwd - Process current working directory
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: cycle_count
       description: battery.cycle_count - The number of charge/discharge cycles
       type: keyword
@@ -2527,19 +1177,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: data
-      description: |-
-        magic.data - Magic number data from libmagic
-        registry.data - Data content of registry value
-        windows_eventlog.data - Data associated with the event
-        windows_events.data - Data associated with the event
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: data_width
       description: memory_devices.data_width - Data width, in bits, of this memory device
@@ -2563,22 +1200,6 @@
         platform_info.date - Self-reported platform code update date
       type: keyword
       ignore_above: 1024
-    - name: datetime
-      description: |-
-        crashes.datetime - Date/Time at which the crash occurred
-        powershell_events.datetime - System time at which the Powershell script event occurred
-        syslog_events.datetime - Time known to syslog
-        time.datetime - Current date and time (ISO format) in the system
-        windows_crashes.datetime - Timestamp (log format) of the crash
-        windows_eventlog.datetime - System time at which the event occurred
-        windows_events.datetime - System time at which the event occurred
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: day
       description: time.day - Current day in the system
       type: keyword
@@ -2586,24 +1207,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: day_of_month
-      description: crontab.day_of_month - The day of the month for the job
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: day_of_week
-      description: crontab.day_of_week - The day of the week for the job
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: days
       description: uptime.days - Days of uptime
@@ -2613,15 +1216,6 @@
         - name: number
           type: long
           default_field: false
-    - name: dc_site_name
-      description: ntdomains.dc_site_name - The name of the site where the domain controller is located.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: decompressed
       description: virtual_memory_info.decompressed - The total number of pages that have been decompressed by the VM compressor.
       type: keyword
@@ -2630,33 +1224,6 @@
         - name: number
           type: long
           default_field: false
-    - name: default_locale
-      description: chrome_extensions.default_locale - Default locale supported by extension
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: default_value
-      description: osquery_flags.default_value - Flag default value
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: denied_mask
-      description: apparmor_events.denied_mask - Denied permissions for the process
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: denylisted
       description: osquery_schedule.denylisted - 1 if the query is denylisted else 0
       type: keyword
@@ -2664,15 +1231,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: dependencies
-      description: kernel_panics.dependencies - Module dependencies existing in crashed module's backtrace
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: depth
       description: |-
@@ -2684,40 +1242,6 @@
         - name: number
           type: long
           default_field: false
-    - name: description
-      description: |-
-        appcompat_shims.description - Description of the SDB.
-        atom_packages.description - Package supplied description
-        browser_plugins.description - Plugin description text
-        chassis_info.description - An extended description of the chassis if available.
-        chrome_extensions.description - Extension-optional description
-        disk_info.description - The OS's description of the disk.
-        drivers.description - Driver description
-        firefox_addons.description - Addon-supplied description string
-        interface_details.description - Short description of the object a one-line string.
-        keychain_acls.description - The description included with the ACL entry
-        keychain_items.description - Optional item description
-        logical_drives.description - The canonical description of the drive, e.g. 'Logical Fixed Disk', 'CD-ROM Disk'.
-        lxd_images.description - Image description
-        lxd_instances.description - Instance description
-        npm_packages.description - Package supplied description
-        osquery_flags.description - Flag description
-        patches.description - Fuller description of the patch.
-        safari_extensions.description - Optional extension description text
-        services.description - Service Description
-        shared_resources.description - A textual description of the object
-        shortcut_files.description - Lnk file description.
-        smbios_tables.description - Table entry description
-        systemd_units.description - Unit description
-        users.description - Optional user description
-        ycloud_instance_metadata.description - Description of the VM
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: designed_capacity
       description: battery.designed_capacity - The battery's designed capacity in mAh
       type: keyword
@@ -2725,38 +1249,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: dest_path
-      description: process_file_events.dest_path - The canonical path associated with the event
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: destination
-      description: |-
-        cups_jobs.destination - The printer the job was sent to
-        docker_container_mounts.destination - Destination path inside container
-        routes.destination - Destination IP address
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: destination_id
-      description: |-
-        time_machine_backups.destination_id - Time Machine destination ID
-        time_machine_destinations.destination_id - Time Machine destination ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: dev_id_enabled
       description: gatekeeper.dev_id_enabled - 1 If a Gatekeeper allows execution from identified developers else 0
@@ -2766,128 +1258,6 @@
         - name: number
           type: long
           default_field: false
-    - name: developer_id
-      description: |-
-        safari_extensions.developer_id - Optional developer identifier
-        xprotect_meta.developer_id - Developer identity (SHA1) of extension
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: development_region
-      description: |-
-        apps.development_region - Info properties CFBundleDevelopmentRegion label
-        browser_plugins.development_region - Plugin language-localization
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: device
-      description: |-
-        device_file.device - Absolute file path to device node
-        device_firmware.device - The device name
-        device_hash.device - Absolute file path to device node
-        device_partitions.device - Absolute file path to device node
-        disk_events.device - Disk event BSD name
-        file.device - Device ID (optional)
-        kernel_info.device - Kernel device identifier
-        lxd_instance_devices.device - Name of the device
-        mounts.device - Mounted device
-        process_memory_map.device - MA:MI Major/minor device ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: device_alias
-      description: mounts.device_alias - Mounted device alias
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: device_error_address
-      description: memory_error_info.device_error_address - 32 bit physical address of the error relative to the start of the failing memory address, in bytes
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: device_id
-      description: |-
-        bitlocker_info.device_id - ID of the encrypted drive.
-        cpu_info.device_id - The DeviceID of the CPU.
-        drivers.device_id - Device ID
-        logical_drives.device_id - The drive id, usually the drive name, e.g., 'C:'.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: device_locator
-      description: memory_devices.device_locator - String number of the string that identifies the physically-labeled socket or board position where the memory device is located
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: device_model
-      description: smart_drive_info.device_model - Device Model
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: device_name
-      description: |-
-        drivers.device_name - Device name
-        md_devices.device_name - md device name
-        smart_drive_info.device_name - Name of block device
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: device_path
-      description: iokit_devicetree.device_path - Device tree path
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: device_type
-      description: |-
-        lxd_instance_devices.device_type - Device type
-        shortcut_files.device_type - Device containing the target file.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: dhcp_enabled
       description: interface_details.dhcp_enabled - If TRUE, the dynamic host configuration protocol (DHCP) server automatically assigns an IP address to the computer system when establishing a network connection.
       type: keyword
@@ -2895,48 +1265,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: dhcp_lease_expires
-      description: interface_details.dhcp_lease_expires - Expiration date and time for a leased IP address that was assigned to the computer by the dynamic host configuration protocol (DHCP) server.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: dhcp_lease_obtained
-      description: interface_details.dhcp_lease_obtained - Date and time the lease was obtained for the IP address assigned to the computer by the dynamic host configuration protocol (DHCP) server.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: dhcp_server
-      description: interface_details.dhcp_server - IP address of the dynamic host configuration protocol (DHCP) server.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: directory
-      description: |-
-        extended_attributes.directory - Directory of file(s)
-        file.directory - Directory of file(s)
-        hash.directory - Must provide a path or directory
-        npm_packages.directory - Node module's directory where this package is located
-        python_packages.directory - Directory where Python modules are located
-        users.directory - User's home directory
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: disabled
       description: |-
@@ -3034,146 +1362,6 @@
         - name: number
           type: long
           default_field: false
-    - name: display_name
-      description: |-
-        apps.display_name - Info properties CFBundleDisplayName label
-        services.display_name - Service Display name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: dns_domain
-      description: interface_details.dns_domain - Organization name followed by a period and an extension that indicates the type of organization, such as 'microsoft.com'.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: dns_domain_name
-      description: logon_sessions.dns_domain_name - The DNS name for the owner of the logon session.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: dns_domain_suffix_search_order
-      description: interface_details.dns_domain_suffix_search_order - Array of DNS domain suffixes to be appended to the end of host names during name resolution.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: dns_forest_name
-      description: ntdomains.dns_forest_name - The name of the root of the DNS tree.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: dns_host_name
-      description: interface_details.dns_host_name - Host name used to identify the local computer for authentication by some utilities.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: dns_server_search_order
-      description: interface_details.dns_server_search_order - Array of server IP addresses to be used in querying for DNS servers.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: domain
-      description: |-
-        ad_config.domain - Active Directory trust domain
-        managed_policies.domain - System or manager-chosen domain key
-        preferences.domain - Application ID usually in com.name.product format
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: domain_controller_address
-      description: ntdomains.domain_controller_address - The IP Address of the discovered domain controller..
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: domain_controller_name
-      description: ntdomains.domain_controller_name - The name of the discovered domain controller.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: domain_name
-      description: ntdomains.domain_name - The name of the domain.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: drive_letter
-      description: |-
-        bitlocker_info.drive_letter - Drive letter of the encrypted drive.
-        ntfs_journal_events.drive_letter - The drive letter identifying the source journal
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: drive_name
-      description: md_drives.drive_name - Drive device name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: driver
-      description: |-
-        docker_container_mounts.driver - Driver providing the mount
-        docker_networks.driver - Network driver
-        docker_volumes.driver - Volume driver
-        hardware_events.driver - Driver claiming the device
-        lxd_storage_pools.driver - Storage driver
-        pci_devices.driver - PCI Device used driver
-        video_info.driver - The driver of the device.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: driver_date
       description: video_info.driver_date - The date listed on the installed driver.
       type: keyword
@@ -3181,60 +1369,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: driver_key
-      description: drivers.driver_key - Driver key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: driver_type
-      description: smart_drive_info.driver_type - The explicit device type used to retrieve the SMART information
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: driver_version
-      description: video_info.driver_version - The version of the installed driver.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: dst_ip
-      description: iptables.dst_ip - Destination IP address.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: dst_mask
-      description: iptables.dst_mask - Destination IP address mask.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: dst_port
-      description: iptables.dst_port - Protocol destination port(s).
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: dtime
       description: shared_memory.dtime - Detached time
@@ -3279,31 +1413,6 @@
         processes.egid - Unsigned effective group ID
       type: keyword
       ignore_above: 1024
-    - name: eid
-      description: |-
-        apparmor_events.eid - Event ID
-        bpf_process_events.eid - Event ID
-        bpf_socket_events.eid - Event ID
-        disk_events.eid - Event ID
-        es_process_events.eid - Event ID
-        file_events.eid - Event ID
-        hardware_events.eid - Event ID
-        ntfs_journal_events.eid - Event ID
-        process_events.eid - Event ID
-        process_file_events.eid - Event ID
-        selinux_events.eid - Event ID
-        socket_events.eid - Event ID
-        syslog_events.eid - Event ID
-        user_events.eid - Event ID
-        windows_events.eid - Event ID
-        yara_events.eid - Event ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: ejectable
       description: disk_events.ejectable - 1 if ejectable, 0 if not
       type: keyword
@@ -3319,15 +1428,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: element
-      description: apps.element - Does the app identify as a background agent
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: elevated_token
       description: processes.elevated_token - Process uses elevated token yes=1, no=0
@@ -3378,87 +1478,6 @@
         - name: number
           type: long
           default_field: false
-    - name: encryption
-      description: time_machine_destinations.encryption - Last known encrypted state
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: encryption_method
-      description: bitlocker_info.encryption_method - The encryption type of the device.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: encryption_status
-      description: "disk_encryption.encryption_status - Disk encryption status with one of following values: encrypted | not encrypted | undefined"
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: end
-      description: |-
-        memory_map.end - End address of memory region
-        process_memory_map.end - Virtual end address (hex)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ending_address
-      description: |-
-        memory_array_mapped_addresses.ending_address - Physical ending address of last kilobyte of a range of memory mapped to physical memory array
-        memory_device_mapped_addresses.ending_address - Physical ending address of last kilobyte of a range of memory mapped to physical memory array
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: endpoint_id
-      description: docker_container_networks.endpoint_id - Endpoint ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: entry
-      description: |-
-        authorization_mechanisms.entry - The whole string entry
-        elf_info.entry - Entry point address
-        shimcache.entry - Execution order.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: env
-      description: |-
-        es_process_events.env - Environment variables delimited by spaces
-        process_events.env - Environment variables delimited by spaces
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: env_count
       description: |-
         es_process_events.env_count - Number of environment variables
@@ -3477,24 +1496,6 @@
         - name: number
           type: long
           default_field: false
-    - name: env_variables
-      description: docker_containers.env_variables - Container environmental variables
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: environment
-      description: apps.environment - Application-set environment variables
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: ephemeral
       description: lxd_instances.ephemeral - Whether the instance is ephemeral(1) or not(0)
       type: keyword
@@ -3511,51 +1512,6 @@
         - name: number
           type: long
           default_field: false
-    - name: error
-      description: apparmor_events.error - Error information
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: error_granularity
-      description: memory_error_info.error_granularity - Granularity to which the error can be resolved
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: error_operation
-      description: memory_error_info.error_operation - Memory access operation that caused the error
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: error_resolution
-      description: memory_error_info.error_resolution - Range, in bytes, within which this error can be determined, when an error address is given
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: error_type
-      description: memory_error_info.error_type - type of error associated with current error status for array or device
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: euid
       description: |-
         docker_container_processes.euid - Effective user ID
@@ -3565,15 +1521,6 @@
         processes.euid - Unsigned effective user ID
       type: keyword
       ignore_above: 1024
-    - name: event
-      description: crontab.event - The job @event name (rare)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: event_queue
       description: carbon_black_info.event_queue - Size in bytes of Carbon Black event files on disk
       type: keyword
@@ -3589,24 +1536,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: event_tapped
-      description: event_taps.event_tapped - The mask that identifies the set of events to be observed.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: event_type
-      description: es_process_events.event_type - Type of EndpointSecurity event
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: eventid
       description: |-
@@ -3626,89 +1555,6 @@
         - name: number
           type: long
           default_field: false
-    - name: exception_address
-      description: windows_crashes.exception_address - Address (in hex) where the exception occurred
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: exception_code
-      description: windows_crashes.exception_code - The Windows exception code
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: exception_codes
-      description: crashes.exception_codes - Exception codes from the crash
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: exception_message
-      description: windows_crashes.exception_message - The NTSTATUS error message associated with the exception code
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: exception_notes
-      description: crashes.exception_notes - Exception notes from the crash
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: exception_type
-      description: crashes.exception_type - Exception type of the crash
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: exe
-      description: seccomp_events.exe - The path to the executable that was used to invoke the analyzed process
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: executable
-      description: |-
-        appcompat_shims.executable - Name of the executable that is being shimmed. This is pulled from the registry.
-        process_file_events.executable - The executable path
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: executable_path
-      description: wmi_cli_event_consumers.executable_path - Module to execute. The string can specify the full path and file name of the module to execute, or it can specify a partial name. If a partial name is specified, the current drive and current directory are assumed.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: execution_flag
       description: shimcache.execution_flag - Boolean Execution flag, 1 for execution, 0 for no execution, -1 for missing (this flag does not exist on Windows 10 and higher).
       type: keyword
@@ -3724,18 +1570,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: exit_code
-      description: |-
-        bpf_process_events.exit_code - Exit code of the system call
-        bpf_socket_events.exit_code - Exit code of the system call
-        es_process_events.exit_code - Exit code of a process in case of an exit event
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: expand
       description: default_environment.expand - 1 if the variable needs expanding, 0 otherwise
@@ -3753,33 +1587,6 @@
         - name: number
           type: long
           default_field: false
-    - name: expires_at
-      description: lxd_images.expires_at - ISO time of image expiration
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: extended_key_usage
-      description: curl_certificate.extended_key_usage - Extended usage of key in certificate
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: extensions
-      description: osquery_info.extensions - osquery extensions status
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: external
       description: app_schemes.external - 1 if this handler does NOT exist on OS X by default, else 0
       type: keyword
@@ -3787,28 +1594,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: extra
-      description: |-
-        asl.extra - Extra columns, in JSON format. Queries against this column are performed entirely in SQLite, so do not benefit from efficient querying via asl.h.
-        platform_info.extra - Platform-specific additional information
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: facility
-      description: |-
-        asl.facility - Sender's facility.  Default is 'user'.
-        syslog_events.facility - Syslog facility
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: fahrenheit
       description: temperature_sensors.fahrenheit - Temperature in Fahrenheit
@@ -3854,15 +1639,6 @@
         - name: number
           type: long
           default_field: false
-    - name: fan
-      description: fan_speed_sensors.fan - Fan number
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: faults
       description: virtual_memory_info.faults - Total number of calls to vm_faults.
       type: keyword
@@ -3870,30 +1646,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: fd
-      description: |-
-        bpf_socket_events.fd - The file description for the process socket
-        listening_ports.fd - Socket file descriptor number
-        process_open_files.fd - Process-specific file descriptor number
-        process_open_pipes.fd - File descriptor
-        process_open_sockets.fd - Socket file descriptor number
-        socket_events.fd - The file description for the process socket
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: feature
-      description: cpuid.feature - Present feature flags
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: feature_control
       description: msr.feature_control - Bitfield controlling enabled features.
@@ -3903,24 +1655,6 @@
         - name: number
           type: long
           default_field: false
-    - name: field_name
-      description: system_controls.field_name - Specific attribute of opaque type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: file_attributes
-      description: ntfs_journal_events.file_attributes - File attributes
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: file_backed
       description: virtual_memory_info.file_backed - Total number of file backed pages.
       type: keyword
@@ -3928,15 +1662,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: file_id
-      description: file.file_id - file ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: file_sharing
       description: sharing_preferences.file_sharing - 1 If file sharing is enabled else 0
@@ -3946,119 +1671,6 @@
         - name: number
           type: long
           default_field: false
-    - name: file_system
-      description: logical_drives.file_system - The file system of the drive.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: file_version
-      description: file.file_version - File version
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: filename
-      description: |-
-        device_file.filename - Name portion of file path
-        file.filename - Name portion of file path
-        lxd_images.filename - Filename of the image file
-        prefetch.filename - Executable filename.
-        xprotect_entries.filename - Use this file name to match
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: filepath
-      description: package_bom.filepath - Package file or directory
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: filesystem
-      description: disk_events.filesystem - Filesystem if available
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: filetype
-      description: xprotect_entries.filetype - Use this file type to match
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: filevault_status
-      description: "disk_encryption.filevault_status - FileVault status with one of following values: on | off | unknown"
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: filter
-      description: wmi_filter_consumer_binding.filter - Reference to an instance of __EventFilter that represents the object path to an event filter which is a query that specifies the type of event to be received.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: filter_name
-      description: iptables.filter_name - Packet matching filter table name.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: fingerprint
-      description: lxd_certificates.fingerprint - SHA256 hash of the certificate
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: finished_at
-      description: docker_containers.finished_at - Container finish time as string
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: firewall
-      description: windows_security_center.firewall - The health of the monitored Firewall (see windows_security_products)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: firewall_unload
       description: alf.firewall_unload - 1 If firewall unloading enabled else 0
       type: keyword
@@ -4066,26 +1678,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: firmware_version
-      description: |-
-        ibridge_info.firmware_version - The build version of the firmware
-        smart_drive_info.firmware_version - Drive firmware version
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: fix_comments
-      description: patches.fix_comments - Additional comments about the patch.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: flag
       description: shadow.flag - Reserved
@@ -4107,24 +1699,6 @@
         - name: number
           type: long
           default_field: false
-    - name: folder_id
-      description: ycloud_instance_metadata.folder_id - Folder identifier for the VM
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: following
-      description: systemd_units.following - The name of another unit that this unit follows in state
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: forced
       description: preferences.forced - 1 if the value is forced/managed, else 0
       type: keyword
@@ -4133,26 +1707,6 @@
         - name: number
           type: long
           default_field: false
-    - name: form_factor
-      description: |-
-        memory_devices.form_factor - Implementation form factor for this memory device
-        smart_drive_info.form_factor - Form factor if reported
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: format
-      description: cups_jobs.format - The format of the print job
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: forwarding_enabled
       description: interface_ipv6.forwarding_enabled - Enable IP forwarding
       type: keyword
@@ -4160,24 +1714,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: fragment_path
-      description: systemd_units.fragment_path - The unit file path this unit was read from, if there is any
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: frame_backtrace
-      description: kernel_panics.frame_backtrace - Backtrace of the crashed module
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: free
       description: virtual_memory_info.free - Total number of free pages.
@@ -4195,35 +1731,6 @@
         - name: number
           type: long
           default_field: false
-    - name: friendly_name
-      description: |-
-        interface_addresses.friendly_name - The friendly display name of the interface.
-        interface_details.friendly_name - The friendly display name of the interface.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: from_webstore
-      description: chrome_extensions.from_webstore - True if this extension was installed from the web store
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: fs_id
-      description: quicklook_cache.fs_id - Quicklook file fs_id key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: fsgid
       description: |-
         process_events.fsgid - Filesystem group ID at process start
@@ -4237,18 +1744,6 @@
         process_file_events.fsuid - Filesystem user ID of the process using the file
       type: keyword
       ignore_above: 1024
-    - name: gateway
-      description: |-
-        docker_container_networks.gateway - Gateway
-        docker_networks.gateway - Network gateway
-        routes.gateway - Route gateway
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: gid
       description: |-
         asl.gid - GID that sent the log message (set by the server).
@@ -4279,15 +1774,6 @@
         - name: number
           type: long
           default_field: false
-    - name: git_commit
-      description: docker_version.git_commit - Docker build git commit
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: global_seq_num
       description: es_process_events.global_seq_num - Global sequence number
       type: keyword
@@ -4304,33 +1790,6 @@
         - name: number
           type: long
           default_field: false
-    - name: go_version
-      description: docker_version.go_version - Go version
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: gpgcheck
-      description: yum_sources.gpgcheck - Whether packages are GPG checked
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: gpgkey
-      description: yum_sources.gpgkey - URL to GPG key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: grace_period
       description: screenlock.grace_period - The amount of time in seconds the screen must be asleep or the screensaver on before a password is required on-wake. 0 = immediately; -1 = no password is required on-wake
       type: keyword
@@ -4338,28 +1797,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: group_sid
-      description: groups.group_sid - Unique group ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: groupname
-      description: |-
-        groups.groupname - Canonical local group name
-        launchd.groupname - Run this daemon or agent as this group
-        rpm_package_files.groupname - File default groupname from info DB
-        suid_bin.groupname - Binary owner group
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: guest
       description: cpu_time.guest - Time spent running a virtual CPU for a guest OS under the control of the Linux kernel
@@ -4377,22 +1814,6 @@
         - name: number
           type: long
           default_field: false
-    - name: handle
-      description: |-
-        memory_array_mapped_addresses.handle - Handle, or instance number, associated with the structure
-        memory_arrays.handle - Handle, or instance number, associated with the array
-        memory_device_mapped_addresses.handle - Handle, or instance number, associated with the structure
-        memory_devices.handle - Handle, or instance number, associated with the structure in SMBIOS
-        memory_error_info.handle - Handle, or instance number, associated with the structure
-        oem_strings.handle - Handle, or instance number, associated with the Type 11 structure
-        smbios_tables.handle - Table entry handle
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: handle_count
       description: processes.handle_count - Total number of handles that the process has open. This number is the sum of the handles currently opened by each thread in the process.
       type: keyword
@@ -4400,24 +1821,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: handler
-      description: app_schemes.handler - Application label for the handler
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: hard_limit
-      description: ulimit_info.hard_limit - Maximum limit value
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: hard_links
       description: |-
@@ -4429,44 +1832,6 @@
         - name: number
           type: long
           default_field: false
-    - name: hardware_model
-      description: |-
-        disk_info.hardware_model - Hard drive model.
-        system_info.hardware_model - Hardware model
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: hardware_serial
-      description: system_info.hardware_serial - Device serial number
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: hardware_vendor
-      description: system_info.hardware_vendor - Hardware vendor
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: hardware_version
-      description: system_info.hardware_version - Hardware version
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: has_expired
       description: curl_certificate.has_expired - 1 if the certificate has expired, 0 otherwise
       type: keyword
@@ -4474,24 +1839,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: hash
-      description: prefetch.hash - Prefetch CRC hash.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: hash_alg
-      description: shadow.hash_alg - Password hashing algorithm
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: hash_resources
       description: signature.hash_resources - Set to 1 to also hash resources, or 0 otherwise. Default is 1
@@ -4509,15 +1856,6 @@
         - name: number
           type: long
           default_field: false
-    - name: header
-      description: sudoers.header - Symbol for given rule
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: header_size
       description: smbios_tables.header_size - Header size in bytes
       type: keyword
@@ -4525,15 +1863,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: health
-      description: 'battery.health - One of the following: "Good" describes a well-performing battery, "Fair" describes a functional battery with limited capacity, or "Poor" describes a battery that''s not capable of providing power'
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: hidden
       description: |-
@@ -4544,51 +1873,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: history_file
-      description: shell_history.history_file - Path to the .*_history for this user
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: hit_count
-      description: quicklook_cache.hit_count - Number of cache hits on thumbnail
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: home_directory
-      description: logon_sessions.home_directory - The home directory for the logon session.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: home_directory_drive
-      description: logon_sessions.home_directory_drive - The drive location of the home directory of the logon session.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: homepage
-      description: atom_packages.homepage - Package supplied homepage
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: hop_limit
       description: interface_ipv6.hop_limit - Current Hop Limit
@@ -4606,29 +1890,6 @@
         - name: number
           type: long
           default_field: false
-    - name: host
-      description: |-
-        asl.host - Sender's address (set by the server).
-        last.host - Entry hostname
-        logged_in_users.host - Remote hostname
-        preferences.host - 'current' or 'any' host, where 'current' takes precedence
-        syslog_events.host - Hostname configured for syslog
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: host_ip
-      description: docker_container_ports.host_ip - Host IP address on which public port is listening
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: host_port
       description: docker_container_ports.host_port - Host port
       type: keyword
@@ -4637,48 +1898,6 @@
         - name: number
           type: long
           default_field: false
-    - name: hostname
-      description: |-
-        curl_certificate.hostname - Hostname (domain[:port]) to CURL
-        shortcut_files.hostname - Optional hostname of the target file.
-        system_info.hostname - Network hostname including domain
-        ycloud_instance_metadata.hostname - Hostname of the VM
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: hostnames
-      description: etc_hosts.hostnames - Raw hosts mapping
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: hotfix_id
-      description: patches.hotfix_id - The KB ID of the patch.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: hour
-      description: |-
-        crontab.hour - The hour of the day for the job
-        time.hour - Current hour in the system
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: hours
       description: uptime.hours - Hours of uptime
       type: keyword
@@ -4686,42 +1905,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: http_proxy
-      description: docker_info.http_proxy - HTTP proxy
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: https_proxy
-      description: docker_info.https_proxy - HTTPS proxy
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: hwaddr
-      description: lxd_networks.hwaddr - Hardware address for this network
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: iam_arn
-      description: ec2_instance_metadata.iam_arn - If there is an IAM role associated with the instance, contains instance profile ARN
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: ibrs_support_enabled
       description: kva_speculative_info.ibrs_support_enabled - Windows uses IBRS.
@@ -4746,82 +1929,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: icon_path
-      description: shortcut_files.icon_path - Lnk file icon location.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: id
-      description: |-
-        disk_info.id - The unique identifier of the drive on the system.
-        dns_resolvers.id - Address type index or order
-        docker_container_fs_changes.id - Container ID
-        docker_container_labels.id - Container ID
-        docker_container_mounts.id - Container ID
-        docker_container_networks.id - Container ID
-        docker_container_ports.id - Container ID
-        docker_container_processes.id - Container ID
-        docker_container_stats.id - Container ID
-        docker_containers.id - Container ID
-        docker_image_history.id - Image ID
-        docker_image_labels.id - Image ID
-        docker_image_layers.id - Image ID
-        docker_images.id - Image ID
-        docker_info.id - Docker system ID
-        docker_network_labels.id - Network ID
-        docker_networks.id - Network ID
-        example.id - An index of some sort
-        iokit_devicetree.id - IOKit internal registry ID
-        iokit_registry.id - IOKit internal registry ID
-        lxd_images.id - Image ID
-        systemd_units.id - Unique unit identifier
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: identifier
-      description: |-
-        browser_plugins.identifier - Plugin identifier
-        chrome_extension_content_scripts.identifier - Extension identifier
-        chrome_extensions.identifier - Extension identifier, computed from its manifest. Empty in case of error.
-        crashes.identifier - Identifier of the crashed process
-        firefox_addons.identifier - Addon identifier
-        safari_extensions.identifier - Extension identifier
-        signature.identifier - The signing identifier sealed into the signature
-        system_extensions.identifier - Identifier name
-        xprotect_meta.identifier - Browser plugin or extension identifier
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: identifying_number
-      description: programs.identifying_number - Product identification such as a serial number on software, or a die number on a hardware chip.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: identity
-      description: xprotect_entries.identity - XProtect identity (SHA1) of content
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: idle
       description: cpu_time.idle - Time spent in the idle task
@@ -4855,26 +1962,6 @@
         - name: number
           type: long
           default_field: false
-    - name: image
-      description: |-
-        docker_containers.image - Docker image (name) used to launch this container
-        drivers.image - Path to driver image file
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: image_id
-      description: docker_containers.image_id - Docker image ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: images
       description: docker_info.images - Number of images
       type: keyword
@@ -4901,78 +1988,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: inetd_compatibility
-      description: launchd.inetd_compatibility - Run this daemon or agent as it was launched from inetd
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: inf
-      description: drivers.inf - Associated inf file
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: info
-      description: apparmor_events.info - Additional information
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: info_access
-      description: curl_certificate.info_access - Authority Information Access
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: info_string
-      description: apps.info_string - Info properties CFBundleGetInfoString label
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: inherited_from
-      description: ntfs_acl_permissions.inherited_from - The inheritance policy of the ACE.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: iniface
-      description: iptables.iniface - Input interface for the rule.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: iniface_mask
-      description: iptables.iniface_mask - Input interface mask for the rule.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: inode
       description: |-
@@ -5023,37 +2038,10 @@
         - name: number
           type: long
           default_field: false
-    - name: input_eax
-      description: cpuid.input_eax - Value of EAX used
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: install_date
       description: "os_version.install_date - The install date of the OS.\npatches.install_date - Indicates when the patch was installed. Lack of a value does not indicate that the patch was not installed.\nprograms.install_date - Date that this product was installed on the system. \nshared_resources.install_date - Indicates when the object was installed. Lack of a value does not indicate that the object is not installed."
       type: keyword
       ignore_above: 1024
-    - name: install_location
-      description: programs.install_location - The installation location directory of the product.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: install_source
-      description: programs.install_source - The installation source of the product.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: install_time
       description: |-
         appcompat_shims.install_time - Install time of the SDB
@@ -5070,64 +2058,6 @@
         - name: number
           type: long
           default_field: false
-    - name: installed_by
-      description: patches.installed_by - The system context in which the patch as installed.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: installed_on
-      description: patches.installed_on - The date when the patch was installed.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: installer_name
-      description: package_receipts.installer_name - Name of installer process
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: instance_id
-      description: |-
-        ec2_instance_metadata.instance_id - EC2 instance ID
-        ec2_instance_tags.instance_id - EC2 instance ID
-        osquery_info.instance_id - Unique, long-lived ID per instance of osquery
-        ycloud_instance_metadata.instance_id - Unique identifier for the VM
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: instance_identifier
-      description: hvci_status.instance_identifier - The instance ID of Device Guard.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: instance_type
-      description: ec2_instance_metadata.instance_type - EC2 instance type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: instances
       description: pipes.instances - Number of instances of the named pipe
       type: keyword
@@ -5135,23 +2065,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: interface
-      description: |-
-        arp_cache.interface - Interface of the network for the MAC
-        interface_addresses.interface - Interface name
-        interface_details.interface - Interface name
-        interface_ipv6.interface - Interface name
-        lldp_neighbors.interface - Interface name
-        routes.interface - Route local interface
-        wifi_status.interface - Name of the interface
-        wifi_survey.interface - Name of the interface
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: interleave_data_depth
       description: memory_device_mapped_addresses.interleave_data_depth - The max number of consecutive rows from memory device that are accessed in a single interleave transfer; 0 indicates device is non-interleave
@@ -5176,15 +2089,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: internet_settings
-      description: windows_security_center.internet_settings - The health of the Internet Settings
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: internet_sharing
       description: sharing_preferences.internet_sharing - 1 If internet sharing is enabled else 0
@@ -5212,24 +2116,6 @@
         - name: number
           type: long
           default_field: false
-    - name: ip
-      description: seccomp_events.ip - Instruction pointer value
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ip_address
-      description: docker_container_networks.ip_address - IP address
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: ip_prefix_len
       description: docker_container_networks.ip_prefix_len - IP subnet prefix length
       type: keyword
@@ -5245,26 +2131,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: ipc_namespace
-      description: |-
-        docker_containers.ipc_namespace - IPC namespace
-        process_namespaces.ipc_namespace - ipc namespace inode
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ipv4_address
-      description: lxd_networks.ipv4_address - IPv4 address
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: ipv4_forwarding
       description: docker_info.ipv4_forwarding - 1 if IPv4 forwarding is enabled. 0 otherwise
@@ -5305,26 +2171,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: ipv6_address
-      description: |-
-        docker_container_networks.ipv6_address - IPv6 address
-        lxd_networks.ipv6_address - IPv6 address
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ipv6_gateway
-      description: docker_container_networks.ipv6_gateway - IPv6 gateway
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: ipv6_internet
       description: connectivity.ipv6_internet - True if any interface is connected to the Internet via IPv6
@@ -5392,69 +2238,6 @@
         - name: number
           type: long
           default_field: false
-    - name: iso_8601
-      description: time.iso_8601 - Current time (ISO format) in the system
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: issuer
-      description: certificates.issuer - Certificate issuer distinguished name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: issuer_alternative_names
-      description: curl_certificate.issuer_alternative_names - Issuer Alternative Name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: issuer_common_name
-      description: curl_certificate.issuer_common_name - Issuer common name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: issuer_name
-      description: authenticode.issuer_name - The certificate issuer name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: issuer_organization
-      description: curl_certificate.issuer_organization - Issuer organization
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: issuer_organization_unit
-      description: curl_certificate.issuer_organization_unit - Issuer organization unit
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: job_id
       description: systemd_units.job_id - Next queued job id
       type: keyword
@@ -5463,42 +2246,6 @@
         - name: number
           type: long
           default_field: false
-    - name: job_path
-      description: systemd_units.job_path - The object path for the job
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: job_type
-      description: systemd_units.job_type - Job type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: json_cmdline
-      description: bpf_process_events.json_cmdline - Command line arguments, in JSON format
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: keep_alive
-      description: launchd.keep_alive - Should the process be restarted if killed
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: kernel_memory
       description: docker_info.kernel_memory - 1 if kernel memory limit support is enabled. 0 otherwise
       type: keyword
@@ -5506,127 +2253,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: kernel_version
-      description: |-
-        docker_info.kernel_version - Kernel version
-        docker_version.kernel_version - Kernel version
-        kernel_panics.kernel_version - Version of the system kernel
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: key
-      description: |-
-        authorized_keys.key - parsed authorized keys line
-        azure_instance_tags.key - The tag key
-        chrome_extensions.key - The extension key, from the manifest file
-        docker_container_labels.key - Label key
-        docker_image_labels.key - Label key
-        docker_network_labels.key - Label key
-        docker_volume_labels.key - Label key
-        ec2_instance_tags.key - Tag key
-        extended_attributes.key - Name of the value generated from the extended attribute
-        known_hosts.key - parsed authorized keys line
-        launchd_overrides.key - Name of the override key
-        lxd_instance_config.key - Configuration parameter name
-        lxd_instance_devices.key - Device info param name
-        mdls.key - Name of the metadata key
-        plist.key - Preference top-level key
-        power_sensors.key - The SMC key on OS X
-        preferences.key - Preference top-level key
-        process_envs.key - Environment variable name
-        registry.key - Name of the key to search for
-        selinux_settings.key - Key or class name.
-        smc_keys.key - 4-character key
-        temperature_sensors.key - The SMC key on OS X
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: key_algorithm
-      description: certificates.key_algorithm - Key algorithm used
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: key_file
-      description: |-
-        authorized_keys.key_file - Path to the authorized_keys file
-        known_hosts.key_file - Path to known_hosts file
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: key_strength
-      description: certificates.key_strength - Key size used for RSA/DSA, or curve name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: key_type
-      description: user_ssh_keys.key_type - The type of the private key. One of [rsa, dsa, dh, ec, hmac, cmac], or the empty string.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: key_usage
-      description: |-
-        certificates.key_usage - Certificate key usage and extended key usage
-        curl_certificate.key_usage - Usage of key in certificate
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: keychain_path
-      description: keychain_acls.keychain_path - The path of the keychain
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: keyword
-      description: portage_keywords.keyword - The keyword applied to the package
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: keywords
-      description: |-
-        windows_eventlog.keywords - A bitmask of the keywords defined in the event
-        windows_events.keywords - A bitmask of the keywords defined in the event
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: kva_shadow_enabled
       description: kva_speculative_info.kva_shadow_enabled - Kernel Virtual Address shadowing is enabled.
@@ -5659,24 +2285,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: label
-      description: "apparmor_events.label - AppArmor label\naugeas.label - The label of the configuration item\nauthorization_mechanisms.label - Label of the authorization right\nauthorizations.label - Item name, usually in reverse domain format\nblock_devices.label - Block device label string\ndevice_partitions.label - \nkeychain_acls.label - An optional label tag that may be included with the keychain entry\nkeychain_items.label - Generic item name\nlaunchd.label - Daemon or agent service name\nlaunchd_overrides.label - Daemon or agent service name\nquicklook_cache.label - Parsed version 'gen' field\nsandboxes.label - UTI-format bundle or label ID"
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: language
-      description: programs.language - The language of the product.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: last_change
       description: |-
@@ -5722,39 +2330,12 @@
         - name: number
           type: long
           default_field: false
-    - name: last_loaded
-      description: kernel_panics.last_loaded - Last loaded module before panic
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: last_opened_time
       description: |-
         apps.last_opened_time - The time that the app was last used
         office_mru.last_opened_time - Most recent opened time file was opened
       type: keyword
       ignore_above: 1024
-    - name: last_run_code
-      description: scheduled_tasks.last_run_code - Exit status code of the last task run
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: last_run_message
-      description: scheduled_tasks.last_run_message - Exit status message of the last task run
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: last_run_time
       description: |-
         prefetch.last_run_time - Most recent time application was run.
@@ -5764,42 +2345,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: last_unloaded
-      description: kernel_panics.last_unloaded - Last unloaded module before panic
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: last_used_at
-      description: lxd_images.last_used_at - ISO time for the most recent use of this image in terms of container spawn
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: launch_type
-      description: xprotect_entries.launch_type - Launch services content type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: layer_id
-      description: docker_image_layers.layer_id - Layer ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: layer_order
       description: docker_image_layers.layer_order - Layer Order (1 = base layer)
@@ -5820,28 +2365,6 @@
         - name: number
           type: long
           default_field: false
-    - name: license
-      description: |-
-        atom_packages.license - License for package
-        chocolatey_packages.license - License under which package is launched
-        npm_packages.license - License for package
-        python_packages.license - License under which package is launched
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: link
-      description: elf_sections.link - Link to other section
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: link_speed
       description: interface_details.link_speed - Interface speed in Mb/s
       type: keyword
@@ -5849,65 +2372,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: linked_against
-      description: kernel_extensions.linked_against - Indexes of extensions this extension is linked against
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: load_state
-      description: systemd_units.load_state - Reflects whether the unit definition was properly loaded
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: local_address
-      description: |-
-        bpf_socket_events.local_address - Local address associated with socket
-        process_open_sockets.local_address - Socket local address
-        socket_events.local_address - Local address associated with socket
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: local_hostname
-      description: |-
-        ec2_instance_metadata.local_hostname - Private IPv4 DNS hostname of the first interface of this instance
-        system_info.local_hostname - Local hostname (optional)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: local_ipv4
-      description: ec2_instance_metadata.local_ipv4 - Private IPv4 address of the first interface of this instance
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: local_path
-      description: shortcut_files.local_path - Local system path to target file.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: local_port
       description: |-
@@ -5927,37 +2391,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: local_timezone
-      description: time.local_timezone - Current local timezone in the system
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: location
-      description: |-
-        azure_instance_metadata.location - Azure Region the VM is running in
-        firefox_addons.location - Global, profile location
-        memory_arrays.location - Physical location of the memory array
-        package_receipts.location - Optional relative install path on volume
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: lock
-      description: chassis_info.lock - If TRUE, the frame is equipped with a lock.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: lock_status
       description: bitlocker_info.lock_status - The accessibility status of the drive from Windows.
@@ -5991,15 +2424,6 @@
         - name: number
           type: long
           default_field: false
-    - name: logging_driver
-      description: docker_info.logging_driver - Logging driver
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: logging_enabled
       description: alf.logging_enabled - 1 If logging mode is enabled else 0
       type: keyword
@@ -6024,15 +2448,6 @@
         - name: number
           type: long
           default_field: false
-    - name: logon_domain
-      description: logon_sessions.logon_domain - The name of the domain used to authenticate the owner of the logon session.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: logon_id
       description: logon_sessions.logon_id - A locally unique identifier (LUID) that identifies a logon session.
       type: keyword
@@ -6040,33 +2455,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: logon_script
-      description: logon_sessions.logon_script - The script used for logging on.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: logon_server
-      description: logon_sessions.logon_server - The name of the server used to authenticate the owner of the logon session.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: logon_sid
-      description: logon_sessions.logon_sid - The user's security identifier (SID).
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: logon_time
       description: logon_sessions.logon_time - The time the session owner logged on.
@@ -6076,45 +2464,6 @@
         - name: number
           type: long
           default_field: false
-    - name: logon_type
-      description: logon_sessions.logon_type - The logon method.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: lu_wwn_device_id
-      description: smart_drive_info.lu_wwn_device_id - Device Identifier
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: mac
-      description: |-
-        arp_cache.mac - MAC address of broadcasted address
-        ec2_instance_metadata.mac - MAC address for the first network interface of this EC2 instance
-        interface_details.mac - MAC of interface (optional)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: mac_address
-      description: docker_container_networks.mac_address - MAC address
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: machine
       description: elf_info.machine - Machine type
       type: keyword
@@ -6122,35 +2471,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: machine_name
-      description: windows_crashes.machine_name - Name of the machine where the crash happened
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: magic_db_files
-      description: "magic.magic_db_files - Colon(:) separated list of files where the magic db file can be found. By default one of the following is used: /usr/share/file/magic/magic, /usr/share/misc/magic or /usr/share/misc/magic.mgc"
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: maintainer
-      description: |-
-        apt_sources.maintainer - Repository maintainer
-        deb_packages.maintainer - Package maintainer
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: major
       description: os_version.major - Major release version
@@ -6176,24 +2496,6 @@
         - name: number
           type: long
           default_field: false
-    - name: manifest_hash
-      description: chrome_extensions.manifest_hash - The SHA256 hash of the manifest.json file
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: manifest_json
-      description: chrome_extensions.manifest_json - The manifest file of the extension
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: manual
       description: managed_policies.manual - 1 if policy was loaded manually, otherwise 0
       type: keyword
@@ -6210,23 +2512,6 @@
         - name: number
           type: long
           default_field: false
-    - name: manufacturer
-      description: |-
-        battery.manufacturer - The battery manufacturer's name
-        chassis_info.manufacturer - The manufacturer of the chassis.
-        cpu_info.manufacturer - The manufacturer of the CPU.
-        disk_info.manufacturer - The manufacturer of the disk.
-        drivers.manufacturer - Device manufacturer
-        interface_details.manufacturer - Name of the network adapter's manufacturer.
-        memory_devices.manufacturer - Manufacturer ID string
-        video_info.manufacturer - The manufacturer of the gpu.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: manufacturer_id
       description: tpm_info.manufacturer_id - TPM manufacturers ID
       type: keyword
@@ -6234,57 +2519,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: manufacturer_name
-      description: tpm_info.manufacturer_name - TPM manufacturers name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: manufacturer_version
-      description: tpm_info.manufacturer_version - TPM version
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: mask
-      description: |-
-        interface_addresses.mask - Interface netmask
-        portage_keywords.mask - If the package is masked
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: match
-      description: |-
-        chrome_extension_content_scripts.match - The pattern that the script is matched against
-        iptables.match - Matching rule that applies.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: matches
-      description: |-
-        yara.matches - List of YARA matches
-        yara_events.matches - List of YARA matches
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: max
       description: |-
@@ -6346,29 +2580,6 @@
         - name: number
           type: long
           default_field: false
-    - name: md5
-      description: |-
-        acpi_tables.md5 - MD5 hash of table content
-        device_hash.md5 - MD5 hash of provided inode data
-        file_events.md5 - The MD5 of the file after change
-        hash.md5 - MD5 hash of provided filesystem data
-        smbios_tables.md5 - MD5 hash of table entry
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: md_device_name
-      description: md_drives.md_device_name - md device name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: mdm_managed
       description: system_extensions.mdm_managed - 1 if managed by MDM system extension payload configuration, 0 otherwise
       type: keyword
@@ -6376,15 +2587,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: mechanism
-      description: authorization_mechanisms.mechanism - Name of the mechanism that will be called
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: med_capability_capabilities
       description: lldp_neighbors.med_capability_capabilities - Is MED capabilities enabled
@@ -6434,33 +2636,6 @@
         - name: number
           type: long
           default_field: false
-    - name: med_device_type
-      description: lldp_neighbors.med_device_type - Chassis MED type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: med_policies
-      description: lldp_neighbors.med_policies - Comma delimited list of MED policies
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: media_name
-      description: disk_events.media_name - Disk event media name string
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: mem
       description: docker_container_processes.mem - Memory utilization as percentage
       type: keyword
@@ -6469,51 +2644,6 @@
         - name: number
           type: double
           default_field: false
-    - name: member_config_description
-      description: lxd_cluster.member_config_description - Config description
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: member_config_entity
-      description: lxd_cluster.member_config_entity - Type of configuration parameter for this node
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: member_config_key
-      description: lxd_cluster.member_config_key - Config key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: member_config_name
-      description: lxd_cluster.member_config_name - Name of configuration parameter
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: member_config_value
-      description: lxd_cluster.member_config_value - Config value
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: memory
       description: docker_info.memory - Total memory
       type: keyword
@@ -6521,60 +2651,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: memory_array_error_address
-      description: memory_error_info.memory_array_error_address - 32 bit physical address of the error based on the addressing of the bus to which the memory array is connected
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: memory_array_handle
-      description: memory_array_mapped_addresses.memory_array_handle - Handle of the memory array associated with this structure
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: memory_array_mapped_address_handle
-      description: memory_device_mapped_addresses.memory_array_mapped_address_handle - Handle of the memory array mapped address to which this device range is mapped to
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: memory_device_handle
-      description: memory_device_mapped_addresses.memory_device_handle - Handle of the memory device structure associated with this structure
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: memory_error_correction
-      description: memory_arrays.memory_error_correction - Primary hardware error correction or detection method supported
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: memory_error_info_handle
-      description: memory_arrays.memory_error_info_handle - Handle, or instance number, associated with any error that was detected for the array
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: memory_free
       description: memory_info.memory_free - The amount of physical RAM, in bytes, left unused by the system
@@ -6610,24 +2686,6 @@
         - name: number
           type: long
           default_field: false
-    - name: memory_type
-      description: memory_devices.memory_type - Type of memory used
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: memory_type_details
-      description: memory_devices.memory_type_details - Additional details for memory device
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: memory_usage
       description: docker_container_stats.memory_usage - Memory usage
       type: keyword
@@ -6635,39 +2693,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: message
-      description: |-
-        apparmor_events.message - Raw audit message
-        asl.message - Message text.
-        lxd_cluster_members.message - Message from the node (Online/Offline)
-        selinux_events.message - Message
-        syslog_events.message - The syslog message
-        user_events.message - Message from the event
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: metadata_endpoint
-      description: ycloud_instance_metadata.metadata_endpoint - Endpoint used to fetch VM metadata
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: method
-      description: curl.method - The HTTP method for the request
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: metric
       description: |-
@@ -6678,15 +2703,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: metric_name
-      description: prometheus_metrics.metric_name - Name of collected Prometheus metric
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: metric_value
       description: prometheus_metrics.metric_value - Value of collected Prometheus metric
@@ -6716,24 +2732,6 @@
         - name: number
           type: long
           default_field: false
-    - name: mime_encoding
-      description: magic.mime_encoding - MIME encoding data from libmagic
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: mime_type
-      description: magic.mime_type - MIME type data from libmagic
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: min
       description: |-
         fan_speed_sensors.min - Minimum speed
@@ -6744,24 +2742,6 @@
         - name: number
           type: long
           default_field: false
-    - name: min_api_version
-      description: docker_version.min_api_version - Minimum API version supported
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: min_version
-      description: xprotect_meta.min_version - The minimum allowed plugin version.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: min_voltage
       description: memory_devices.min_voltage - Minimum operating voltage of device in millivolts
       type: keyword
@@ -6769,15 +2749,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: minimum_system_version
-      description: apps.minimum_system_version - Minimum version of OS X required for the app to run
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: minor
       description: os_version.minor - Minor release version
@@ -6794,15 +2765,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: minute
-      description: crontab.minute - The exact minute for the job
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: minutes
       description: |-
@@ -6830,85 +2792,6 @@
         - name: number
           type: long
           default_field: false
-    - name: mnt_namespace
-      description: |-
-        docker_containers.mnt_namespace - Mount namespace
-        process_namespaces.mnt_namespace - mnt namespace inode
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: mode
-      description: |-
-        apparmor_profiles.mode - How the policy is applied.
-        device_file.mode - Permission bits
-        docker_container_mounts.mode - Mount options (rw, ro)
-        file.mode - Permission bits
-        file_events.mode - Permission bits
-        package_bom.mode - Expected permissions
-        process_events.mode - File mode permissions
-        process_open_pipes.mode - Pipe open mode (r/w)
-        rpm_package_files.mode - File permissions mode from info DB
-        wifi_status.mode - The current operating mode for the Wi-Fi interface
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: model
-      description: |-
-        battery.model - The battery's model number
-        block_devices.model - Block device model string identifier
-        chassis_info.model - The model of the chassis.
-        cpu_info.model - The model of the CPU.
-        hardware_events.model - Hardware device model
-        pci_devices.model - PCI Device model
-        usb_devices.model - USB Device model string
-        video_info.model - The model of the gpu.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: model_family
-      description: smart_drive_info.model_family - Drive model family
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: model_id
-      description: |-
-        hardware_events.model_id - Hex encoded Hardware model identifier
-        pci_devices.model_id - Hex encoded PCI Device model identifier
-        usb_devices.model_id - Hex encoded USB Device model identifier
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: modified
-      description: |-
-        authorizations.modified - Label top-level key
-        keychain_items.modified - Date of last modification
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: modified_time
       description: |-
         package_bom.modified_time - Timestamp the file was installed
@@ -6919,68 +2802,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: module
-      description: windows_crashes.module - Path of the crashed module within the process
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: module_backtrace
-      description: kernel_panics.module_backtrace - Modules appearing in the crashed module's backtrace
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: module_path
-      description: services.module_path - Path to ServiceDll
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: month
-      description: |-
-        crontab.month - The month of the year for the job
-        time.month - Current month in the system
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: mount_namespace_id
-      description: |-
-        deb_packages.mount_namespace_id - Mount namespace id
-        file.mount_namespace_id - Mount namespace id
-        hash.mount_namespace_id - Mount namespace id
-        npm_packages.mount_namespace_id - Mount namespace id
-        os_version.mount_namespace_id - Mount namespace id
-        rpm_packages.mount_namespace_id - Mount namespace id
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: mount_point
-      description: docker_volumes.mount_point - Mount point
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: mountable
       description: disk_events.mountable - 1 if mountable, 0 if not
@@ -7020,33 +2841,6 @@
         - name: number
           type: long
           default_field: false
-    - name: name
-      description: "acpi_tables.name - ACPI table name\nad_config.name - The OS X-specific configuration name\napparmor_events.name - Process name\napparmor_profiles.name - Policy name.\napps.name - Name of the Name.app folder\napt_sources.name - Repository name\natom_packages.name - Package display name\nautoexec.name - Name of the program\nazure_instance_metadata.name - Name of the VM\nblock_devices.name - Block device name\nbrowser_plugins.name - Plugin display name\nchocolatey_packages.name - Package display name\nchrome_extensions.name - Extension display name\ncups_destinations.name - Name of the printer\ndeb_packages.name - Package name\ndisk_encryption.name - Disk name\ndisk_events.name - Disk event name\ndisk_info.name - The label of the disk object.\ndns_cache.name - DNS record name\ndocker_container_mounts.name - Optional mount name\ndocker_container_networks.name - Network name\ndocker_container_processes.name - The process path or shorthand argv[0]\ndocker_container_stats.name - Container name\ndocker_containers.name - Container name\ndocker_info.name - Name of the docker host\ndocker_networks.name - Network name\ndocker_volume_labels.name - Volume name\ndocker_volumes.name - Volume name\nelf_sections.name - Section name\nelf_segments.name - Segment type/name\nelf_symbols.name - Symbol name\netc_protocols.name - Protocol name\netc_services.name - Service name\nexample.name - Description for name column\nfan_speed_sensors.name - Fan name\nfbsd_kmods.name - Module name\nfirefox_addons.name - Addon display name\nhomebrew_packages.name - Package name\nie_extensions.name - Extension display name\niokit_devicetree.name - Device node name\niokit_registry.name - Default name of the node\nkernel_extensions.name - Extension label\nkernel_modules.name - Module name\nkernel_panics.name - Process name corresponding to crashed thread\nlaunchd.name - File name of plist (used by launchd)\nlxd_certificates.name - Name of the certificate\nlxd_instance_config.name - Instance name\nlxd_instance_devices.name - Instance name\nlxd_instances.name - Instance name\nlxd_networks.name - Name of the network\nlxd_storage_pools.name - Name of the storage pool\nmanaged_policies.name - Policy key name\nmd_personalities.name - Name of personality supported by kernel\nmemory_map.name - Region name\nnpm_packages.name - Package display name\nntdomains.name - The label by which the object is known.\nnvram.name - Variable name\nos_version.name - Distribution or product name\nosquery_events.name - Event publisher or subscriber name\nosquery_extensions.name - Extension's name\nosquery_flags.name - Flag name\nosquery_packs.name - The given name for this query pack\nosquery_registry.name - Name of the plugin item\nosquery_schedule.name - The given name for this query\npackage_install_history.name - Package display name\nphysical_disk_performance.name - Name of the physical disk\npipes.name - Name of the pipe\npkg_packages.name - Package name\npower_sensors.name - Name of power source\nprocesses.name - The process path or shorthand argv[0]\nprograms.name - Commonly used product name.\npython_packages.name - Package display name\nregistry.name - Name of the registry value entry\nrpm_packages.name - RPM package name\nsafari_extensions.name - Extension display name\nscheduled_tasks.name - Name of the scheduled task\nservices.name - Service name\nshared_folders.name - The shared name of the folder as it appears to other users\nshared_resources.name - Alias given to a path set up as a share on a computer system running Windows.\nstartup_items.name - Name of startup item\nsystem_controls.name - Full sysctl MIB name\ntemperature_sensors.name - Name of temperature source\nwindows_optional_features.name - Name of the feature\nwindows_security_products.name - Name of product\nwmi_bios_info.name - Name of the Bios setting\nwmi_cli_event_consumers.name - Unique name of a consumer.\nwmi_event_filters.name - Unique identifier of an event filter.\nwmi_script_event_consumers.name - Unique identifier for the event consumer. \nxprotect_entries.name - Description of XProtected malware\nxprotect_reports.name - Description of XProtected malware\nycloud_instance_metadata.name - Name of the VM\nyum_sources.name - Repository name"
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: name_constraints
-      description: curl_certificate.name_constraints - Name Constraints
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: namespace
-      description: apparmor_events.namespace - AppArmor namespace
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: native
       description: |-
         browser_plugins.native - Plugin requires native execution
@@ -7056,51 +2850,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: net_namespace
-      description: |-
-        docker_containers.net_namespace - Network namespace
-        listening_ports.net_namespace - The inode number of the network namespace
-        process_namespaces.net_namespace - net namespace inode
-        process_open_sockets.net_namespace - The inode number of the network namespace
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: netmask
-      description: |-
-        dns_resolvers.netmask - Address (sortlist) netmask length
-        routes.netmask - Netmask length
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: network_id
-      description: docker_container_networks.network_id - Network ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: network_name
-      description: |-
-        wifi_networks.network_name - Name of the network
-        wifi_status.network_name - Name of the network
-        wifi_survey.network_name - Name of the network
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: network_rx_bytes
       description: docker_container_stats.network_rx_bytes - Total network bytes read
@@ -7137,33 +2886,6 @@
         - name: number
           type: long
           default_field: false
-    - name: no_proxy
-      description: docker_info.no_proxy - Comma-separated list of domain extensions proxy should not be used for
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: node
-      description: augeas.node - The node path of the configuration item
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: node_ref_number
-      description: ntfs_journal_events.node_ref_number - The ordinal that associates a journal record with a filename
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: noise
       description: |-
         wifi_status.noise - The current noise measurement (dBm)
@@ -7174,24 +2896,6 @@
         - name: number
           type: long
           default_field: false
-    - name: not_valid_after
-      description: certificates.not_valid_after - Certificate expiration data
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: not_valid_before
-      description: certificates.not_valid_before - Lower bound of valid date
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: nr_raid_disks
       description: md_devices.nr_raid_disks - Number of partitions or disk devices to comprise the array
       type: keyword
@@ -7199,17 +2903,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: ntime
-      description: |-
-        bpf_process_events.ntime - The nsecs uptime timestamp as obtained from BPF
-        bpf_socket_events.ntime - The nsecs uptime timestamp as obtained from BPF
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: num_procs
       description: docker_container_stats.num_procs - Number of processors
@@ -7238,42 +2931,6 @@
         - name: number
           type: long
           default_field: false
-    - name: number_of_cores
-      description: cpu_info.number_of_cores - The number of cores of the CPU.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: object_name
-      description: winbaseobj.object_name - Object Name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: object_path
-      description: systemd_units.object_path - The object path for this unit
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: object_type
-      description: winbaseobj.object_type - Object Type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: obytes
       description: interface_details.obytes - Output bytes
       type: keyword
@@ -7298,15 +2955,6 @@
         - name: number
           type: long
           default_field: false
-    - name: offer
-      description: azure_instance_metadata.offer - Offer information for the VM image (Azure image gallery VMs only)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: offset
       description: "device_partitions.offset - \nelf_sections.offset - Offset of section in file\nelf_segments.offset - Segment offset in file\nelf_symbols.offset - Section table index\nprocess_memory_map.offset - Offset into mapped path"
       type: keyword
@@ -7314,33 +2962,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: oid
-      description: system_controls.oid - Control MIB
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: old_path
-      description: ntfs_journal_events.old_path - Old path (renames only)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: on_demand
-      description: launchd.on_demand - Deprecated key, replaced by keep_alive
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: on_disk
       description: processes.on_disk - The process path exists yes=1, no=0, unknown=-1
@@ -7374,55 +2995,6 @@
         - name: number
           type: long
           default_field: false
-    - name: opaque_version
-      description: gatekeeper.opaque_version - Version of Gatekeeper's gkopaque.bundle
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: operation
-      description: |-
-        apparmor_events.operation - Permission requested by the process
-        process_file_events.operation - Operation type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: option
-      description: |-
-        ad_config.option - Canonical name of option
-        ssh_configs.option - The option and value
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: option_name
-      description: cups_destinations.option_name - Option name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: option_value
-      description: cups_destinations.option_value - Option value
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: optional
       description: xprotect_entries.optional - Match any of the identities/patterns for this XProtect name
       type: keyword
@@ -7431,48 +3003,12 @@
         - name: number
           type: long
           default_field: false
-    - name: optional_permissions
-      description: chrome_extensions.optional_permissions - The permissions optionally required by the extensions
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: optional_permissions_json
-      description: chrome_extensions.optional_permissions_json - The JSON-encoded permissions optionally required by the extensions
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: options
       description: |-
         dns_resolvers.options - Resolver options
         nfs_shares.options - Options string set on the export share
       type: keyword
       ignore_above: 1024
-    - name: organization
-      description: curl_certificate.organization - Organization issued to
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: organization_unit
-      description: curl_certificate.organization_unit - Organization unit issued to
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: original_parent
       description: es_process_events.original_parent - Original parent process ID in case of reparenting
       type: keyword
@@ -7480,66 +3016,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: original_program_name
-      description: authenticode.original_program_name - The original program name that the publisher has signed
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: os
-      description: |-
-        docker_info.os - Operating system
-        docker_version.os - Operating system
-        lxd_images.os - OS on which image is based
-        lxd_instances.os - The OS of this instance
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: os_type
-      description: |-
-        azure_instance_metadata.os_type - Linux or Windows
-        docker_info.os_type - Operating system type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: os_version
-      description: kernel_panics.os_version - Version of the operating system
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: other
-      description: md_devices.other - Other information associated with array from /proc/mdstat
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: other_run_times
-      description: prefetch.other_run_times - Other execution times in prefetch file.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: ouid
       description: apparmor_events.ouid - Object owner's user ID
@@ -7549,24 +3025,6 @@
         - name: number
           type: long
           default_field: false
-    - name: outiface
-      description: iptables.outiface - Output interface for the rule.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: outiface_mask
-      description: iptables.outiface_mask - Output interface mask for the rule.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: output_bit
       description: cpuid.output_bit - Bit in register value for feature value
       type: keyword
@@ -7575,15 +3033,6 @@
         - name: number
           type: long
           default_field: false
-    - name: output_register
-      description: cpuid.output_register - Register used to for feature value
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: output_size
       description: osquery_schedule.output_size - Total number of bytes generated by the query
       type: keyword
@@ -7591,15 +3040,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: overflows
-      description: process_events.overflows - List of structures that overflowed
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: owned
       description: tpm_info.owned - TPM is ownned
@@ -7634,57 +3074,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: package
-      description: |-
-        portage_keywords.package - Package name
-        portage_packages.package - Package name
-        portage_use.package - Package name
-        rpm_package_files.package - RPM package name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: package_filename
-      description: package_receipts.package_filename - Filename of original .pkg file
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: package_group
-      description: rpm_packages.package_group - Package group
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: package_id
-      description: |-
-        package_install_history.package_id - Label packageIdentifiers
-        package_receipts.package_id - Package domain identifier
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: packet_device_type
-      description: smart_drive_info.packet_device_type - Packet device type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: packets
       description: iptables.packets - Number of matching packets for this rule.
@@ -7741,42 +3130,12 @@
         processes.parent - Process parent's PID
       type: keyword
       ignore_above: 1024
-    - name: parent_ref_number
-      description: ntfs_journal_events.parent_ref_number - The ordinal that associates a journal record with a filename's parent directory
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: part_number
-      description: memory_devices.part_number - Manufacturer specific serial number of memory device
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: partial
       description: |-
         ntfs_journal_events.partial - Set to 1 if either path or old_path only contains the file or folder name
         process_file_events.partial - True if this is a partial event (i.e.: this process existed before we started osquery)
       type: keyword
       ignore_above: 1024
-    - name: partition
-      description: |-
-        device_file.partition - A partition number
-        device_hash.partition - A partition number
-        device_partitions.partition - A partition number or description
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: partition_row_position
       description: memory_device_mapped_addresses.partition_row_position - Identifies the position of the referenced memory device in a row of the address partition
       type: keyword
@@ -7809,15 +3168,6 @@
         - name: number
           type: long
           default_field: false
-    - name: partner_mode
-      description: process_open_pipes.partner_mode - Mode of shared pipe at partner's end
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: partner_pid
       description: process_open_pipes.partner_pid - Process ID of partner process sharing a particular pipe
       type: keyword
@@ -7842,15 +3192,6 @@
         - name: number
           type: double
           default_field: false
-    - name: password_status
-      description: shadow.password_status - Password status
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: patch
       description: os_version.patch - Optional patch release
       type: keyword
@@ -7858,159 +3199,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: path
-      description: |-
-        alf_exceptions.path - Path to the executable that is excepted
-        apparmor_profiles.path - Unique, aa-status compatible, policy identifier.
-        appcompat_shims.path - This is the path to the SDB database.
-        apps.path - Absolute and full Name.app path
-        atom_packages.path - Package's package.json path
-        augeas.path - The path to the configuration file
-        authenticode.path - Must provide a path or directory
-        autoexec.path - Path to the executable
-        background_activities_moderator.path - Application file path.
-        bpf_process_events.path - Binary path
-        bpf_socket_events.path - Path of executed file
-        browser_plugins.path - Path to plugin bundle
-        carves.path - The path of the requested carve
-        certificates.path - Path to Keychain or PEM bundle
-        chocolatey_packages.path - Path at which this package resides
-        chrome_extension_content_scripts.path - Path to extension folder
-        chrome_extensions.path - Path to extension folder
-        crashes.path - Path to the crashed process
-        crontab.path - File parsed
-        device_file.path - A logical path within the device node
-        disk_events.path - Path of the DMG file accessed
-        docker_container_fs_changes.path - FIle or directory path relative to rootfs
-        docker_containers.path - Container path
-        elf_dynamic.path - Path to ELF file
-        elf_info.path - Path to ELF file
-        elf_sections.path - Path to ELF file
-        elf_segments.path - Path to ELF file
-        elf_symbols.path - Path to ELF file
-        es_process_events.path - Path of executed file
-        example.path - Path of example
-        extended_attributes.path - Absolute file path
-        file.path - Absolute file path
-        firefox_addons.path - Path to plugin bundle
-        gatekeeper_approved_apps.path - Path of executable allowed to run
-        hardware_events.path - Local device path assigned (optional)
-        hash.path - Must provide a path or directory
-        homebrew_packages.path - Package install path
-        ie_extensions.path - Path to executable
-        kernel_extensions.path - Optional path to extension bundle
-        kernel_info.path - Kernel path
-        kernel_panics.path - Location of log file
-        keychain_acls.path - The path of the authorized application
-        keychain_items.path - Path to keychain containing item
-        launchd.path - Path to daemon or agent plist
-        launchd_overrides.path - Path to daemon or agent plist
-        listening_ports.path - Path for UNIX domain sockets
-        magic.path - Absolute path to target file
-        mdfind.path - Path of the file returned from spotlight
-        mdls.path - Path of the file
-        mounts.path - Mounted device path
-        npm_packages.path - Module's package.json path
-        ntfs_acl_permissions.path - Path to the file or directory.
-        ntfs_journal_events.path - Path
-        office_mru.path - File path
-        osquery_extensions.path - Path of the extension's Thrift connection or library path
-        package_bom.path - Path of package bom
-        package_receipts.path - Path of receipt plist
-        plist.path - (required) read preferences from a plist
-        prefetch.path - Prefetch file path.
-        process_events.path - Path of executed file
-        process_file_events.path - The path associated with the event
-        process_memory_map.path - Path to mapped file or mapped type
-        process_open_files.path - Filesystem path of descriptor
-        process_open_sockets.path - For UNIX sockets (family=AF_UNIX), the domain path
-        processes.path - Path to executed binary
-        python_packages.path - Path at which this module resides
-        quicklook_cache.path - Path of file
-        registry.path - Full path to the value
-        rpm_package_files.path - File path within the package
-        safari_extensions.path - Path to extension XAR bundle
-        sandboxes.path - Path to sandbox container directory
-        scheduled_tasks.path - Path to the executable to be run
-        services.path - Path to Service Executable
-        shared_folders.path - Absolute path of shared folder on the local system
-        shared_resources.path - Local path of the Windows share.
-        shellbags.path - Directory name.
-        shimcache.path - This is the path to the executed file.
-        shortcut_files.path - Directory name.
-        signature.path - Must provide a path or directory
-        socket_events.path - Path of executed file
-        startup_items.path - Path of startup item
-        suid_bin.path - Binary path
-        system_extensions.path - Original path of system extension
-        user_events.path - Supplied path from event
-        user_ssh_keys.path - Path to key file
-        userassist.path - Application file path.
-        windows_crashes.path - Path of the executable file for the crashed process
-        yara.path - The path scanned
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: pci_class
-      description: pci_devices.pci_class - PCI Device class
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: pci_class_id
-      description: pci_devices.pci_class_id - PCI Device class ID in hex format
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: pci_slot
-      description: |-
-        interface_details.pci_slot - PCI slot number
-        pci_devices.pci_slot - PCI Device used slot
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: pci_subclass
-      description: pci_devices.pci_subclass - PCI Device subclass
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: pci_subclass_id
-      description: pci_devices.pci_subclass_id - PCI Device  subclass in hex format
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: pem
-      description: curl_certificate.pem - Certificate PEM format
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: percent_disk_read_time
       description: physical_disk_performance.percent_disk_read_time - Percentage of elapsed time that the selected disk drive is busy servicing read requests
@@ -8084,46 +3272,6 @@
         - name: number
           type: long
           default_field: false
-    - name: period
-      description: load_average.period - Period over which the average is calculated.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: permanent
-      description: arp_cache.permanent - 1 for true, 0 for false
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: permissions
-      description: |-
-        chrome_extensions.permissions - The permissions required by the extension
-        process_memory_map.permissions - r=read, w=write, x=execute, p=private (cow)
-        shared_memory.permissions - Memory segment permissions
-        suid_bin.permissions - Binary permissions
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: permissions_json
-      description: chrome_extensions.permissions_json - The JSON-encoded permissions required by the extension
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: persistent
       description: chrome_extensions.persistent - 1 If extension is persistent across all tabs else 0
       type: keyword
@@ -8131,15 +3279,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: persistent_volume_id
-      description: bitlocker_info.persistent_volume_id - Persistent ID of the drive.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: pgroup
       description: |-
@@ -8166,15 +3305,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: physical_presence_version
-      description: tpm_info.physical_presence_version - Version of the Physical Presence Interface
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: pid
       description: |-
@@ -8215,17 +3345,6 @@
         - name: number
           type: long
           default_field: false
-    - name: pid_namespace
-      description: |-
-        docker_containers.pid_namespace - PID namespace
-        process_namespaces.pid_namespace - pid namespace inode
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: pid_with_namespace
       description: |-
         apt_sources.pid_with_namespace - Pids that contain a namespace
@@ -8257,26 +3376,6 @@
         lldp_neighbors.pids - Comma delimited list of PIDs
       type: keyword
       ignore_above: 1024
-    - name: placement_group_id
-      description: azure_instance_metadata.placement_group_id - Placement group for the VM scale set
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: platform
-      description: |-
-        os_version.platform - OS Platform or ID
-        osquery_packs.platform - Platforms this query is supported on
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: platform_binary
       description: es_process_events.platform_binary - Indicates if the binary is Apple signed binary (1) or not (0)
       type: keyword
@@ -8284,15 +3383,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: platform_fault_domain
-      description: azure_instance_metadata.platform_fault_domain - Fault domain the VM is running in
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: platform_info
       description: msr.platform_info - Platform information.
@@ -8302,15 +3392,6 @@
         - name: number
           type: long
           default_field: false
-    - name: platform_like
-      description: os_version.platform_like - Closely related platforms
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: platform_mask
       description: osquery_info.platform_mask - The osquery platform bitmask
       type: keyword
@@ -8319,42 +3400,6 @@
         - name: number
           type: long
           default_field: false
-    - name: platform_update_domain
-      description: azure_instance_metadata.platform_update_domain - Update domain the VM is running in
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: plugin
-      description: authorization_mechanisms.plugin - Authorization plugin name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: pnp_device_id
-      description: disk_info.pnp_device_id - The unique identifier of the drive on the system.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: point_to_point
-      description: interface_addresses.point_to_point - PtP address for the interface
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: points
       description: example.points - This is a signed SQLite int column
       type: keyword
@@ -8362,42 +3407,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: policies
-      description: curl_certificate.policies - Certificate Policies
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: policy
-      description: iptables.policy - Policy that applies for this rule.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: policy_constraints
-      description: curl_certificate.policy_constraints - Policy Constraints
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: policy_mappings
-      description: curl_certificate.policy_mappings - Policy Mappings
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: port
       description: |-
@@ -8409,15 +3418,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: port_aggregation_id
-      description: lldp_neighbors.port_aggregation_id - Port aggregation ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: port_autoneg_1000baset_fd_enabled
       description: lldp_neighbors.port_autoneg_1000baset_fd_enabled - 1000Base-T FD auto negotiation enabled
@@ -8531,42 +3531,6 @@
         - name: number
           type: long
           default_field: false
-    - name: port_description
-      description: lldp_neighbors.port_description - Port description
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: port_id
-      description: lldp_neighbors.port_id - Port ID value
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: port_id_type
-      description: lldp_neighbors.port_id_type - Port ID type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: port_mau_type
-      description: lldp_neighbors.port_mau_type - MAU type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: port_mfs
       description: lldp_neighbors.port_mfs - Port max frame size
       type: keyword
@@ -8599,69 +3563,6 @@
         - name: number
           type: long
           default_field: false
-    - name: power_8023at_power_allocated
-      description: lldp_neighbors.power_8023at_power_allocated - 802.3at power allocated
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: power_8023at_power_priority
-      description: lldp_neighbors.power_8023at_power_priority - 802.3at power priority
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: power_8023at_power_requested
-      description: lldp_neighbors.power_8023at_power_requested - 802.3at power requested
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: power_8023at_power_source
-      description: lldp_neighbors.power_8023at_power_source - 802.3at power source
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: power_8023at_power_type
-      description: lldp_neighbors.power_8023at_power_type - 802.3at power type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: power_class
-      description: lldp_neighbors.power_class - Power class
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: power_device_type
-      description: lldp_neighbors.power_device_type - Dot3 power device type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: power_mdi_enabled
       description: lldp_neighbors.power_mdi_enabled - Is MDI power enabled
       type: keyword
@@ -8678,15 +3579,6 @@
         - name: number
           type: long
           default_field: false
-    - name: power_mode
-      description: smart_drive_info.power_mode - Device power mode
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: power_paircontrol_enabled
       description: lldp_neighbors.power_paircontrol_enabled - Is power pair control enabled
       type: keyword
@@ -8695,15 +3587,6 @@
         - name: number
           type: long
           default_field: false
-    - name: power_pairs
-      description: lldp_neighbors.power_pairs - Dot3 power pairs
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: ppid
       description: process_file_events.ppid - Parent process ID
       type: keyword
@@ -8711,24 +3594,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: ppvids_enabled
-      description: lldp_neighbors.ppvids_enabled - Comma delimited list of enabled PPVIDs
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ppvids_supported
-      description: lldp_neighbors.ppvids_supported - Comma delimited list of supported PPVIDs
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: pre_cpu_kernelmode_usage
       description: docker_container_stats.pre_cpu_kernelmode_usage - Last read CPU kernel mode usage
@@ -8770,15 +3635,6 @@
         - name: number
           type: long
           default_field: false
-    - name: prefix
-      description: homebrew_packages.prefix - Homebrew install prefix
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: preread
       description: docker_container_stats.preread - UNIX time when stats were last read
       type: keyword
@@ -8787,15 +3643,6 @@
         - name: number
           type: long
           default_field: false
-    - name: principal
-      description: ntfs_acl_permissions.principal - User or group to which the ACE applies.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: printer_sharing
       description: sharing_preferences.printer_sharing - 1 If printer sharing is enabled else 0
       type: keyword
@@ -8803,26 +3650,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: priority
-      description: deb_packages.priority - Package priority
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: privileged
-      description: |-
-        authorization_mechanisms.privileged - If privileged it will run as root, else as an anonymous user
-        docker_containers.privileged - Is the container privileged
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: probe_error
       description: |-
@@ -8834,15 +3661,6 @@
         - name: number
           type: long
           default_field: false
-    - name: process
-      description: alf_explicit_auths.process - Process name explicitly allowed
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: process_being_tapped
       description: event_taps.process_being_tapped - The process ID of the target application
       type: keyword
@@ -8850,15 +3668,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: process_type
-      description: launchd.process_type - Key describes the intended purpose of the job
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: process_uptime
       description: windows_crashes.process_uptime - Uptime of the process in seconds
@@ -8892,83 +3701,6 @@
         - name: number
           type: long
           default_field: false
-    - name: processor_type
-      description: cpu_info.processor_type - The processor type, such as Central, Math, or Video.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: product_name
-      description: tpm_info.product_name - Product name of the TPM
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: product_version
-      description: file.product_version - File product version
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: profile
-      description: |-
-        apparmor_events.profile - Apparmor profile name
-        chrome_extensions.profile - The name of the Chrome profile that contains this extension
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: profile_path
-      description: |-
-        chrome_extension_content_scripts.profile_path - The profile path
-        chrome_extensions.profile_path - The profile path
-        logon_sessions.profile_path - The home directory for the logon session.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: program
-      description: launchd.program - Path to target program
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: program_arguments
-      description: launchd.program_arguments - Command line arguments passed to program
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: propagation
-      description: docker_container_mounts.propagation - Mount propagation
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: protected
       description: app_schemes.protected - 1 if this handler is protected (reserved) by OS X, else 0
       type: keyword
@@ -8993,15 +3725,6 @@
         - name: number
           type: long
           default_field: false
-    - name: protection_type
-      description: processes.protection_type - The protection type of the process
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: protocol
       description: |-
         bpf_socket_events.protocol - The network protocol ID
@@ -9013,37 +3736,6 @@
         usb_devices.protocol - USB Device protocol
       type: keyword
       ignore_above: 1024
-    - name: provider
-      description: drivers.provider - Driver provider
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: provider_guid
-      description: |-
-        windows_eventlog.provider_guid - Provider guid of the event
-        windows_events.provider_guid - Provider guid of the event
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: provider_name
-      description: |-
-        windows_eventlog.provider_name - Provider name of the event
-        windows_events.provider_name - Provider name of the event
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: pseudo
       description: process_memory_map.pseudo - 1 If path is a pseudo path, else 0
       type: keyword
@@ -9068,18 +3760,6 @@
         - name: number
           type: long
           default_field: false
-    - name: publisher
-      description: |-
-        azure_instance_metadata.publisher - Publisher of the VM image
-        osquery_events.publisher - Name of the associated publisher
-        programs.publisher - Name of the product supplier.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: purgeable
       description: virtual_memory_info.purgeable - Total number of purgeable pages.
       type: keyword
@@ -9095,45 +3775,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: pvid
-      description: lldp_neighbors.pvid - Primary VLAN id
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: query
-      description: |-
-        mdfind.query - The query that was run to find the file
-        osquery_schedule.query - The exact query to run
-        wmi_event_filters.query - Windows Management Instrumentation Query Language (WQL) event query that specifies the set of events for consumer notification, and the specific conditions for notification.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: query_language
-      description: wmi_event_filters.query_language - Query language that the query is written in.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: queue_directories
-      description: launchd.queue_directories - Similar to watch_paths but only with non-empty directories
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: raid_disks
       description: md_devices.raid_disks - Number of configured RAID disks in array
@@ -9191,15 +3832,6 @@
         - name: number
           type: long
           default_field: false
-    - name: read_device_identity_failure
-      description: smart_drive_info.read_device_identity_failure - Error string for device id read, if any
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: readonly
       description: nfs_shares.readonly - 1 if the share is exported readonly else 0
       type: keyword
@@ -9215,51 +3847,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: record_timestamp
-      description: ntfs_journal_events.record_timestamp - Journal record timestamp
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: record_usn
-      description: ntfs_journal_events.record_usn - The update sequence number that identifies the journal record
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: recovery_finish
-      description: md_devices.recovery_finish - Estimated duration of recovery activity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: recovery_progress
-      description: md_devices.recovery_progress - Progress of the recovery activity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: recovery_speed
-      description: md_devices.recovery_speed - Speed of recovery activity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: redirect_accept
       description: interface_ipv6.redirect_accept - Accept ICMP redirect messages
@@ -9277,15 +3864,6 @@
         - name: number
           type: long
           default_field: false
-    - name: ref_proc
-      description: asl.ref_proc - Reference process for messages proxied by launchd
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: referenced
       description: |-
         chrome_extension_content_scripts.referenced - 1 if this extension is referenced by the Preferences file of the profile
@@ -9295,15 +3873,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: referenced_identifier
-      description: chrome_extensions.referenced_identifier - Extension identifier, as specified by the preferences file. Empty if the extension is not in the profile.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: refreshes
       description: "osquery_events.refreshes - Publisher only: number of runloop restarts"
@@ -9322,101 +3891,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: region
-      description: ec2_instance_metadata.region - AWS region in which this instance launched
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: registers
-      description: |-
-        crashes.registers - The value of the system registers
-        kernel_panics.registers - A space delimited line of register:value pairs
-        windows_crashes.registers - The values of the system registers
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: registry
-      description: osquery_registry.registry - Name of the osquery registry
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: registry_hive
-      description: logged_in_users.registry_hive - HKEY_USERS registry hive
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: registry_path
-      description: ie_extensions.registry_path - Extension identifier
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: relative_path
-      description: |-
-        shortcut_files.relative_path - Relative path to target file from lnk file.
-        wmi_cli_event_consumers.relative_path - Relative path to the class or instance.
-        wmi_event_filters.relative_path - Relative path to the class or instance.
-        wmi_filter_consumer_binding.relative_path - Relative path to the class or instance.
-        wmi_script_event_consumers.relative_path - Relative path to the class or instance.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: release
-      description: |-
-        apt_sources.release - Release name
-        lxd_images.release - OS release version on which the image is based
-        rpm_packages.release - Package release
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: remediation_path
-      description: windows_security_products.remediation_path - Remediation path
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: remote_address
-      description: |-
-        bpf_socket_events.remote_address - Remote address associated with socket
-        process_open_sockets.remote_address - Socket remote address
-        socket_events.remote_address - Remote address associated with socket
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: remote_apple_events
       description: sharing_preferences.remote_apple_events - 1 If remote apple events are enabled else 0
@@ -9461,78 +3935,6 @@
         - name: number
           type: long
           default_field: false
-    - name: repository
-      description: portage_packages.repository - From which repository the ebuild was used
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: request_id
-      description: carves.request_id - Identifying value of the carve request (e.g., scheduled query name, distributed request, etc)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: requested_mask
-      description: apparmor_events.requested_mask - Requested access mask
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: requirement
-      description: gatekeeper_approved_apps.requirement - Code signing requirement language
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: reservation_id
-      description: ec2_instance_metadata.reservation_id - ID of the reservation
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: reshape_finish
-      description: md_devices.reshape_finish - Estimated duration of reshape activity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: reshape_progress
-      description: md_devices.reshape_progress - Progress of the reshape activity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: reshape_speed
-      description: md_devices.reshape_speed - Speed of reshape activity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: resident_size
       description: |-
         docker_container_processes.resident_size - Bytes of private memory used by process
@@ -9543,15 +3945,6 @@
         - name: number
           type: long
           default_field: false
-    - name: resource_group_name
-      description: azure_instance_metadata.resource_group_name - Resource group for the VM
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: response_code
       description: curl.response_code - The HTTP status code for the response
       type: keyword
@@ -9559,53 +3952,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: responsible
-      description: crashes.responsible - Process responsible for the crashed process
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: result
-      description: |-
-        authenticode.result - The signature check result
-        curl.result - The HTTP response body
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: resync_finish
-      description: md_devices.resync_finish - Estimated duration of resync activity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: resync_progress
-      description: md_devices.resync_progress - Progress of the resync activity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: resync_speed
-      description: md_devices.resync_speed - Speed of resync activity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: retain_count
       description: |-
@@ -9616,18 +3962,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: revision
-      description: |-
-        deb_packages.revision - Package revision
-        hardware_events.revision - Device revision (optional)
-        platform_info.revision - BIOS major and minor revision
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: rid
       description: lldp_neighbors.rid - Neighbor chassis index
@@ -9644,60 +3978,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: roaming_profile
-      description: wifi_networks.roaming_profile - Describe the roaming profile, usually one of Single, Dual  or Multi
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: root
-      description: processes.root - Process virtual root directory
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: root_dir
-      description: docker_info.root_dir - Docker root directory
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: root_directory
-      description: launchd.root_directory - Key used to specify a directory to chroot to before launch
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: root_volume_uuid
-      description: time_machine_destinations.root_volume_uuid - Root UUID of backup volume
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: rotation_rate
-      description: smart_drive_info.rotation_rate - Drive RPM
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: round_trip_time
       description: curl.round_trip_time - Time taken to complete the request
@@ -9733,24 +4013,6 @@
         - name: number
           type: long
           default_field: false
-    - name: rule_details
-      description: sudoers.rule_details - Rule definition
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: run_at_load
-      description: launchd.run_at_load - Should the program run on launch load
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: run_count
       description: prefetch.run_count - Number of times the application has been run.
       type: keyword
@@ -9767,33 +4029,6 @@
         - name: number
           type: long
           default_field: false
-    - name: sata_version
-      description: smart_drive_info.sata_version - SATA version, if any
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: scheme
-      description: app_schemes.scheme - Name of the scheme/protocol
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: scope
-      description: selinux_settings.scope - Where the key is located inside the SELinuxFS mount point.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: screen_sharing
       description: sharing_preferences.screen_sharing - 1 If screen sharing is enabled else 0
       type: keyword
@@ -9802,15 +4037,6 @@
         - name: number
           type: long
           default_field: false
-    - name: script
-      description: chrome_extension_content_scripts.script - The content script used by the extension
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: script_block_count
       description: powershell_events.script_block_count - The total number of script blocks for this script
       type: keyword
@@ -9818,91 +4044,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: script_block_id
-      description: powershell_events.script_block_id - The unique GUID of the powershell script to which this block belongs
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: script_file_name
-      description: wmi_script_event_consumers.script_file_name - Name of the file from which the script text is read, intended as an alternative to specifying the text of the script in the ScriptText property.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: script_name
-      description: powershell_events.script_name - The name of the Powershell script
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: script_path
-      description: powershell_events.script_path - The path for the Powershell script
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: script_text
-      description: |-
-        powershell_events.script_text - The text content of the Powershell script
-        wmi_script_event_consumers.script_text - Text of the script that is expressed in a language known to the scripting engine. This property must be NULL if the ScriptFileName property is not NULL.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: scripting_engine
-      description: wmi_script_event_consumers.scripting_engine - Name of the scripting engine to use, for example, 'VBScript'. This property cannot be NULL.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sdb_id
-      description: appcompat_shims.sdb_id - Unique GUID of the SDB.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sdk
-      description: |-
-        browser_plugins.sdk - Build SDK used to compile plugin
-        safari_extensions.sdk - Bundle SDK used to compile extension
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sdk_version
-      description: osquery_extensions.sdk_version - osquery SDK version used to build the extension
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: seconds
       description: |-
@@ -9913,24 +4054,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: section
-      description: deb_packages.section - Package section
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sector_sizes
-      description: smart_drive_info.sector_sizes - Bytes of drive sector sizes
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: secure_boot
       description: secureboot.secure_boot - Whether secure boot is enabled
@@ -9948,44 +4071,6 @@
         - name: number
           type: long
           default_field: false
-    - name: security_breach
-      description: chassis_info.security_breach - The physical status of the chassis such as Breach Successful, Breach Attempted, etc.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: security_groups
-      description: ec2_instance_metadata.security_groups - Comma separated list of security group names
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: security_options
-      description: docker_containers.security_options - List of container security options
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: security_type
-      description: |-
-        wifi_networks.security_type - Type of security on this network
-        wifi_status.security_type - Type of security on this network
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: self_signed
       description: certificates.self_signed - 1 if self-signed, else 0
       type: keyword
@@ -9993,24 +4078,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: sender
-      description: asl.sender - Sender's identification string.  Default is process name.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sensor_backend_server
-      description: carbon_black_info.sensor_backend_server - Carbon Black server
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: sensor_id
       description: carbon_black_info.sensor_id - Sensor ID of the Carbon Black sensor
@@ -10020,15 +4087,6 @@
         - name: number
           type: long
           default_field: false
-    - name: sensor_ip_addr
-      description: carbon_black_info.sensor_ip_addr - IP address of the sensor
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: seq_num
       description: es_process_events.seq_num - Per event sequence number
       type: keyword
@@ -10037,84 +4095,6 @@
         - name: number
           type: long
           default_field: false
-    - name: serial
-      description: |-
-        certificates.serial - Certificate serial number
-        chassis_info.serial - The serial number of the chassis.
-        disk_info.serial - The serial number of the disk.
-        hardware_events.serial - Device serial (optional)
-        usb_devices.serial - USB Device serial connection
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: serial_number
-      description: |-
-        authenticode.serial_number - The certificate serial number
-        battery.serial_number - The battery's unique serial number
-        curl_certificate.serial_number - Certificate serial number
-        memory_devices.serial_number - Serial number of memory device
-        smart_drive_info.serial_number - Device serial number
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: serial_port_enabled
-      description: ycloud_instance_metadata.serial_port_enabled - Indicates if serial port is enabled for the VM
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: series
-      description: video_info.series - The series of the gpu.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: server_name
-      description: |-
-        lxd_cluster.server_name - Name of the LXD server node
-        lxd_cluster_members.server_name - Name of the LXD server node
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: server_version
-      description: docker_info.server_version - Server version
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: service
-      description: |-
-        drivers.service - Driver service name, if one exists
-        interface_details.service - The name of the service the network adapter uses.
-        iokit_devicetree.service - 1 if the device conforms to IOService else 0
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: service_exit_code
       description: services.service_exit_code - The service-specific error code that the service returns when an error occurs while the service is starting or stopping
       type: keyword
@@ -10122,24 +4102,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: service_key
-      description: drivers.service_key - Driver service registry key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: service_type
-      description: "services.service_type - Service Type: OWN_PROCESS, SHARE_PROCESS and maybe Interactive (can interact with the desktop)"
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: ses
       description: seccomp_events.ses - Session ID of the session from which the analyzed process was invoked
@@ -10158,15 +4120,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: session_owner
-      description: authorizations.session_owner - Label top-level key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: set
       description: memory_devices.set - Identifies if memory device is one of a set of devices.  A value of 0 indicates no set affiliation.
@@ -10200,53 +4153,6 @@
         processes.sgid - Unsigned saved group ID
       type: keyword
       ignore_above: 1024
-    - name: sha1
-      description: |-
-        apparmor_profiles.sha1 - A unique hash that identifies this policy.
-        certificates.sha1 - SHA1 hash of the raw certificate contents
-        device_hash.sha1 - SHA1 hash of provided inode data
-        file_events.sha1 - The SHA1 of the file after change
-        hash.sha1 - SHA1 hash of provided filesystem data
-        rpm_packages.sha1 - SHA1 hash of the package contents
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sha1_fingerprint
-      description: curl_certificate.sha1_fingerprint - SHA1 fingerprint
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sha256
-      description: |-
-        carves.sha256 - A SHA256 sum of the carved archive
-        device_hash.sha256 - SHA256 hash of provided inode data
-        file_events.sha256 - The SHA256 of the file after change
-        hash.sha256 - SHA256 hash of provided filesystem data
-        rpm_package_files.sha256 - SHA256 file digest from RPM info DB
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sha256_fingerprint
-      description: curl_certificate.sha256_fingerprint - SHA-256 fingerprint
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: shard
       description: osquery_packs.shard - Shard restriction limit, 1-100, 0 meaning no restriction
       type: keyword
@@ -10254,42 +4160,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: share
-      description: nfs_shares.share - Filesystem path to the share
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: share_name
-      description: shortcut_files.share_name - Share name of the target file.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: shared
-      description: authorizations.shared - Label top-level key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: shell
-      description: users.shell - User's configured default shell
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: shell_only
       description: osquery_flags.shell_only - Is the flag shell only?
@@ -10307,21 +4177,6 @@
         - name: number
           type: long
           default_field: false
-    - name: sid
-      description: |-
-        background_activities_moderator.sid - User SID.
-        certificates.sid - SID
-        logged_in_users.sid - The user's unique security identifier
-        office_mru.sid - User SID
-        shellbags.sid - User SID
-        userassist.sid - User SID.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: sig
       description: seccomp_events.sig - Signal value sent to process by seccomp
       type: keyword
@@ -10329,42 +4184,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: sig_group
-      description: yara.sig_group - Signature group used
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sigfile
-      description: yara.sigfile - Signature file used
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: signature
-      description: curl_certificate.signature - Signature
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: signature_algorithm
-      description: curl_certificate.signature_algorithm - Signature Algorithm
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: signatures_up_to_date
       description: windows_security_products.signatures_up_to_date - 1 if product signatures are up to date, else 0
@@ -10383,42 +4202,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: signing_algorithm
-      description: certificates.signing_algorithm - Signing algorithm used
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: signing_id
-      description: es_process_events.signing_id - Signature identifier of the process
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sigrule
-      description: yara.sigrule - Signature strings used
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sigurl
-      description: yara.sigurl - Signature url
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: size
       description: |-
@@ -10463,50 +4246,12 @@
         - name: number
           type: long
           default_field: false
-    - name: sku
-      description: |-
-        azure_instance_metadata.sku - SKU for the VM image
-        chassis_info.sku - The Stock Keeping Unit number if available.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: slot
       description: |-
         md_drives.slot - Slot position of disk
         portage_packages.slot - The slot used by package
       type: keyword
       ignore_above: 1024
-    - name: smart_enabled
-      description: smart_drive_info.smart_enabled - SMART enabled status
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: smart_supported
-      description: smart_drive_info.smart_supported - SMART support status
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: smbios_tag
-      description: chassis_info.smbios_tag - The assigned asset tag number of the chassis.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: socket
       description: |-
         listening_ports.socket - Socket handle or inode number
@@ -10514,24 +4259,6 @@
         socket_events.socket - The local path (UNIX domain socket only)
       type: keyword
       ignore_above: 1024
-    - name: socket_designation
-      description: cpu_info.socket_designation - The assigned socket on the board for the given CPU.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: soft_limit
-      description: ulimit_info.soft_limit - Current limit value
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: softirq
       description: cpu_time.softirq - Time spent servicing softirqs
       type: keyword
@@ -10539,45 +4266,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: source
-      description: |-
-        apt_sources.source - Source file
-        autoexec.source - Source table of the autoexec item
-        deb_packages.source - Package source
-        docker_container_mounts.source - Source path on host
-        lxd_storage_pools.source - Storage pool source
-        package_install_history.source - Install source: usually the installer process name
-        routes.source - Route source
-        rpm_packages.source - Source RPM package name (optional)
-        shellbags.source - Shellbags source Registry file
-        startup_items.source - Directory or plist containing startup item
-        sudoers.source - Source file containing the given rule
-        windows_events.source - Source or channel of the event
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: source_path
-      description: systemd_units.source_path - Path to the (possibly generated) unit configuration file
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: source_url
-      description: firefox_addons.source_url - URL that installed the addon
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: space_total
       description: lxd_storage_pools.space_total - Total available storage space in bytes for this storage pool
@@ -10603,15 +4291,6 @@
         - name: number
           type: long
           default_field: false
-    - name: spec_version
-      description: tpm_info.spec_version - Trusted Computing Group specification that the TPM supports
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: speculative
       description: virtual_memory_info.speculative - Total number of speculative pages.
       type: keyword
@@ -10628,114 +4307,6 @@
         - name: number
           type: long
           default_field: false
-    - name: src_ip
-      description: iptables.src_ip - Source IP address.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: src_mask
-      description: iptables.src_mask - Source IP address mask.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: src_port
-      description: iptables.src_port - Protocol source port(s).
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ssdeep
-      description: hash.ssdeep - ssdeep hash of provided filesystem data
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ssh_config_file
-      description: ssh_configs.ssh_config_file - Path to the ssh_config file
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ssh_public_key
-      description: |-
-        ec2_instance_metadata.ssh_public_key - SSH public key. Only available if supplied at instance launch time
-        ycloud_instance_metadata.ssh_public_key - SSH public key. Only available if supplied at instance launch time
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ssid
-      description: |-
-        wifi_networks.ssid - SSID octets of the network
-        wifi_status.ssid - SSID octets of the network
-        wifi_survey.ssid - SSID octets of the network
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: stack_trace
-      description: |-
-        crashes.stack_trace - Most recent frame from the stack trace
-        windows_crashes.stack_trace - Multiple stack frames from the stack trace
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: start
-      description: |-
-        memory_map.start - Start address of memory region
-        process_memory_map.start - Virtual start address (hex)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: start_interval
-      description: launchd.start_interval - Frequency to run in seconds
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: start_on_mount
-      description: launchd.start_on_mount - Run daemon or agent every time a filesystem is mounted
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: start_time
       description: |-
         docker_container_processes.start_time - Process start in seconds since boot (non-sleeping)
@@ -10746,35 +4317,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: start_type
-      description: "services.start_type - Service start type: BOOT_START, SYSTEM_START, AUTO_START, DEMAND_START, DISABLED"
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: started_at
-      description: docker_containers.started_at - Container start time as string
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: starting_address
-      description: |-
-        memory_array_mapped_addresses.starting_address - Physical stating address, in kilobytes, of a range of memory mapped to physical memory array
-        memory_device_mapped_addresses.starting_address - Physical stating address, in kilobytes, of a range of memory mapped to physical memory array
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: state
       description: |-
@@ -10793,15 +4335,6 @@
         windows_security_products.state - State of protection
       type: keyword
       ignore_above: 1024
-    - name: state_timestamp
-      description: windows_security_products.state_timestamp - Timestamp for the product state
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: stateful
       description: lxd_instances.stateful - Whether the instance is stateful(1) or not(0)
       type: keyword
@@ -10809,57 +4342,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: statename
-      description: windows_optional_features.statename - Installation state name. 'Enabled','Disabled','Absent'
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: status
-      description: |-
-        carves.status - Status of the carve, can be STARTING, PENDING, SUCCESS, or FAILED
-        chassis_info.status - If available, gives various operational or nonoperational statuses such as OK, Degraded, and Pred Fail.
-        deb_packages.status - Package status
-        docker_containers.status - Container status information
-        kernel_modules.status - Kernel module status
-        lxd_cluster_members.status - Status of the node (Online/Offline)
-        lxd_instances.status - Instance state (running, stopped, etc.)
-        md_devices.status - Current state of the array
-        ntdomains.status - The current status of the domain object.
-        process_events.status - OpenBSM Attribute: Status of the process
-        services.status - Service Current status: STOPPED, START_PENDING, STOP_PENDING, RUNNING, CONTINUE_PENDING, PAUSE_PENDING, PAUSED
-        shared_memory.status - Destination/attach status
-        shared_resources.status - String that indicates the current status of the object.
-        socket_events.status - Either 'succeeded', 'failed', 'in_progress' (connect() on non-blocking socket) or 'no_client' (null accept() on non-blocking socket)
-        startup_items.status - Startup status; either enabled or disabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: stderr_path
-      description: launchd.stderr_path - Pipe stderr to a target path
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: stdout_path
-      description: launchd.stdout_path - Pipe stdout to a target path
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: steal
       description: cpu_time.steal - Time spent in other operating systems when running in a virtualized environment
@@ -10885,154 +4367,6 @@
         - name: number
           type: long
           default_field: false
-    - name: storage_driver
-      description: docker_info.storage_driver - Storage driver
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: store
-      description: certificates.store - Certificate system store
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: store_id
-      description: certificates.store_id - Exists for service/user stores. Contains raw store id provided by WinAPI.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: store_location
-      description: certificates.store_location - Certificate system store location
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: strings
-      description: |-
-        yara.strings - Matching strings
-        yara_events.strings - Matching strings
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: sub_state
-      description: systemd_units.sub_state - The low-level unit activation state, values depend on unit type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: subclass
-      description: usb_devices.subclass - USB Device subclass
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: subject
-      description: certificates.subject - Certificate distinguished name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: subject_alternative_names
-      description: curl_certificate.subject_alternative_names - Subject Alternative Name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: subject_info_access
-      description: curl_certificate.subject_info_access - Subject Information Access
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: subject_key_id
-      description: certificates.subject_key_id - SKID an optionally included SHA1
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: subject_key_identifier
-      description: curl_certificate.subject_key_identifier - Subject Key Identifier
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: subject_name
-      description: authenticode.subject_name - The certificate subject name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: subkey
-      description: |-
-        plist.subkey - Intermediate key path, includes lists/dicts
-        preferences.subkey - Intemediate key path, includes lists/dicts
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: subnet
-      description: docker_networks.subnet - Network subnet
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: subscription_id
-      description: azure_instance_metadata.subscription_id - Azure subscription for the VM
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: subscriptions
       description: osquery_events.subscriptions - Number of subscriptions the publisher received or subscriber used
       type: keyword
@@ -11040,51 +4374,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: subsystem
-      description: system_controls.subsystem - Subsystem ID, control type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: subsystem_model
-      description: pci_devices.subsystem_model - Device description of PCI device subsystem
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: subsystem_model_id
-      description: pci_devices.subsystem_model_id - Model ID of PCI device subsystem
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: subsystem_vendor
-      description: pci_devices.subsystem_vendor - Vendor of PCI device subsystem
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: subsystem_vendor_id
-      description: pci_devices.subsystem_vendor_id - Vendor ID of PCI device subsystem
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: success
       description: socket_events.success - Deprecated. Use the 'status' column instead
@@ -11102,26 +4391,6 @@
         processes.suid - Unsigned saved user ID
       type: keyword
       ignore_above: 1024
-    - name: summary
-      description: |-
-        chocolatey_packages.summary - Package-supplied summary
-        python_packages.summary - Package-supplied summary
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: superblock_state
-      description: md_devices.superblock_state - State of the superblock
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: superblock_update_time
       description: md_devices.superblock_update_time - Unix timestamp of last update
       type: keyword
@@ -11129,15 +4398,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: superblock_version
-      description: md_devices.superblock_version - Version of the superblock
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: swap_cached
       description: memory_info.swap_cached - The amount of swap, in bytes, used as cache memory
@@ -11195,19 +4455,6 @@
         - name: number
           type: long
           default_field: false
-    - name: syscall
-      description: |-
-        bpf_process_events.syscall - System call name
-        bpf_socket_events.syscall - System call name
-        process_events.syscall - Syscall name: fork, vfork, clone, execve, execveat
-        seccomp_events.syscall - Type of the system call
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: system
       description: cpu_time.system - Time spent in system mode
       type: keyword
@@ -11224,15 +4471,6 @@
         - name: number
           type: long
           default_field: false
-    - name: system_model
-      description: kernel_panics.system_model - Physical system model, for example 'MacBookPro12,1 (Mac-E43C1C25D4880AD6)'
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: system_time
       description: |-
         osquery_schedule.system_time - Total system time spent executing
@@ -11243,34 +4481,12 @@
         - name: number
           type: long
           default_field: false
-    - name: table
-      description: elf_symbols.table - Table name containing symbol
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: tag
       description: |-
         elf_dynamic.tag - Tag ID
         syslog_events.tag - The syslog tag
       type: keyword
       ignore_above: 1024
-    - name: tags
-      description: |-
-        docker_image_history.tags - Comma-separated list of tags
-        docker_images.tags - Comma-separated list of repository tags
-        yara.tags - Matching tags
-        yara_events.tags - Matching tags
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: tapping_process
       description: event_taps.tapping_process - The process ID of the application that created the event tap.
       type: keyword
@@ -11309,27 +4525,6 @@
         - name: number
           type: long
           default_field: false
-    - name: target_name
-      description: prometheus_metrics.target_name - Address of prometheus target
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: target_path
-      description: |-
-        file_events.target_path - The path associated with the event
-        shortcut_files.target_path - Target file path
-        yara_events.target_path - The path scanned
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: target_size
       description: shortcut_files.target_size - Size of target file.
       type: keyword
@@ -11348,33 +4543,6 @@
         - name: number
           type: long
           default_field: false
-    - name: team
-      description: system_extensions.team - Signing team ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: team_id
-      description: es_process_events.team_id - Team identifier of thd process
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: team_identifier
-      description: signature.team_identifier - The team signing identifier sealed into the signature
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: temporarily_disabled
       description: wifi_networks.temporarily_disabled - 1 if this network is temporarily disabled, 0 otherwise
       type: keyword
@@ -11382,15 +4550,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: terminal
-      description: user_events.terminal - The network protocol ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: threads
       description: |-
@@ -11462,37 +4621,6 @@
         - name: number
           type: long
           default_field: false
-    - name: time_range
-      description: windows_eventlog.time_range - System time to selectively filter the events
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: timeout
-      description: |-
-        authorizations.timeout - Label top-level key
-        curl_certificate.timeout - Set this value to the timeout in seconds to complete the TLS handshake (default 4s, use 0 for no timeout)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: timestamp
-      description: |-
-        time.timestamp - Current timestamp (log format) in the system
-        windows_eventlog.timestamp - Timestamp to selectively filter the events
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: timestamp_ms
       description: prometheus_metrics.timestamp_ms - Unix timestamp of collected data in MS
       type: keyword
@@ -11500,24 +4628,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: timezone
-      description: time.timezone - Current timezone in the system
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: title
-      description: cups_jobs.title - Title of the printed job
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: total_seconds
       description: uptime.total_seconds - Total uptime seconds
@@ -11555,44 +4665,6 @@
         - name: number
           type: long
           default_field: false
-    - name: transmit_rate
-      description: wifi_status.transmit_rate - The current transmit rate
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: transport_type
-      description: smart_drive_info.transport_type - Drive transport type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: tries
-      description: authorizations.tries - Label top-level key
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: tty
-      description: |-
-        last.tty - Entry terminal
-        logged_in_users.tty - Device name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: turbo_disabled
       description: msr.turbo_disabled - Whether the turbo feature is disabled.
       type: keyword
@@ -11608,24 +4680,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: type
-      description: "apparmor_events.type - Event type\nappcompat_shims.type - Type of the SDB database.\nblock_devices.type - Block device type string\nbpf_socket_events.type - The socket type\ncrashes.type - Type of crash log\ndevice_file.type - File status\ndevice_firmware.type - Type of device\ndevice_partitions.type - \ndisk_encryption.type - Description of cipher type and mode if available\ndisk_info.type - The interface type of the disk.\ndns_cache.type - DNS record type\ndns_resolvers.type - Address type: sortlist, nameserver, search\ndocker_container_mounts.type - Type of mount (bind, volume)\ndocker_container_ports.type - Protocol (tcp, udp)\ndocker_volumes.type - Volume type\nelf_info.type - Offset of section in file\nelf_sections.type - Section type\nelf_symbols.type - Symbol type\nfile.type - File status\nfirefox_addons.type - Extension, addon, webapp\nhardware_events.type - Type of hardware and hardware event\ninterface_addresses.type - Type of address. One of dhcp, manual, auto, other, unknown\ninterface_details.type - Interface type (includes virtual)\nkeychain_items.type - Keychain item type (class)\nlast.type - Entry type, according to ut_type types (utmp.h)\nlogged_in_users.type - Login type\nlogical_drives.type - Deprecated (always 'Unknown').\nlxd_certificates.type - Type of the certificate\nlxd_networks.type - Type of network\nmounts.type - Mounted device type\nntfs_acl_permissions.type - Type of access mode for the access control entry.\nnvram.type - Data type (CFData, CFString, etc)\nosquery_events.type - Either publisher or subscriber\nosquery_extensions.type - SDK extension type: extension or module\nosquery_flags.type - Flag type\nprocess_open_pipes.type - Pipe Type: named vs unnamed/anonymous\nregistry.type - Type of the registry value, or 'subkey' if item is a subkey\nroutes.type - Type of route\nselinux_events.type - Event type\nshared_resources.type - Type of resource being shared. Types include: disk drives, print queues, interprocess communications (IPC), and general devices.\nsmbios_tables.type - Table entry type\nsmc_keys.type - SMC-reported type literal type\nstartup_items.type - Startup Item or Login Item\nsystem_controls.type - Data type\nulimit_info.type - System resource to be limited\nuser_events.type - The file description for the process socket\nusers.type - Whether the account is roaming (domain), local, or a system profile\nwindows_crashes.type - Type of crash log\nwindows_security_products.type - Type of security product\nxprotect_meta.type - Either plugin or extension"
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: type_name
-      description: last.type_name - Entry type name, according to ut_type types (utmp.h)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: uid
       description: |-
@@ -11670,15 +4724,6 @@
         - name: number
           type: long
           default_field: false
-    - name: umci_policy_status
-      description: hvci_status.umci_policy_status - The status of the User Mode Code Integrity security settings. Returns UNKNOWN if an error is encountered.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: uncompressed
       description: virtual_memory_info.uncompressed - Total number of uncompressed pages.
       type: keyword
@@ -11686,24 +4731,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: uninstall_string
-      description: programs.uninstall_string - Path and filename of the uninstaller.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: unique_chip_id
-      description: ibridge_info.unique_chip_id - Unique id of the iBridge controller
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: unix_time
       description: time.unix_time - Current UNIX time in the system, converted to UTC if --utc enabled
@@ -11721,62 +4748,6 @@
         - name: number
           type: long
           default_field: false
-    - name: unused_devices
-      description: md_devices.unused_devices - Unused devices
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: update_source_alias
-      description: lxd_images.update_source_alias - Alias of image at update source server
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: update_source_certificate
-      description: lxd_images.update_source_certificate - Certificate for update source server
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: update_source_protocol
-      description: lxd_images.update_source_protocol - Protocol used for image information update and image import from source server
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: update_source_server
-      description: lxd_images.update_source_server - Server for image update
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: update_url
-      description: |-
-        chrome_extensions.update_url - Extension-supplied update URI
-        safari_extensions.update_url - Extension-supplied update URI
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: upid
       description: processes.upid - A 64bit pid that is never reused. Returns -1 if we couldn't gather them from the system.
       type: keyword
@@ -11784,24 +4755,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: uploaded_at
-      description: lxd_images.uploaded_at - ISO time of image upload
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: upn
-      description: logon_sessions.upn - The user principal name (UPN) for the owner of the logon session.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: uppid
       description: processes.uppid - The 64bit parent pid that is never reused. Returns -1 if we couldn't gather them from the system.
@@ -11827,17 +4780,6 @@
         - name: number
           type: long
           default_field: false
-    - name: url
-      description: |-
-        curl.url - The url for the request
-        lxd_cluster_members.url - URL of the node
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: usb_address
       description: usb_devices.usb_address - USB Device used address
       type: keyword
@@ -11854,28 +4796,6 @@
         - name: number
           type: long
           default_field: false
-    - name: use
-      description: |-
-        memory_arrays.use - Function for which the array is used
-        portage_use.use - USE flag which has been enabled for package
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: used_by
-      description: |-
-        kernel_modules.used_by - Module reverse dependencies
-        lxd_networks.used_by - URLs for containers using this network
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: user
       description: |-
         cpu_time.user - Time spent in user mode
@@ -11887,62 +4807,6 @@
         systemd_units.user - The configured user, if any
       type: keyword
       ignore_above: 1024
-    - name: user_account
-      description: services.user_account - The name of the account that the service process will be logged on as when it runs. This name can be of the form Domain\UserName. If the account belongs to the built-in domain, the name can be of the form .\UserName.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: user_account_control
-      description: windows_security_center.user_account_control - The health of the User Account Control (UAC) capability in Windows
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: user_action
-      description: xprotect_reports.user_action - Action taken by user after prompted
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: user_agent
-      description: curl.user_agent - The user-agent string to use for the request
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: user_capacity
-      description: smart_drive_info.user_capacity - Bytes of drive capacity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: user_namespace
-      description: |-
-        docker_containers.user_namespace - User namespace
-        process_namespaces.user_namespace - user namespace inode
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: user_time
       description: |-
         osquery_schedule.user_time - Total user time spent executing
@@ -11953,36 +4817,6 @@
         - name: number
           type: long
           default_field: false
-    - name: user_uuid
-      description: disk_encryption.user_uuid - UUID of authenticated user if available
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: username
-      description: |-
-        certificates.username - Username
-        es_process_events.username - Username
-        last.username - Entry username
-        launchd.username - Run this daemon or agent as this username
-        managed_policies.username - Policy applies only this user
-        preferences.username - (optional) read preferences for a specific user
-        rpm_package_files.username - File default username from info DB
-        shadow.username - Username
-        startup_items.username - The user associated with the startup item
-        suid_bin.username - Binary owner username
-        users.username - Username
-        windows_crashes.username - Username of the user who ran the crashed process
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: uses_pattern
       description: xprotect_entries.uses_pattern - Uses a match pattern instead of identity
       type: keyword
@@ -11990,34 +4824,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: uts_namespace
-      description: |-
-        docker_containers.uts_namespace - UTS namespace
-        process_namespaces.uts_namespace - uts namespace inode
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: uuid
-      description: |-
-        block_devices.uuid - Block device Universally Unique Identifier
-        disk_encryption.uuid - Disk Universally Unique Identifier
-        disk_events.uuid - UUID of the volume inside DMG if available
-        managed_policies.uuid - Optional UUID assigned to policy set
-        osquery_extensions.uuid - The transient ID assigned for communication
-        osquery_info.uuid - Unique ID provided by the system
-        system_info.uuid - Unique ID provided by the system
-        users.uuid - User's UUID (Apple) or SID (Windows)
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: vaddr
       description: |-
@@ -12028,188 +4834,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: valid_from
-      description: curl_certificate.valid_from - Period of validity start date
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: valid_to
-      description: curl_certificate.valid_to - Period of validity end date
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: value
-      description: |-
-        ad_config.value - Variable typed option value
-        augeas.value - The value of the configuration item
-        azure_instance_tags.value - The tag value
-        cpuid.value - Bit value or string
-        default_environment.value - Value of the environment variable
-        docker_container_labels.value - Optional label value
-        docker_image_labels.value - Optional label value
-        docker_network_labels.value - Optional label value
-        docker_volume_labels.value - Optional label value
-        ec2_instance_tags.value - Tag value
-        elf_dynamic.value - Tag value
-        extended_attributes.value - The parsed information from the attribute
-        launchd_overrides.value - Overridden value
-        lxd_instance_config.value - Configuration parameter value
-        lxd_instance_devices.value - Device info param value
-        managed_policies.value - Policy value
-        mdls.value - Value stored in the metadata key
-        nvram.value - Raw variable data
-        oem_strings.value - The value of the OEM string
-        osquery_flags.value - Flag value
-        plist.value - String value of most CF types
-        power_sensors.value - Power in Watts
-        preferences.value - String value of most CF types
-        process_envs.value - Environment variable value
-        selinux_settings.value - Active value.
-        smc_keys.value - A type-encoded representation of the key value
-        wmi_bios_info.value - Value of the Bios setting
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: valuetype
-      description: mdls.valuetype - CoreFoundation type of data stored in value
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: variable
-      description: default_environment.variable - Name of the environment variable
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: vbs_status
-      description: hvci_status.vbs_status - The status of the virtualization based security settings. Returns UNKNOWN if an error is encountered.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: vendor
-      description: |-
-        block_devices.vendor - Block device vendor string
-        disk_events.vendor - Disk event vendor string
-        hardware_events.vendor - Hardware device vendor
-        pci_devices.vendor - PCI Device vendor
-        platform_info.vendor - Platform code vendor
-        rpm_packages.vendor - Package vendor
-        usb_devices.vendor - USB Device vendor string
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: vendor_id
-      description: |-
-        hardware_events.vendor_id - Hex encoded Hardware vendor identifier
-        pci_devices.vendor_id - Hex encoded PCI Device vendor identifier
-        usb_devices.vendor_id - Hex encoded USB Device vendor identifier
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: vendor_syndrome
-      description: memory_error_info.vendor_syndrome - Vendor specific ECC syndrome or CRC data associated with the erroneous access
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: version
-      description: |-
-        alf.version - Application Layer Firewall version
-        apt_sources.version - Repository source version
-        atom_packages.version - Package supplied version
-        authorizations.version - Label top-level key
-        azure_instance_metadata.version - Version of the VM image
-        bitlocker_info.version - The FVE metadata version of the drive.
-        browser_plugins.version - Plugin short version
-        chocolatey_packages.version - Package-supplied version
-        chrome_extension_content_scripts.version - Extension-supplied version
-        chrome_extensions.version - Extension-supplied version
-        crashes.version - Version info of the crashed process
-        curl_certificate.version - Version Number
-        deb_packages.version - Package version
-        device_firmware.version - Firmware version
-        docker_version.version - Docker version
-        drivers.version - Driver version
-        elf_info.version - Object file version
-        es_process_events.version - Version of EndpointSecurity event
-        firefox_addons.version - Addon-supplied version string
-        gatekeeper.version - Version of Gatekeeper's gke.bundle
-        homebrew_packages.version - Current 'linked' version
-        hvci_status.version - The version number of the Device Guard build.
-        ie_extensions.version - Version of the executable
-        intel_me_info.version - Intel ME version
-        kernel_extensions.version - Extension version
-        kernel_info.version - Kernel version
-        npm_packages.version - Package supplied version
-        office_mru.version - Office application version number
-        os_version.version - Pretty, suitable for presentation, OS version
-        osquery_extensions.version - Extension's version
-        osquery_info.version - osquery toolkit version
-        osquery_packs.version - Minimum osquery version that this query will run on
-        package_install_history.version - Package display version
-        package_receipts.version - Installed package version
-        pkg_packages.version - Package version
-        platform_info.version - Platform code version
-        portage_keywords.version - The version which are affected by the use flags, empty means all
-        portage_packages.version - The version which are affected by the use flags, empty means all
-        portage_use.version - The version of the installed package
-        programs.version - Product version information.
-        python_packages.version - Package-supplied version
-        rpm_packages.version - Package version
-        safari_extensions.version - Extension long version
-        system_extensions.version - System extension version
-        usb_devices.version - USB Device version number
-        windows_crashes.version - File version info of the crashed process
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: video_mode
-      description: video_info.video_mode - The current resolution of the display.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: virtual_process
       description: processes.virtual_process - Process is virtual (e.g. System, Registry, vmmem) yes=1, no=0
@@ -12227,53 +4851,6 @@
         - name: number
           type: long
           default_field: false
-    - name: visible_alarm
-      description: chassis_info.visible_alarm - If TRUE, the frame is equipped with a visual alarm.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: vlans
-      description: lldp_neighbors.vlans - Comma delimited list of vlan ids
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: vm_id
-      description: |-
-        azure_instance_metadata.vm_id - Unique identifier for the VM
-        azure_instance_tags.vm_id - Unique identifier for the VM
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: vm_scale_set_name
-      description: azure_instance_metadata.vm_scale_set_name - VM scale set name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: vm_size
-      description: azure_instance_metadata.vm_size - VM size
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: voltage
       description: battery.voltage - The battery's current voltage in mV
       type: keyword
@@ -12282,15 +4859,6 @@
         - name: number
           type: long
           default_field: false
-    - name: volume_creation
-      description: prefetch.volume_creation - Volume creation time.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: volume_id
       description: quicklook_cache.volume_id - Parsed volume ID from fs_id
       type: keyword
@@ -12298,18 +4866,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: volume_serial
-      description: |-
-        file.volume_serial - Volume serial number
-        prefetch.volume_serial - Volume serial number.
-        shortcut_files.volume_serial - Volume serial number.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: volume_size
       description: platform_info.volume_size - (Optional) size of firmware volume
@@ -12335,24 +4891,6 @@
         - name: number
           type: long
           default_field: false
-    - name: warnings
-      description: smart_drive_info.warnings - Warning messages from SMART controller
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: watch_paths
-      description: launchd.watch_paths - Key that launches daemon or agent if path is modified
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: watcher
       description: osquery_info.watcher - Process (or thread/handle) ID of optional watcher process
       type: keyword
@@ -12360,15 +4898,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: weekday
-      description: time.weekday - Current weekday in the system
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: win32_exit_code
       description: services.win32_exit_code - The error code that the service uses to report an error that occurs when it is starting or stopping
@@ -12385,15 +4914,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: windows_security_center_service
-      description: windows_security_center.windows_security_center_service - The health of the Windows Security Center Service
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: wired
       description: virtual_memory_info.wired - Total number of wired down pages.
@@ -12413,15 +4933,6 @@
         - name: number
           type: long
           default_field: false
-    - name: working_directory
-      description: launchd.working_directory - Key used to specify a directory to chdir to before launch
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: working_disks
       description: md_devices.working_disks - Number of working disks in array
       type: keyword
@@ -12429,15 +4940,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: working_path
-      description: shortcut_files.working_path - Target file directory.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: world
       description: portage_packages.world - If package is in the world file
@@ -12455,15 +4957,6 @@
         - name: number
           type: long
           default_field: false
-    - name: xpath
-      description: windows_eventlog.xpath - The custom query to filter events
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: year
       description: time.year - Current year in the system
       type: keyword
@@ -12479,15 +4972,4 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: zone
-      description: |-
-        azure_instance_metadata.zone - Availability zone of the VM
-        ycloud_instance_metadata.zone - Availability zone of the VM
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false

--- a/packages/osquery_manager/docs/README.md
+++ b/packages/osquery_manager/docs/README.md
@@ -292,6 +292,7 @@ For more information about osquery tables, see the [osquery schema documentation
 |  | **es_process_events.cmdline** - Command line arguments (argv) |  |
 |  | **process_events.cmdline** - Command line arguments (argv) |  |
 |  | **processes.cmdline** - Complete argv |  |
+|  | **host_processes.cmdline** - Complete argv |  |
 | **cmdline_count** | **es_process_events.cmdline_count** - Number of command line arguments | keyword, number.long |
 | **cmdline_size** | **process_events.cmdline_size** - Actual size (bytes) of command line arguments | keyword, number.long |
 | **code** | **seccomp_events.code** - The seccomp action | keyword, text.text |
@@ -325,6 +326,7 @@ For more information about osquery tables, see the [osquery schema documentation
 |  | **etc_services.comment** - Optional comment for a service. |  |
 |  | **groups.comment** - Remarks or comments associated with the group |  |
 |  | **keychain_items.comment** - Optional keychain comment |  |
+|  | **host_groups.comment** - Remarks or comments associated with the group |  |
 | **common_name** | **certificates.common_name** - Certificate CommonName | keyword, text.text |
 |  | **curl_certificate.common_name** - Common name of company issued to |  |
 | **common_path** | **shortcut_files.common_path** - Common system path to target file. | keyword, text.text |
@@ -383,9 +385,11 @@ For more information about osquery tables, see the [osquery schema documentation
 | **cpu_status** | **cpu_info.cpu_status** - The current operating status of the CPU. | keyword, number.long |
 | **cpu_subtype** | **processes.cpu_subtype** - Indicates the specific processor on which an entry may be used. | keyword |
 |  | **system_info.cpu_subtype** - CPU subtype |  |
+|  | **host_processes.cpu_subtype** - Indicates the specific processor on which an entry may be used. |  |
 | **cpu_total_usage** | **docker_container_stats.cpu_total_usage** - Total CPU usage | keyword, number.long |
 | **cpu_type** | **processes.cpu_type** - Indicates the specific processor designed for installation. | keyword |
 |  | **system_info.cpu_type** - CPU type |  |
+|  | **host_processes.cpu_type** - Indicates the specific processor designed for installation. |  |
 | **cpu_usermode_usage** | **docker_container_stats.cpu_usermode_usage** - CPU user mode usage | keyword, number.long |
 | **cpus** | **docker_info.cpus** - Number of CPUs | keyword, number.long |
 | **crash_path** | **crashes.crash_path** - Location of log file | keyword, text.text |
@@ -424,6 +428,7 @@ For more information about osquery tables, see the [osquery schema documentation
 |  | **process_events.cwd** - The process current working directory |  |
 |  | **process_file_events.cwd** - The current working directory of the process |  |
 |  | **processes.cwd** - Process current working directory |  |
+|  | **host_processes.cwd** - Process current working directory |  |
 | **cycle_count** | **battery.cycle_count** - The number of charge/discharge cycles | keyword, number.long |
 | **data** | **magic.data** - Magic number data from libmagic | keyword, text.text |
 |  | **registry.data** - Data content of registry value |  |
@@ -478,6 +483,7 @@ For more information about osquery tables, see the [osquery schema documentation
 |  | **systemd_units.description** - Unit description |  |
 |  | **users.description** - Optional user description |  |
 |  | **ycloud_instance_metadata.description** - Description of the VM |  |
+|  | **host_users.description** - Optional user description |  |
 | **designed_capacity** | **battery.designed_capacity** - The battery's designed capacity in mAh | keyword, number.long |
 | **dest_path** | **process_file_events.dest_path** - The canonical path associated with the event | keyword, text.text |
 | **destination** | **cups_jobs.destination** - The printer the job was sent to | keyword, text.text |
@@ -524,6 +530,7 @@ For more information about osquery tables, see the [osquery schema documentation
 |  | **npm_packages.directory** - Node module's directory where this package is located |  |
 |  | **python_packages.directory** - Directory where Python modules are located |  |
 |  | **users.directory** - User's home directory |  |
+|  | **host_users.directory** - User's home directory |  |
 | **disabled** | **browser_plugins.disabled** - Is the plugin disabled. 1 = Disabled | keyword |
 |  | **firefox_addons.disabled** - 1 If the addon is application-disabled else 0 |  |
 |  | **launchd.disabled** - Skip loading this daemon or agent on boot |  |
@@ -533,7 +540,9 @@ For more information about osquery tables, see the [osquery schema documentation
 | **discovery_cache_hits** | **osquery_packs.discovery_cache_hits** - The number of times that the discovery query used cached values since the last time the config was reloaded | keyword, number.long |
 | **discovery_executions** | **osquery_packs.discovery_executions** - The number of times that the discovery queries have been executed since the last time the config was reloaded | keyword, number.long |
 | **disk_bytes_read** | **processes.disk_bytes_read** - Bytes read from disk | keyword, number.long |
+|  | **host_processes.disk_bytes_read** - Bytes read from disk |  |
 | **disk_bytes_written** | **processes.disk_bytes_written** - Bytes written to disk | keyword, number.long |
+|  | **host_processes.disk_bytes_written** - Bytes written to disk |  |
 | **disk_id** | **smart_drive_info.disk_id** - Physical slot number of device, only exists when hardware storage controller exists | keyword, number.long |
 | **disk_index** | **disk_info.disk_index** - Physical drive number of the disk. | keyword, number.long |
 | **disk_read** | **docker_container_stats.disk_read** - Total disk read bytes | keyword, number.long |
@@ -580,6 +589,7 @@ For more information about osquery tables, see the [osquery schema documentation
 |  | **process_events.egid** - Effective group ID at process start |  |
 |  | **process_file_events.egid** - Effective group ID of the process using the file |  |
 |  | **processes.egid** - Unsigned effective group ID |  |
+|  | **host_processes.egid** - Unsigned effective group ID |  |
 | **eid** | **apparmor_events.eid** - Event ID | keyword, text.text |
 |  | **bpf_process_events.eid** - Event ID |  |
 |  | **bpf_socket_events.eid** - Event ID |  |
@@ -598,8 +608,10 @@ For more information about osquery tables, see the [osquery schema documentation
 |  | **yara_events.eid** - Event ID |  |
 | **ejectable** | **disk_events.ejectable** - 1 if ejectable, 0 if not | keyword, number.long |
 | **elapsed_time** | **processes.elapsed_time** - Elapsed time in seconds this process has been running. | keyword, number.long |
+|  | **host_processes.elapsed_time** - Elapsed time in seconds this process has been running. |  |
 | **element** | **apps.element** - Does the app identify as a background agent | keyword, text.text |
 | **elevated_token** | **processes.elevated_token** - Process uses elevated token yes=1, no=0 | keyword, number.long |
+|  | **host_processes.elevated_token** - Process uses elevated token yes=1, no=0 |  |
 | **enable_ipv6** | **docker_networks.enable_ipv6** - 1 if IPv6 is enabled on this network. 0 otherwise | keyword, number.long |
 | **enabled** | **app_schemes.enabled** - 1 if this handler is the OS default, else 0 | keyword |
 |  | **event_taps.enabled** - Is the Event Tap enabled |  |
@@ -645,6 +657,7 @@ For more information about osquery tables, see the [osquery schema documentation
 |  | **process_events.euid** - Effective user ID at process start |  |
 |  | **process_file_events.euid** - Effective user ID of the process using the file |  |
 |  | **processes.euid** - Unsigned effective user ID |  |
+|  | **host_processes.euid** - Unsigned effective user ID |  |
 | **event** | **crontab.event** - The job @event name (rare) | keyword, text.text |
 | **event_queue** | **carbon_black_info.event_queue** - Size in bytes of Carbon Black event files on disk | keyword, number.long |
 | **event_tap_id** | **event_taps.event_tap_id** - Unique ID for the Tap | keyword, number.long |
@@ -771,8 +784,13 @@ For more information about osquery tables, see the [osquery schema documentation
 |  | **seccomp_events.gid** - Group ID of the user who started the analyzed process |  |
 |  | **user_groups.gid** - Group ID |  |
 |  | **users.gid** - Group ID (unsigned) |  |
+|  | **host_groups.gid** - Unsigned int64 group ID |  |
+|  | **host_processes.gid** - Unsigned group ID |  |
+|  | **host_users.gid** - Group ID (unsigned) |  |
 | **gid_signed** | **groups.gid_signed** - A signed int64 version of gid | keyword, number.long |
 |  | **users.gid_signed** - Default group ID as int64 signed (Apple) |  |
+|  | **host_groups.gid_signed** - A signed int64 version of gid |  |
+|  | **host_users.gid_signed** - Default group ID as int64 signed (Apple) |  |
 | **git_commit** | **docker_version.git_commit** - Docker build git commit | keyword, text.text |
 | **global_seq_num** | **es_process_events.global_seq_num** - Global sequence number | keyword, number.long |
 | **global_state** | **alf.global_state** - 1 If the firewall is enabled with exceptions, 2 if the firewall is configured to block all incoming connections, else 0 | keyword, number.long |
@@ -781,10 +799,12 @@ For more information about osquery tables, see the [osquery schema documentation
 | **gpgkey** | **yum_sources.gpgkey** - URL to GPG key | keyword, text.text |
 | **grace_period** | **screenlock.grace_period** - The amount of time in seconds the screen must be asleep or the screensaver on before a password is required on-wake. 0 = immediately; -1 = no password is required on-wake | keyword, number.long |
 | **group_sid** | **groups.group_sid** - Unique group ID | keyword, text.text |
+|  | **host_groups.group_sid** - Unique group ID |  |
 | **groupname** | **groups.groupname** - Canonical local group name | keyword, text.text |
 |  | **launchd.groupname** - Run this daemon or agent as this group |  |
 |  | **rpm_package_files.groupname** - File default groupname from info DB |  |
 |  | **suid_bin.groupname** - Binary owner group |  |
+|  | **host_groups.groupname** - Canonical local group name |  |
 | **guest** | **cpu_time.guest** - Time spent running a virtual CPU for a guest OS under the control of the Linux kernel | keyword, number.long |
 | **guest_nice** | **cpu_time.guest_nice** - Time spent running a niced guest  | keyword, number.long |
 | **handle** | **memory_array_mapped_addresses.handle** - Handle, or instance number, associated with the structure | keyword, text.text |
@@ -795,6 +815,7 @@ For more information about osquery tables, see the [osquery schema documentation
 |  | **oem_strings.handle** - Handle, or instance number, associated with the Type 11 structure |  |
 |  | **smbios_tables.handle** - Table entry handle |  |
 | **handle_count** | **processes.handle_count** - Total number of handles that the process has open. This number is the sum of the handles currently opened by each thread in the process. | keyword, number.long |
+|  | **host_processes.handle_count** - Total number of handles that the process has open. This number is the sum of the handles currently opened by each thread in the process. |  |
 | **handler** | **app_schemes.handler** - Application label for the handler | keyword, text.text |
 | **hard_limit** | **ulimit_info.hard_limit** - Maximum limit value | keyword, text.text |
 | **hard_links** | **device_file.hard_links** - Number of hard links | keyword, number.long |
@@ -972,6 +993,8 @@ For more information about osquery tables, see the [osquery schema documentation
 | **is_active** | **running_apps.is_active** - 1 if the application is in focus, 0 otherwise | keyword, number.long |
 | **is_hidden** | **groups.is_hidden** - IsHidden attribute set in OpenDirectory | keyword, number.long |
 |  | **users.is_hidden** - IsHidden attribute set in OpenDirectory |  |
+|  | **host_groups.is_hidden** - IsHidden attribute set in OpenDirectory |  |
+|  | **host_users.is_hidden** - IsHidden attribute set in OpenDirectory |  |
 | **iso_8601** | **time.iso_8601** - Current time (ISO format) in the system | keyword, text.text |
 | **issuer** | **certificates.issuer** - Certificate issuer distinguished name | keyword, text.text |
 | **issuer_alternative_names** | **curl_certificate.issuer_alternative_names** - Issuer Alternative Name | keyword, text.text |
@@ -1357,6 +1380,7 @@ For more information about osquery tables, see the [osquery schema documentation
 |  | **xprotect_reports.name** - Description of XProtected malware |  |
 |  | **ycloud_instance_metadata.name** - Name of the VM |  |
 |  | **yum_sources.name** - Repository name |  |
+|  | **host_processes.name** - The process path or shorthand argv[0] |  |
 | **name_constraints** | **curl_certificate.name_constraints** - Name Constraints | keyword, text.text |
 | **namespace** | **apparmor_events.namespace** - AppArmor namespace | keyword, text.text |
 | **native** | **browser_plugins.native** - Plugin requires native execution | keyword, number.long |
@@ -1377,6 +1401,7 @@ For more information about osquery tables, see the [osquery schema documentation
 | **nice** | **cpu_time.nice** - Time spent in user mode with low priority (nice) | keyword, number.long |
 |  | **docker_container_processes.nice** - Process nice level (-20 to 20, default 0) |  |
 |  | **processes.nice** - Process nice level (-20 to 20, default 0) |  |
+|  | **host_processes.nice** - Process nice level (-20 to 20, default 0) |  |
 | **no_proxy** | **docker_info.no_proxy** - Comma-separated list of domain extensions proxy should not be used for | keyword, text.text |
 | **node** | **augeas.node** - The node path of the configuration item | keyword, text.text |
 | **node_ref_number** | **ntfs_journal_events.node_ref_number** - The ordinal that associates a journal record with a filename | keyword, text.text |
@@ -1409,6 +1434,7 @@ For more information about osquery tables, see the [osquery schema documentation
 | **old_path** | **ntfs_journal_events.old_path** - Old path (renames only) | keyword, text.text |
 | **on_demand** | **launchd.on_demand** - Deprecated key, replaced by keep_alive | keyword, text.text |
 | **on_disk** | **processes.on_disk** - The process path exists yes=1, no=0, unknown=-1 | keyword, number.long |
+|  | **host_processes.on_disk** - The process path exists yes=1, no=0, unknown=-1 |  |
 | **online_cpus** | **docker_container_stats.online_cpus** - Online CPUs | keyword, number.long |
 | **oom_kill_disable** | **docker_info.oom_kill_disable** - 1 if Out-of-memory kill is disabled. 0 otherwise | keyword, number.long |
 | **opackets** | **interface_details.opackets** - Output packets | keyword, number.long |
@@ -1474,6 +1500,7 @@ For more information about osquery tables, see the [osquery schema documentation
 |  | **iokit_registry.parent** - Parent registry ID |  |
 |  | **process_events.parent** - Process parent's PID, or -1 if cannot be determined. |  |
 |  | **processes.parent** - Process parent's PID |  |
+|  | **host_processes.parent** - Process parent's PID |  |
 | **parent_ref_number** | **ntfs_journal_events.parent_ref_number** - The ordinal that associates a journal record with a filename's parent directory | keyword, text.text |
 | **part_number** | **memory_devices.part_number** - Manufacturer specific serial number of memory device | keyword, text.text |
 | **partial** | **ntfs_journal_events.partial** - Set to 1 if either path or old_path only contains the file or folder name | keyword |
@@ -1579,6 +1606,7 @@ For more information about osquery tables, see the [osquery schema documentation
 |  | **userassist.path** - Application file path. |  |
 |  | **windows_crashes.path** - Path of the executable file for the crashed process |  |
 |  | **yara.path** - The path scanned |  |
+|  | **host_processes.path** - Path to executed binary |  |
 | **pci_class** | **pci_devices.pci_class** - PCI Device class | keyword, text.text |
 | **pci_class_id** | **pci_devices.pci_class_id** - PCI Device class ID in hex format | keyword, text.text |
 | **pci_slot** | **interface_details.pci_slot** - PCI slot number | keyword, text.text |
@@ -1591,6 +1619,7 @@ For more information about osquery tables, see the [osquery schema documentation
 | **percent_disk_write_time** | **physical_disk_performance.percent_disk_write_time** - Percentage of elapsed time that the selected disk drive is busy servicing write requests | keyword, number.long |
 | **percent_idle_time** | **physical_disk_performance.percent_idle_time** - Percentage of time during the sample interval that the disk was idle | keyword, number.long |
 | **percent_processor_time** | **processes.percent_processor_time** - Returns elapsed time that all of the threads of this process used the processor to execute instructions in 100 nanoseconds ticks. | keyword, number.long |
+|  | **host_processes.percent_processor_time** - Returns elapsed time that all of the threads of this process used the processor to execute instructions in 100 nanoseconds ticks. |  |
 | **percent_remaining** | **battery.percent_remaining** - The percentage of battery remaining before it is drained | keyword, number.long |
 | **percentage_encrypted** | **bitlocker_info.percentage_encrypted** - The percentage of the drive that is encrypted. | keyword, number.long |
 | **perf_ctl** | **msr.perf_ctl** - Performance setting for the processor. | keyword, number.long |
@@ -1606,6 +1635,7 @@ For more information about osquery tables, see the [osquery schema documentation
 | **persistent_volume_id** | **bitlocker_info.persistent_volume_id** - Persistent ID of the drive. | keyword, text.text |
 | **pgroup** | **docker_container_processes.pgroup** - Process group | keyword, number.long |
 |  | **processes.pgroup** - Process group |  |
+|  | **host_processes.pgroup** - Process group |  |
 | **physical_adapter** | **interface_details.physical_adapter** - Indicates whether the adapter is a physical or a logical adapter. | keyword, number.long |
 | **physical_memory** | **system_info.physical_memory** - Total physical memory in bytes | keyword, number.long |
 | **physical_presence_version** | **tpm_info.physical_presence_version** - Version of the Physical Presence Interface | keyword, text.text |
@@ -1640,6 +1670,7 @@ For more information about osquery tables, see the [osquery schema documentation
 |  | **user_events.pid** - Process (or thread) ID |  |
 |  | **windows_crashes.pid** - Process ID of the crashed process |  |
 |  | **windows_eventlog.pid** - Process ID which emitted the event record |  |
+|  | **host_processes.pid** - Process (or thread) ID |  |
 | **pid_namespace** | **docker_containers.pid_namespace** - PID namespace | keyword, text.text |
 |  | **process_namespaces.pid_namespace** - pid namespace inode |  |
 | **pid_with_namespace** | **apt_sources.pid_with_namespace** - Pids that contain a namespace | keyword, number.long |
@@ -1659,6 +1690,8 @@ For more information about osquery tables, see the [osquery schema documentation
 |  | **user_ssh_keys.pid_with_namespace** - Pids that contain a namespace |  |
 |  | **users.pid_with_namespace** - Pids that contain a namespace |  |
 |  | **yum_sources.pid_with_namespace** - Pids that contain a namespace |  |
+|  | **host_groups.pid_with_namespace** - Pids that contain a namespace |  |
+|  | **host_users.pid_with_namespace** - Pids that contain a namespace |  |
 | **pids** | **docker_container_stats.pids** - Number of processes | keyword |
 |  | **lldp_neighbors.pids** - Comma delimited list of PIDs |  |
 | **placement_group_id** | **azure_instance_metadata.placement_group_id** - Placement group for the VM scale set | keyword, text.text |
@@ -1755,6 +1788,7 @@ For more information about osquery tables, see the [osquery schema documentation
 | **protection_disabled** | **carbon_black_info.protection_disabled** - If the sensor is configured to report tamper events | keyword, number.long |
 | **protection_status** | **bitlocker_info.protection_status** - The bitlocker protection status of the drive. | keyword, number.long |
 | **protection_type** | **processes.protection_type** - The protection type of the process | keyword, text.text |
+|  | **host_processes.protection_type** - The protection type of the process |  |
 | **protocol** | **bpf_socket_events.protocol** - The network protocol ID | keyword |
 |  | **etc_services.protocol** - Transport protocol (TCP/UDP) |  |
 |  | **iptables.protocol** - Protocol number identification. |  |
@@ -1841,6 +1875,7 @@ For more information about osquery tables, see the [osquery schema documentation
 | **reshape_speed** | **md_devices.reshape_speed** - Speed of reshape activity | keyword, text.text |
 | **resident_size** | **docker_container_processes.resident_size** - Bytes of private memory used by process | keyword, number.long |
 |  | **processes.resident_size** - Bytes of private memory used by process |  |
+|  | **host_processes.resident_size** - Bytes of private memory used by process |  |
 | **resource_group_name** | **azure_instance_metadata.resource_group_name** - Resource group for the VM | keyword, text.text |
 | **response_code** | **curl.response_code** - The HTTP status code for the response | keyword, number.long |
 | **responsible** | **crashes.responsible** - Process responsible for the crashed process | keyword, text.text |
@@ -1858,6 +1893,7 @@ For more information about osquery tables, see the [osquery schema documentation
 | **roaming** | **wifi_networks.roaming** - 1 if roaming is supported, 0 otherwise | keyword, number.long |
 | **roaming_profile** | **wifi_networks.roaming_profile** - Describe the roaming profile, usually one of Single, Dual  or Multi | keyword, text.text |
 | **root** | **processes.root** - Process virtual root directory | keyword, text.text |
+|  | **host_processes.root** - Process virtual root directory |  |
 | **root_dir** | **docker_info.root_dir** - Docker root directory | keyword, text.text |
 | **root_directory** | **launchd.root_directory** - Key used to specify a directory to chroot to before launch | keyword, text.text |
 | **root_volume_uuid** | **time_machine_destinations.root_volume_uuid** - Root UUID of backup volume | keyword, text.text |
@@ -1894,6 +1930,7 @@ For more information about osquery tables, see the [osquery schema documentation
 | **sector_sizes** | **smart_drive_info.sector_sizes** - Bytes of drive sector sizes | keyword, text.text |
 | **secure_boot** | **secureboot.secure_boot** - Whether secure boot is enabled | keyword, number.long |
 | **secure_process** | **processes.secure_process** - Process is secure (IUM) yes=1, no=0 | keyword, number.long |
+|  | **host_processes.secure_process** - Process is secure (IUM) yes=1, no=0 |  |
 | **security_breach** | **chassis_info.security_breach** - The physical status of the chassis such as Breach Successful, Breach Attempted, etc. | keyword, text.text |
 | **security_groups** | **ec2_instance_metadata.security_groups** - Comma separated list of security group names | keyword, text.text |
 | **security_options** | **docker_containers.security_options** - List of container security options | keyword, text.text |
@@ -1937,6 +1974,7 @@ For more information about osquery tables, see the [osquery schema documentation
 |  | **process_events.sgid** - Saved group ID at process start |  |
 |  | **process_file_events.sgid** - Saved group ID of the process using the file |  |
 |  | **processes.sgid** - Unsigned saved group ID |  |
+|  | **host_processes.sgid** - Unsigned saved group ID |  |
 | **sha1** | **apparmor_profiles.sha1** - A unique hash that identifies this policy. | keyword, text.text |
 |  | **certificates.sha1** - SHA1 hash of the raw certificate contents |  |
 |  | **device_hash.sha1** - SHA1 hash of provided inode data |  |
@@ -1955,6 +1993,7 @@ For more information about osquery tables, see the [osquery schema documentation
 | **share_name** | **shortcut_files.share_name** - Share name of the target file. | keyword, text.text |
 | **shared** | **authorizations.shared** - Label top-level key | keyword, text.text |
 | **shell** | **users.shell** - User's configured default shell | keyword, text.text |
+|  | **host_users.shell** - User's configured default shell |  |
 | **shell_only** | **osquery_flags.shell_only** - Is the flag shell only? | keyword, number.long |
 | **shmid** | **shared_memory.shmid** - Shared memory segment ID | keyword, number.long |
 | **sid** | **background_activities_moderator.sid** - User SID. | keyword, text.text |
@@ -2059,6 +2098,7 @@ For more information about osquery tables, see the [osquery schema documentation
 | **start_time** | **docker_container_processes.start_time** - Process start in seconds since boot (non-sleeping) | keyword, number.long |
 |  | **osquery_info.start_time** - UNIX time in seconds when the process started |  |
 |  | **processes.start_time** - Process start time in seconds since Epoch, in case of error -1 |  |
+|  | **host_processes.start_time** - Process start time in seconds since Epoch, in case of error -1 |  |
 | **start_type** | **services.start_type** - Service start type: BOOT_START, SYSTEM_START, AUTO_START, DEMAND_START, DISABLED | keyword, text.text |
 | **started_at** | **docker_containers.started_at** - Container start time as string | keyword, text.text |
 | **starting_address** | **memory_array_mapped_addresses.starting_address** - Physical stating address, in kilobytes, of a range of memory mapped to physical memory array | keyword, text.text |
@@ -2076,6 +2116,7 @@ For more information about osquery tables, see the [osquery schema documentation
 |  | **system_extensions.state** - System extension state |  |
 |  | **windows_optional_features.state** - Installation state value. 1 == Enabled, 2 == Disabled, 3 == Absent |  |
 |  | **windows_security_products.state** - State of protection |  |
+|  | **host_processes.state** - Process state |  |
 | **state_timestamp** | **windows_security_products.state_timestamp** - Timestamp for the product state | keyword, text.text |
 | **stateful** | **lxd_instances.stateful** - Whether the instance is stateful(1) or not(0) | keyword, number.long |
 | **statename** | **windows_optional_features.statename** - Installation state name. 'Enabled','Disabled','Absent' | keyword, text.text |
@@ -2128,6 +2169,7 @@ For more information about osquery tables, see the [osquery schema documentation
 |  | **process_events.suid** - Saved user ID at process start |  |
 |  | **process_file_events.suid** - Saved user ID of the process using the file |  |
 |  | **processes.suid** - Unsigned saved user ID |  |
+|  | **host_processes.suid** - Unsigned saved user ID |  |
 | **summary** | **chocolatey_packages.summary** - Package-supplied summary | keyword, text.text |
 |  | **python_packages.summary** - Package-supplied summary |  |
 | **superblock_state** | **md_devices.superblock_state** - State of the superblock | keyword, text.text |
@@ -2149,6 +2191,7 @@ For more information about osquery tables, see the [osquery schema documentation
 | **system_model** | **kernel_panics.system_model** - Physical system model, for example 'MacBookPro12,1 (Mac-E43C1C25D4880AD6)' | keyword, text.text |
 | **system_time** | **osquery_schedule.system_time** - Total system time spent executing | keyword, number.long |
 |  | **processes.system_time** - CPU time in milliseconds spent in kernel space |  |
+|  | **host_processes.system_time** - CPU time in milliseconds spent in kernel space |  |
 | **table** | **elf_symbols.table** - Table name containing symbol | keyword, text.text |
 | **tag** | **elf_dynamic.tag** - Tag ID | keyword |
 |  | **syslog_events.tag** - The syslog tag |  |
@@ -2176,6 +2219,7 @@ For more information about osquery tables, see the [osquery schema documentation
 | **terminal** | **user_events.terminal** - The network protocol ID | keyword, text.text |
 | **threads** | **docker_container_processes.threads** - Number of threads used by process | keyword, number.long |
 |  | **processes.threads** - Number of threads used by process |  |
+|  | **host_processes.threads** - Number of threads used by process |  |
 | **throttled** | **virtual_memory_info.throttled** - Total number of throttled pages. | keyword, number.long |
 | **tid** | **bpf_process_events.tid** - Thread ID | keyword, number.long |
 |  | **bpf_socket_events.tid** - Thread ID |  |
@@ -2221,6 +2265,7 @@ For more information about osquery tables, see the [osquery schema documentation
 | **total_seconds** | **uptime.total_seconds** - Total uptime seconds | keyword, number.long |
 | **total_size** | **docker_container_processes.total_size** - Total virtual memory size | keyword, number.long |
 |  | **processes.total_size** - Total virtual memory size |  |
+|  | **host_processes.total_size** - Total virtual memory size |  |
 | **total_width** | **memory_devices.total_width** - Total width, in bits, of this memory device, including any check or error-correction bits | keyword, number.long |
 | **transaction_id** | **file_events.transaction_id** - ID used during bulk update | keyword, number.long |
 |  | **yara_events.transaction_id** - ID used during bulk update |  |
@@ -2281,6 +2326,7 @@ For more information about osquery tables, see the [osquery schema documentation
 |  | **windows_crashes.type** - Type of crash log |  |
 |  | **windows_security_products.type** - Type of security product |  |
 |  | **xprotect_meta.type** - Either plugin or extension |  |
+|  | **host_users.type** - Whether the account is roaming (domain), local, or a system profile |  |
 | **type_name** | **last.type_name** - Entry type name, according to ut_type types (utmp.h) | keyword, text.text |
 | **uid** | **account_policy_data.uid** - User ID | keyword |
 |  | **asl.uid** - UID that sent the log message (set by the server). |  |
@@ -2313,7 +2359,10 @@ For more information about osquery tables, see the [osquery schema documentation
 |  | **user_groups.uid** - User ID |  |
 |  | **user_ssh_keys.uid** - The local user that owns the key file |  |
 |  | **users.uid** - User ID |  |
+|  | **host_processes.uid** - Unsigned user ID |  |
+|  | **host_users.uid** - User ID |  |
 | **uid_signed** | **users.uid_signed** - User ID as int64 signed (Apple) | keyword, number.long |
+|  | **host_users.uid_signed** - User ID as int64 signed (Apple) |  |
 | **umci_policy_status** | **hvci_status.umci_policy_status** - The status of the User Mode Code Integrity security settings. Returns UNKNOWN if an error is encountered. | keyword, text.text |
 | **uncompressed** | **virtual_memory_info.uncompressed** - Total number of uncompressed pages. | keyword, number.long |
 | **uninstall_string** | **programs.uninstall_string** - Path and filename of the uninstaller. | keyword, text.text |
@@ -2328,9 +2377,11 @@ For more information about osquery tables, see the [osquery schema documentation
 | **update_url** | **chrome_extensions.update_url** - Extension-supplied update URI | keyword, text.text |
 |  | **safari_extensions.update_url** - Extension-supplied update URI |  |
 | **upid** | **processes.upid** - A 64bit pid that is never reused. Returns -1 if we couldn't gather them from the system. | keyword, number.long |
+|  | **host_processes.upid** - A 64bit pid that is never reused. Returns -1 if we couldn't gather them from the system. |  |
 | **uploaded_at** | **lxd_images.uploaded_at** - ISO time of image upload | keyword, text.text |
 | **upn** | **logon_sessions.upn** - The user principal name (UPN) for the owner of the logon session. | keyword, text.text |
 | **uppid** | **processes.uppid** - The 64bit parent pid that is never reused. Returns -1 if we couldn't gather them from the system. | keyword, number.long |
+|  | **host_processes.uppid** - The 64bit parent pid that is never reused. Returns -1 if we couldn't gather them from the system. |  |
 | **uptime** | **apparmor_events.uptime** - Time of execution in system uptime | keyword, number.long |
 |  | **kernel_panics.uptime** - System uptime at kernel panic in nanoseconds |  |
 |  | **process_events.uptime** - Time of execution in system uptime |  |
@@ -2363,6 +2414,7 @@ For more information about osquery tables, see the [osquery schema documentation
 |  | **process_namespaces.user_namespace** - user namespace inode |  |
 | **user_time** | **osquery_schedule.user_time** - Total user time spent executing | keyword, number.long |
 |  | **processes.user_time** - CPU time in milliseconds spent in user space |  |
+|  | **host_processes.user_time** - CPU time in milliseconds spent in user space |  |
 | **user_uuid** | **disk_encryption.user_uuid** - UUID of authenticated user if available | keyword, text.text |
 | **username** | **certificates.username** - Username | keyword, text.text |
 |  | **es_process_events.username** - Username |  |
@@ -2376,6 +2428,7 @@ For more information about osquery tables, see the [osquery schema documentation
 |  | **suid_bin.username** - Binary owner username |  |
 |  | **users.username** - Username |  |
 |  | **windows_crashes.username** - Username of the user who ran the crashed process |  |
+|  | **host_users.username** - Username |  |
 | **uses_pattern** | **xprotect_entries.uses_pattern** - Uses a match pattern instead of identity | keyword, number.long |
 | **uts_namespace** | **docker_containers.uts_namespace** - UTS namespace | keyword, text.text |
 |  | **process_namespaces.uts_namespace** - uts namespace inode |  |
@@ -2387,6 +2440,7 @@ For more information about osquery tables, see the [osquery schema documentation
 |  | **osquery_info.uuid** - Unique ID provided by the system |  |
 |  | **system_info.uuid** - Unique ID provided by the system |  |
 |  | **users.uuid** - User's UUID (Apple) or SID (Windows) |  |
+|  | **host_users.uuid** - User's UUID (Apple) or SID (Windows) |  |
 | **vaddr** | **elf_sections.vaddr** - Section virtual address in memory | keyword, number.long |
 |  | **elf_segments.vaddr** - Segment virtual address in memory |  |
 | **valid_from** | **curl_certificate.valid_from** - Period of validity start date | keyword, text.text |
@@ -2480,6 +2534,7 @@ For more information about osquery tables, see the [osquery schema documentation
 |  | **windows_crashes.version** - File version info of the crashed process |  |
 | **video_mode** | **video_info.video_mode** - The current resolution of the display. | keyword, text.text |
 | **virtual_process** | **processes.virtual_process** - Process is virtual (e.g. System, Registry, vmmem) yes=1, no=0 | keyword, number.long |
+|  | **host_processes.virtual_process** - Process is virtual (e.g. System, Registry, vmmem) yes=1, no=0 |  |
 | **visible** | **firefox_addons.visible** - 1 If the addon is shown in browser else 0 | keyword, number.long |
 | **visible_alarm** | **chassis_info.visible_alarm** - If TRUE, the frame is equipped with a visual alarm. | keyword, text.text |
 | **vlans** | **lldp_neighbors.vlans** - Comma delimited list of vlan ids | keyword, text.text |
@@ -2506,6 +2561,7 @@ For more information about osquery tables, see the [osquery schema documentation
 | **wired** | **virtual_memory_info.wired** - Total number of wired down pages. | keyword, number.long |
 | **wired_size** | **docker_container_processes.wired_size** - Bytes of unpageable memory used by process | keyword, number.long |
 |  | **processes.wired_size** - Bytes of unpageable memory used by process |  |
+|  | **host_processes.wired_size** - Bytes of unpageable memory used by process |  |
 | **working_directory** | **launchd.working_directory** - Key used to specify a directory to chdir to before launch | keyword, text.text |
 | **working_disks** | **md_devices.working_disks** - Number of working disks in array | keyword, number.long |
 | **working_path** | **shortcut_files.working_path** - Target file directory. | keyword, text.text |

--- a/packages/osquery_manager/manifest.yml
+++ b/packages/osquery_manager/manifest.yml
@@ -1,11 +1,11 @@
 format_version: 1.0.0
 name: osquery_manager
 title: Osquery Manager
-version: 0.7.3
+version: 0.7.4
 license: basic
 description: Deploy osquery with Elastic Agent, then run and schedule queries in Kibana
 type: integration
-release: beta
+release: ga
 categories:
   - security
   - os_system


### PR DESCRIPTION
## What does this PR do?

* Update manifest release tag from beta to ga
* Add host_users, host_groups, host_processes tables columns into package readme
* Remove previously explicitly mapped text/keywords fields. This relies on the dynamic keyword[1024] mapping
```
      "dynamic_templates": [
        {
          "strings_as_keyword": {
            "match_mapping_type": "string",
            "mapping": {
              "ignore_above": 1024,
              "type": "keyword"
            }
          }
        }
      ]
```
and helps to:
** Reduce the size of the mapping
** Eliminate the kibana warning 
```
kibana         | [2021-11-03T19:02:37.819+00:00][WARN ][plugins.fleet] large amount of default fields detected for index template logs-osquery_manager.result in package osquery_manager, applying the first 1024 fields
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Screenshots
<img width="544" alt="Screen Shot 2021-11-03 at 4 19 21 PM" src="https://user-images.githubusercontent.com/872351/140188110-43507162-513f-407a-b010-cd9753efdf25.png">


