### PR TITLE
Run daily jobs with 7.16 and 8.0 snapshots

### DIFF
--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -22,11 +22,22 @@ pipeline {
     cron('H H(2-5) * * *')
   }
   stages {
-    stage('Daily integration builds') {
+    stage('Daily integration builds with 7.16') {
       steps {
         build(
           job: env.INTEGRATION_JOB,
-          parameters: [stringParam(name: 'stackVersion', value: '7.x-SNAPSHOT')],
+          parameters: [stringParam(name: 'stackVersion', value: '7.16-SNAPSHOT')],
+          quietPeriod: 0,
+          wait: true,
+          propagate: true,
+        )
+      }
+    }
+    stage('Daily integration builds with 8.0') {
+      steps {
+        build(
+          job: env.INTEGRATION_JOB,
+          parameters: [stringParam(name: 'stackVersion', value: '8.0-SNAPSHOT')],
           quietPeriod: 0,
           wait: true,
           propagate: true,


### PR DESCRIPTION
## What does this PR do?

* Adds a daily stage to run integration tests with 8.0 snapshots.
* 7.x branches don't exist anymore, use 7.16 snapshots instead for this major.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] We will need to add a check to skip the daily tests of an integration if it doesn't support the version given in `STACK_VERSION`. I will do it in a follow up, some tests will surely fail in the meantime, but this is not new, [they are already failing](https://beats-ci.elastic.co/job/Ingest-manager/job/integrations/job/master/1107/) for 8.0-only packages.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
