### PR TITLE
zeek: fix changelog link

### DIFF
--- a/packages/zeek/changelog.yml
+++ b/packages/zeek/changelog.yml
@@ -8,7 +8,7 @@
   changes:
     - description: Update Title and Description.
       type: enhancement
-      link: ""
+      link: https://github.com/elastic/integrations/pull/1992
 - version: "1.4.1"
   changes:
     - description: Fix logic that checks for the 'forwarded' tag


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

PR https://github.com/elastic/integrations/pull/2110 introduced an unexpected and unwanted change to Zeek package changelog.

This commit reverts that change.
## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Related  https://github.com/elastic/integrations/pull/2110

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
