### PR TITLE
Fix visualizations on the Kubernetes overview dashboard

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.1"
+  changes:
+    - description: Fix visualizations on the Kubernetes overview dashboard
+      type: enhancement
+      link:
 - version: "1.4.0"
   changes:
     - description: Use filestream input for container_logs data stream

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix visualizations on the Kubernetes overview dashboard
       type: enhancement
-      link:
+      link: https://github.com/elastic/integrations/pull/2151
 - version: "1.4.0"
   changes:
     - description: Use filestream input for container_logs data stream

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.4.1"
   changes:
-    - description: Fix visualizations on the Kubernetes overview dashboard
+    - description: Remove overriding of index pattern on the Kubernetes overview dashboard
       type: enhancement
       link: https://github.com/elastic/integrations/pull/2151
 - version: "1.4.0"

--- a/packages/kubernetes/kibana/visualization/kubernetes-174a6ad0-30e0-11e7-8df8-6d3604a72912.json
+++ b/packages/kubernetes/kibana/visualization/kubernetes-174a6ad0-30e0-11e7-8df8-6d3604a72912.json
@@ -63,7 +63,6 @@
                                 "type": "sum"
                             }
                         ],
-                        "override_index_pattern": 1,
                         "point_size": 1,
                         "seperate_axis": 0,
                         "series_interval": "10s",

--- a/packages/kubernetes/kibana/visualization/kubernetes-da1ff7c0-30ed-11e7-b9e5-2b5b07213ab3.json
+++ b/packages/kubernetes/kibana/visualization/kubernetes-da1ff7c0-30ed-11e7-b9e5-2b5b07213ab3.json
@@ -63,12 +63,9 @@
                                 "type": "sum"
                             }
                         ],
-                        "override_index_pattern": 1,
                         "point_size": 1,
                         "seperate_axis": 0,
-                        "series_index_pattern": "*",
                         "series_interval": "10s",
-                        "series_time_field": "@timestamp",
                         "split_color_mode": "gradient",
                         "split_mode": "everything",
                         "stacked": "none"

--- a/packages/kubernetes/kibana/visualization/kubernetes-e1018b90-2bfb-11e7-859b-f78b612cde28.json
+++ b/packages/kubernetes/kibana/visualization/kubernetes-e1018b90-2bfb-11e7-859b-f78b612cde28.json
@@ -63,7 +63,6 @@
                                 "type": "sum"
                             }
                         ],
-                        "override_index_pattern": 1,
                         "point_size": 1,
                         "seperate_axis": 0,
                         "series_interval": "10s",

--- a/packages/kubernetes/kibana/visualization/kubernetes-e1018b90-2bfb-11e7-859b-f78b612cde28.json
+++ b/packages/kubernetes/kibana/visualization/kubernetes-e1018b90-2bfb-11e7-859b-f78b612cde28.json
@@ -66,7 +66,6 @@
                         "point_size": 1,
                         "seperate_axis": 0,
                         "series_interval": "10s",
-                        "series_time_field": "@timestamp",
                         "split_color_mode": "gradient",
                         "split_mode": "everything",
                         "stacked": "none"

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.4.0
+version: 1.4.1
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
Signed-off-by: Tetiana Kravchenko <tetiana.kravchenko@elastic.co>

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

There are two visualizations on the `[Metrics Kubernetes] Overview dashboard` with 2 broken visualizations (`Desired Pods` and `Unavailable Pods`), reason for that: index pattern is overridden (they have "yes" checked),  but `series_Index_pattern`  is not specified:
<img width="1215" alt="Screenshot 2021-11-11 at 09 57 40" src="https://user-images.githubusercontent.com/28299531/141268452-f027d458-8590-471a-95d3-b5094289f0d3.png">
(note that in the picture as an index_pattern was picked `logs-*`)

index pattern shouldn't be overridden.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
- Closes https://github.com/elastic/beats/issues/28792
## Screenshots


Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration:
local setup:
<img width="1779" alt="Screenshot 2021-11-11 at 14 46 39" src="https://user-images.githubusercontent.com/28299531/141309606-8fed7cbd-1a4a-4723-8c9a-1f5ca523dc36.png">


