### PR TITLE
[New Package] httpjson custom input

### DIFF
--- a/packages/httpjson/_dev/build/build.yml
+++ b/packages/httpjson/_dev/build/build.yml
@@ -1,0 +1,3 @@
+dependencies:
+  ecs:
+    reference: git@1.12

--- a/packages/httpjson/_dev/build/docs/README.md
+++ b/packages/httpjson/_dev/build/docs/README.md
@@ -8,7 +8,7 @@ The input itself supports sending both GET and POST requests, transform requests
 
 The extensive documentation for the input are currently available [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html).
 
-The most commonly used configuration options are available on the main integration page, while more advanced and customizable options currently resides under the "advanced options" part of the integration settings page.
+The most commonly used configuration options are available on the main integration page, while more advanced and customizable options currently resides under the "Advanced options" part of the integration settings page.
 
 Configuration is split into three main categories, Request, Response, and Cursor.
 

--- a/packages/httpjson/_dev/build/docs/README.md
+++ b/packages/httpjson/_dev/build/docs/README.md
@@ -10,7 +10,7 @@ The extensive documentation for the input are currently available [here](https:/
 
 The most commonly used configuration options are available on the main integration page, while more advanced and customizable options currently resides under the "advanced options" part of the integration settings page.
 
-Configuration is split into 3 main categories, Request, Response and Cursor.
+Configuration is split into three main categories, Request, Response, and Cursor.
 
 The request part of the configuration handles points like which URL endpoint to communicate with, the request body, specific transformations that have to happen before a request is sent out and some custom options like request proxy, timeout and similar options.
 

--- a/packages/httpjson/_dev/build/docs/README.md
+++ b/packages/httpjson/_dev/build/docs/README.md
@@ -1,19 +1,18 @@
 # Custom HTTPJSON input integration
 
-The custom HTTPJSON input integration is used to ingest data from custom RESTful API's that does
-not currently have an existing integration.
+The custom HTTPJSON input integration is used to ingest data from custom RESTful API's that do not currently have an existing integration.
 
 The input itself supports sending both GET and POST requests, transform requests and responses during runtime, paginate and keep a running state on information from the last collected events.
 
 ## Configuration
 
-The extensive documentation for the input is currently available [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html).
+The extensive documentation for the input are currently available [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html).
 
-The most commonly used configuration options is available on the main integration page, while more advanced and customizable options currently resides under the "advanced options" part of the integration settings page.
+The most commonly used configuration options are available on the main integration page, while more advanced and customizable options currently resides under the "advanced options" part of the integration settings page.
 
 Configuration is split into 3 main categories, Request, Response and Cursor.
 
-The request part of the configuration handles points like which URL endpoint to communicate with, the request body, specific transformations that has to happen before a request is sent out and some custom options like request proxy, timeout and similar options.
+The request part of the configuration handles points like which URL endpoint to communicate with, the request body, specific transformations that have to happen before a request is sent out and some custom options like request proxy, timeout and similar options.
 
 The response part of the configuration handles options like transformation, rate limiting, pagination, and splitting the response into different documents before it is sent to Elasticsearch.
 

--- a/packages/httpjson/_dev/build/docs/README.md
+++ b/packages/httpjson/_dev/build/docs/README.md
@@ -1,0 +1,21 @@
+# Custom HTTPJSON input integration
+
+The custom HTTPJSON input integration is used to ingest data from custom RESTful API's that does
+not currently have an existing integration.
+
+The input itself supports sending both GET and POST requests, transform requests and responses during runtime, paginate and keep a running state on information from the last collected events.
+
+## Configuration
+
+The extensive documentation for the input is currently available [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html).
+
+The most commonly used configuration options is available on the main integration page, while more advanced and customizable options currently resides under the "advanced options" part of the integration settings page.
+
+Configuration is split into 3 main categories, Request, Response and Cursor.
+
+The request part of the configuration handles points like which URL endpoint to communicate with, the request body, specific transformations that has to happen before a request is sent out and some custom options like request proxy, timeout and similar options.
+
+The response part of the configuration handles options like transformation, rate limiting, pagination, and splitting the response into different documents before it is sent to Elasticsearch.
+
+The cursor part of the configuration is used when there is a need to keep state between each of the API requests, for example if a timestamp is returned in the response, that should be used as a filter in the next request after that, the cursor is a place where this is stored.
+

--- a/packages/httpjson/_dev/deploy/docker/docker-compose.yml
+++ b/packages/httpjson/_dev/deploy/docker/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "2.3"
+services:
+  httpjson:
+    image: docker.elastic.co/observability/stream:v0.6.1
+    ports:
+      - 8080
+    volumes:
+      - ./files:/files:ro
+    environment:
+      PORT: 8080
+    command:
+      - http-server
+      - --addr=:8080
+      - --config=/files/config.yml

--- a/packages/httpjson/_dev/deploy/docker/files/config.yml
+++ b/packages/httpjson/_dev/deploy/docker/files/config.yml
@@ -1,0 +1,62 @@
+rules:
+  - path: /testtransforms/api
+    methods: ["POST"]
+    request_headers:
+      Authorization: "Basic dGVzdDp0ZXN0"
+    request_body: '{"message":{"limit":"1500"}}'
+    responses:
+      - status_code: 200
+        body: |-
+          {"message": "success"}
+  - path: /testpagination/api
+    methods: ["GET"]
+    query_params:
+      page: 2
+    request_headers:
+      Authorization: "Basic dGVzdDp0ZXN0"
+    responses:
+      - status_code: 200
+        body: |-
+          {"message": "success"}
+  - path: /testpagination/api
+    methods: ["GET"]
+    query_params:
+      page: 1
+    request_headers:
+      Authorization: "Basic dGVzdDp0ZXN0"
+    responses:
+      - status_code: 200
+        body: |-
+          {"message": "success", "page": 2}
+  - path: /testbasicauth/api
+    methods: ["GET"]
+    request_headers:
+      Authorization: "Basic dGVzdDp0ZXN0"
+    responses:
+      - status_code: 200
+        body: |-
+          {"message": "success"}
+  - path: /testoauth/token
+    methods: [POST]
+    query_params:
+      grant_type: client_credentials
+    request_headers:
+      Content-Type:
+        - application/x-www-form-urlencoded
+      Authorization:
+        - "Basic dGVzdDp0ZXN0"
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"access_token": "testaccess","token_type": "Bearer","expires_in": 172799,"refresh_token": "testrefresh"}
+  - path: /testoauth/api
+    methods: ["GET"]
+    request_headers:
+      Authorization: "Bearer testaccess"
+    responses:
+      - status_code: 200
+        body: |-
+          {"message": "success"}

--- a/packages/httpjson/changelog.yml
+++ b/packages/httpjson/changelog.yml
@@ -2,4 +2,4 @@
   changes:
     - description: Initial Implementation
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/2079
+      link: https://github.com/elastic/integrations/pull/2154

--- a/packages/httpjson/changelog.yml
+++ b/packages/httpjson/changelog.yml
@@ -1,0 +1,5 @@
+- version: "1.0.0"
+  changes:
+    - description: Initial Implementation
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/2079

--- a/packages/httpjson/data_stream/generic/_dev/test/system/test-basicauth-config.yml
+++ b/packages/httpjson/data_stream/generic/_dev/test/system/test-basicauth-config.yml
@@ -1,0 +1,8 @@
+input: httpjson
+service: httpjson
+data_stream:
+  vars:
+    data_stream.dataset: httpjson.generic
+    username: test
+    password: test
+    request_url: http://{{Hostname}}:{{Port}}/testbasicauth/api

--- a/packages/httpjson/data_stream/generic/_dev/test/system/test-oauth-config.yml
+++ b/packages/httpjson/data_stream/generic/_dev/test/system/test-oauth-config.yml
@@ -1,0 +1,9 @@
+input: httpjson
+service: httpjson
+data_stream:
+  vars:
+    data_stream.dataset: httpjson.generic
+    oauth_id: test
+    oauth_secret: test
+    oauth_token_url: http://{{Hostname}}:{{Port}}/testoauth/token
+    request_url: http://{{Hostname}}:{{Port}}/testoauth/api

--- a/packages/httpjson/data_stream/generic/_dev/test/system/test-pagination-config.yml
+++ b/packages/httpjson/data_stream/generic/_dev/test/system/test-pagination-config.yml
@@ -1,0 +1,13 @@
+input: httpjson
+service: httpjson
+data_stream:
+  vars:
+    data_stream.dataset: httpjson.generic
+    username: test
+    password: test
+    request_url: http://{{Hostname}}:{{Port}}/testpagination/api?page=1
+    response_pagination: |-
+      - set:
+          target: url.params.page
+          value: '[[.last_response.body.page]]'
+          fail_on_template_error: true

--- a/packages/httpjson/data_stream/generic/_dev/test/system/test-transforms-config.yml
+++ b/packages/httpjson/data_stream/generic/_dev/test/system/test-transforms-config.yml
@@ -1,0 +1,23 @@
+input: httpjson
+service: httpjson
+data_stream:
+  vars:
+    data_stream.dataset: httpjson.generic
+    username: test
+    password: test
+    request_url: http://{{Hostname}}:{{Port}}/testtransforms/api
+    request_method: POST
+    request_body:
+      message:
+        limit: 1000
+    request_transforms: |-
+      - set:
+          target: body.message.limit
+          value: 1500
+    response_transforms: |-
+      - set:
+          target: body.test
+          value: success
+    request_custom: |-
+      encode_as: application/json
+      timeout: 25s

--- a/packages/httpjson/data_stream/generic/agent/stream/httpjson.yml.hbs
+++ b/packages/httpjson/data_stream/generic/agent/stream/httpjson.yml.hbs
@@ -1,0 +1,74 @@
+data_stream:
+  dataset: {{data_stream.dataset}}
+interval: {{request_interval}}
+{{#unless oauth_id}}
+{{#if username}}
+auth.basic.user: {{username}}
+{{/if}}
+{{#if password}}
+auth.basic.password: {{password}}
+{{/if}}
+{{/unless}}
+
+{{#if oauth_id}}
+auth.oauth2:
+{{#if oauth_id}}
+  client.id: {{oauth_id}}
+{{/if}}
+{{#if oauth_secret}}
+  client.secret: {{oauth_secret}}
+{{/if}}
+{{#if oauth_token_url}}
+  token_url: {{oauth_token_url}}
+{{/if}}
+{{#if oauth_custom}}
+{{oauth_custom}}
+{{/if}}
+{{/if}}
+
+request:
+  url: {{request_url}}
+  method: {{request_method}}
+{{#if request_body}}
+  body: 
+    {{request_body}}
+{{/if}}
+{{#if request_transforms}}
+  transforms:
+    {{request_transforms}}
+{{/if}}
+{{#if request_ssl}}
+  ssl: 
+    {{ssl}}
+{{/if}}
+{{#if request_custom}}
+{{request_custom}}
+{{/if}}
+
+{{#if response_transforms}}
+response.transforms: 
+{{response_transforms}}
+{{/if}}
+{{#if response_split}}
+response.split: 
+{{response_split}}
+{{/if}}
+{{#if response_pagination}}
+response.pagination: {{response_pagination}}
+{{/if}}
+{{#if response_decode_as}}
+response.decode_as: {{response_decode_as}}
+{{/if}}
+{{#if response_request_body_on_pagination}}
+response.request_body_on_pagination: {{response_request_body_on_pagination}}
+{{/if}}
+
+{{#if cursor}}
+cursor:
+  {{cursor}}
+{{/if}}
+
+{{#if processors}}
+processors:
+  {{processors}}
+{{/if}}

--- a/packages/httpjson/data_stream/generic/agent/stream/httpjson.yml.hbs
+++ b/packages/httpjson/data_stream/generic/agent/stream/httpjson.yml.hbs
@@ -1,3 +1,4 @@
+config_version: 2
 data_stream:
   dataset: {{data_stream.dataset}}
 interval: {{request_interval}}

--- a/packages/httpjson/data_stream/generic/agent/stream/httpjson.yml.hbs
+++ b/packages/httpjson/data_stream/generic/agent/stream/httpjson.yml.hbs
@@ -10,7 +10,9 @@ auth.basic.user: {{username}}
 auth.basic.password: {{password}}
 {{/if}}
 {{/unless}}
-
+{{#if pipeline}}
+pipeline: {{pipeline}}
+{{/if}}
 {{#if oauth_id}}
 auth.oauth2:
 {{#if oauth_id}}
@@ -69,6 +71,15 @@ cursor:
   {{cursor}}
 {{/if}}
 
+{{#if tags}}
+tags:
+{{#each tags as |tag i|}}
+  - {{tag}}
+{{/each}}
+{{/if}}
+{{#contains "forwarded" tags}}
+publisher_pipeline.disable_host: true
+{{/contains}}
 {{#if processors}}
 processors:
   {{processors}}

--- a/packages/httpjson/data_stream/generic/fields/base-fields.yml
+++ b/packages/httpjson/data_stream/generic/fields/base-fields.yml
@@ -1,0 +1,20 @@
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: httpjson
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: httpjson.generic
+- name: "@timestamp"
+  type: date
+  description: Event timestamp.

--- a/packages/httpjson/data_stream/generic/fields/beats.yml
+++ b/packages/httpjson/data_stream/generic/fields/beats.yml
@@ -1,0 +1,6 @@
+- name: input.type
+  description: Type of Filebeat input.
+  type: keyword
+- name: tags
+  type: keyword
+  description: User defined tags

--- a/packages/httpjson/data_stream/generic/fields/ecs.yml
+++ b/packages/httpjson/data_stream/generic/fields/ecs.yml
@@ -1,0 +1,4 @@
+- name: ecs.version
+  external: ecs
+- name: message
+  external: ecs

--- a/packages/httpjson/data_stream/generic/manifest.yml
+++ b/packages/httpjson/data_stream/generic/manifest.yml
@@ -14,6 +14,13 @@ streams:
         default: httpjson.generic
         required: true
         show_user: true
+      - name: pipeline
+        type: text
+        title: Ingest Pipeline
+        description: |
+          The Ingest Node pipeline ID to be used by the integration.
+        required: false
+        show_user: true
       - name: request_url
         type: text
         title: Request URL
@@ -62,13 +69,13 @@ streams:
       - name: oauth_token_url
         type: text
         title: Oauth2 Token URL
-        description: The URL endpoint that will be used to generate the tokens during the oauth2 flow. It is required if no provider is specified.
+        description: The URL endpoint that will be used to generate the tokens during the oauth2 flow. It is required if no oauth_custom variable is set or provider is not specified in oauth_custom variable.
         show_user: true
         required: false
       - name: request_body
         type: yaml
         title: Request Body
-        description: An optional HTTP body if the request method is POST
+        description: An optional HTTP body if the request method is POST. All available options can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_body)
         show_user: true
         multi: false
         required: false
@@ -192,14 +199,7 @@ streams:
         type: text
         title: Response decode settings
         description: |
-          ContentType used for decoding the response body. Supported values: application/json, application/x-ndjson. It is not set by default.
-        show_user: false
-        required: false
-      - name: response_decode_as
-        type: text
-        title: Response decode settings
-        description: |
-          Override the decoder to be used, defaults to what is returned in Content-Type header. Supported values: application/json, application/x-ndjson. It is not set by default.
+          ContentType used for decoding the response body. Supported values: application/json, application/x-ndjson. By default it will use what is in the response Content-Type header.
         show_user: false
         required: false
       - name: response_request_body_on_pagination

--- a/packages/httpjson/data_stream/generic/manifest.yml
+++ b/packages/httpjson/data_stream/generic/manifest.yml
@@ -1,0 +1,228 @@
+title: Custom HTTPJSON Input
+type: logs
+streams:
+  - input: httpjson
+    description: Collect custom data from REST API's
+    template_path: httpjson.yml.hbs
+    title: Custom HTTPJSON Input
+    vars:
+      - name: data_stream.dataset
+        type: text
+        title: Dataset name
+        description: |
+          Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
+        default: httpjson.generic
+        required: true
+        show_user: true
+      - name: request_url
+        type: text
+        title: Request URL
+        description: i.e. scheme://host:port/path
+        show_user: true
+        required: true
+        default: https://server.example.com:8089/api
+      - name: request_interval
+        type: text
+        title: Request Interval
+        description: How often the API is polled, supports seconds, minutes and hours.
+        show_user: true
+        required: true
+        default: 1m
+      - name: request_method
+        type: text
+        title: Request HTTP Method
+        description: Supports either GET or POST
+        show_user: true
+        required: true
+        default: GET
+      - name: username
+        type: text
+        title: Basic Auth Username
+        show_user: true
+        required: false
+        description: The username to be used with Basic Auth headers
+      - name: password
+        type: password
+        title: Basic Auth Password
+        show_user: true
+        required: false
+        description: The password to be used with Basic Auth headers
+      - name: oauth_id
+        type: text
+        title: Oauth2 Client ID
+        description: Client ID used for Oauth2 authentication
+        show_user: true
+        required: false
+      - name: oauth_secret
+        type: password
+        title: Oauth2 Client Secret
+        description: Client secret used for Oauth2 authentication
+        show_user: true
+        required: false
+      - name: oauth_token_url
+        type: text
+        title: Oauth2 Token URL
+        description: The URL endpoint that will be used to generate the tokens during the oauth2 flow. It is required if no provider is specified.
+        show_user: true
+        required: false
+      - name: request_body
+        type: yaml
+        title: Request Body
+        description: An optional HTTP body if the request method is POST
+        show_user: true
+        multi: false
+        required: false
+        default: |
+          #query:
+          #  bool:
+          #    filter:
+          #      term:
+          #        type: authentication
+      - name: request_transforms
+        type: yaml
+        title: Request Transforms
+        description: Optional transformations to perform on the request before it is sent. All available options can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#request-transforms).
+        show_user: true
+        multi: false
+        required: false
+        default: |
+          #- set:
+          #    target: body.from
+          #    value: '[[now (parseDuration "-1h")]]'
+          #- set:
+          #    target: url.params.limit
+          #    value: 10
+      - name: response_transforms
+        type: yaml
+        title: Response Transforms
+        description: Optional transformations to perform on the response before it is sent to Elasticsearch. All available options can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#response-transforms).
+        show_user: true
+        multi: false
+        required: false
+        default: |
+          #- delete:
+          #    target: body.very_confidential
+      - name: response_split
+        type: yaml
+        title: Response Split
+        description: Optional transformations to perform on the response to split the response into separate documents before it is sent to Elasticsearch. All available options can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#response-split).
+        show_user: true
+        multi: false
+        required: false
+        default: |
+          #target: body.data
+          #keep_parent: true
+      - name: response_pagination
+        type: yaml
+        title: Response Pagination
+        description: Optional settings if pagination is required to retrieve all results. All available options can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#response-pagination).
+        show_user: true
+        multi: false
+        required: false
+        default: |
+          #- set:
+          #    target: url.value
+          #    value: http://localhost:9200/_search/scroll
+          #- set:
+          #    target: url.params.scroll_id
+          #    value: '[[.last_response.body._scroll_id]]'
+      - name: cursor
+        type: yaml
+        title: Custom request cursor
+        description: |
+          A cursor is used to keep state between each API request, and can be set to for example the value of something in the response body.
+          More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#cursor)
+        show_user: true
+        multi: false
+        required: false
+        default: |
+          #last_requested_at:
+          #  value: '[[now]]'
+      - name: request_ssl
+        type: yaml
+        title: Request SSL Configuration
+        description: i.e. certificate_authorities, supported_protocols, verification_mode etc, more examples found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config)
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #verification_mode: none
+      - name: request_custom
+        type: yaml
+        title: Request Custom settings
+        description: Optional Requests settings, comment out the ones to override, more information found in the httpjson [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_url)
+        show_user: false
+        multi: false
+        required: false
+        default: |
+          #encode_as: application/json
+          #timeout: 30s
+          #proxy_url: http[s]://<user>:<password>@<server name/ip>:<port>
+          #retry.max_attempts: 5
+          #retry.wait_min: 1s
+          #retry.wait_max: 60s
+          #redirect.forward_headers: false
+          #redirect.headers_ban_list: []
+          #redirect.max_redirects: 10
+          #rate_limit.limit: '[[ .last_response.header.Get "X-RateLimit-Limit" ]]'
+          #rate_limit.reset: '[[ .last_response.header.Get "X-RateLimit-Reset" ]]'
+          #rate_limit.remaining: '[[ .last_response.header.Get "X-RateLimit-Remaining" ]]'
+      - name: oauth_custom
+        type: yaml
+        title: Oauth2 Custom settings
+        description: Optional Oauth2 settings, comment out the ones to override, more information found in the httpjson [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_auth_oauth2_enabled)
+        show_user: false
+        multi: false
+        required: false
+        default: |
+          #provider: default
+          #scopes: []
+          #google.credentials_file: /path/to/file
+          #google.credentials_json: '{\"example\":\"credentials\"}'
+          #google.jwt_file: /path/to/jwt
+          #azure.tenant_id: ID
+          #azure.resource: https://api.windows.com/
+          #endpoint_params:
+          #  Param1:
+          #  - ValueA
+          #  - ValueB
+          #  Param2:
+          #    - Value
+      - name: response_decode_as
+        type: text
+        title: Response decode settings
+        description: |
+          ContentType used for decoding the response body. Supported values: application/json, application/x-ndjson. It is not set by default.
+        show_user: false
+        required: false
+      - name: response_decode_as
+        type: text
+        title: Response decode settings
+        description: |
+          Override the decoder to be used, defaults to what is returned in Content-Type header. Supported values: application/json, application/x-ndjson. It is not set by default.
+        show_user: false
+        required: false
+      - name: response_request_body_on_pagination
+        type: bool
+        title: Include request body on Pagination
+        description: |
+          If set to true, the values in request.body are sent with pagination requests.
+        show_user: false
+        multi: false
+        required: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
+      - name: tags
+        type: text
+        title: Tags
+        multi: true
+        show_user: false
+        default:
+          - forwarded

--- a/packages/httpjson/data_stream/generic/sample_event.json
+++ b/packages/httpjson/data_stream/generic/sample_event.json
@@ -1,11 +1,12 @@
 {
-    "@timestamp": "2021-11-11T15:54:37.484Z",
+    "@timestamp": "2021-11-11T20:33:49.979Z",
     "agent": {
-        "ephemeral_id": "1736ba5e-065b-4a1b-a569-622b6d406c61",
-        "id": "a356943e-88d1-4212-805f-53a01ce37665",
+        "ephemeral_id": "2132e155-b535-44f4-a5ba-a8776a544cfd",
+        "hostname": "docker-fleet-agent",
+        "id": "9f7d558c-23d9-4d78-8e85-ff0649586d7f",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0"
+        "version": "7.16.0"
     },
     "data_stream": {
         "dataset": "httpjson.generic",
@@ -13,29 +14,29 @@
         "type": "logs"
     },
     "ecs": {
-        "version": "1.12.0"
+        "version": "1.11.0"
     },
     "elastic_agent": {
-        "id": "a356943e-88d1-4212-805f-53a01ce37665",
+        "id": "9f7d558c-23d9-4d78-8e85-ff0649586d7f",
         "snapshot": true,
-        "version": "8.0.0"
+        "version": "7.16.0"
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2021-11-11T15:54:37.484Z",
+        "created": "2021-11-11T20:33:49.979Z",
         "dataset": "httpjson.generic",
-        "ingested": "2021-11-11T15:54:38Z"
+        "ingested": "2021-11-11T20:33:50Z"
     },
     "host": {
         "architecture": "x86_64",
         "containerized": true,
         "hostname": "docker-fleet-agent",
-        "id": "93993efdcc535a914679e68b8b60bd71",
+        "id": "b7d928c66a441dff2fa2fb14971411df",
         "ip": [
-            "172.28.0.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02:42:ac:1c:00:07"
+            "02:42:c0:a8:30:07"
         ],
         "name": "docker-fleet-agent",
         "os": {

--- a/packages/httpjson/data_stream/generic/sample_event.json
+++ b/packages/httpjson/data_stream/generic/sample_event.json
@@ -1,0 +1,55 @@
+{
+    "@timestamp": "2021-11-11T15:54:37.484Z",
+    "agent": {
+        "ephemeral_id": "1736ba5e-065b-4a1b-a569-622b6d406c61",
+        "id": "a356943e-88d1-4212-805f-53a01ce37665",
+        "name": "docker-fleet-agent",
+        "type": "filebeat",
+        "version": "8.0.0"
+    },
+    "data_stream": {
+        "dataset": "httpjson.generic",
+        "namespace": "ep",
+        "type": "logs"
+    },
+    "ecs": {
+        "version": "1.12.0"
+    },
+    "elastic_agent": {
+        "id": "a356943e-88d1-4212-805f-53a01ce37665",
+        "snapshot": true,
+        "version": "8.0.0"
+    },
+    "event": {
+        "agent_id_status": "verified",
+        "created": "2021-11-11T15:54:37.484Z",
+        "dataset": "httpjson.generic",
+        "ingested": "2021-11-11T15:54:38Z"
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": true,
+        "hostname": "docker-fleet-agent",
+        "id": "93993efdcc535a914679e68b8b60bd71",
+        "ip": [
+            "172.28.0.7"
+        ],
+        "mac": [
+            "02:42:ac:1c:00:07"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+            "codename": "Core",
+            "family": "redhat",
+            "kernel": "5.10.60.1-microsoft-standard-WSL2",
+            "name": "CentOS Linux",
+            "platform": "centos",
+            "type": "linux",
+            "version": "7 (Core)"
+        }
+    },
+    "input": {
+        "type": "httpjson"
+    },
+    "message": "{\"message\":\"success\",\"page\":2}"
+}

--- a/packages/httpjson/docs/README.md
+++ b/packages/httpjson/docs/README.md
@@ -8,9 +8,9 @@ The input itself supports sending both GET and POST requests, transform requests
 
 The extensive documentation for the input are currently available [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html).
 
-The most commonly used configuration options are available on the main integration page, while more advanced and customizable options currently resides under the "advanced options" part of the integration settings page.
+The most commonly used configuration options are available on the main integration page, while more advanced and customizable options currently resides under the "Advanced options" part of the integration settings page.
 
-Configuration is split into 3 main categories, Request, Response and Cursor.
+Configuration is split into three main categories, Request, Response, and Cursor.
 
 The request part of the configuration handles points like which URL endpoint to communicate with, the request body, specific transformations that have to happen before a request is sent out and some custom options like request proxy, timeout and similar options.
 

--- a/packages/httpjson/docs/README.md
+++ b/packages/httpjson/docs/README.md
@@ -1,19 +1,18 @@
 # Custom HTTPJSON input integration
 
-The custom HTTPJSON input integration is used to ingest data from custom RESTful API's that does
-not currently have an existing integration.
+The custom HTTPJSON input integration is used to ingest data from custom RESTful API's that do not currently have an existing integration.
 
 The input itself supports sending both GET and POST requests, transform requests and responses during runtime, paginate and keep a running state on information from the last collected events.
 
 ## Configuration
 
-The extensive documentation for the input is currently available [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html).
+The extensive documentation for the input are currently available [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html).
 
-The most commonly used configuration options is available on the main integration page, while more advanced and customizable options currently resides under the "advanced options" part of the integration settings page.
+The most commonly used configuration options are available on the main integration page, while more advanced and customizable options currently resides under the "advanced options" part of the integration settings page.
 
 Configuration is split into 3 main categories, Request, Response and Cursor.
 
-The request part of the configuration handles points like which URL endpoint to communicate with, the request body, specific transformations that has to happen before a request is sent out and some custom options like request proxy, timeout and similar options.
+The request part of the configuration handles points like which URL endpoint to communicate with, the request body, specific transformations that have to happen before a request is sent out and some custom options like request proxy, timeout and similar options.
 
 The response part of the configuration handles options like transformation, rate limiting, pagination, and splitting the response into different documents before it is sent to Elasticsearch.
 

--- a/packages/httpjson/docs/README.md
+++ b/packages/httpjson/docs/README.md
@@ -1,0 +1,21 @@
+# Custom HTTPJSON input integration
+
+The custom HTTPJSON input integration is used to ingest data from custom RESTful API's that does
+not currently have an existing integration.
+
+The input itself supports sending both GET and POST requests, transform requests and responses during runtime, paginate and keep a running state on information from the last collected events.
+
+## Configuration
+
+The extensive documentation for the input is currently available [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html).
+
+The most commonly used configuration options is available on the main integration page, while more advanced and customizable options currently resides under the "advanced options" part of the integration settings page.
+
+Configuration is split into 3 main categories, Request, Response and Cursor.
+
+The request part of the configuration handles points like which URL endpoint to communicate with, the request body, specific transformations that has to happen before a request is sent out and some custom options like request proxy, timeout and similar options.
+
+The response part of the configuration handles options like transformation, rate limiting, pagination, and splitting the response into different documents before it is sent to Elasticsearch.
+
+The cursor part of the configuration is used when there is a need to keep state between each of the API requests, for example if a timestamp is returned in the response, that should be used as a filter in the next request after that, the cursor is a place where this is stored.
+

--- a/packages/httpjson/manifest.yml
+++ b/packages/httpjson/manifest.yml
@@ -6,7 +6,7 @@ type: integration
 version: 1.0.0
 release: ga
 conditions:
-  kibana.version: "^7.16.0"
+  kibana.version: "^7.16.0 || ^8.0.0"
 license: basic
 categories:
   - custom

--- a/packages/httpjson/manifest.yml
+++ b/packages/httpjson/manifest.yml
@@ -6,7 +6,7 @@ type: integration
 version: 1.0.0
 release: ga
 conditions:
-  kibana.version: "^8.0.0"
+  kibana.version: "^7.16.0"
 license: basic
 categories:
   - custom

--- a/packages/httpjson/manifest.yml
+++ b/packages/httpjson/manifest.yml
@@ -1,0 +1,22 @@
+format_version: 1.0.0
+name: httpjson
+title: Custom HTTPJSON Input
+description: Collect custom data from REST API's with Elastic Agent.
+type: integration
+version: 1.0.0
+release: ga
+conditions:
+  kibana.version: "^8.0.0"
+license: basic
+categories:
+  - custom
+policy_templates:
+  - name: generic
+    title: Custom HTTPJSON Input
+    description: Collect custom data from REST API's
+    inputs:
+      - type: httpjson
+        title: Collect custom data from REST API's
+        description: Collect custom data from REST API's
+owner:
+  github: elastic/security-external-integrations


### PR DESCRIPTION
## What does this PR do?

This PR adds a package to utilize the httpjson input with custom integration, similar to winlog and log packages.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

