### PR TITLE
Release IIS for Kibana 8

### DIFF
--- a/packages/iis/changelog.yml
+++ b/packages/iis/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.8.0"
+  changes:
+    - description: Support Kibana 8.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/2173
 - version: "0.7.2"
   changes:
     - description: Uniform with guidelines

--- a/packages/iis/changelog.yml
+++ b/packages/iis/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Support Kibana 8.0
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/2173
+      link: https://github.com/elastic/integrations/pull/2178
 - version: "0.7.2"
   changes:
     - description: Uniform with guidelines

--- a/packages/iis/manifest.yml
+++ b/packages/iis/manifest.yml
@@ -1,6 +1,6 @@
 name: iis
 title: IIS
-version: 0.7.2
+version: 0.8.0
 description: Collect logs and metrics from Internet Information Services (IIS) servers with Elastic Agent.
 type: integration
 icons:
@@ -14,7 +14,7 @@ categories:
   - web
 release: beta
 conditions:
-  kibana.version: "^7.14.0"
+  kibana.version: "^7.14.0 || ^8.0.0"
 screenshots:
   - src: /img/kibana-iis.png
     title: kibana iis


### PR DESCRIPTION
## What does this PR do?

Release IIS for Kibana 8
No breaking changes for 8.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- https://github.com/elastic/elastic-package/pull/571
