### PR TITLE
Release Windows for Kibana 8

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Support Kibana 8.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/2173
 - version: "1.4.0"
   changes:
     - description: Don't split hyphenated tokens for PowerShell scripts

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Support Kibana 8.0
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/2173
+      link: https://github.com/elastic/integrations/pull/2179
 - version: "1.4.0"
   changes:
     - description: Don't split hyphenated tokens for PowerShell scripts

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.4.0
+version: 1.5.0
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:
@@ -15,7 +15,7 @@ format_version: 1.0.0
 license: basic
 release: ga
 conditions:
-  kibana.version: '^7.14.0'
+  kibana.version: "^7.14.0 || ^8.0.0"
 screenshots:
   - src: /img/metricbeat-windows-service.png
     title: metricbeat windows service


### PR DESCRIPTION
## What does this PR do?

Release Windows for Kibana 8
The breaking changes should not affect current configuration 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- https://github.com/elastic/elastic-package/pull/571
