### PR TITLE
[ML] Fix Apache ML module manifest query to ignore frozen and cold tiers

### DIFF
--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.2"
+  changes:
+    - description: Fix ML module manifest queries to ignore frozen and cold tiers
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull
 - version: "1.3.1"
   changes:
     - description: Fix parsing of trace log levels

--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "1.3.2"
   changes:
-    - description: Fix ML module manifest queries to ignore frozen and cold tiers
+    - description: Fix ML module manifest query to ignore frozen and cold tiers
       type: bugfix
-      link: https://github.com/elastic/integrations/pull
+      link: https://github.com/elastic/integrations/pull/2217
 - version: "1.3.1"
   changes:
     - description: Fix parsing of trace log levels

--- a/packages/apache/kibana/ml_module/apache-Logs-ml.json
+++ b/packages/apache/kibana/ml_module/apache-Logs-ml.json
@@ -31,7 +31,15 @@
                             "field": "http.response.status_code"
                         }
                     }
-                ]
+                ],
+                "must_not": {
+                    "terms": {
+                        "_tier": [
+                            "data_frozen",
+                            "data_cold"
+                        ]
+                    }
+                }
             }
         },
         "jobs": [

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: apache
 title: Apache HTTP Server
-version: 1.3.1
+version: 1.3.2
 license: basic
 description: Collect logs and metrics from Apache servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

The query defined in the json configuration files of anomaly detection modules are run to determine if the module is match for data in the selected index. These queries run over the full time range of the index so can potentially take a long time to return, particularly if searching over documents which are not in the hot or warm data tiers. This PR adds an extra condition to the query to ignore data from the cold and frozen tiers.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Related issues

https://github.com/elastic/kibana/issues/116696

