### PR TITLE
Update checkbox in template for version constraint guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@ Explain here the changes you made on the PR.
 - [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
 - [ ] I have verified that all data streams collect metrics or logs.
 - [ ] I have added an entry to my package's `changelog.yml` file.
-- [ ] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).
+- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
 
 ## Author's Checklist
 


### PR DESCRIPTION
Current checkbox seems to recommend release of new features only for
current or next versions of the stack, what seems to indicate the
preference of in-band releases, when current preference is out-of-band
releases.

Relax the recommendation in the checkbox, with a reference to existing
guidelines.