### PR TITLE
[microsoft_dhcp] Add more event.action and event.outcome values

### DIFF
--- a/packages/microsoft_dhcp/changelog.yml
+++ b/packages/microsoft_dhcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Add more event.action and event.outcome values
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/2296
 - version: "1.0.0"
   changes:
     - description: GA integration

--- a/packages/microsoft_dhcp/data_stream/log/_dev/test/pipeline/test-log.log-expected.json
+++ b/packages/microsoft_dhcp/data_stream/log/_dev/test/pipeline/test-log.log-expected.json
@@ -6,7 +6,6 @@
                 "version": "1.12.0"
             },
             "event": {
-                "ingested": "2021-12-09T13:41:22.171223700Z",
                 "original": "01,04/19/20,13:11:13,Stopped,,,",
                 "code": "01",
                 "kind": "event",
@@ -31,7 +30,6 @@
                 "version": "1.12.0"
             },
             "event": {
-                "ingested": "2021-12-09T13:41:22.171228300Z",
                 "original": "00,04/19/20,12:43:06,Started,,,",
                 "code": "00",
                 "kind": "event",
@@ -60,11 +58,11 @@
                 "domain": "057182593757.test.com"
             },
             "event": {
-                "ingested": "2021-12-09T13:41:22.171233100Z",
                 "original": "30,09/20/21,09:16:15,DNS Update Request,172.28.43.169,057182593757.test.com,,,0,6,,,,,,,,,0",
                 "code": "30",
                 "kind": "event",
                 "timezone": "America/New_York",
+                "action": "dhcp-dns-update",
                 "category": [
                     "network"
                 ],
@@ -95,11 +93,11 @@
                 "domain": "1-07.test.com"
             },
             "event": {
-                "ingested": "2021-12-09T13:41:22.171238100Z",
                 "original": "30,09/20/21,09:16:09,DNS Update Request,172.28.53.173,1-07.test.com,,,0,6,,,,,,,,,0",
                 "code": "30",
                 "kind": "event",
                 "timezone": "America/New_York",
+                "action": "dhcp-dns-update",
                 "category": [
                     "network"
                 ],
@@ -130,11 +128,11 @@
                 "domain": "3-07.test.com"
             },
             "event": {
-                "ingested": "2021-12-09T13:41:22.171242700Z",
                 "original": "32,09/20/21,09:16:03,DNS Update Successful,172.28.53.36,3-07.test.com,,,0,6,,,,,,,,,0",
                 "code": "32",
                 "kind": "event",
                 "timezone": "America/New_York",
+                "action": "dhcp-dns-update",
                 "category": [
                     "network"
                 ],
@@ -165,7 +163,6 @@
                 "ip": "172.28.52.0"
             },
             "event": {
-                "ingested": "2021-12-09T13:41:22.171249400Z",
                 "original": "36,09/20/21,09:18:01,Packet dropped because of Client ID hash mismatch or standby server.,172.28.52.0,,76691ED45C90,,0,6,,,,,,,,,0",
                 "code": "36",
                 "kind": "event",
@@ -174,9 +171,10 @@
                     "network"
                 ],
                 "type": [
-                    "connection"
+                    "connection",
+                    "denied"
                 ],
-                "outcome": "success"
+                "outcome": "failure"
             },
             "message": "Packet dropped because of Client ID hash mismatch or standby server.",
             "microsoft": {
@@ -200,18 +198,18 @@
                 "domain": "035856103966.test.com"
             },
             "event": {
-                "ingested": "2021-12-09T13:41:22.171254600Z",
                 "original": "31,09/20/21,09:18:00,DNS Update Failed,172.28.43.159,035856103966.test.com,,,0,6,,,,,,,,,10054",
                 "code": "31",
                 "kind": "event",
                 "timezone": "America/New_York",
+                "action": "dhcp-dns-update",
                 "category": [
                     "network"
                 ],
                 "type": [
                     "connection"
                 ],
-                "outcome": "success"
+                "outcome": "failure"
             },
             "message": "DNS Update Failed",
             "microsoft": {
@@ -235,18 +233,18 @@
                 "domain": "001100581357.test.com"
             },
             "event": {
-                "ingested": "2021-12-09T13:41:22.171260Z",
                 "original": "31,09/20/21,09:18:01,DNS Update Failed,172.28.40.35,001100581357.test.com,,,0,6,,,,,,,,,10054",
                 "code": "31",
                 "kind": "event",
                 "timezone": "America/New_York",
+                "action": "dhcp-dns-update",
                 "category": [
                     "network"
                 ],
                 "type": [
                     "connection"
                 ],
-                "outcome": "success"
+                "outcome": "failure"
             },
             "message": "DNS Update Failed",
             "microsoft": {
@@ -271,18 +269,19 @@
                 "domain": "host.test.com"
             },
             "event": {
-                "ingested": "2021-12-09T13:41:22.171266400Z",
                 "original": "35,01/01/01,01:01:01,DNS update request failed,192.168.2.1,host.test.com,000000000000,",
                 "code": "35",
                 "kind": "event",
                 "timezone": "America/New_York",
+                "action": "dhcp-dns-update",
                 "category": [
                     "network"
                 ],
                 "type": [
-                    "connection"
+                    "connection",
+                    "denied"
                 ],
-                "outcome": "success"
+                "outcome": "failure"
             },
             "message": "DNS update request failed",
             "tags": [
@@ -300,7 +299,6 @@
                 "domain": "host.test.com"
             },
             "event": {
-                "ingested": "2021-12-09T13:41:22.171271800Z",
                 "original": "10,01/01/01,01:01:01,Assign,192.168.2.10,host.test.com,000000000000,,17739,0,,,",
                 "code": "10",
                 "kind": "event",
@@ -310,7 +308,8 @@
                     "network"
                 ],
                 "type": [
-                    "connection"
+                    "connection",
+                    "allowed"
                 ],
                 "outcome": "success"
             },
@@ -336,7 +335,6 @@
                 "domain": "host.test.com"
             },
             "event": {
-                "ingested": "2021-12-09T13:41:22.171277Z",
                 "original": "10,01/01/01,01:01:01,Assign,192.168.2.20,host.test.com,000000000000,,3096562285,0,,,,0x4D53465420352E30,MSFT 5.0,,,,0",
                 "code": "10",
                 "kind": "event",
@@ -346,7 +344,8 @@
                     "network"
                 ],
                 "type": [
-                    "connection"
+                    "connection",
+                    "allowed"
                 ],
                 "outcome": "success"
             },
@@ -372,11 +371,11 @@
                 "version": "1.12.0"
             },
             "event": {
-                "ingested": "2021-12-09T13:41:22.171281100Z",
                 "original": "24,11/20/20,00:00:05,Database Cleanup Begin,,,,,0,6,,,,,,,,,0",
                 "code": "24",
                 "kind": "event",
                 "timezone": "America/New_York",
+                "action": "ip-cleanup-start",
                 "category": [
                     "network"
                 ],
@@ -407,11 +406,11 @@
                 "domain": "hostname.test.com"
             },
             "event": {
-                "ingested": "2021-12-09T13:41:22.171285200Z",
                 "original": "30,11/20/20,00:00:05,DNS Update Request,10.10.10.10,hostname.test.com,,,0,6,,,,,,,,,0",
                 "code": "30",
                 "kind": "event",
                 "timezone": "America/New_York",
+                "action": "dhcp-dns-update",
                 "category": [
                     "network"
                 ],
@@ -438,11 +437,11 @@
                 "version": "1.12.0"
             },
             "event": {
-                "ingested": "2021-12-09T13:41:22.171289600Z",
                 "original": "17,11/20/20,00:00:05,DNS record not deleted67.43.156.15,,,,0,6,,,,,,,,,0",
                 "code": "17",
                 "kind": "event",
                 "timezone": "America/New_York",
+                "action": "dhcp-expire",
                 "category": [
                     "network"
                 ],
@@ -474,11 +473,11 @@
                 "domain": "domain.local"
             },
             "event": {
-                "ingested": "2021-12-09T13:41:22.171294600Z",
                 "original": "55,04/19/20,12:43:54,Authorized(servicing),,domain.local,",
                 "code": "55",
                 "kind": "event",
                 "timezone": "America/New_York",
+                "action": "rogue-server-detection",
                 "category": [
                     "network"
                 ],
@@ -501,11 +500,11 @@
                 "domain": "domain.local"
             },
             "event": {
-                "ingested": "2021-12-09T13:41:22.171299500Z",
                 "original": "60,04/19/20,12:43:21,No DC is DS Enabled,,domain.local,",
                 "code": "60",
                 "kind": "event",
                 "timezone": "America/New_York",
+                "action": "rogue-server-detection",
                 "category": [
                     "network",
                     "authentication"
@@ -527,11 +526,11 @@
                 "version": "1.12.0"
             },
             "event": {
-                "ingested": "2021-12-09T13:41:22.171305200Z",
                 "original": "63,04/19/20,12:43:28,Restarting rogue detection,,,",
                 "code": "63",
                 "kind": "event",
                 "timezone": "America/New_York",
+                "action": "rogue-server-detection",
                 "category": [
                     "network",
                     "authentication"

--- a/packages/microsoft_dhcp/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft_dhcp/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -82,6 +82,34 @@ processors:
       field: event.action
       value: dhcp-release
       if: "ctx.event?.code == '12'"
+  - set:
+      field: event.action
+      value: dhcp-deny
+      if: "ctx.event?.code == '15'"
+  - set:
+      field: event.action
+      value: dhcp-delete
+      if: "ctx.event?.code == '16'"
+  - set:
+      field: event.action
+      value: dhcp-expire
+      if: "['17', '18'].contains(ctx.event?.code)"
+  - set:
+      field: event.action
+      value: ip-cleanup-start
+      if: "ctx.event?.code == '24'"
+  - set:
+      field: event.action
+      value: ip-cleanup-end
+      if: "ctx.event?.code == '25'"
+  - set:
+      field: event.action
+      value: dhcp-dns-update
+      if: "['30', '31', '32', '34', '35'].contains(ctx.event?.code)"
+  - set:
+      field: event.action
+      value: rogue-server-detection
+      if: "ctx._tmp_?.code > 50"
   - append:
       field: event.category
       value: network
@@ -96,15 +124,19 @@ processors:
       field: event.type
       value: user
       if: "ctx._tmp_?.code >= 50 && ctx._tmp_?.code >= 60"
-  # Related error codes according to documentation
   - append:
       field: event.type
-      value: error
-      if: "['50', '54', '56', '59', '64'].contains(ctx.checkpoint?.rule_action)"
+      value: allowed
+      if: "['10', '11', '12', '20', '21'].contains(ctx.event?.code)"
+  - append:
+      field: event.type
+      value: denied
+      if: "['14', '15', '22', '35', '36'].contains(ctx.event?.code)"
+  # Related error codes according to documentation
   - set:
       field: event.outcome
       value: failure
-      if: "['50', '54', '56', '59', '64'].contains(ctx.checkpoint?.rule_action)"
+      if: "['02', '15', '22', '31', '33', '34', '35', '36'].contains(ctx.event?.code)"
   - set:
       field: event.outcome
       value: success

--- a/packages/microsoft_dhcp/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft_dhcp/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -3,9 +3,6 @@
 description: Pipeline for processing Microsoft DHCP logs.
 processors:
   - set:
-      field: event.ingested
-      value: "{{ _ingest.timestamp }}"
-  - set:
       field: ecs.version
       value: "1.12.0"
   - set:

--- a/packages/microsoft_dhcp/manifest.yml
+++ b/packages/microsoft_dhcp/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_dhcp
 title: Microsoft DHCP
-version: 1.0.0
+version: 1.1.0
 license: basic
 description: Collect logs from Microsoft DHCP with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

This PR adds more MS DHCP action types and uses those codes to determine failure outcomes.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

https://github.com/elastic/beats/issues/29221

