### PR TITLE
[aws] Add max_number_of_messages to AWS integration config

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.0"
+  changes:
+    - description: Add max_number_of_messages config option to AWS S3 input config.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/2299
 - version: "1.5.1"
   changes:
     - description: Add missing sample events

--- a/packages/aws/data_stream/cloudtrail/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/cloudtrail/agent/stream/aws-s3.yml.hbs
@@ -24,6 +24,9 @@ visibility_timeout: {{visibility_timeout}}
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+{{#if max_number_of_messages}}
+max_number_of_messages: {{max_number_of_messages}}
+{{/if}}
 {{#if endpoint}}
 endpoint: {{endpoint}}
 {{/if}}

--- a/packages/aws/data_stream/cloudtrail/manifest.yml
+++ b/packages/aws/data_stream/cloudtrail/manifest.yml
@@ -87,6 +87,13 @@ streams:
         description: |
           Regex to match path of CloudTrail Insight S3 Objects.  If
           blank CloudTrail Insight logs will be skipped.
+      - name: max_number_of_messages
+        type: integer
+        title: Maximum Concurrent SQS Messages
+        description: The maximum number of SQS messages that can be inflight at any time.
+        default: 5
+        required: false
+        show_user: false
   - input: httpjson
     title: AWS CloudTrail Logs via Splunk Enterprise REST API
     description: Collect AWS CloudTrail logs via Splunk Enterprise REST API

--- a/packages/aws/data_stream/cloudwatch_logs/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/cloudwatch_logs/agent/stream/aws-s3.yml.hbs
@@ -11,6 +11,9 @@ visibility_timeout: {{visibility_timeout}}
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+{{#if max_number_of_messages}}
+max_number_of_messages: {{max_number_of_messages}}
+{{/if}}
 {{#if endpoint}}
 endpoint: {{endpoint}}
 {{/if}}

--- a/packages/aws/data_stream/cloudwatch_logs/manifest.yml
+++ b/packages/aws/data_stream/cloudwatch_logs/manifest.yml
@@ -61,3 +61,10 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: max_number_of_messages
+        type: integer
+        title: Maximum Concurrent SQS Messages
+        description: The maximum number of SQS messages that can be inflight at any time.
+        default: 5
+        required: false
+        show_user: false

--- a/packages/aws/data_stream/ec2_logs/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/ec2_logs/agent/stream/aws-s3.yml.hbs
@@ -11,6 +11,9 @@ visibility_timeout: {{visibility_timeout}}
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+{{#if max_number_of_messages}}
+max_number_of_messages: {{max_number_of_messages}}
+{{/if}}
 {{#if endpoint}}
 endpoint: {{endpoint}}
 {{/if}}

--- a/packages/aws/data_stream/ec2_logs/manifest.yml
+++ b/packages/aws/data_stream/ec2_logs/manifest.yml
@@ -61,3 +61,10 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: max_number_of_messages
+        type: integer
+        title: Maximum Concurrent SQS Messages
+        description: The maximum number of SQS messages that can be inflight at any time.
+        default: 5
+        required: false
+        show_user: false

--- a/packages/aws/data_stream/elb_logs/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/elb_logs/agent/stream/aws-s3.yml.hbs
@@ -11,6 +11,9 @@ visibility_timeout: {{visibility_timeout}}
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+{{#if max_number_of_messages}}
+max_number_of_messages: {{max_number_of_messages}}
+{{/if}}
 {{#if endpoint}}
 endpoint: {{endpoint}}
 {{/if}}

--- a/packages/aws/data_stream/elb_logs/manifest.yml
+++ b/packages/aws/data_stream/elb_logs/manifest.yml
@@ -61,3 +61,10 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: max_number_of_messages
+        type: integer
+        title: Maximum Concurrent SQS Messages
+        description: The maximum number of SQS messages that can be inflight at any time.
+        default: 5
+        required: false
+        show_user: false

--- a/packages/aws/data_stream/s3access/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/s3access/agent/stream/aws-s3.yml.hbs
@@ -11,6 +11,9 @@ visibility_timeout: {{visibility_timeout}}
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+{{#if max_number_of_messages}}
+max_number_of_messages: {{max_number_of_messages}}
+{{/if}}
 {{#if endpoint}}
 endpoint: {{endpoint}}
 {{/if}}

--- a/packages/aws/data_stream/s3access/manifest.yml
+++ b/packages/aws/data_stream/s3access/manifest.yml
@@ -61,3 +61,10 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: max_number_of_messages
+        type: integer
+        title: Maximum Concurrent SQS Messages
+        description: The maximum number of SQS messages that can be inflight at any time.
+        default: 5
+        required: false
+        show_user: false

--- a/packages/aws/data_stream/vpcflow/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/vpcflow/agent/stream/aws-s3.yml.hbs
@@ -11,6 +11,9 @@ visibility_timeout: {{visibility_timeout}}
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+{{#if max_number_of_messages}}
+max_number_of_messages: {{max_number_of_messages}}
+{{/if}}
 {{#if endpoint}}
 endpoint: {{endpoint}}
 {{/if}}

--- a/packages/aws/data_stream/vpcflow/manifest.yml
+++ b/packages/aws/data_stream/vpcflow/manifest.yml
@@ -61,3 +61,10 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: max_number_of_messages
+        type: integer
+        title: Maximum Concurrent SQS Messages
+        description: The maximum number of SQS messages that can be inflight at any time.
+        default: 5
+        required: false
+        show_user: false

--- a/packages/aws/data_stream/waf/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/waf/agent/stream/aws-s3.yml.hbs
@@ -12,6 +12,9 @@ visibility_timeout: {{visibility_timeout}}
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+{{#if max_number_of_messages}}
+max_number_of_messages: {{max_number_of_messages}}
+{{/if}}
 {{#if endpoint}}
 endpoint: {{endpoint}}
 {{/if}}

--- a/packages/aws/data_stream/waf/manifest.yml
+++ b/packages/aws/data_stream/waf/manifest.yml
@@ -61,3 +61,10 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: max_number_of_messages
+        type: integer
+        title: Maximum Concurrent SQS Messages
+        description: The maximum number of SQS messages that can be inflight at any time.
+        default: 5
+        required: false
+        show_user: false

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.5.1
+version: 1.6.0
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Give users the ability to set max_number_of_messages for the aws-s3 input.

https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#_max_number_of_messages

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes #2298

## Screenshots

<img width="377" alt="Screen Shot 2021-12-01 at 5 12 17 PM" src="https://user-images.githubusercontent.com/4565752/144322565-8e728c77-acf6-4d79-a609-3fa39616c2e7.png">
