### PR TITLE
[Synthetics] add index optimizations

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,10 @@
 # newer versions go on top
+- version: "0.8.0"
+  changes:
+    - description: Add index optimizations
+      type: enhancement
+      link: |
+        https://github.com/elastic/integrations/pull/2319
 - version: "0.7.0"
   changes:
     - description: Add heartbeat enabled key

--- a/packages/synthetics/data_stream/browser/fields/ecs.yml
+++ b/packages/synthetics/data_stream/browser/fields/ecs.yml
@@ -1122,6 +1122,8 @@
           type: text
           norms: false
           default_field: false
+        - name: keyword
+          type: keyword
       description: If full URLs are important to your use case, they should be stored in `url.full`, whether this field is reconstructed or present in the event source.
       example: https://www.elastic.co:443/search?q=elasticsearch#top
     - name: original

--- a/packages/synthetics/data_stream/browser/manifest.yml
+++ b/packages/synthetics/data_stream/browser/manifest.yml
@@ -9,11 +9,11 @@ elasticsearch:
     settings:
       index:
         codec: best_compression
-        sort.field: 
-        - "url.full"
-        - "http.request.url"
-        - "http.response.headers.etag"
-        - "monitor.id"
+        sort.field:
+          - "url.full"
+          - "http.request.url"
+          - "http.response.headers.etag"
+          - "monitor.id"
 streams:
   - input: synthetics/browser
     title: Synthetic monitor check

--- a/packages/synthetics/data_stream/browser/manifest.yml
+++ b/packages/synthetics/data_stream/browser/manifest.yml
@@ -2,6 +2,18 @@ type: synthetics
 title: synthetic monitor check
 release: beta
 dataset: browser
+elasticsearch:
+  index_template:
+    mappings:
+      dynamic: false
+    settings:
+      index:
+        codec: best_compression
+        sort.field: 
+        - "url.full"
+        - "http.request.url"
+        - "http.response.headers.etag"
+        - "monitor.id"
 streams:
   - input: synthetics/browser
     title: Synthetic monitor check

--- a/packages/synthetics/data_stream/browser/manifest.yml
+++ b/packages/synthetics/data_stream/browser/manifest.yml
@@ -10,9 +10,6 @@ elasticsearch:
       index:
         codec: best_compression
         sort.field:
-          - "url.full"
-          - "http.request.url"
-          - "http.response.headers.etag"
           - "monitor.id"
 streams:
   - input: synthetics/browser

--- a/packages/synthetics/data_stream/browser/manifest.yml
+++ b/packages/synthetics/data_stream/browser/manifest.yml
@@ -10,6 +10,7 @@ elasticsearch:
       index:
         codec: best_compression
         sort.field:
+          - "url.full.keyword"
           - "monitor.id"
 streams:
   - input: synthetics/browser

--- a/packages/synthetics/data_stream/browser_network/fields/ecs.yml
+++ b/packages/synthetics/data_stream/browser_network/fields/ecs.yml
@@ -1122,6 +1122,8 @@
           type: text
           norms: false
           default_field: false
+        - name: keyword
+          type: keyword
       description: If full URLs are important to your use case, they should be stored in `url.full`, whether this field is reconstructed or present in the event source.
       example: https://www.elastic.co:443/search?q=elasticsearch#top
     - name: original

--- a/packages/synthetics/data_stream/browser_network/fields/http.yml
+++ b/packages/synthetics/data_stream/browser_network/fields/http.yml
@@ -30,10 +30,12 @@
           type: keyword
           description: >
             List of redirects followed to arrive at final content. Last item on the list is the URL for which body content is shown.
+
         - name: headers.etag
           type: keyword
           description: >
             Identifier for a specific version of a resource
+
         - name: headers.*
           type: object
           enabled: false

--- a/packages/synthetics/data_stream/browser_network/fields/http.yml
+++ b/packages/synthetics/data_stream/browser_network/fields/http.yml
@@ -4,6 +4,17 @@
     HTTP related fields.
 
   fields:
+    - name: request.url
+      level: extended
+      type: wildcard
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+        - name: keyword
+          type: keyword
+      description: The request url
     - name: response
       type: group
       fields:
@@ -19,7 +30,10 @@
           type: keyword
           description: >
             List of redirects followed to arrive at final content. Last item on the list is the URL for which body content is shown.
-
+        - name: headers.etag
+          type: keyword
+          description: >
+            Identifier for a specific version of a resource
         - name: headers.*
           type: object
           enabled: false

--- a/packages/synthetics/data_stream/browser_network/manifest.yml
+++ b/packages/synthetics/data_stream/browser_network/manifest.yml
@@ -9,11 +9,11 @@ elasticsearch:
     settings:
       index:
         codec: best_compression
-        sort.field: 
-        - "url.full"
-        - "http.request.url"
-        - "http.response.headers.etag"
-        - "monitor.id"
+        sort.field:
+          - "url.full"
+          - "http.request.url"
+          - "http.response.headers.etag"
+          - "monitor.id"
 streams:
   - input: synthetics/browser
     title: Synthetics monitors network information

--- a/packages/synthetics/data_stream/browser_network/manifest.yml
+++ b/packages/synthetics/data_stream/browser_network/manifest.yml
@@ -2,6 +2,18 @@ type: synthetics
 title: synthetic monitor check
 release: beta
 dataset: browser.network
+elasticsearch:
+  index_template:
+    mappings:
+      dynamic: false
+    settings:
+      index:
+        codec: best_compression
+        sort.field: 
+        - "url.full"
+        - "http.request.url"
+        - "http.response.headers.etag"
+        - "monitor.id"
 streams:
   - input: synthetics/browser
     title: Synthetics monitors network information

--- a/packages/synthetics/data_stream/browser_network/manifest.yml
+++ b/packages/synthetics/data_stream/browser_network/manifest.yml
@@ -10,8 +10,8 @@ elasticsearch:
       index:
         codec: best_compression
         sort.field:
-          - "url.full"
-          - "http.request.url"
+          - "url.full.keyword"
+          - "http.request.url.keyword"
           - "http.response.headers.etag"
           - "monitor.id"
 streams:

--- a/packages/synthetics/data_stream/browser_screenshot/manifest.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/manifest.yml
@@ -10,9 +10,6 @@ elasticsearch:
       index:
         codec: best_compression
         sort.field:
-          - "url.full"
-          - "http.request.url"
-          - "http.response.headers.etag"
           - "monitor.id"
 streams:
   - input: synthetics/browser

--- a/packages/synthetics/data_stream/browser_screenshot/manifest.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/manifest.yml
@@ -2,6 +2,18 @@ type: synthetics
 title: synthetic monitor check
 release: beta
 dataset: browser.screenshot
+elasticsearch:
+  index_template:
+    mappings:
+      dynamic: false
+    settings:
+      index:
+        codec: best_compression
+        sort.field: 
+        - "url.full"
+        - "http.request.url"
+        - "http.response.headers.etag"
+        - "monitor.id"
 streams:
   - input: synthetics/browser
     title: Synthetics monitors screenshot information

--- a/packages/synthetics/data_stream/browser_screenshot/manifest.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/manifest.yml
@@ -9,11 +9,11 @@ elasticsearch:
     settings:
       index:
         codec: best_compression
-        sort.field: 
-        - "url.full"
-        - "http.request.url"
-        - "http.response.headers.etag"
-        - "monitor.id"
+        sort.field:
+          - "url.full"
+          - "http.request.url"
+          - "http.response.headers.etag"
+          - "monitor.id"
 streams:
   - input: synthetics/browser
     title: Synthetics monitors screenshot information

--- a/packages/synthetics/data_stream/http/fields/ecs.yml
+++ b/packages/synthetics/data_stream/http/fields/ecs.yml
@@ -1122,6 +1122,8 @@
           type: text
           norms: false
           default_field: false
+        - name: keyword
+          type: keyword
       description: If full URLs are important to your use case, they should be stored in `url.full`, whether this field is reconstructed or present in the event source.
       example: https://www.elastic.co:443/search?q=elasticsearch#top
     - name: original

--- a/packages/synthetics/data_stream/http/manifest.yml
+++ b/packages/synthetics/data_stream/http/manifest.yml
@@ -2,6 +2,18 @@ type: synthetics
 title: synthetic monitor check
 release: experimental
 dataset: http
+elasticsearch:
+  index_template:
+    mappings:
+      dynamic: false
+    settings:
+      index:
+        codec: best_compression
+        sort.field: 
+        - "url.full"
+        - "http.request.url"
+        - "http.response.headers.etag"
+        - "monitor.id"
 streams:
   - input: synthetics/http
     title: Synthetic monitor check

--- a/packages/synthetics/data_stream/http/manifest.yml
+++ b/packages/synthetics/data_stream/http/manifest.yml
@@ -10,10 +10,8 @@ elasticsearch:
       index:
         codec: best_compression
         sort.field:
-          - "url.full"
-          - "http.request.url"
-          - "http.response.headers.etag"
           - "monitor.id"
+          - "url.full.keyword"
 streams:
   - input: synthetics/http
     title: Synthetic monitor check

--- a/packages/synthetics/data_stream/http/manifest.yml
+++ b/packages/synthetics/data_stream/http/manifest.yml
@@ -9,11 +9,11 @@ elasticsearch:
     settings:
       index:
         codec: best_compression
-        sort.field: 
-        - "url.full"
-        - "http.request.url"
-        - "http.response.headers.etag"
-        - "monitor.id"
+        sort.field:
+          - "url.full"
+          - "http.request.url"
+          - "http.response.headers.etag"
+          - "monitor.id"
 streams:
   - input: synthetics/http
     title: Synthetic monitor check

--- a/packages/synthetics/data_stream/icmp/fields/ecs.yml
+++ b/packages/synthetics/data_stream/icmp/fields/ecs.yml
@@ -1122,6 +1122,8 @@
           type: text
           norms: false
           default_field: false
+        - name: keyword
+          type: keyword
       description: If full URLs are important to your use case, they should be stored in `url.full`, whether this field is reconstructed or present in the event source.
       example: https://www.elastic.co:443/search?q=elasticsearch#top
     - name: original

--- a/packages/synthetics/data_stream/icmp/manifest.yml
+++ b/packages/synthetics/data_stream/icmp/manifest.yml
@@ -10,10 +10,8 @@ elasticsearch:
       index:
         codec: best_compression
         sort.field:
-          - "url.full"
-          - "http.request.url"
-          - "http.response.headers.etag"
           - "monitor.id"
+          - "url.full.keyword"
 streams:
   - input: synthetics/icmp
     title: Synthetic monitor check

--- a/packages/synthetics/data_stream/icmp/manifest.yml
+++ b/packages/synthetics/data_stream/icmp/manifest.yml
@@ -2,6 +2,18 @@ type: synthetics
 title: synthetic monitor check
 release: experimental
 dataset: icmp
+elasticsearch:
+  index_template:
+    mappings:
+      dynamic: false
+    settings:
+      index:
+        codec: best_compression
+        sort.field: 
+        - "url.full"
+        - "http.request.url"
+        - "http.response.headers.etag"
+        - "monitor.id"
 streams:
   - input: synthetics/icmp
     title: Synthetic monitor check

--- a/packages/synthetics/data_stream/icmp/manifest.yml
+++ b/packages/synthetics/data_stream/icmp/manifest.yml
@@ -9,11 +9,11 @@ elasticsearch:
     settings:
       index:
         codec: best_compression
-        sort.field: 
-        - "url.full"
-        - "http.request.url"
-        - "http.response.headers.etag"
-        - "monitor.id"
+        sort.field:
+          - "url.full"
+          - "http.request.url"
+          - "http.response.headers.etag"
+          - "monitor.id"
 streams:
   - input: synthetics/icmp
     title: Synthetic monitor check

--- a/packages/synthetics/data_stream/tcp/fields/ecs.yml
+++ b/packages/synthetics/data_stream/tcp/fields/ecs.yml
@@ -1122,6 +1122,8 @@
           type: text
           norms: false
           default_field: false
+        - name: keyword
+          type: keyword
       description: If full URLs are important to your use case, they should be stored in `url.full`, whether this field is reconstructed or present in the event source.
       example: https://www.elastic.co:443/search?q=elasticsearch#top
     - name: original

--- a/packages/synthetics/data_stream/tcp/manifest.yml
+++ b/packages/synthetics/data_stream/tcp/manifest.yml
@@ -9,11 +9,11 @@ elasticsearch:
     settings:
       index:
         codec: best_compression
-        sort.field: 
-        - "url.full"
-        - "http.request.url"
-        - "http.response.headers.etag"
-        - "monitor.id"
+        sort.field:
+          - "url.full"
+          - "http.request.url"
+          - "http.response.headers.etag"
+          - "monitor.id"
 streams:
   - input: synthetics/tcp
     title: Synthetic monitor check

--- a/packages/synthetics/data_stream/tcp/manifest.yml
+++ b/packages/synthetics/data_stream/tcp/manifest.yml
@@ -10,10 +10,8 @@ elasticsearch:
       index:
         codec: best_compression
         sort.field:
-          - "url.full"
-          - "http.request.url"
-          - "http.response.headers.etag"
           - "monitor.id"
+          - "url.full.keyword"
 streams:
   - input: synthetics/tcp
     title: Synthetic monitor check

--- a/packages/synthetics/data_stream/tcp/manifest.yml
+++ b/packages/synthetics/data_stream/tcp/manifest.yml
@@ -2,6 +2,18 @@ type: synthetics
 title: synthetic monitor check
 release: experimental
 dataset: tcp
+elasticsearch:
+  index_template:
+    mappings:
+      dynamic: false
+    settings:
+      index:
+        codec: best_compression
+        sort.field: 
+        - "url.full"
+        - "http.request.url"
+        - "http.response.headers.etag"
+        - "monitor.id"
 streams:
   - input: synthetics/tcp
     title: Synthetic monitor check

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Monitor the availability of your services with Elastic Synthetics.
-version: 0.7.0
+version: 0.8.0
 categories: ["elastic_stack", "monitoring", "web"]
 release: beta
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement
-->

## What does this PR do?

Adds index optimization settings to all Synthetics data streams

The following settings have been added Synthetics data streams:

* http
* icmp
* TCP
* browser
```
elasticsearch:
  index_template:
    mappings:
      dynamic: false
    settings:
      index:
        codec: best_compression
        sort.field: 
        - "url.full.keyword"
        - "monitor.id"
```

* browser.screenshot
```
elasticsearch:
  index_template:
    mappings:
      dynamic: false
    settings:
      index:
        codec: best_compression
        sort.field: 
        - "monitor.id"
```
browser.network
```
elasticsearch:
  index_template:
    mappings:
      dynamic: false
    settings:
      index:
        codec: best_compression
        sort.field: 
        - "url.full.keyword"
        - "http.request.url"
        - "http.response.headers.etag"
        - "monitor.id"
```

<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs or synthetics.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Navigate to `packages/synthetics`
2. Run `elastic-package stack clean`, then `elastic-package stack build`
3. Run `elastic-package stack up -d -v --version 8.1.0-SNAPSHOT --services "package-registry"`
4. Add `xpack.fleet.registryUrl: "http://localhost:8080"`
5. Navigate to index patterns in Stack Management and find the following index templates: `synthetics-http`, `synthetics-tcp`, `synthetics-icmp`, `synthetics-browser`, `synthetics-browser.network`, and `synthetics-browser.screenshot`
6. Click on each data stream and then click on the `Preview` tab. Observe the updates have been applied
<img width="525" alt="Screen Shot 2021-12-06 at 2 51 54 PM" src="https://user-images.githubusercontent.com/11356435/144913109-7ce6fe7f-6e01-4460-b6fc-8be9e33d4234.png">
7. Create a monitor of each browser type and ensure that they all index successfully. 

## Related issues

- Closes #2196
