### PR TITLE
[osquery_manager] Add 8.0.0 constraint

### DIFF
--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.8.0"
+  changes:
+    - description: Add 8.0.0 version constraint
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "0.7.4"
   changes:
     - description: Update fields and readme with host_users, host_groups, host_processes tables.

--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add 8.0.0 version constraint
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/2322
 - version: "0.7.4"
   changes:
     - description: Update fields and readme with host_users, host_groups, host_processes tables.

--- a/packages/osquery_manager/manifest.yml
+++ b/packages/osquery_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: osquery_manager
 title: Osquery Manager
-version: 0.7.4
+version: 0.8.0
 license: basic
 description: Deploy osquery with Elastic Agent, then run and schedule queries in Kibana
 type: integration
@@ -11,7 +11,7 @@ categories:
   - os_system
   - config_management
 conditions:
-  kibana.version: '^7.16.0'
+  kibana.version: ^7.16.0 || ^8.0.0
 icons:
   - src: /img/logo_osquery.svg
     title: logo osquery


### PR DESCRIPTION
## What does this PR do?

Add 8.0.0 constraint to osquery_manager.
Fixes: https://github.com/elastic/security-team/issues/2439

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues
- Closes https://github.com/elastic/security-team/issues/2439

## Screenshots
<img width="1316" alt="Screen Shot 2021-12-08 at 10 26 03 AM" src="https://user-images.githubusercontent.com/872351/145235789-af2a0336-5f8a-468a-8a4d-b55d0be09d44.png">
 
<img width="1645" alt="Screen Shot 2021-12-08 at 10 25 35 AM" src="https://user-images.githubusercontent.com/872351/145235820-02c27f40-ed8e-4495-86d3-11672cd57dce.png">

