### PR TITLE
Add skip_older setting for event data_stream

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add skip_older option for event datastream
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/2342
 - version: "1.5.0"
   changes:
     - description: Revert Kubernetes namespace field breaking change

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.0"
+  changes:
+    - description: Add skip_older option for event datastream
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.5.0"
   changes:
     - description: Revert Kubernetes namespace field breaking change

--- a/packages/kubernetes/data_stream/event/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/event/agent/stream/stream.yml.hbs
@@ -1,6 +1,7 @@
 metricsets: ["event"]
 period: {{period}}
 add_metadata: {{add_metadata}}
+skip_older: {{skip_older}}
 {{#if leaderelection}}
 condition: ${kubernetes_leaderelection.leader} == true
 {{/if}}

--- a/packages/kubernetes/data_stream/event/manifest.yml
+++ b/packages/kubernetes/data_stream/event/manifest.yml
@@ -17,6 +17,13 @@ streams:
         required: true
         show_user: true
         default: true
+      - name: skip_older
+        type: bool
+        title: Skip older events
+        multi: false
+        required: false
+        show_user: true
+        default: true
       - name: leaderelection
         type: bool
         title: Leader Election

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.5.0
+version: 1.6.0
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?
This PR adds `skip_older` setting introduced at https://github.com/elastic/beats/pull/29396.