### PR TITLE
Expose event_id, and language options to all winlog inputs

### DIFF
--- a/packages/microsoft_sqlserver/changelog.yml
+++ b/packages/microsoft_sqlserver/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Expose winlog input language option.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/2344
 - version: "0.1.0"
   changes:
     - description: Initial draft of the package

--- a/packages/microsoft_sqlserver/changelog.yml
+++ b/packages/microsoft_sqlserver/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.0"
+  changes:
+    - description: Expose winlog input language option.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "0.1.0"
   changes:
     - description: Initial draft of the package

--- a/packages/microsoft_sqlserver/data_stream/audit/agent/stream/winlog.yml.hbs
+++ b/packages/microsoft_sqlserver/data_stream/audit/agent/stream/winlog.yml.hbs
@@ -1,6 +1,9 @@
 name: {{channel}}
 condition: ${host.platform} == 'windows'
 event_id: {{event_id}}
+{{#if language}}
+language: {{language}}
+{{/if}}
 {{#if tags.length}}
 tags:
 {{else if preserve_original_event}}

--- a/packages/microsoft_sqlserver/data_stream/audit/manifest.yml
+++ b/packages/microsoft_sqlserver/data_stream/audit/manifest.yml
@@ -23,6 +23,14 @@ streams:
         required: true
         default: Security
         show_user: true
+      - name: language
+        type: text
+        title: Language ID
+        description: >-
+          The language ID the events will be rendered in. The language will be forced regardless of the system language. A complete list of language IDs can be found https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c[here]. It defaults to `0`, which indicates to use the system language. E.g.: 0x0409 for en-US
+        required: false
+        show_user: false
+        default: 0
       - name: preserve_original_event
         required: true
         show_user: true

--- a/packages/microsoft_sqlserver/manifest.yml
+++ b/packages/microsoft_sqlserver/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_sqlserver
 title: "Microsoft SQL Server"
-version: 0.1.0
+version: 0.2.0
 license: basic
 description: Collect audit events from Microsoft SQL Server with Elastic Agent.
 type: integration

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Expose winlog input language option.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/2344
 - version: "1.6.6"
   changes:
     - description: Regenerate test files using the new GeoIP database

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.0"
+  changes:
+    - description: Expose winlog input language option.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.6.6"
   changes:
     - description: Regenerate test files using the new GeoIP database

--- a/packages/system/data_stream/application/agent/stream/winlog.yml.hbs
+++ b/packages/system/data_stream/application/agent/stream/winlog.yml.hbs
@@ -4,6 +4,9 @@ ignore_older: 72h
 {{#if event_id}}
 event_id: {{event_id}}
 {{/if}}
+{{#if language}}
+language: {{language}}
+{{/if}}
 {{#if processors}}
 processors:
 {{processors}}

--- a/packages/system/data_stream/application/manifest.yml
+++ b/packages/system/data_stream/application/manifest.yml
@@ -28,6 +28,14 @@ streams:
         title: Tags
         multi: true
         show_user: false
+      - name: language
+        type: text
+        title: Language ID
+        description: >-
+          The language ID the events will be rendered in. The language will be forced regardless of the system language. A complete list of language IDs can be found https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c[here]. It defaults to `0`, which indicates to use the system language. E.g.: 0x0409 for en-US
+        required: false
+        show_user: false
+        default: 0
   - input: httpjson
     title: Windows Application Events via Splunk Enterprise REST API
     description: Collect Application Events via Splunk Enterprise REST API

--- a/packages/system/data_stream/security/agent/stream/winlog.yml.hbs
+++ b/packages/system/data_stream/security/agent/stream/winlog.yml.hbs
@@ -3,6 +3,9 @@ condition: ${host.platform} == 'windows'
 {{#if event_id}}
 event_id: {{event_id}}
 {{/if}}
+{{#if language}}
+language: {{language}}
+{{/if}}
 {{#if processors}}
 processors:
 {{processors}}

--- a/packages/system/data_stream/security/manifest.yml
+++ b/packages/system/data_stream/security/manifest.yml
@@ -28,6 +28,14 @@ streams:
         title: Tags
         multi: true
         show_user: false
+      - name: language
+        type: text
+        title: Language ID
+        description: >-
+          The language ID the events will be rendered in. The language will be forced regardless of the system language. A complete list of language IDs can be found https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c[here]. It defaults to `0`, which indicates to use the system language. E.g.: 0x0409 for en-US
+        required: false
+        show_user: false
+        default: 0
   - input: httpjson
     title: Windows Security Events via Splunk Enterprise REST API
     description: Collect Security Events via Splunk Enterprise REST API

--- a/packages/system/data_stream/system/agent/stream/winlog.yml.hbs
+++ b/packages/system/data_stream/system/agent/stream/winlog.yml.hbs
@@ -3,6 +3,9 @@ condition: ${host.platform} == 'windows'
 {{#if event_id}}
 event_id: {{event_id}}
 {{/if}}
+{{#if language}}
+language: {{language}}
+{{/if}}
 {{#if processors}}
 processors:
 {{processors}}

--- a/packages/system/data_stream/system/manifest.yml
+++ b/packages/system/data_stream/system/manifest.yml
@@ -28,6 +28,14 @@ streams:
         title: Tags
         multi: true
         show_user: false
+      - name: language
+        type: text
+        title: Language ID
+        description: >-
+          The language ID the events will be rendered in. The language will be forced regardless of the system language. A complete list of language IDs can be found https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c[here]. It defaults to `0`, which indicates to use the system language. E.g.: 0x0409 for en-US
+        required: false
+        show_user: false
+        default: 0
   - input: httpjson
     title: Windows System Events via Splunk Enterprise REST API
     description: Collect System Events via Splunk Enterprise REST API

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 1.6.6
+version: 1.7.0
 license: basic
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
@@ -10,7 +10,7 @@ categories:
   - security
 release: ga
 conditions:
-  kibana.version: '^7.14.0 || ^8.0.0'
+  kibana.version: '^7.16.0 || ^8.0.0'
 screenshots:
   - src: /img/kibana-system.png
     title: kibana system

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.0"
+  changes:
+    - description: Expose winlog input language option.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.5.1"
   changes:
     - description: Change test public IPs to the supported subset

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Expose winlog input language option.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/2344
 - version: "1.5.1"
   changes:
     - description: Change test public IPs to the supported subset

--- a/packages/windows/data_stream/forwarded/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/forwarded/agent/stream/winlog.yml.hbs
@@ -1,5 +1,11 @@
 name: ForwardedEvents
 condition: ${host.platform} == 'windows'
+{{#if event_id}}
+event_id: {{event_id}}
+{{/if}}
+{{#if language}}
+language: {{language}}
+{{/if}}
 {{#if tags.length}}
 tags:
 {{else if preserve_original_event}}

--- a/packages/windows/data_stream/forwarded/manifest.yml
+++ b/packages/windows/data_stream/forwarded/manifest.yml
@@ -14,6 +14,21 @@ streams:
     title: Forwarded
     description: 'Collect ForwardedEvents channel logs'
     vars:
+      - name: event_id
+        type: text
+        title: Event ID
+        description: >-
+          A list of included and excluded (blocked) event IDs. The value is a comma-separated list.  The accepted values are single event IDs to include (e.g. 4624), a range of event IDs to include (e.g. 4700-4800),  and single event IDs to exclude (e.g. -4735).  Limit 22 IDs.
+        required: true
+        show_user: false
+      - name: language
+        type: text
+        title: Language ID
+        description: >-
+          The language ID the events will be rendered in. The language will be forced regardless of the system language. A complete list of language IDs can be found https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c[here]. It defaults to `0`, which indicates to use the system language. E.g.: 0x0409 for en-US
+        required: false
+        show_user: false
+        default: 0
       - name: tags
         type: text
         title: Tags

--- a/packages/windows/data_stream/powershell/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/powershell/agent/stream/winlog.yml.hbs
@@ -1,6 +1,11 @@
 name: Windows PowerShell
 condition: ${host.platform} == 'windows'
-event_id: 400, 403, 600, 800
+{{#if event_id}}
+event_id: {{event_id}}
+{{/if}}
+{{#if language}}
+language: {{language}}
+{{/if}}
 {{#if tags.length}}
 tags:
 {{else if preserve_original_event}}

--- a/packages/windows/data_stream/powershell/manifest.yml
+++ b/packages/windows/data_stream/powershell/manifest.yml
@@ -14,6 +14,22 @@ streams:
     title: Powershell
     description: 'Windows Powershell channel'
     vars:
+      - name: event_id
+        type: text
+        title: Event ID
+        description: >-
+          A list of included and excluded (blocked) event IDs. The value is a comma-separated list.  The accepted values are single event IDs to include (e.g. 4624), a range of event IDs to include (e.g. 4700-4800),  and single event IDs to exclude (e.g. -4735).  Limit 22 IDs.
+        required: true
+        show_user: false
+        default: 400, 403, 600, 800
+      - name: language
+        type: text
+        title: Language ID
+        description: >-
+          The language ID the events will be rendered in. The language will be forced regardless of the system language. A complete list of language IDs can be found https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c[here]. It defaults to `0`, which indicates to use the system language. E.g.: 0x0409 for en-US
+        required: false
+        show_user: false
+        default: 0
       - name: tags
         type: text
         title: Tags

--- a/packages/windows/data_stream/powershell_operational/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/powershell_operational/agent/stream/winlog.yml.hbs
@@ -1,6 +1,11 @@
 name: Microsoft-Windows-PowerShell/Operational
 condition: ${host.platform} == 'windows'
-event_id: 4103, 4104, 4105, 4106
+{{#if event_id}}
+event_id: {{event_id}}
+{{/if}}
+{{#if language}}
+language: {{language}}
+{{/if}}
 {{#if tags.length}}
 tags:
 {{else if preserve_original_event}}

--- a/packages/windows/data_stream/powershell_operational/manifest.yml
+++ b/packages/windows/data_stream/powershell_operational/manifest.yml
@@ -14,6 +14,22 @@ streams:
     title: Powershell Operational
     description: 'Microsoft-Windows-Powershell/Operational channel'
     vars:
+      - name: event_id
+        type: text
+        title: Event ID
+        description: >-
+          A list of included and excluded (blocked) event IDs. The value is a comma-separated list.  The accepted values are single event IDs to include (e.g. 4624), a range of event IDs to include (e.g. 4700-4800),  and single event IDs to exclude (e.g. -4735).  Limit 22 IDs.
+        required: true
+        show_user: false
+        default: 4103, 4104, 4105, 4106
+      - name: language
+        type: text
+        title: Language ID
+        description: >-
+          The language ID the events will be rendered in. The language will be forced regardless of the system language. A complete list of language IDs can be found https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c[here]. It defaults to `0`, which indicates to use the system language. E.g.: 0x0409 for en-US
+        required: false
+        show_user: false
+        default: 0
       - name: tags
         type: text
         title: Tags

--- a/packages/windows/data_stream/sysmon_operational/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/sysmon_operational/agent/stream/winlog.yml.hbs
@@ -1,5 +1,11 @@
 name: Microsoft-Windows-Sysmon/Operational
 condition: ${host.platform} == 'windows'
+{{#if event_id}}
+event_id: {{event_id}}
+{{/if}}
+{{#if language}}
+language: {{language}}
+{{/if}}
 {{#if tags.length}}
 tags:
 {{else if preserve_original_event}}

--- a/packages/windows/data_stream/sysmon_operational/manifest.yml
+++ b/packages/windows/data_stream/sysmon_operational/manifest.yml
@@ -6,6 +6,21 @@ streams:
     title: Sysmon Operational
     description: 'Collect Microsoft-Windows-Sysmon/Operational channel logs'
     vars:
+      - name: event_id
+        type: text
+        title: Event ID
+        description: >-
+          A list of included and excluded (blocked) event IDs. The value is a comma-separated list.  The accepted values are single event IDs to include (e.g. 4624), a range of event IDs to include (e.g. 4700-4800),  and single event IDs to exclude (e.g. -4735).  Limit 22 IDs.
+        required: true
+        show_user: false
+      - name: language
+        type: text
+        title: Language ID
+        description: >-
+          The language ID the events will be rendered in. The language will be forced regardless of the system language. A complete list of language IDs can be found https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c[here]. It defaults to `0`, which indicates to use the system language. E.g.: 0x0409 for en-US
+        required: false
+        show_user: false
+        default: 0
       - name: tags
         type: text
         title: Tags

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.5.1
+version: 1.6.0
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:
@@ -15,7 +15,7 @@ format_version: 1.0.0
 license: basic
 release: ga
 conditions:
-  kibana.version: "^7.14.0 || ^8.0.0"
+  kibana.version: "^7.16.0 || ^8.0.0"
 screenshots:
   - src: /img/metricbeat-windows-service.png
     title: metricbeat windows service

--- a/packages/winlog/changelog.yml
+++ b/packages/winlog/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.0"
+  changes:
+    - description: Expose winlog input language option.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.2.0"
   changes:
     - description: Add 8.0.0 version constraint

--- a/packages/winlog/changelog.yml
+++ b/packages/winlog/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Expose winlog input language option.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/2344
 - version: "1.2.0"
   changes:
     - description: Add 8.0.0 version constraint

--- a/packages/winlog/data_stream/winlog/agent/stream/winlog.yml.hbs
+++ b/packages/winlog/data_stream/winlog/agent/stream/winlog.yml.hbs
@@ -2,6 +2,12 @@ condition: ${host.platform} == 'windows'
 data_stream:
   dataset: {{data_stream.dataset}}
 name: {{channel}}
+{{#if event_id}}
+event_id: {{event_id}}
+{{/if}}
+{{#if language}}
+language: {{language}}
+{{/if}}
 tags:
 {{#each tags}}
   - {{this}}

--- a/packages/winlog/data_stream/winlog/manifest.yml
+++ b/packages/winlog/data_stream/winlog/manifest.yml
@@ -52,7 +52,7 @@ streams:
         type: text
         title: Language ID
         description: >-
-          The language ID the events will be rendered in. The language will be forced regardless of the system language. A complete list of language IDs can be found https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c[here]. It defaults to `0`, which indicates to use the system language. E.g.: 0x0409 for en-US
+          The language ID the events will be rendered in. The language will be forced regardless of the system language. A complete list of language IDs can be found [here](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c). It defaults to `0`, which indicates to use the system language. E.g.: `0x0409` for `en-US`
         required: false
         show_user: false
         default: 0

--- a/packages/winlog/data_stream/winlog/manifest.yml
+++ b/packages/winlog/data_stream/winlog/manifest.yml
@@ -4,6 +4,7 @@ streams:
   - input: winlog
     description: Collect Windows event logs from a custom channel
     title: Windows Event Logs
+    template_path: winlog.yml.hbs
     vars:
       - name: channel
         type: text
@@ -40,6 +41,21 @@ streams:
           #  - drop_event.when.not.or:
           #    - equals.winlog.event_id: '903'
           #    - equals.winlog.event_id: '1024'
+      - name: event_id
+        type: text
+        title: Event ID
+        description: >-
+          A list of included and excluded (blocked) event IDs. The value is a comma-separated list.  The accepted values are single event IDs to include (e.g. 4624), a range of event IDs to include (e.g. 4700-4800),  and single event IDs to exclude (e.g. -4735).  Limit 22 IDs.
+        required: true
+        show_user: false
+      - name: language
+        type: text
+        title: Language ID
+        description: >-
+          The language ID the events will be rendered in. The language will be forced regardless of the system language. A complete list of language IDs can be found https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c[here]. It defaults to `0`, which indicates to use the system language. E.g.: 0x0409 for en-US
+        required: false
+        show_user: false
+        default: 0
   - input: httpjson
     title: Windows ForwardedEvents via Splunk Enterprise REST API
     description: Collect ForwardedEvents via Splunk Enterprise REST API

--- a/packages/winlog/manifest.yml
+++ b/packages/winlog/manifest.yml
@@ -3,7 +3,7 @@ name: winlog
 title: Custom Windows Event Logs
 description: Collect and parse logs from any Windows event log channel with Elastic Agent.
 type: integration
-version: 1.2.0
+version: 1.3.0
 release: ga
 conditions:
   kibana.version: '^7.16.0 || ^8.0.0'


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

- Exposes the new `language` option for all integrations using the `winlog` input.
- Exposes `event_id` for all integrations that didn't let the user customize this option.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
