### PR TITLE
CI: Increase execution timeout for daily job

### DIFF
--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -9,7 +9,7 @@ pipeline {
     INTEGRATION_JOB = 'Ingest-manager/integrations/master'
   }
   options {
-    timeout(time: 2, unit: 'HOURS')
+    timeout(time: 4, unit: 'HOURS')
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')


### PR DESCRIPTION
This PR adjusts execution timeout for the daily job.

If we need 2h to finish single job, a we want 2 jobs, then we need to increase the total timeout :)