### PR TITLE
Workaround: skip ppid deprecation notice

### DIFF
--- a/packages/auditd/_dev/build/build.yml
+++ b/packages/auditd/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@1.12
+    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701

--- a/packages/cisco/_dev/build/build.yml
+++ b/packages/cisco/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@1.12
+    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701

--- a/packages/cisco_meraki/_dev/build/build.yml
+++ b/packages/cisco_meraki/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@1.12
+    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701

--- a/packages/cisco_nexus/_dev/build/build.yml
+++ b/packages/cisco_nexus/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@1.12
+    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701

--- a/packages/fortinet/_dev/build/build.yml
+++ b/packages/fortinet/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@1.12
+    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701

--- a/packages/juniper/_dev/build/build.yml
+++ b/packages/juniper/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@1.12
+    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701

--- a/packages/juniper_junos/_dev/build/build.yml
+++ b/packages/juniper_junos/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@1.12
+    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701

--- a/packages/juniper_netscreen/_dev/build/build.yml
+++ b/packages/juniper_netscreen/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@1.12
+    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701

--- a/packages/juniper_srx/_dev/build/build.yml
+++ b/packages/juniper_srx/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@1.12
+    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701

--- a/packages/linux/_dev/build/build.yml
+++ b/packages/linux/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@1.12
+    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701

--- a/packages/microsoft/_dev/build/build.yml
+++ b/packages/microsoft/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@1.12
+    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701

--- a/packages/netflow/_dev/build/build.yml
+++ b/packages/netflow/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@1.12
+    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701

--- a/packages/santa/_dev/build/build.yml
+++ b/packages/santa/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@1.12
+    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701

--- a/packages/sonicwall/_dev/build/build.yml
+++ b/packages/sonicwall/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@1.12
+    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701

--- a/packages/sophos/_dev/build/build.yml
+++ b/packages/sophos/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@1.12
+    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701

--- a/packages/system/_dev/build/build.yml
+++ b/packages/system/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@1.12
+    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701

--- a/packages/tomcat/_dev/build/build.yml
+++ b/packages/tomcat/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@1.12
+    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701


### PR DESCRIPTION
This PR introduces a workaround for the [ECS issue](https://github.com/elastic/ecs/issues/1701), it impacted the master branch, caused trouble with successful builds.

As the ECS 1.12 was altered with a deprecation notice,  it was detected as a non-versioned change in README:

```diff
diff --git a/packages/auditd/docs/README.md b/packages/auditd/docs/README.md
index fc85d483c..a70e0cff8 100644
--- a/packages/auditd/docs/README.md
+++ b/packages/auditd/docs/README.md
@@ -229,7 +229,7 @@ An example event for `log` looks as following:
 | process.exit_code | The exit code of the process, if this is a termination event. The field should be absent if there is no exit code for the event (e.g. process start). | long |
 | process.name | Process name. Sometimes called program name or similar. | keyword |
 | process.pid | Process id. | long |
-| process.ppid | Parent process' pid. | long |
+| process.ppid | Deprecated for removal in the next major version. This field is superseded by `process.parent.pid`. Parent process' pid. | long |
 | process.working_directory | The working directory of the process. | keyword |
 | source.address | Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
```

Output packages are the same as the last healthy ones, so we don't need to bump up the dependency.