### PR TITLE
Revert "Workaround for ppid deprecation notice (#2364)"

### DIFF
--- a/packages/auditd/_dev/build/build.yml
+++ b/packages/auditd/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701
+    reference: git@1.12

--- a/packages/cisco/_dev/build/build.yml
+++ b/packages/cisco/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701
+    reference: git@1.12

--- a/packages/cisco_meraki/_dev/build/build.yml
+++ b/packages/cisco_meraki/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701
+    reference: git@1.12

--- a/packages/cisco_nexus/_dev/build/build.yml
+++ b/packages/cisco_nexus/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701
+    reference: git@1.12

--- a/packages/fortinet/_dev/build/build.yml
+++ b/packages/fortinet/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701
+    reference: git@1.12

--- a/packages/juniper/_dev/build/build.yml
+++ b/packages/juniper/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701
+    reference: git@1.12

--- a/packages/juniper_junos/_dev/build/build.yml
+++ b/packages/juniper_junos/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701
+    reference: git@1.12

--- a/packages/juniper_netscreen/_dev/build/build.yml
+++ b/packages/juniper_netscreen/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701
+    reference: git@1.12

--- a/packages/juniper_srx/_dev/build/build.yml
+++ b/packages/juniper_srx/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701
+    reference: git@1.12

--- a/packages/linux/_dev/build/build.yml
+++ b/packages/linux/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701
+    reference: git@1.12

--- a/packages/microsoft/_dev/build/build.yml
+++ b/packages/microsoft/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701
+    reference: git@1.12

--- a/packages/netflow/_dev/build/build.yml
+++ b/packages/netflow/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701
+    reference: git@1.12

--- a/packages/santa/_dev/build/build.yml
+++ b/packages/santa/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701
+    reference: git@1.12

--- a/packages/sonicwall/_dev/build/build.yml
+++ b/packages/sonicwall/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701
+    reference: git@1.12

--- a/packages/sophos/_dev/build/build.yml
+++ b/packages/sophos/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701
+    reference: git@1.12

--- a/packages/system/_dev/build/build.yml
+++ b/packages/system/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701
+    reference: git@1.12

--- a/packages/tomcat/_dev/build/build.yml
+++ b/packages/tomcat/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@bfaf83e2ba9d2d0db03bd10cc6bde93d41a08550 # Workaround for ECS 1.12, see: https://github.com/elastic/ecs/issues/1701
+    reference: git@1.12


### PR DESCRIPTION
This PR reverts the workaround for ECS related changes (deprecation notice).

Related: https://github.com/elastic/integrations/pull/2364