### PR TITLE
Add new event.action to 1Password item usages

### DIFF
--- a/packages/1password/data_stream/item_usages/_dev/test/pipeline/test-itemusages.json
+++ b/packages/1password/data_stream/item_usages/_dev/test/pipeline/test-itemusages.json
@@ -6,7 +6,7 @@
         },
         {
             "@timestamp": "2021-08-30T22:57:42.484Z",
-            "message": "{\"uuid\":\"5HBWJDWCQADISKY2DVBNP3HJPV\",\"timestamp\":\"2021-08-30T19:10:00.123Z\",\"used_version\":1,\"vault_uuid\":\"jaqxqf5qylslqiitnduawrndc5\",\"item_uuid\":\"bvwmmwxisuca7wbehrbyqhag54\",\"user\":{\"uuid\":\"OJQGU46KAPROEJLCK674RHSAY5\",\"name\":\"Name\",\"email\":\"email@1password.com\"},\"client\":{\"app_name\":\"1Password Browser Extension\",\"app_version\":\"1109\",\"platform_name\":\"Chrome\",\"platform_version\":\"93.0.4577.62\",\"os_name\":\"Android\",\"os_version\":\"10\",\"ip_address\":\"89.160.20.156\"}}"
+            "message": "{\"uuid\":\"5HBWJDWCQADISKY2DVBNP3HJPV\",\"timestamp\":\"2021-08-30T19:10:00.123Z\",\"used_version\":1,\"action\":\"reveal\",\"vault_uuid\":\"jaqxqf5qylslqiitnduawrndc5\",\"item_uuid\":\"bvwmmwxisuca7wbehrbyqhag54\",\"user\":{\"uuid\":\"OJQGU46KAPROEJLCK674RHSAY5\",\"name\":\"Name\",\"email\":\"email@1password.com\"},\"client\":{\"app_name\":\"1Password Browser Extension\",\"app_version\":\"1109\",\"platform_name\":\"Chrome\",\"platform_version\":\"93.0.4577.62\",\"os_name\":\"Android\",\"os_version\":\"10\",\"ip_address\":\"89.160.20.156\"}}"
         }
     ]
 }

--- a/packages/1password/data_stream/item_usages/_dev/test/pipeline/test-itemusages.json-expected.json
+++ b/packages/1password/data_stream/item_usages/_dev/test/pipeline/test-itemusages.json-expected.json
@@ -127,7 +127,7 @@
             },
             "event": {
                 "ingested": "2021-12-14T14:34:03.382906002Z",
-                "original": "{\"uuid\":\"5HBWJDWCQADISKY2DVBNP3HJPV\",\"timestamp\":\"2021-08-30T19:10:00.123Z\",\"used_version\":1,\"vault_uuid\":\"jaqxqf5qylslqiitnduawrndc5\",\"item_uuid\":\"bvwmmwxisuca7wbehrbyqhag54\",\"user\":{\"uuid\":\"OJQGU46KAPROEJLCK674RHSAY5\",\"name\":\"Name\",\"email\":\"email@1password.com\"},\"client\":{\"app_name\":\"1Password Browser Extension\",\"app_version\":\"1109\",\"platform_name\":\"Chrome\",\"platform_version\":\"93.0.4577.62\",\"os_name\":\"Android\",\"os_version\":\"10\",\"ip_address\":\"89.160.20.156\"}}",
+                "original": "{\"uuid\":\"5HBWJDWCQADISKY2DVBNP3HJPV\",\"timestamp\":\"2021-08-30T19:10:00.123Z\",\"used_version\":1,\"action\":\"reveal\",\"vault_uuid\":\"jaqxqf5qylslqiitnduawrndc5\",\"item_uuid\":\"bvwmmwxisuca7wbehrbyqhag54\",\"user\":{\"uuid\":\"OJQGU46KAPROEJLCK674RHSAY5\",\"name\":\"Name\",\"email\":\"email@1password.com\"},\"client\":{\"app_name\":\"1Password Browser Extension\",\"app_version\":\"1109\",\"platform_name\":\"Chrome\",\"platform_version\":\"93.0.4577.62\",\"os_name\":\"Android\",\"os_version\":\"10\",\"ip_address\":\"89.160.20.156\"}}",
                 "category": [
                     "file"
                 ],
@@ -135,7 +135,8 @@
                     "access"
                 ],
                 "created": "2021-08-30T22:57:42.484Z",
-                "kind": "event"
+                "kind": "event",
+                "action": "reveal"
             },
             "user": {
                 "email": "email@1password.com",

--- a/packages/1password/data_stream/item_usages/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/1password/data_stream/item_usages/elasticsearch/ingest_pipeline/default.yml
@@ -33,6 +33,10 @@ processors:
   - append:
       field: event.type
       value: [access]
+  - rename:
+      field: onepassword.action
+      target_field: event.action
+      ignore_missing: true
 
   #########################
   ## ECS Related Mapping ##

--- a/packages/1password/data_stream/item_usages/fields/ecs.yml
+++ b/packages/1password/data_stream/item_usages/fields/ecs.yml
@@ -17,6 +17,9 @@
   name: event.type
   description: This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types
 - external: ecs
+  name: event.action
+  description: The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer
+- external: ecs
   name: user.id
   description: The UUID of the user that accessed the item
 - external: ecs

--- a/packages/1password/data_stream/item_usages/sample_event.json
+++ b/packages/1password/data_stream/item_usages/sample_event.json
@@ -25,6 +25,7 @@
         "agent_id_status": "verified",
         "ingested": "2021-09-14T13:54:21Z",
         "created": "2021-09-14T13:54:19.267Z",
+        "action": "reveal",
         "dataset": "1password.item_usages"
     },
     "onepassword": {

--- a/packages/1password/docs/README.md
+++ b/packages/1password/docs/README.md
@@ -50,7 +50,8 @@ Uses the 1Password Events API to retrieve information about items in shared vaul
 
 | Field                                 | Description                                                                                                                                               |
 |---------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `@timestamp`                          | The date and time of the sign-in attempt                                                                                                                  |
+| `@timestamp`                          | The date and time of the item usage                                                                                                                       |
+| `event.action`                        | The action performed on the item usage                                                                                                                    |
 | `user.id`                             | The UUID of the user that accessed the item                                                                                                               |
 | `user.full_name`                      | The name of the user, hydrated at the time the event was generated                                                                                        |
 | `user.email`                          | The email address of the user, hydrated at the time the event was generated                                                                               |

--- a/packages/1password/kibana/search/1password-item-usages.json
+++ b/packages/1password/kibana/search/1password-item-usages.json
@@ -2,6 +2,7 @@
     "attributes": {
         "columns": [
             "user.email",
+            "event.action",
             "onepassword.vault_uuid",
             "onepassword.item_uuid",
             "source.geo.country_iso_code"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR adds the `event.action` field to Item Usages stream on 1Password Events Reporting integration package.  

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] I have added the new processor rule to the item usages elasticsearch ingest pipeline
- [x] I have updated the tests to match the addition

## Related

- [1Password Events API reference for the new action field](https://support.1password.com/events-api-reference/#:~:text=A%20Client%20object.-,action,-string)

## Screenshots

![item_usages_event_action](https://user-images.githubusercontent.com/167090/147006059-38787eac-dff8-4248-b073-df98b43b392b.png)

