### PR TITLE
Expose add_resource_metadata for container and pods resources

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0"
+  changes:
+    - description: Expose add_recourse_metadata configuration option
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/2370
 - version: "1.11.0"
   changes:
     - description: Add memory.working_set.limit.pct for pod and container data streams

--- a/packages/kubernetes/data_stream/container/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/container/agent/stream/stream.yml.hbs
@@ -1,5 +1,8 @@
 metricsets: ["container"]
 add_metadata: {{add_metadata}}
+{{#if add_resource_metadata_config}}
+{{add_resource_metadata_config}}
+{{/if}}
 hosts:
 {{#each hosts}}
   - {{this}}

--- a/packages/kubernetes/data_stream/container/manifest.yml
+++ b/packages/kubernetes/data_stream/container/manifest.yml
@@ -41,7 +41,7 @@ streams:
         default: none
       - name: add_resource_metadata_config
         type: yaml
-        title: Add additionally node and namespace metadata
+        title: Add node and namespace metadata
         required: false
         show_user: false
         default: |

--- a/packages/kubernetes/data_stream/container/manifest.yml
+++ b/packages/kubernetes/data_stream/container/manifest.yml
@@ -39,5 +39,18 @@ streams:
         required: true
         show_user: true
         default: none
+      - name: add_resource_metadata_config
+        type: yaml
+        title: Add additionally node and namespace metadata
+        required: false
+        show_user: false
+        default: |
+          # add_resource_metadata:
+          #   namespace:
+          #     include_labels: ["namespacelabel1"]
+          #   node:
+          #     include_labels: ["nodelabel2"]
+          #     include_annotations: ["nodeannotation1"]
+          #   deployment: false
     title: Kubernetes Container metrics
     description: Collect Kubernetes Container metrics

--- a/packages/kubernetes/data_stream/pod/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/pod/agent/stream/stream.yml.hbs
@@ -1,5 +1,8 @@
 metricsets: ["pod"]
 add_metadata: {{add_metadata}}
+{{#if add_resource_metadata_config}}
+{{add_resource_metadata_config}}
+{{/if}}
 hosts:
 {{#each hosts}}
   - {{this}}

--- a/packages/kubernetes/data_stream/pod/manifest.yml
+++ b/packages/kubernetes/data_stream/pod/manifest.yml
@@ -39,5 +39,18 @@ streams:
         required: true
         show_user: true
         default: none
+      - name: add_resource_metadata_config
+        type: yaml
+        title: Add additionally node and namespace metadata
+        required: false
+        show_user: false
+        default: |
+          # add_resource_metadata:
+          #   namespace:
+          #     include_labels: ["namespacelabel1"]
+          #   node:
+          #     include_labels: ["nodelabel2"]
+          #     include_annotations: ["nodeannotation1"]
+          #   deployment: false
     title: Kubernetes Pod metrics
     description: Collect Kubernetes Pod metrics

--- a/packages/kubernetes/data_stream/pod/manifest.yml
+++ b/packages/kubernetes/data_stream/pod/manifest.yml
@@ -41,7 +41,7 @@ streams:
         default: none
       - name: add_resource_metadata_config
         type: yaml
-        title: Add additionally node and namespace metadata
+        title: Add node and namespace metadata
         required: false
         show_user: false
         default: |

--- a/packages/kubernetes/data_stream/state_container/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_container/agent/stream/stream.yml.hbs
@@ -1,5 +1,8 @@
 metricsets: ["state_container"]
 add_metadata: {{add_metadata}}
+{{#if add_resource_metadata_config}}
+{{add_resource_metadata_config}}
+{{/if}}
 hosts:
 {{#each hosts}}
   - {{this}}

--- a/packages/kubernetes/data_stream/state_container/manifest.yml
+++ b/packages/kubernetes/data_stream/state_container/manifest.yml
@@ -33,5 +33,18 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: add_resource_metadata_config
+        type: yaml
+        title: Add additionally node and namespace metadata
+        required: false
+        show_user: false
+        default: |
+          # add_resource_metadata:
+          #   namespace:
+          #     include_labels: ["namespacelabel1"]
+          #   node:
+          #     include_labels: ["nodelabel2"]
+          #     include_annotations: ["nodeannotation1"]
+          #   deployment: false
     title: Kubernetes Container metrics
     description: Collect Kubernetes Container metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_container/manifest.yml
+++ b/packages/kubernetes/data_stream/state_container/manifest.yml
@@ -35,7 +35,7 @@ streams:
         default: 10s
       - name: add_resource_metadata_config
         type: yaml
-        title: Add additionally node and namespace metadata
+        title: Add node and namespace metadata
         required: false
         show_user: false
         default: |

--- a/packages/kubernetes/data_stream/state_pod/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_pod/agent/stream/stream.yml.hbs
@@ -1,5 +1,8 @@
 metricsets: ["state_pod"]
 add_metadata: {{add_metadata}}
+{{#if add_resource_metadata_config}}
+{{add_resource_metadata_config}}
+{{/if}}
 hosts:
 {{#each hosts}}
   - {{this}}

--- a/packages/kubernetes/data_stream/state_pod/manifest.yml
+++ b/packages/kubernetes/data_stream/state_pod/manifest.yml
@@ -33,5 +33,18 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: add_resource_metadata_config
+        type: yaml
+        title: Add additionally node and namespace metadata
+        required: false
+        show_user: false
+        default: |
+          # add_resource_metadata:
+          #   namespace:
+          #     include_labels: ["namespacelabel1"]
+          #   node:
+          #     include_labels: ["nodelabel2"]
+          #     include_annotations: ["nodeannotation1"]
+          #   deployment: false
     title: Kubernetes Pod metrics
     description: Collect Kubernetes Pod metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_pod/manifest.yml
+++ b/packages/kubernetes/data_stream/state_pod/manifest.yml
@@ -35,7 +35,7 @@ streams:
         default: 10s
       - name: add_resource_metadata_config
         type: yaml
-        title: Add additionally node and namespace metadata
+        title: Add node and namespace metadata
         required: false
         show_user: false
         default: |

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.11.0
+version: 1.12.0
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
Signed-off-by: Tetiana Kravchenko <tetiana.kravchenko@elastic.co>
## What does this PR do?
Add possibility to configure `add_recourse_metadata` for pod and container resources.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/elastic/integrations/issues/2362

## Screenshots

<img width="752" alt="Screenshot 2021-12-22 at 10 31 31" src="https://user-images.githubusercontent.com/28299531/147070890-7283b3d1-2127-4991-a593-b76dece4f451.png">

