### PR TITLE
Add missing leaderelection condition to state_job data stream

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add leader election in state_job data stream
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/2377
 - version: "1.9.0"
   changes:
     - description: Add missing fields

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.0"
+  changes:
+    - description: Add leader election in state_job data stream
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.9.0"
   changes:
     - description: Add missing fields

--- a/packages/kubernetes/data_stream/state_job/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_job/agent/stream/stream.yml.hbs
@@ -5,3 +5,6 @@ hosts:
   - {{this}}
 {{/each}}
 period: {{period}}
+{{#if leaderelection}}
+condition: ${kubernetes_leaderelection.leader} == true
+{{/if}}

--- a/packages/kubernetes/data_stream/state_job/manifest.yml
+++ b/packages/kubernetes/data_stream/state_job/manifest.yml
@@ -19,6 +19,13 @@ streams:
         show_user: true
         default:
           - kube-state-metrics:8080
+      - name: leaderelection
+        type: bool
+        title: Leader Election
+        multi: false
+        required: true
+        show_user: true
+        default: true
       - name: period
         type: text
         title: Period

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.9.0
+version: 1.10.0
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
Signed-off-by: Tetiana Kravchenko <tetiana.kravchenko@elastic.co>

## What does this PR do?

align elastic-agent-standalone manifest and k8s package: https://github.com/elastic/beats/blob/master/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml#L93-L101
## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- relates https://github.com/elastic/beats/issues/29565

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
