### PR TITLE
[Cisco Umbrella] adding support for Cisco Managed S3 buckets and non SQS

### DIFF
--- a/packages/cisco_umbrella/_dev/build/docs/README.md
+++ b/packages/cisco_umbrella/_dev/build/docs/README.md
@@ -9,7 +9,7 @@ datasets for receiving logs from an AWS S3 bucket using an SQS notification queu
 
 ### Umbrella
 
-When using Cisco Managed S3 buckets that does not use SQS there is no load balancing possibilities for multiple agents, a single agent should be configured to poll the S3 bucket for new and updated files, and the number of workers can be configured to scale vertically
+When using Cisco Managed S3 buckets that does not use SQS there is no load balancing possibilities for multiple agents, a single agent should be configured to poll the S3 bucket for new and updated files, and the number of workers can be configured to scale vertically.
 
 The `log` dataset collects Cisco Umbrella logs.
 

--- a/packages/cisco_umbrella/_dev/build/docs/README.md
+++ b/packages/cisco_umbrella/_dev/build/docs/README.md
@@ -1,13 +1,15 @@
 # Cisco Umbrella Integration
 
 This integration is for Cisco Umbrella . It includes the following
-datasets for receiving logs from an AWS S3 bucket using an SQS notification queue:
+datasets for receiving logs from an AWS S3 bucket using an SQS notification queue and Cisco Managed S3 bucket without SQS:
 
 - `log` dataset: supports Cisco Umbrella logs.
 
 ## Logs
 
 ### Umbrella
+
+When using Cisco Managed S3 buckets that does not use SQS there is no load balancing possibilities for multiple agents, a single agent should be configured to poll the S3 bucket for new and updated files, and the number of workers can be configured to scale vertically
 
 The `log` dataset collects Cisco Umbrella logs.
 

--- a/packages/cisco_umbrella/changelog.yml
+++ b/packages/cisco_umbrella/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.3.3"
+- version: "0.4.0"
   changes:
     - description: Update config to support Cisco Managed S3
       type: bugfix

--- a/packages/cisco_umbrella/changelog.yml
+++ b/packages/cisco_umbrella/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.3"
+  changes:
+    - description: Update config to support Cisco Managed S3
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/2339
 - version: "0.3.2"
   changes:
     - description: Regenerate test files using the new GeoIP database

--- a/packages/cisco_umbrella/changelog.yml
+++ b/packages/cisco_umbrella/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update config to support Cisco Managed S3
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/2339
+      link: https://github.com/elastic/integrations/pull/2462
 - version: "0.3.2"
   changes:
     - description: Regenerate test files using the new GeoIP database

--- a/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-cloudfirewalllogs.log-config.yml
+++ b/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-cloudfirewalllogs.log-config.yml
@@ -1,0 +1,4 @@
+fields:
+  log:
+    file:
+      path: /test/path/cloudfirewalllogs

--- a/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-cloudfirewalllogs.log-expected.json
+++ b/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-cloudfirewalllogs.log-expected.json
@@ -48,7 +48,7 @@
                 ]
             },
             "event": {
-                "ingested": "2021-12-14T14:41:06.773947594Z",
+                "ingested": "2022-01-04T08:29:26.469588606Z",
                 "original": "2020-07-23 18:03:46,[211039844],Passive Monitor,CDFW Tunnel Device,OUTBOUND,1,84,172.17.3.4,,67.43.156.12,,ams1.edc,12,ALLOW",
                 "category": "network",
                 "type": [
@@ -114,7 +114,7 @@
                 ]
             },
             "event": {
-                "ingested": "2021-12-14T14:41:06.773950384Z",
+                "ingested": "2022-01-04T08:29:26.469612981Z",
                 "original": "2020-07-23 18:03:46,[211039844],Passive Monitor,CDFW Tunnel Device,INBOUND,1,84,172.17.3.4,,67.43.156.12,,ams1.edc,12,BLOCK",
                 "category": "network",
                 "type": [

--- a/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-cloudfirewalllogs.log-expected.json
+++ b/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-cloudfirewalllogs.log-expected.json
@@ -1,6 +1,11 @@
 {
     "expected": [
         {
+            "log": {
+                "file": {
+                    "path": "/test/path/cloudfirewalllogs"
+                }
+            },
             "destination": {
                 "geo": {
                     "continent_name": "Asia",
@@ -34,6 +39,7 @@
                 "direction": "outbound"
             },
             "observer": {
+                "type": "firewall",
                 "product": "Umbrella",
                 "vendor": "Cisco"
             },
@@ -48,7 +54,7 @@
                 ]
             },
             "event": {
-                "ingested": "2022-01-04T08:29:26.469588606Z",
+                "ingested": "2022-01-04T12:39:22.661159854Z",
                 "original": "2020-07-23 18:03:46,[211039844],Passive Monitor,CDFW Tunnel Device,OUTBOUND,1,84,172.17.3.4,,67.43.156.12,,ams1.edc,12,ALLOW",
                 "category": "network",
                 "type": [
@@ -58,8 +64,8 @@
             "cisco": {
                 "umbrella": {
                     "identity_types": "CDFW Tunnel Device",
-                    "datacenter": "ams1.edc",
-                    "origin_id": "211039844"
+                    "origin_id": "[211039844]",
+                    "datacenter": "ams1.edc"
                 }
             },
             "user": {
@@ -67,6 +73,11 @@
             }
         },
         {
+            "log": {
+                "file": {
+                    "path": "/test/path/cloudfirewalllogs"
+                }
+            },
             "destination": {
                 "geo": {
                     "continent_name": "Asia",
@@ -100,6 +111,7 @@
                 "direction": "inbound"
             },
             "observer": {
+                "type": "firewall",
                 "product": "Umbrella",
                 "vendor": "Cisco"
             },
@@ -114,7 +126,7 @@
                 ]
             },
             "event": {
-                "ingested": "2022-01-04T08:29:26.469612981Z",
+                "ingested": "2022-01-04T12:39:22.661202885Z",
                 "original": "2020-07-23 18:03:46,[211039844],Passive Monitor,CDFW Tunnel Device,INBOUND,1,84,172.17.3.4,,67.43.156.12,,ams1.edc,12,BLOCK",
                 "category": "network",
                 "type": [
@@ -124,8 +136,8 @@
             "cisco": {
                 "umbrella": {
                     "identity_types": "CDFW Tunnel Device",
-                    "datacenter": "ams1.edc",
-                    "origin_id": "211039844"
+                    "origin_id": "[211039844]",
+                    "datacenter": "ams1.edc"
                 }
             },
             "user": {

--- a/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-dnslogs.log-config.yml
+++ b/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-dnslogs.log-config.yml
@@ -1,0 +1,4 @@
+fields:
+  log:
+    file:
+      path: /test/path/dnslogs

--- a/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-dnslogs.log-expected.json
+++ b/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-dnslogs.log-expected.json
@@ -52,7 +52,7 @@
             },
             "event": {
                 "action": "dns-request-Allowed",
-                "ingested": "2021-12-14T14:41:07.042646644Z",
+                "ingested": "2022-01-04T08:29:26.828312429Z",
                 "original": "\"2020-07-23 23:49:54\",\"elasticuser\",\"elasticuser2,some other identity\",\"192.168.1.1\",\"81.2.69.144\",\"Allowed\",\"1 (A)\",\"NOERROR\",\"elastic.co.\",\"Software/Technology,Business Services,Application\",\"Test Policy Name\",\"SomeIdentityType\",\"\"",
                 "category": "network",
                 "type": [
@@ -128,7 +128,7 @@
             },
             "event": {
                 "action": "dns-request-Blocked",
-                "ingested": "2021-12-14T14:41:07.042649340Z",
+                "ingested": "2022-01-04T08:29:26.828334620Z",
                 "original": "\"2020-07-23 23:50:25\",\"elasticuser\",\"elasticuser2,some other identity\",\"192.168.1.1\",\"67.43.156.12\",\"Blocked\",\"1 (A)\",\"NOERROR\",\"elastic.co.\",\"Chat,Instant Messaging,Block List,Application\",\"Test Policy Name\",\"SomeIdentityType\",\"BlockedCategories\"",
                 "category": "network",
                 "type": [
@@ -219,7 +219,7 @@
             },
             "event": {
                 "action": "dns-request-Allowed",
-                "ingested": "2021-12-14T14:41:07.042649780Z",
+                "ingested": "2022-01-04T08:29:26.828340992Z",
                 "original": "\"2021-05-14 19:39:58\",\"elastic_machine\",\"elastic_machine,Elastic User (ElasticUser@elastic.co)\",\"67.43.156.12\",\"81.2.69.144\",\"Allowed\",\"1 (A)\",\"NOERROR\",\"elastic.co.\",\"Infrastructure\",\"Roaming Computers\",\"Roaming Computers,AD Users\",\"\"",
                 "category": "network",
                 "type": [

--- a/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-dnslogs.log-expected.json
+++ b/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-dnslogs.log-expected.json
@@ -1,13 +1,10 @@
 {
     "expected": [
         {
-            "dns": {
-                "question": {
-                    "name": "elastic.co.",
-                    "type": "A"
-                },
-                "type": "query",
-                "response_code": "NOERROR"
+            "log": {
+                "file": {
+                    "path": "/test/path/dnslogs"
+                }
             },
             "destination": {
                 "geo": {
@@ -24,6 +21,14 @@
                 },
                 "address": "81.2.69.144",
                 "ip": "81.2.69.144"
+            },
+            "dns": {
+                "question": {
+                    "name": "elastic.co.",
+                    "type": "1 (A)"
+                },
+                "type": "query",
+                "response_code": "NOERROR"
             },
             "source": {
                 "address": "192.168.1.1",
@@ -52,7 +57,7 @@
             },
             "event": {
                 "action": "dns-request-Allowed",
-                "ingested": "2022-01-04T08:29:26.828312429Z",
+                "ingested": "2022-01-04T12:39:23.074201967Z",
                 "original": "\"2020-07-23 23:49:54\",\"elasticuser\",\"elasticuser2,some other identity\",\"192.168.1.1\",\"81.2.69.144\",\"Allowed\",\"1 (A)\",\"NOERROR\",\"elastic.co.\",\"Software/Technology,Business Services,Application\",\"Test Policy Name\",\"SomeIdentityType\",\"\"",
                 "category": "network",
                 "type": [
@@ -66,9 +71,12 @@
                         "elasticuser2",
                         "some other identity"
                     ],
-                    "categories": "Software/Technology,Business Services,Application",
+                    "categories": [
+                        "Software/Technology",
+                        "Business Services",
+                        "Application"
+                    ],
                     "identity_types": "SomeIdentityType",
-                    "blocked_categories": "",
                     "policy_identity_type": "Test Policy Name"
                 }
             },
@@ -77,13 +85,10 @@
             }
         },
         {
-            "dns": {
-                "question": {
-                    "name": "elastic.co.",
-                    "type": "A"
-                },
-                "type": "query",
-                "response_code": "NOERROR"
+            "log": {
+                "file": {
+                    "path": "/test/path/dnslogs"
+                }
             },
             "destination": {
                 "geo": {
@@ -100,6 +105,14 @@
                 },
                 "address": "67.43.156.12",
                 "ip": "67.43.156.12"
+            },
+            "dns": {
+                "question": {
+                    "name": "elastic.co.",
+                    "type": "1 (A)"
+                },
+                "type": "query",
+                "response_code": "NOERROR"
             },
             "source": {
                 "address": "192.168.1.1",
@@ -128,7 +141,7 @@
             },
             "event": {
                 "action": "dns-request-Blocked",
-                "ingested": "2022-01-04T08:29:26.828334620Z",
+                "ingested": "2022-01-04T12:39:23.074224469Z",
                 "original": "\"2020-07-23 23:50:25\",\"elasticuser\",\"elasticuser2,some other identity\",\"192.168.1.1\",\"67.43.156.12\",\"Blocked\",\"1 (A)\",\"NOERROR\",\"elastic.co.\",\"Chat,Instant Messaging,Block List,Application\",\"Test Policy Name\",\"SomeIdentityType\",\"BlockedCategories\"",
                 "category": "network",
                 "type": [
@@ -142,9 +155,16 @@
                         "elasticuser2",
                         "some other identity"
                     ],
-                    "categories": "Chat,Instant Messaging,Block List,Application",
+                    "categories": [
+                        "Chat",
+                        "Instant Messaging",
+                        "Block List",
+                        "Application"
+                    ],
                     "identity_types": "SomeIdentityType",
-                    "blocked_categories": "BlockedCategories",
+                    "blocked_categories": [
+                        "BlockedCategories"
+                    ],
                     "policy_identity_type": "Test Policy Name"
                 }
             },
@@ -153,13 +173,10 @@
             }
         },
         {
-            "dns": {
-                "question": {
-                    "name": "elastic.co.",
-                    "type": "A"
-                },
-                "type": "query",
-                "response_code": "NOERROR"
+            "log": {
+                "file": {
+                    "path": "/test/path/dnslogs"
+                }
             },
             "destination": {
                 "geo": {
@@ -176,6 +193,14 @@
                 },
                 "address": "81.2.69.144",
                 "ip": "81.2.69.144"
+            },
+            "dns": {
+                "question": {
+                    "name": "elastic.co.",
+                    "type": "1 (A)"
+                },
+                "type": "query",
+                "response_code": "NOERROR"
             },
             "source": {
                 "geo": {
@@ -219,7 +244,7 @@
             },
             "event": {
                 "action": "dns-request-Allowed",
-                "ingested": "2022-01-04T08:29:26.828340992Z",
+                "ingested": "2022-01-04T12:39:23.074231302Z",
                 "original": "\"2021-05-14 19:39:58\",\"elastic_machine\",\"elastic_machine,Elastic User (ElasticUser@elastic.co)\",\"67.43.156.12\",\"81.2.69.144\",\"Allowed\",\"1 (A)\",\"NOERROR\",\"elastic.co.\",\"Infrastructure\",\"Roaming Computers\",\"Roaming Computers,AD Users\",\"\"",
                 "category": "network",
                 "type": [
@@ -233,9 +258,10 @@
                         "elastic_machine",
                         "Elastic User (ElasticUser@elastic.co)"
                     ],
-                    "categories": "Infrastructure",
+                    "categories": [
+                        "Infrastructure"
+                    ],
                     "identity_types": "Roaming Computers,AD Users",
-                    "blocked_categories": "",
                     "policy_identity_type": "Roaming Computers"
                 }
             },

--- a/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-iplogs.log-config.yml
+++ b/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-iplogs.log-config.yml
@@ -1,0 +1,4 @@
+fields:
+  log:
+    file:
+      path: /test/path/iplogs

--- a/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-iplogs.log-expected.json
+++ b/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-iplogs.log-expected.json
@@ -1,21 +1,6 @@
 {
     "expected": [
         {
-            "observer": {
-                "type": "firewall",
-                "product": "Umbrella",
-                "vendor": "Cisco"
-            },
-            "@timestamp": "2020-08-26T20:32:46.000Z",
-            "ecs": {
-                "version": "1.12.0"
-            },
-            "related": {
-                "ip": [
-                    "192.168.1.1",
-                    "81.2.69.144"
-                ]
-            },
             "destination": {
                 "geo": {
                     "continent_name": "Europe",
@@ -38,30 +23,15 @@
                 "address": "192.168.1.1",
                 "ip": "192.168.1.1"
             },
-            "event": {
-                "category": "network",
-                "ingested": "2021-12-14T14:41:08.374045169Z",
-                "original": "\"2020-08-26 20:32:46\",\"elasticuser\",\"192.168.1.1\",\"0\",\"81.2.69.144\",\"0\",\"Test Category\""
-            },
-            "cisco": {
-                "umbrella": {
-                    "categories": "Test Category"
-                }
-            },
-            "user": {
-                "name": "elasticuser"
-            },
             "tags": [
                 "preserve_original_event"
-            ]
-        },
-        {
+            ],
             "observer": {
                 "type": "firewall",
                 "product": "Umbrella",
                 "vendor": "Cisco"
             },
-            "@timestamp": "2020-08-26T20:32:45.000Z",
+            "@timestamp": "2020-08-26T20:32:46.000Z",
             "ecs": {
                 "version": "1.12.0"
             },
@@ -71,6 +41,21 @@
                     "81.2.69.144"
                 ]
             },
+            "event": {
+                "category": "network",
+                "ingested": "2022-01-04T08:29:27.088073623Z",
+                "original": "\"2020-08-26 20:32:46\",\"elasticuser\",\"192.168.1.1\",\"0\",\"81.2.69.144\",\"0\",\"Test Category\""
+            },
+            "cisco": {
+                "umbrella": {
+                    "categories": "Test Category"
+                }
+            },
+            "user": {
+                "name": "elasticuser"
+            }
+        },
+        {
             "destination": {
                 "geo": {
                     "continent_name": "Europe",
@@ -93,9 +78,27 @@
                 "address": "192.168.1.1",
                 "ip": "192.168.1.1"
             },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "observer": {
+                "type": "firewall",
+                "product": "Umbrella",
+                "vendor": "Cisco"
+            },
+            "@timestamp": "2020-08-26T20:32:45.000Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "related": {
+                "ip": [
+                    "192.168.1.1",
+                    "81.2.69.144"
+                ]
+            },
             "event": {
                 "category": "network",
-                "ingested": "2021-12-14T14:41:08.374049248Z",
+                "ingested": "2022-01-04T08:29:27.088095804Z",
                 "original": "\"2020-08-26 20:32:45\",\"elasticuser\",\"192.168.1.1\",\"61095\",\"81.2.69.144\",\"445\",\"Test Category\""
             },
             "cisco": {
@@ -105,10 +108,7 @@
             },
             "user": {
                 "name": "elasticuser"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
+            }
         }
     ]
 }

--- a/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-iplogs.log-expected.json
+++ b/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-iplogs.log-expected.json
@@ -1,6 +1,11 @@
 {
     "expected": [
         {
+            "log": {
+                "file": {
+                    "path": "/test/path/iplogs"
+                }
+            },
             "destination": {
                 "geo": {
                     "continent_name": "Europe",
@@ -43,7 +48,7 @@
             },
             "event": {
                 "category": "network",
-                "ingested": "2022-01-04T08:29:27.088073623Z",
+                "ingested": "2022-01-04T12:39:23.343978034Z",
                 "original": "\"2020-08-26 20:32:46\",\"elasticuser\",\"192.168.1.1\",\"0\",\"81.2.69.144\",\"0\",\"Test Category\""
             },
             "cisco": {
@@ -56,6 +61,11 @@
             }
         },
         {
+            "log": {
+                "file": {
+                    "path": "/test/path/iplogs"
+                }
+            },
             "destination": {
                 "geo": {
                     "continent_name": "Europe",
@@ -98,7 +108,7 @@
             },
             "event": {
                 "category": "network",
-                "ingested": "2022-01-04T08:29:27.088095804Z",
+                "ingested": "2022-01-04T12:39:23.343999875Z",
                 "original": "\"2020-08-26 20:32:45\",\"elasticuser\",\"192.168.1.1\",\"61095\",\"81.2.69.144\",\"445\",\"Test Category\""
             },
             "cisco": {

--- a/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-proxylogs.log-config.yml
+++ b/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-proxylogs.log-config.yml
@@ -1,0 +1,4 @@
+fields:
+  log:
+    file:
+      path: /test/path/proxylogs

--- a/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-proxylogs.log-expected.json
+++ b/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-proxylogs.log-expected.json
@@ -63,7 +63,7 @@
                 }
             },
             "event": {
-                "ingested": "2021-12-14T14:41:08.650910742Z",
+                "ingested": "2022-01-04T08:29:27.222238434Z",
                 "original": "\"2020-07-23 23:48:56\",\"elasticuser\",\"someotheruser\",\"192.168.1.1\",\"67.43.156.12\",\"81.2.69.144\",\"\",\"ALLOWED\",\"https://elastic.co/blog/ext_id=Anyclip\",\"https://google.com/elastic\",\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.89 Safari/537.36\",\"200\",\"850\",\"\",\"\",\"\",\"Business Services\",\"AVDetectionName\",\"Malicious\",\"MalwareName\",\"\",\"\",\"Roaming Computers\",\"\"",
                 "category": "network",
                 "type": [
@@ -157,7 +157,7 @@
                 }
             },
             "event": {
-                "ingested": "2021-12-14T14:41:08.650913272Z",
+                "ingested": "2022-01-04T08:29:27.222258792Z",
                 "original": "\"2020-07-23 23:48:56\",\"elasticuser\",\"someotheruser\",\"192.168.1.1\",\"67.43.156.12\",\"81.2.69.144\",\"\",\"BLOCKED\",\"https://elastic.co/blog/ext_id=Anyclip\",\"https://google.com/elastic\",\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.89 Safari/537.36\",\"200\",\"850\",\"\",\"\",\"\",\"Business Services\",\"AVDetectionName\",\"Malicious\",\"MalwareName\",\"\",\"\",\"Roaming Computers\",\"\"",
                 "category": "network",
                 "type": [
@@ -236,7 +236,7 @@
                 }
             },
             "event": {
-                "ingested": "2021-12-14T14:41:08.650913743Z",
+                "ingested": "2022-01-04T08:29:27.222272638Z",
                 "original": "\"2017-10-02 23:52:53\",\"elasticuser\",\"ActiveDirectoryUserName,ADSite,Network\",\"192.168.192.135\",\"67.43.156.12\",\"\",\"\",\"ALLOWED\",\"http://google.com/the.js\",\"www.google.com\",\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36\",\"200\",\"562\",\"1489\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"Networks\"",
                 "category": "network",
                 "type": [

--- a/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-proxylogs.log-expected.json
+++ b/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-proxylogs.log-expected.json
@@ -1,6 +1,11 @@
 {
     "expected": [
         {
+            "log": {
+                "file": {
+                    "path": "/test/path/proxylogs"
+                }
+            },
             "destination": {
                 "geo": {
                     "continent_name": "Europe",
@@ -28,8 +33,7 @@
                 "path": "/blog/ext_id=Anyclip",
                 "original": "https://elastic.co/blog/ext_id=Anyclip",
                 "scheme": "https",
-                "domain": "elastic.co",
-                "full": "https://elastic.co/blog/ext_id=Anyclip"
+                "domain": "elastic.co"
             },
             "tags": [
                 "preserve_original_event"
@@ -44,9 +48,6 @@
                 "version": "1.12.0"
             },
             "related": {
-                "hash": [
-                    ""
-                ],
                 "ip": [
                     "192.168.1.1",
                     "67.43.156.12",
@@ -63,7 +64,7 @@
                 }
             },
             "event": {
-                "ingested": "2022-01-04T08:29:27.222238434Z",
+                "ingested": "2022-01-04T12:39:23.528315992Z",
                 "original": "\"2020-07-23 23:48:56\",\"elasticuser\",\"someotheruser\",\"192.168.1.1\",\"67.43.156.12\",\"81.2.69.144\",\"\",\"ALLOWED\",\"https://elastic.co/blog/ext_id=Anyclip\",\"https://google.com/elastic\",\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.89 Safari/537.36\",\"200\",\"850\",\"\",\"\",\"\",\"Business Services\",\"AVDetectionName\",\"Malicious\",\"MalwareName\",\"\",\"\",\"Roaming Computers\",\"\"",
                 "category": "network",
                 "type": [
@@ -72,29 +73,25 @@
             },
             "cisco": {
                 "umbrella": {
-                    "amp_score": "",
+                    "computer_name": "elasticuser",
+                    "identities": "someotheruser",
                     "puas": "Malicious",
-                    "identities": [
-                        "someotheruser"
-                    ],
-                    "content_type": "",
                     "identity_types": "Roaming Computers",
-                    "blocked_categories": "",
-                    "sha_sha256": "",
-                    "amp_disposition": "MalwareName",
                     "categories": "Business Services",
-                    "av_detections": "AVDetectionName",
-                    "amp_malware_name": ""
+                    "amp_disposition": "MalwareName",
+                    "av_detections": "AVDetectionName"
                 }
-            },
-            "user": {
-                "name": "elasticuser"
             },
             "user_agent": {
                 "original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.89 Safari/537.36"
             }
         },
         {
+            "log": {
+                "file": {
+                    "path": "/test/path/proxylogs"
+                }
+            },
             "destination": {
                 "geo": {
                     "continent_name": "Europe",
@@ -122,8 +119,7 @@
                 "path": "/blog/ext_id=Anyclip",
                 "original": "https://elastic.co/blog/ext_id=Anyclip",
                 "scheme": "https",
-                "domain": "elastic.co",
-                "full": "https://elastic.co/blog/ext_id=Anyclip"
+                "domain": "elastic.co"
             },
             "tags": [
                 "preserve_original_event"
@@ -138,9 +134,6 @@
                 "version": "1.12.0"
             },
             "related": {
-                "hash": [
-                    ""
-                ],
                 "ip": [
                     "192.168.1.1",
                     "67.43.156.12",
@@ -157,7 +150,7 @@
                 }
             },
             "event": {
-                "ingested": "2022-01-04T08:29:27.222258792Z",
+                "ingested": "2022-01-04T12:39:23.528350036Z",
                 "original": "\"2020-07-23 23:48:56\",\"elasticuser\",\"someotheruser\",\"192.168.1.1\",\"67.43.156.12\",\"81.2.69.144\",\"\",\"BLOCKED\",\"https://elastic.co/blog/ext_id=Anyclip\",\"https://google.com/elastic\",\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.89 Safari/537.36\",\"200\",\"850\",\"\",\"\",\"\",\"Business Services\",\"AVDetectionName\",\"Malicious\",\"MalwareName\",\"\",\"\",\"Roaming Computers\",\"\"",
                 "category": "network",
                 "type": [
@@ -166,29 +159,25 @@
             },
             "cisco": {
                 "umbrella": {
-                    "amp_score": "",
+                    "computer_name": "elasticuser",
+                    "identities": "someotheruser",
                     "puas": "Malicious",
-                    "identities": [
-                        "someotheruser"
-                    ],
-                    "content_type": "",
                     "identity_types": "Roaming Computers",
-                    "blocked_categories": "",
-                    "sha_sha256": "",
-                    "amp_disposition": "MalwareName",
                     "categories": "Business Services",
-                    "av_detections": "AVDetectionName",
-                    "amp_malware_name": ""
+                    "amp_disposition": "MalwareName",
+                    "av_detections": "AVDetectionName"
                 }
-            },
-            "user": {
-                "name": "elasticuser"
             },
             "user_agent": {
                 "original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.89 Safari/537.36"
             }
         },
         {
+            "log": {
+                "file": {
+                    "path": "/test/path/proxylogs"
+                }
+            },
             "source": {
                 "nat": {
                     "ip": "67.43.156.12"
@@ -201,8 +190,7 @@
                 "extension": "js",
                 "original": "http://google.com/the.js",
                 "scheme": "http",
-                "domain": "google.com",
-                "full": "http://google.com/the.js"
+                "domain": "google.com"
             },
             "tags": [
                 "preserve_original_event"
@@ -217,9 +205,6 @@
                 "version": "1.12.0"
             },
             "related": {
-                "hash": [
-                    ""
-                ],
                 "ip": [
                     "192.168.192.135",
                     "67.43.156.12"
@@ -236,7 +221,7 @@
                 }
             },
             "event": {
-                "ingested": "2022-01-04T08:29:27.222272638Z",
+                "ingested": "2022-01-04T12:39:23.528355797Z",
                 "original": "\"2017-10-02 23:52:53\",\"elasticuser\",\"ActiveDirectoryUserName,ADSite,Network\",\"192.168.192.135\",\"67.43.156.12\",\"\",\"\",\"ALLOWED\",\"http://google.com/the.js\",\"www.google.com\",\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36\",\"200\",\"562\",\"1489\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"Networks\"",
                 "category": "network",
                 "type": [
@@ -245,25 +230,10 @@
             },
             "cisco": {
                 "umbrella": {
-                    "amp_score": "",
-                    "puas": "",
-                    "identities": [
-                        "ActiveDirectoryUserName",
-                        "ADSite",
-                        "Network"
-                    ],
-                    "content_type": "",
-                    "identity_types": "",
+                    "computer_name": "elasticuser",
                     "blocked_categories": "Networks",
-                    "sha_sha256": "",
-                    "amp_disposition": "",
-                    "categories": "",
-                    "av_detections": "",
-                    "amp_malware_name": ""
+                    "identities": "ActiveDirectoryUserName,ADSite,Network"
                 }
-            },
-            "user": {
-                "name": "elasticuser"
             },
             "user_agent": {
                 "original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36"

--- a/packages/cisco_umbrella/data_stream/log/agent/stream/aws-s3.yml.hbs
+++ b/packages/cisco_umbrella/data_stream/log/agent/stream/aws-s3.yml.hbs
@@ -5,11 +5,17 @@ queue_url: {{queue_url}}
 bucket_arn: {{bucket_arn}}
 {{/if}}
 {{#if bucket_list_prefix}}
-bucket_list_prefix: {{bucket_list_prefix}}
+bucket_list_prefix: {{bucket_list_prefix}}/
 {{/if}}
-{{#if file_selectors}}
+{{#if bucket_list_prefix}}
 file_selectors: 
-  - regex: {{file_selectors}}/
+  - regex: {{bucket_list_prefix}}/dnslogs/.+
+  - regex: {{bucket_list_prefix}}/proxylogs/.+
+  - regex: {{bucket_list_prefix}}/cloudfirewalllogs/.+
+  - regex: {{bucket_list_prefix}}/iplogs/.+
+{{/if}}
+{{#if region}}
+default_region: {{region}}
 {{/if}}
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}
@@ -43,6 +49,9 @@ fips_enabled: {{fips_enabled}}
 {{/if}}
 {{#if number_of_workers}}
 number_of_workers: {{number_of_workers}}
+{{/if}}
+{{#if bucket_list_interval}}
+bucket_list_interval: {{bucket_list_interval}}
 {{/if}}
 tags:
 {{#if preserve_original_event}}

--- a/packages/cisco_umbrella/data_stream/log/agent/stream/aws-s3.yml.hbs
+++ b/packages/cisco_umbrella/data_stream/log/agent/stream/aws-s3.yml.hbs
@@ -1,4 +1,16 @@
+{{#if queue_url}}
 queue_url: {{queue_url}}
+{{/if}}
+{{#if bucket_arn}}
+bucket_arn: {{bucket_arn}}
+{{/if}}
+{{#if bucket_list_prefix}}
+bucket_list_prefix: {{bucket_list_prefix}}
+{{/if}}
+{{#if file_selectors}}
+file_selectors: 
+  - regex: {{file_selectors}}/
+{{/if}}
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}
 {{/if}}
@@ -28,6 +40,9 @@ role_arn: {{role_arn}}
 {{/if}}
 {{#if fips_enabled}}
 fips_enabled: {{fips_enabled}}
+{{/if}}
+{{#if number_of_workers}}
+number_of_workers: {{number_of_workers}}
 {{/if}}
 tags:
 {{#if preserve_original_event}}

--- a/packages/cisco_umbrella/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_umbrella/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -2,243 +2,368 @@
 description: Pipeline for Cisco Umbrella
 
 processors:
-# ECS event.ingested
-- set:
-    field: event.ingested
-    value: '{{_ingest.timestamp}}'
-- set:
-    field: ecs.version
-    value: '1.12.0'
-- set:
-    field: observer.vendor
-    value: Cisco
-- set:
-    field: observer.product
-    value: Umbrella
-- rename:
-    field: message
-    target_field: event.original
+  # ECS event.ingested
+  - set:
+      field: event.ingested
+      value: "{{_ingest.timestamp}}"
+  - set:
+      field: ecs.version
+      value: "1.12.0"
+  - set:
+      field: observer.vendor
+      value: Cisco
+  - set:
+      field: observer.product
+      value: Umbrella
+  - rename:
+      field: message
+      target_field: event.original
+  ############
+  # DNS Logs #
+  ############
+  - csv:
+      field: event.original
+      target_fields:
+        - cisco.umbrella._tmp.time
+        - user.name
+        - cisco.umbrella.identities
+        - source.address
+        - destination.address
+        - cisco.umbrella.action
+        - dns.question.type
+        - dns.response_code
+        - dns.question.name
+        - cisco.umbrella.categories
+        - cisco.umbrella.policy_identity_type
+        - cisco.umbrella.identity_types
+        - cisco.umbrella.blocked_categories
+      if: ctx?.log?.file?.path.contains('dnslogs')
 
-- grok:
-    field: event.original
-    patterns:
-      - '"%{TIMESTAMP_ISO8601:cisco.umbrella._tmp_time}","%{DATA:user.name}","%{DATA:cisco.umbrella.identities}","%{IP:source.address}","%{IP:destination.address}","%{WORD:cisco.umbrella.action}","%{DATA}\(%{WORD:dns.question.type}\)","%{WORD:dns.response_code}","%{HOSTNAME:dns.question.name}","%{DATA:cisco.umbrella.categories}","%{DATA:cisco.umbrella.policy_identity_type}","%{DATA:cisco.umbrella.identity_types}","%{DATA:cisco.umbrella.blocked_categories}"'
-      - '"%{TIMESTAMP_ISO8601:cisco.umbrella._tmp_time}","%{DATA:user.name}","%{IP:source.address}","%{NONNEGINT:source.port:long}","%{IP:destination.address}","%{NONNEGINT:destination.port:long}","%{DATA:cisco.umbrella.categories}"'
-      - '"%{TIMESTAMP_ISO8601:cisco.umbrella._tmp_time}","%{DATA:user.name}","%{DATA:cisco.umbrella.identities}","%{IP:source.address}","%{IP:source.nat.ip}","(%{IP:destination.address}|)","%{DATA:cisco.umbrella.content_type}","%{WORD:cisco.umbrella.verdict}","%{DATA:url.original}","%{DATA:http.request.referrer}","%{DATA:user_agent.original}","%{POSINT:http.response.status_code:long}","%{POSINT:http.request.bytes:long}","(%{POSINT:http.response.bytes:long}|)","(%{POSINT:http.response.body.bytes:long}|)","%{DATA:cisco.umbrella.sha_sha256}","%{DATA:cisco.umbrella.categories}","%{DATA:cisco.umbrella.av_detections}","%{DATA:cisco.umbrella.puas}","%{DATA:cisco.umbrella.amp_disposition}","%{DATA:cisco.umbrella.amp_malware_name}","%{DATA:cisco.umbrella.amp_score}","%{DATA:cisco.umbrella.identity_types}","%{DATA:cisco.umbrella.blocked_categories}"'
-      - '%{TIMESTAMP_ISO8601:cisco.umbrella._tmp_time},\[%{DATA:cisco.umbrella.origin_id}\],%{DATA:user.name},%{DATA:cisco.umbrella.identity_types},%{WORD:cisco.umbrella.direction},%{NONNEGINT:network.transport},%{NONNEGINT:source.bytes:long},%{IP:source.address},(%{NONNEGINT:source.port:long}|),%{IP:destination.address},(%{NONNEGINT:destination.port:long}|),%{DATA:cisco.umbrella.datacenter},%{DATA:cisco.umbrella.ruleid},%{WORD:cisco.umbrella.verdict}'
-    ignore_failure: true
-- set:
-    field: observer.type
-    value: dns
-    if: ctx?.dns != null
-- set:
-    field: observer.type
-    value: firewall
-    if: ctx?.destination?.port != null
-- set:
-    field: observer.type
-    value: proxy
-    if: ctx?.url?.original != null
-- uri_parts:
-    field: url.original
-    ignore_failure: true
-    if: ctx?.url?.original != null
-- set:
-    field: url.full
-    copy_from: url.original
-    ignore_empty_value: true
+  - set:
+      field: observer.type
+      value: dns
+      if: ctx?.log?.file?.path.contains('dnslogs')
+  ###########
+  # IP Logs #
+  ###########
+  - csv:
+      field: event.original
+      target_fields:
+        - cisco.umbrella._tmp.time
+        - user.name
+        - source.address
+        - source.port
+        - destination.address
+        - destination.port
+        - cisco.umbrella.categories
+      if: ctx?.log?.file?.path.contains('iplogs')
 
-# Identifies is a field that includes any sort of username, device or other asset that is included in the request.
-# Converting this to an array to make it easier to use in searches and visualizations
-- split:
-    field: cisco.umbrella.identities
-    separator: ","
-    preserve_trailing: false
-    if: "ctx?.cisco?.umbrella?.identities != null"
+  - set:
+      field: observer.type
+      value: firewall
+      if: ctx?.log?.file?.path.contains('iplogs')
 
-######################
-# General ECS Fields #
-######################
-# This field is always in UTC, so no timezone should need to be set
-- date:
-    field: cisco.umbrella._tmp_time
-    target_field: "@timestamp"
-    formats:
-      - "yyyy-MM-dd HH:mm:ss"
+  ##############
+  # Proxy Logs #
+  ##############
+  - csv:
+      field: event.original
+      target_fields:
+        - cisco.umbrella._tmp.time
+        - cisco.umbrella.computer_name
+        - cisco.umbrella.identities
+        - source.address
+        - source.nat.ip
+        - destination.address
+        - cisco.umbrella.content_type
+        - cisco.umbrella.verdict
+        - url.full
+        - http.request.referrer
+        - user_agent.original
+        - http.response.status_code
+        - http.request.bytes
+        - http.response.bytes
+        - http.response.body.bytes
+        - cisco.umbrella.sha_sha256
+        - cisco.umbrella.categories
+        - cisco.umbrella.av_detections
+        - cisco.umbrella.puas
+        - cisco.umbrella.amp_disposition
+        - cisco.umbrella.amp_malware_name
+        - cisco.umbrella.amp_score
+        - cisco.umbrella.identity_types
+        - cisco.umbrella.blocked_categories
+        - cisco.umbrella.identity_types
+        - cisco.umbrella.request_method
+        - cisco.umbrella.dlp_status
+        - cisco.umbrella.certificate_errors
+        - cisco.umbrella.file_name
+        - cisco.umbrella.ruleset_id
+        - cisco.umbrella.rule_id
+        - cisco.umbrella.destination_lists_id
+      if: ctx?.log?.file?.path.contains('proxylogs')
 
-##################
-# DNS ECS Fields #
-##################
-- set:
-    field: dns.type
-    value: query
-    if: ctx?.cisco?.umbrella?.action != null
+  - set:
+      field: observer.type
+      value: proxy
+      if: ctx?.log?.file?.path.contains('proxylogs')
 
-######################
-# Network ECS Fields #
-######################
-- lowercase:
-    field: cisco.umbrella.direction
-    target_field: network.direction
-    if: ctx?.cisco?.umbrella?.direction != null
+  #######################
+  # Cloud Firewall Logs #
+  #######################
+  - csv:
+      field: event.original
+      target_fields:
+        - cisco.umbrella._tmp.time
+        - cisco.umbrella.origin_id
+        - user.name
+        - cisco.umbrella.identity_types
+        - cisco.umbrella.direction
+        - network.transport
+        - source.bytes
+        - source.address
+        - source.port
+        - destination.address
+        - destination.port
+        - cisco.umbrella.datacenter
+        - cisco.umbrella.ruleid
+        - cisco.umbrella.verdict
+      if: ctx?.log?.file?.path.contains('cloudfirewalllogs')
 
-###################
-# Rule ECS Fields #
-###################
-- rename:
-    field: cisco.umbrella.ruleid
-    target_field: rule.id
-    if: ctx?.cisco?.umbrella?.ruleid != null
+  - set:
+      field: observer.type
+      value: firewall
+      if: ctx?.log?.file?.path.contains('cloudfirewalllogs')
 
-####################
-# Event ECS Fields #
-####################
-- set:
-    field: event.action
-    value: "dns-request-{{cisco.umbrella.action}}"
-    if: ctx?.cisco?.umbrella?.action != null
-- set:
-    field: event.category
-    value: network
-- append:
-    field: event.type
-    value: allowed
-    if: "ctx?.cisco?.umbrella?.action == 'Allowed' || ['ALLOWED','ALLOW'].contains(ctx?.cisco?.umbrella?.verdict)"
-- append:
-    field: event.type
-    value: denied
-    if: "ctx?.cisco?.umbrella?.action == 'Blocked' || ['BLOCKED','BLOCK'].contains(ctx?.cisco?.umbrella?.verdict)"
-- append:
-    field: event.type
-    value: connection
-    if: ctx?.cisco?.umbrella?.action != null
-# Converting address fields to either ip or domain
-- convert:
-    field: source.address
-    target_field: source.ip
-    type: ip
-    ignore_failure: true
-    ignore_missing: true
-- convert:
-    field: destination.address
-    target_field: destination.ip
-    type: ip
-    ignore_failure: true
-    ignore_missing: true
-- community_id:
-    ignore_missing: true
-- geoip:
-    field: source.ip
-    target_field: source.geo
-    ignore_missing: true
-- geoip:
-    database_file: GeoLite2-ASN.mmdb
-    field: source.ip
-    target_field: source.as
-    properties:
-    - asn
-    - organization_name
-    ignore_missing: true
-- rename:
-    field: source.as.asn
-    target_field: source.as.number
-    ignore_missing: true
-- rename:
-    field: source.as.organization_name
-    target_field: source.as.organization.name
-    ignore_missing: true
-- geoip:
-    field: destination.ip
-    target_field: destination.geo
-    ignore_missing: true
-- geoip:
-    database_file: GeoLite2-ASN.mmdb
-    field: destination.ip
-    target_field: destination.as
-    properties:
-    - asn
-    - organization_name
-    ignore_missing: true
-- rename:
-    field: destination.as.asn
-    target_field: destination.as.number
-    ignore_missing: true
-- rename:
-    field: destination.as.organization_name
-    target_field: destination.as.organization.name
-    ignore_missing: true
-######################
-# Related ECS Fields #
-######################
-- append:
-    field: related.user
-    value: "{{user.name}}"
-    if: ctx?.source?.user?.name != null
-- append:
-    field: related.ip
-    value: "{{source.ip}}"
-    if: ctx?.source?.ip != null
-- append:
-    field: related.ip
-    value: "{{source.nat.ip}}"
-    if: ctx?.source?.nat?.ip != null
-- append:
-    field: related.ip
-    value: "{{destination.ip}}"
-    if: ctx?.destination?.ip != null
-- append:
-    field: related.hosts
-    value: "{{source.domain}}"
-    if: ctx?.source?.domain != null
-- append:
-    field: related.hosts
-    value: "{{dns.question.name}}"
-    if: ctx?.dns?.question?.name != null
-- append:
-    field: related.hash
-    value: "{{cisco.umbrella.sha_sha256}}"
-    if: ctx?.cisco?.umbrella?.sha_sha256 != null
-- script:
-    if: ctx?.cisco?.umbrella?.identities != null && ctx.cisco.umbrella.identities instanceof List
-    lang: painless
-    description: "Extract user name values from ctx.cisco.umbrella.identities and append it to related.user"
-    source: |-
-      void addRelatedUser(def ctx, def x) {
-        if (ctx?.related == null) {
-          Map map = new HashMap();
-          ctx.put("related", map);
+  - uri_parts:
+      field: url.full
+      ignore_failure: true
+      if: ctx?.url?.full != null
+
+  # Identifies is a field that includes any sort of username, device or other asset that is included in the request.
+  # Converting this to an array to make it easier to use in searches and visualizations
+  - split:
+      field: cisco.umbrella.identities
+      separator: ","
+      preserve_trailing: false
+      if: "ctx?.log?.file?.path.contains('dnslogs') && ctx?.cisco?.umbrella?.identities != null"
+
+  - split:
+      field: cisco.umbrella.categories
+      separator: ","
+      preserve_trailing: false
+      if: "ctx?.log?.file?.path.contains('dnslogs') && ctx?.cisco?.umbrella?.categories != null"
+  - split:
+      field: cisco.umbrella.blocked_categories
+      separator: ","
+      preserve_trailing: false
+      if: "ctx?.log?.file?.path.contains('dnslogs') && ctx?.cisco?.umbrella?.blocked_categories != null"
+  ######################
+  # General ECS Fields #
+  ######################
+  # This field is always in UTC, so no timezone should need to be set
+  - date:
+      field: cisco.umbrella._tmp.time
+      target_field: "@timestamp"
+      formats:
+        - "yyyy-MM-dd HH:mm:ss"
+      if: ctx?.cisco?.umbrella?._tmp?.time != null
+  ##################
+  # DNS ECS Fields #
+  ##################
+  - set:
+      field: dns.type
+      value: query
+      if: ctx?.cisco?.umbrella?.action != null
+  ######################
+  # Network ECS Fields #
+  ######################
+  - lowercase:
+      field: cisco.umbrella.direction
+      target_field: network.direction
+      if: ctx?.cisco?.umbrella?.direction != null
+  - convert:
+      field: source.bytes
+      type: long
+      if: ctx?.source?.bytes != null
+  - convert:
+      field: source.port
+      type: long
+      if: ctx?.source?.port != null
+  - convert:
+      field: destination.port
+      type: long
+      if: ctx?.destination?.port != null
+  ###################
+  # HTTP ECS Fields #
+  ###################
+  - convert:
+      field: http.request.bytes
+      type: long
+      if: ctx?.http?.request?.bytes != null
+  - convert:
+      field: http.response.bytes
+      type: long
+      if: ctx?.http?.response?.bytes != null
+  - convert:
+      field: http.response.status_code
+      type: long
+      if: ctx?.http?.response?.status_code != null
+  ###################
+  # Rule ECS Fields #
+  ###################
+  - rename:
+      field: cisco.umbrella.ruleid
+      target_field: rule.id
+      if: ctx?.cisco?.umbrella?.ruleid != null
+
+  ####################
+  # Event ECS Fields #
+  ####################
+  - set:
+      field: event.action
+      value: "dns-request-{{cisco.umbrella.action}}"
+      if: ctx?.cisco?.umbrella?.action != null
+  - set:
+      field: event.category
+      value: network
+  - append:
+      field: event.type
+      value: allowed
+      if: "ctx?.cisco?.umbrella?.action == 'Allowed' || ['ALLOWED','ALLOW'].contains(ctx?.cisco?.umbrella?.verdict)"
+  - append:
+      field: event.type
+      value: denied
+      if: "ctx?.cisco?.umbrella?.action == 'Blocked' || ['BLOCKED','BLOCK'].contains(ctx?.cisco?.umbrella?.verdict)"
+  - append:
+      field: event.type
+      value: connection
+      if: ctx?.cisco?.umbrella?.action != null
+  # Converting address fields to either ip or domain
+  - grok:
+      field: source.address
+      patterns:
+        - "(?:%{IP:source.ip}|%{GREEDYDATA:source.domain})"
+      ignore_failure: true
+  - grok:
+      field: destination.address
+      patterns:
+        - "(?:%{IP:destination.ip}|%{GREEDYDATA:destination.domain})"
+      ignore_failure: true
+  - community_id:
+      ignore_missing: true
+  - geoip:
+      field: source.ip
+      target_field: source.geo
+      ignore_missing: true
+  - geoip:
+      database_file: GeoLite2-ASN.mmdb
+      field: source.ip
+      target_field: source.as
+      properties:
+        - asn
+        - organization_name
+      ignore_missing: true
+  - rename:
+      field: source.as.asn
+      target_field: source.as.number
+      ignore_missing: true
+  - rename:
+      field: source.as.organization_name
+      target_field: source.as.organization.name
+      ignore_missing: true
+  - geoip:
+      field: destination.ip
+      target_field: destination.geo
+      ignore_missing: true
+  - geoip:
+      database_file: GeoLite2-ASN.mmdb
+      field: destination.ip
+      target_field: destination.as
+      properties:
+        - asn
+        - organization_name
+      ignore_missing: true
+  - rename:
+      field: destination.as.asn
+      target_field: destination.as.number
+      ignore_missing: true
+  - rename:
+      field: destination.as.organization_name
+      target_field: destination.as.organization.name
+      ignore_missing: true
+  ######################
+  # Related ECS Fields #
+  ######################
+  - append:
+      field: related.user
+      value: "{{user.name}}"
+      if: ctx?.source?.user?.name != null
+  - append:
+      field: related.ip
+      value: "{{source.ip}}"
+      if: ctx?.source?.ip != null
+  - append:
+      field: related.ip
+      value: "{{source.nat.ip}}"
+      if: ctx?.source?.nat?.ip != null
+  - append:
+      field: related.ip
+      value: "{{destination.ip}}"
+      if: ctx?.destination?.ip != null
+  - append:
+      field: related.hosts
+      value: "{{source.domain}}"
+      if: ctx?.source?.domain != null
+  - append:
+      field: related.hosts
+      value: "{{dns.question.name}}"
+      if: ctx?.dns?.question?.name != null
+  - append:
+      field: related.hash
+      value: "{{cisco.umbrella.sha_sha256}}"
+      if: ctx?.cisco?.umbrella?.sha_sha256 != null
+  - script:
+      if: ctx?.cisco?.umbrella?.identities != null && ctx.cisco.umbrella.identities instanceof List
+      lang: painless
+      description: "Extract user name values from ctx.cisco.umbrella.identities and append it to related.user"
+      source: |-
+        void addRelatedUser(def ctx, def x) {
+          if (ctx?.related == null) {
+            Map map = new HashMap();
+            ctx.put("related", map);
+          }
+          if (ctx?.related?.user == null) {
+            ArrayList al = new ArrayList();
+            ctx.related.put("user", al);
+          }
+          if (!ctx.related.user.contains(x)) {
+            ctx.related.user.add(x);
+          }
         }
-        if (ctx?.related?.user == null) {
-          ArrayList al = new ArrayList();
-          ctx.related.put("user", al);
+        for (cisco_identity in ctx.cisco.umbrella.identities) {
+          if (cisco_identity.contains('@')) {
+            addRelatedUser(ctx, cisco_identity);
+          }
         }
-        if (!ctx.related.user.contains(x)) {
-          ctx.related.user.add(x);
-        }
-      }
-      for (cisco_identity in ctx.cisco.umbrella.identities) {
-        if (cisco_identity.contains('@')) {
-          addRelatedUser(ctx, cisco_identity);
-        }
-      }
 
-###########
-# Cleanup #
-###########
-- remove:
-    field:
-    - cisco.umbrella._tmp_time
-    - cisco.umbrella.direction
-    - cisco.umbrella.action
-    - cisco.umbrella.verdict
-    ignore_missing: true
-    
-- remove:
-    field: event.original
-    if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"
-    ignore_failure: true
-    ignore_missing: true
+  ###########
+  # Cleanup #
+  ###########
+  - remove:
+      field:
+        - cisco.umbrella._tmp
+        - cisco.umbrella.direction
+        - cisco.umbrella.action
+        - cisco.umbrella.verdict
+      ignore_missing: true
+
+  - remove:
+      field: event.original
+      if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"
+      ignore_failure: true
+      ignore_missing: true
 on_failure:
-- append:
-    field: error.message
-    value: "{{ _ingest.on_failure_message }}"
+  - set:
+      field: error.message
+      value: "{{ _ingest.on_failure_message }}"

--- a/packages/cisco_umbrella/data_stream/log/fields/ecs.yml
+++ b/packages/cisco_umbrella/data_stream/log/fields/ecs.yml
@@ -1,5 +1,5 @@
 - external: ecs
-  name: '@timestamp'
+  name: "@timestamp"
 - external: ecs
   name: client.domain
 - external: ecs
@@ -174,3 +174,5 @@
   name: user_agent.original
 - external: ecs
   name: rule.id
+- external: ecs
+  name: log.file.path

--- a/packages/cisco_umbrella/data_stream/log/fields/fields.yml
+++ b/packages/cisco_umbrella/data_stream/log/fields/fields.yml
@@ -9,6 +9,11 @@
       description: >
         An array of the different identities related to the event.
 
+    - name: computer_name
+      type: keyword
+      description: >
+        The computer name related to the event.
+
     - name: categories
       type: keyword
       description: >
@@ -74,3 +79,21 @@
       description: >
         The unique identity of the network tunnel.
 
+    - name: cisco.umbrella.identities
+      type: keyword
+    - name: cisco.umbrella.identity_types
+      type: keyword
+    - name: cisco.umbrella.request_method
+      type: keyword
+    - name: cisco.umbrella.dlp_status
+      type: keyword
+    - name: cisco.umbrella.certificate_errors
+      type: keyword
+    - name: cisco.umbrella.file_name
+      type: keyword
+    - name: cisco.umbrella.ruleset_id
+      type: keyword
+    - name: cisco.umbrella.rule_id
+      type: keyword
+    - name: cisco.umbrella.destination_lists_id
+      type: keyword

--- a/packages/cisco_umbrella/data_stream/log/manifest.yml
+++ b/packages/cisco_umbrella/data_stream/log/manifest.yml
@@ -32,19 +32,27 @@ streams:
           Required for Cisco Managed S3. This sets the root folder of the S3 bucket that should be monitored, found in the S3 Web UI. Example value: 1235_654vcasd23431e5dd6f7fsad457sdf1fd5
       - name: file_selectors
         type: text
-        title: Bucket List Prefix
-        multi: true
+        title: File Selectors
+        multi: false
         required: false
         show_user: true
         description: >-
-          Required for Cisco Managed S3. When using S3 without SQS, a regex pattern to fit the folders is required. When using Cisco Managed S3, this should be the same value as Bucket List Prefix ending with a forward slash. Example: "1235_654vcasd23431e5dd6f7fsad457sdf1fd5/"
+          Required for Cisco Managed S3. When using S3 without SQS, a regex pattern to fit the folders is required. When using Cisco Managed S3, this should be the same value as Bucket List Prefix, Example: "1235_654vcasd23431e5dd6f7fsad457sdf1fd5"
       - name: number_of_workers
         type: text
         title: Number of Workers
         multi: false
         required: false
         show_user: true
-        description: Required for Cisco Managed S3. Number of workers that will process the S3 objects listed. Default is 1.
+        default: 1
+        description: Required for Cisco Managed S3. Number of workers that will process the S3 objects listed. Minimum is 1
+      - name: bucket_list_interval
+        type: text
+        title: Bucket List Interval
+        multi: false
+        required: false
+        show_user: true
+        description: Time interval for polling listing of the S3 bucket. Defaults to 120s.
       - name: shared_credential_file
         type: text
         title: Shared Credential File

--- a/packages/cisco_umbrella/data_stream/log/manifest.yml
+++ b/packages/cisco_umbrella/data_stream/log/manifest.yml
@@ -11,9 +11,40 @@ streams:
         type: text
         title: Queue URL
         multi: false
-        required: true
+        required: false
         show_user: true
-        description: URL of the AWS SQS queue that messages will be received from.
+        description: URL of the AWS SQS queue that messages will be received from. For Cisco Managed S3 buckets or S3 without SQS, use Bucket ARN
+      - name: bucket_arn
+        type: text
+        title: Bucket ARN
+        multi: false
+        required: false
+        show_user: true
+        description: >-
+          Required for Cisco Managed S3. If the S3 bucket does not use SQS, this is the address for the S3 bucket, one example is "arn:aws:s3:::cisco-managed-eu-central-1" For a list of Cisco Managed buckets, please see https://docs.umbrella.com/mssp-deployment/docs/enable-logging-to-a-cisco-managed-s3-bucket
+      - name: bucket_list_prefix
+        type: text
+        title: Bucket List Prefix
+        multi: false
+        required: false
+        show_user: true
+        description: >-
+          Required for Cisco Managed S3. This sets the root folder of the S3 bucket that should be monitored, found in the S3 Web UI. Example value: 1235_654vcasd23431e5dd6f7fsad457sdf1fd5
+      - name: file_selectors
+        type: text
+        title: Bucket List Prefix
+        multi: true
+        required: false
+        show_user: true
+        description: >-
+          Required for Cisco Managed S3. When using S3 without SQS, a regex pattern to fit the folders is required. When using Cisco Managed S3, this should be the same value as Bucket List Prefix ending with a forward slash. Example: "1235_654vcasd23431e5dd6f7fsad457sdf1fd5/"
+      - name: number_of_workers
+        type: text
+        title: Number of Workers
+        multi: false
+        required: false
+        show_user: true
+        description: Required for Cisco Managed S3. Number of workers that will process the S3 objects listed. Default is 1.
       - name: shared_credential_file
         type: text
         title: Shared Credential File

--- a/packages/cisco_umbrella/data_stream/log/manifest.yml
+++ b/packages/cisco_umbrella/data_stream/log/manifest.yml
@@ -6,6 +6,7 @@ streams:
     enabled: false
     title: Cisco Umbrella logs
     description: Collect Cisco Umbrella logs
+    template_path: aws-s3.yml.hbs
     vars:
       - name: queue_url
         type: text
@@ -13,7 +14,7 @@ streams:
         multi: false
         required: false
         show_user: true
-        description: URL of the AWS SQS queue that messages will be received from. For Cisco Managed S3 buckets or S3 without SQS, use Bucket ARN
+        description: URL of the AWS SQS queue that messages will be received from. For Cisco Managed S3 buckets or S3 without SQS, use Bucket ARN.
       - name: bucket_arn
         type: text
         title: Bucket ARN
@@ -21,7 +22,15 @@ streams:
         required: false
         show_user: true
         description: >-
-          Required for Cisco Managed S3. If the S3 bucket does not use SQS, this is the address for the S3 bucket, one example is "arn:aws:s3:::cisco-managed-eu-central-1" For a list of Cisco Managed buckets, please see https://docs.umbrella.com/mssp-deployment/docs/enable-logging-to-a-cisco-managed-s3-bucket
+          Required for Cisco Managed S3. If the S3 bucket does not use SQS, this is the address for the S3 bucket, one example is `arn:aws:s3:::cisco-managed-eu-central-1` For a list of Cisco Managed buckets, please see https://docs.umbrella.com/mssp-deployment/docs/enable-logging-to-a-cisco-managed-s3-bucket.
+      - name: region
+        type: text
+        title: Bucket Region
+        multi: false
+        required: false
+        show_user: true
+        description: >-
+          Required for Cisco Managed S3. The region the bucket is located in.
       - name: bucket_list_prefix
         type: text
         title: Bucket List Prefix
@@ -29,15 +38,7 @@ streams:
         required: false
         show_user: true
         description: >-
-          Required for Cisco Managed S3. This sets the root folder of the S3 bucket that should be monitored, found in the S3 Web UI. Example value: 1235_654vcasd23431e5dd6f7fsad457sdf1fd5
-      - name: file_selectors
-        type: text
-        title: File Selectors
-        multi: false
-        required: false
-        show_user: true
-        description: >-
-          Required for Cisco Managed S3. When using S3 without SQS, a regex pattern to fit the folders is required. When using Cisco Managed S3, this should be the same value as Bucket List Prefix, Example: "1235_654vcasd23431e5dd6f7fsad457sdf1fd5"
+          Required for Cisco Managed S3. This sets the root folder of the S3 bucket that should be monitored, found in the S3 Web UI. Example value: `1235_654vcasd23431e5dd6f7fsad457sdf1fd5`. Forward slash at the end required for Cisco Managed S3.
       - name: number_of_workers
         type: text
         title: Number of Workers
@@ -45,7 +46,7 @@ streams:
         required: false
         show_user: true
         default: 1
-        description: Required for Cisco Managed S3. Number of workers that will process the S3 objects listed. Minimum is 1
+        description: Required for Cisco Managed S3. Number of workers that will process the S3 objects listed. Minimum is 1.
       - name: bucket_list_interval
         type: text
         title: Bucket List Interval
@@ -59,7 +60,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: Directory of the shared credentials file
+        description: Directory of the shared credentials file.
       - name: credential_profile_name
         type: text
         title: Credential Profile Name
@@ -97,7 +98,7 @@ streams:
         required: false
         show_user: false
         default: "amazonaws.com"
-        description: URL of the entry point for an AWS web service
+        description: URL of the entry point for an AWS web service.
       - name: visibility_timeout
         type: text
         title: Visibility Timeout
@@ -133,7 +134,7 @@ streams:
         required: true
         show_user: true
         title: Preserve original event
-        description: Preserves a raw copy of the original event, added to the field `event.original`
+        description: Preserves a raw copy of the original event, added to the field `event.original`.
         type: bool
         multi: false
         default: false

--- a/packages/cisco_umbrella/docs/README.md
+++ b/packages/cisco_umbrella/docs/README.md
@@ -9,7 +9,7 @@ datasets for receiving logs from an AWS S3 bucket using an SQS notification queu
 
 ### Umbrella
 
-When using Cisco Managed S3 buckets that does not use SQS there is no load balancing possibilities for multiple agents, a single agent should be configured to poll the S3 bucket for new and updated files, and the number of workers can be configured to scale vertically
+When using Cisco Managed S3 buckets that does not use SQS there is no load balancing possibilities for multiple agents, a single agent should be configured to poll the S3 bucket for new and updated files, and the number of workers can be configured to scale vertically.
 
 The `log` dataset collects Cisco Umbrella logs.
 

--- a/packages/cisco_umbrella/docs/README.md
+++ b/packages/cisco_umbrella/docs/README.md
@@ -1,13 +1,15 @@
 # Cisco Umbrella Integration
 
 This integration is for Cisco Umbrella . It includes the following
-datasets for receiving logs from an AWS S3 bucket using an SQS notification queue:
+datasets for receiving logs from an AWS S3 bucket using an SQS notification queue and Cisco Managed S3 bucket without SQS:
 
 - `log` dataset: supports Cisco Umbrella logs.
 
 ## Logs
 
 ### Umbrella
+
+When using Cisco Managed S3 buckets that does not use SQS there is no load balancing possibilities for multiple agents, a single agent should be configured to poll the S3 bucket for new and updated files, and the number of workers can be configured to scale vertically
 
 The `log` dataset collects Cisco Umbrella logs.
 

--- a/packages/cisco_umbrella/docs/README.md
+++ b/packages/cisco_umbrella/docs/README.md
@@ -126,6 +126,16 @@ An example event for `log` looks as following:
 | cisco.umbrella.av_detections | The detection name according to the antivirus engine used in file inspection. | keyword |
 | cisco.umbrella.blocked_categories | The categories that resulted in the destination being blocked. Available in version 4 and above. | keyword |
 | cisco.umbrella.categories | The security or content categories that the destination matches. | keyword |
+| cisco.umbrella.cisco.umbrella.certificate_errors |  | keyword |
+| cisco.umbrella.cisco.umbrella.destination_lists_id |  | keyword |
+| cisco.umbrella.cisco.umbrella.dlp_status |  | keyword |
+| cisco.umbrella.cisco.umbrella.file_name |  | keyword |
+| cisco.umbrella.cisco.umbrella.identities |  | keyword |
+| cisco.umbrella.cisco.umbrella.identity_types |  | keyword |
+| cisco.umbrella.cisco.umbrella.request_method |  | keyword |
+| cisco.umbrella.cisco.umbrella.rule_id |  | keyword |
+| cisco.umbrella.cisco.umbrella.ruleset_id |  | keyword |
+| cisco.umbrella.computer_name | The computer name related to the event. | keyword |
 | cisco.umbrella.content_type | The type of web content, typically text/html. | keyword |
 | cisco.umbrella.datacenter | The name of the Umbrella Data Center that processed the user-generated traffic. | keyword |
 | cisco.umbrella.identities | An array of the different identities related to the event. | keyword |
@@ -207,6 +217,7 @@ An example event for `log` looks as following:
 | http.response.bytes | Total size in bytes of the response (body and headers). | long |
 | http.response.status_code | HTTP response status code. | long |
 | input.type | Type of Filebeat input. | keyword |
+| log.file.path | Full path to the log file this event came from, including the file name. It should include the drive letter, when appropriate. If the event wasn't read from a log file, do not populate this field. | keyword |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
 | network.community_id | A hash of source and destination IPs and ports, as well as the protocol used in a communication. This is a tool-agnostic standard to identify flows. Learn more at https://github.com/corelight/community-id-spec. | keyword |
 | network.direction | Direction of the network traffic. Recommended values are:   \* ingress   \* egress   \* inbound   \* outbound   \* internal   \* external   \* unknown  When mapping events from a host-based monitoring context, populate this field from the host's point of view, using the values "ingress" or "egress". When mapping events from a network or perimeter-based monitoring context, populate this field from the point of view of the network perimeter, using the values "inbound", "outbound", "internal" or "external". Note that "internal" is not crossing perimeter boundaries, and is meant to describe communication between two hosts within the perimeter. Note also that "external" is meant to describe traffic between two hosts that are external to the perimeter. This could for example be useful for ISPs or VPN service providers. | keyword |

--- a/packages/cisco_umbrella/manifest.yml
+++ b/packages/cisco_umbrella/manifest.yml
@@ -10,7 +10,7 @@ categories:
   - security
 release: experimental
 conditions:
-  kibana.version: "^7.16.0 || ^8.0.0"
+  kibana.version: "^8.0.0"
 icons:
   - src: /img/cisco.svg
     title: cisco

--- a/packages/cisco_umbrella/manifest.yml
+++ b/packages/cisco_umbrella/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_umbrella
 title: Cisco Umbrella
-version: 0.3.2
+version: 0.3.3
 license: basic
 description: Collect logs from Cisco Umbrella with Elastic Agent.
 type: integration

--- a/packages/cisco_umbrella/manifest.yml
+++ b/packages/cisco_umbrella/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_umbrella
 title: Cisco Umbrella
-version: 0.3.3
+version: 0.4.0
 license: basic
 description: Collect logs from Cisco Umbrella with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Adds support for Non SQS type S3 buckets, including Cisco Managed S3 buckets.
Updates pipeline to support the newest proxy logs.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
