### PR TITLE
[cisco_ios] Add syslog header and timestamp parsing

### DIFF
--- a/packages/cisco_ios/_dev/deploy/docker/sample_logs/cisco-ios.log
+++ b/packages/cisco_ios/_dev/deploy/docker/sample_logs/cisco-ios.log
@@ -11,3 +11,7 @@ Jun 20 02:43:09 192.168.100.2 1663321: Jun 20 02:43:08.454: %SEC-6-IPACCESSLOGP:
 Jun 20 02:43:29 192.168.100.2 1663325: Jun 20 02:43:28.403: %SEC-6-IPACCESSLOGRL: access-list logging rate-limited or missed 23 packets
 Jun 20 02:43:29 192.168.100.2 1663326: Jun 20 02:43:28.403: %SEC-6-IPACCESSLOGDP: list 150 denied icmp 192.168.100.12 -> 192.168.100.1 (3/3), 32 packets
 Jun 20 02:43:30 192.168.100.2 1663327: Jun 20 02:43:29.451: %SEC-6-IPACCESSLOGP: list 150 denied tcp 192.168.100.12(59834) -> 81.2.69.144(80), 1 packet
+<189>2360957: Jan  6 2022 20:52:12.861: %SYS-5-CONFIG_I: Configured from console by akroh on vty0 (10.100.11.10)
+<189>: Jan  6 2022 20:54:26.961: %SYS-5-CONFIG_I: Configured from console by akroh on vty0 (10.100.11.10)
+<190>: Jan  6 2022 20:55:50.671: %SEC-6-IPACCESSLOGDP: list 100 denied icmp 172.16.0.26 -> 10.100.8.34 (3/3), 20 packets
+<189>: sw01: Jan  6 2022 21:01:34.964: %SYS-5-CONFIG_I: Configured from console by akroh on vty0 (10.100.11.10)

--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.0"
+  changes:
+    - description: Add syslog header and timestamp parsing.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/2475
 - version: "1.2.2"
   changes:
     - description: Regenerate test files using the new GeoIP database

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-cisco-ios.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-cisco-ios.log-expected.json
@@ -1,19 +1,10 @@
 {
     "expected": [
         {
-            "ecs": {
-                "version": "1.12.0"
-            },
-            "related": {
-                "ip": [
-                    "192.168.100.197",
-                    "224.0.0.22"
-                ]
-            },
             "log": {
                 "level": "informational",
-                "source": {
-                    "address": "192.168.100.2"
+                "syslog": {
+                    "hostname": "192.168.100.2"
                 }
             },
             "destination": {
@@ -26,10 +17,28 @@
                 "ip": "192.168.100.197"
             },
             "message": "list 177 denied igmp 192.168.100.197 -\u003e 224.0.0.22, 1 packet",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "community_id": "1:NCx7UOZoQUvxIB+uzqMmGnZTSzI=",
+                "transport": "igmp",
+                "type": "ipv4",
+                "packets": 1
+            },
+            "@timestamp": "2022-02-08T04:00:47.272Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "related": {
+                "ip": [
+                    "192.168.100.197",
+                    "224.0.0.22"
+                ]
+            },
             "event": {
                 "severity": 6,
                 "sequence": 585917,
-                "ingested": "2021-12-14T14:40:24.398623068Z",
                 "original": "Feb  8 04:00:48 192.168.100.2 585917: Feb  8 04:00:47.272: %SEC-6-IPACCESSLOGRP: list 177 denied igmp 192.168.100.197 -\u003e 224.0.0.22, 1 packet",
                 "code": "IPACCESSLOGRP",
                 "provider": "firewall",
@@ -42,22 +51,13 @@
                     "facility": "SEC",
                     "access_list": "177"
                 }
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "network": {
-                "community_id": "1:NCx7UOZoQUvxIB+uzqMmGnZTSzI=",
-                "transport": "igmp",
-                "type": "ipv4",
-                "packets": 1
             }
         },
         {
             "log": {
                 "level": "informational",
-                "source": {
-                    "address": "192.168.100.2"
+                "syslog": {
+                    "hostname": "192.168.100.2"
                 }
             },
             "destination": {
@@ -82,6 +82,7 @@
             "igmp": {
                 "type": "20"
             },
+            "@timestamp": "2022-02-09T04:00:47.272Z",
             "ecs": {
                 "version": "1.12.0"
             },
@@ -94,7 +95,6 @@
             "event": {
                 "severity": 6,
                 "sequence": 585918,
-                "ingested": "2021-12-14T14:40:24.398625713Z",
                 "original": "Feb  9 04:00:48 192.168.100.2 585918: Feb  9 04:00:47.272: %SEC-6-IPACCESSLOGSP: list INBOUND-ON-F11 denied igmp 192.168.100.2 -\u003e 224.0.0.2 (20), 1 packet",
                 "code": "IPACCESSLOGSP",
                 "provider": "firewall",
@@ -110,19 +110,10 @@
             }
         },
         {
-            "ecs": {
-                "version": "1.12.0"
-            },
-            "related": {
-                "ip": [
-                    "192.168.100.1",
-                    "255.255.255.255"
-                ]
-            },
             "log": {
                 "level": "informational",
-                "source": {
-                    "address": "192.168.100.2"
+                "syslog": {
+                    "hostname": "192.168.100.2"
                 }
             },
             "destination": {
@@ -135,10 +126,27 @@
                 "ip": "192.168.100.1"
             },
             "message": "list 171 denied 0 192.168.100.1 -\u003e 255.255.255.255, 1 packet",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "type": "ipv4",
+                "iana_number": "0",
+                "packets": 1
+            },
+            "@timestamp": "2022-02-10T04:00:47.272Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "related": {
+                "ip": [
+                    "192.168.100.1",
+                    "255.255.255.255"
+                ]
+            },
             "event": {
                 "severity": 6,
                 "sequence": 585919,
-                "ingested": "2021-12-14T14:40:24.398626168Z",
                 "original": "Feb 10 04:00:48 192.168.100.2 585919: Feb 10 04:00:47.272: %SEC-6-IPACCESSLOGNP: list 171 denied 0 192.168.100.1 -\u003e 255.255.255.255, 1 packet",
                 "code": "IPACCESSLOGNP",
                 "provider": "firewall",
@@ -151,29 +159,13 @@
                     "facility": "SEC",
                     "access_list": "171"
                 }
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "network": {
-                "type": "ipv4",
-                "iana_number": "0",
-                "packets": 1
             }
         },
         {
-            "ecs": {
-                "version": "1.12.0"
-            },
-            "related": {
-                "ip": [
-                    "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
-                ]
-            },
             "log": {
                 "level": "informational",
-                "source": {
-                    "address": "192.168.100.2"
+                "syslog": {
+                    "hostname": "192.168.100.2"
                 }
             },
             "destination": {
@@ -206,10 +198,27 @@
                 "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
             },
             "message": "list ACL-IPv6-E0/0-IN/10 permitted tcp 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6(1027) -\u003e 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6(22), 9 packets",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "community_id": "1:BI3p2ifMfqVkYuAqbGRcjozcbnA=",
+                "transport": "tcp",
+                "type": "ipv6",
+                "packets": 9
+            },
+            "@timestamp": "2022-05-03T19:11:32.619Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "related": {
+                "ip": [
+                    "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
+                ]
+            },
             "event": {
                 "severity": 6,
                 "sequence": 585920,
-                "ingested": "2021-12-14T14:40:24.398626589Z",
                 "original": "May  3 19:11:33 192.168.100.2 585920: May  3 19:11:32.619: %IPV6-6-ACCESSLOGP: list ACL-IPv6-E0/0-IN/10 permitted tcp 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6(1027) -\u003e 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6(22), 9 packets",
                 "code": "ACCESSLOGP",
                 "provider": "firewall",
@@ -222,31 +231,13 @@
                     "facility": "IPV6",
                     "access_list": "ACL-IPv6-E0/0-IN/10"
                 }
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "network": {
-                "community_id": "1:BI3p2ifMfqVkYuAqbGRcjozcbnA=",
-                "transport": "tcp",
-                "type": "ipv6",
-                "packets": 9
             }
         },
         {
-            "ecs": {
-                "version": "1.12.0"
-            },
-            "related": {
-                "ip": [
-                    "192.168.100.195",
-                    "192.168.100.255"
-                ]
-            },
             "log": {
                 "level": "informational",
-                "source": {
-                    "address": "192.168.100.2"
+                "syslog": {
+                    "hostname": "192.168.100.2"
                 }
             },
             "destination": {
@@ -261,10 +252,28 @@
                 "ip": "192.168.100.195"
             },
             "message": "list 177 denied udp 192.168.100.195(55250) -\u003e 192.168.100.255(15600), 1 packet",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "community_id": "1:StJhZzrkK7s6tPeVb3BmxbE0NZ0=",
+                "transport": "udp",
+                "type": "ipv4",
+                "packets": 1
+            },
+            "@timestamp": "2022-06-20T02:41:39.326Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "related": {
+                "ip": [
+                    "192.168.100.195",
+                    "192.168.100.255"
+                ]
+            },
             "event": {
                 "severity": 6,
                 "sequence": 1663303,
-                "ingested": "2021-12-14T14:40:24.398627015Z",
                 "original": "Jun 20 02:41:40 192.168.100.2 1663303: Jun 20 02:41:39.326: %SEC-6-IPACCESSLOGP: list 177 denied udp 192.168.100.195(55250) -\u003e 192.168.100.255(15600), 1 packet",
                 "code": "IPACCESSLOGP",
                 "provider": "firewall",
@@ -277,22 +286,13 @@
                     "facility": "SEC",
                     "access_list": "177"
                 }
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "network": {
-                "community_id": "1:StJhZzrkK7s6tPeVb3BmxbE0NZ0=",
-                "transport": "udp",
-                "type": "ipv4",
-                "packets": 1
             }
         },
         {
             "log": {
                 "level": "informational",
-                "source": {
-                    "address": "192.168.100.2"
+                "syslog": {
+                    "hostname": "192.168.100.2"
                 }
             },
             "destination": {
@@ -318,6 +318,7 @@
                 "type": "ipv4",
                 "packets": 1
             },
+            "@timestamp": "2022-06-20T02:41:44.921Z",
             "ecs": {
                 "version": "1.12.0"
             },
@@ -330,7 +331,6 @@
             "event": {
                 "severity": 6,
                 "sequence": 1663304,
-                "ingested": "2021-12-14T14:40:24.398627402Z",
                 "original": "Jun 20 02:41:45 192.168.100.2 1663304: Jun 20 02:41:44.921: %SEC-6-IPACCESSLOGDP: list 151 denied icmp 192.168.100.1 -\u003e 192.168.100.2 (3/4), 1 packet",
                 "code": "IPACCESSLOGDP",
                 "provider": "firewall",
@@ -346,19 +346,10 @@
             }
         },
         {
-            "ecs": {
-                "version": "1.12.0"
-            },
-            "related": {
-                "ip": [
-                    "192.168.100.195",
-                    "192.168.100.255"
-                ]
-            },
             "log": {
                 "level": "informational",
-                "source": {
-                    "address": "192.168.100.2"
+                "syslog": {
+                    "hostname": "192.168.100.2"
                 }
             },
             "destination": {
@@ -373,10 +364,28 @@
                 "ip": "192.168.100.195"
             },
             "message": "list 177 denied udp 192.168.100.195(54309) -\u003e 192.168.100.255(15600), 1 packet",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "community_id": "1:l5C5fxVKRjXx6kz2MZOPm+0MjuU=",
+                "transport": "udp",
+                "type": "ipv4",
+                "packets": 1
+            },
+            "@timestamp": "2022-06-20T02:42:27.342Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "related": {
+                "ip": [
+                    "192.168.100.195",
+                    "192.168.100.255"
+                ]
+            },
             "event": {
                 "severity": 6,
                 "sequence": 1663312,
-                "ingested": "2021-12-14T14:40:24.398627791Z",
                 "original": "Jun 20 02:42:28 192.168.100.2 1663312: Jun 20 02:42:27.342: %SEC-6-IPACCESSLOGP: list 177 denied udp 192.168.100.195(54309) -\u003e 192.168.100.255(15600), 1 packet",
                 "code": "IPACCESSLOGP",
                 "provider": "firewall",
@@ -389,31 +398,22 @@
                     "facility": "SEC",
                     "access_list": "177"
                 }
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "network": {
-                "community_id": "1:l5C5fxVKRjXx6kz2MZOPm+0MjuU=",
-                "transport": "udp",
-                "type": "ipv4",
-                "packets": 1
             }
         },
         {
+            "@timestamp": "2022-06-20T02:42:28.374Z",
             "ecs": {
                 "version": "1.12.0"
             },
             "log": {
                 "level": "informational",
-                "source": {
-                    "address": "192.168.100.2"
+                "syslog": {
+                    "hostname": "192.168.100.2"
                 }
             },
             "event": {
                 "severity": 6,
                 "sequence": 1663313,
-                "ingested": "2021-12-14T14:40:24.398628192Z",
                 "original": "Jun 20 02:42:28 192.168.100.2 1663313: Jun 20 02:42:28.374: %SEC-6-IPACCESSLOGRL: access-list logging rate-limited or missed 18 packets",
                 "code": "IPACCESSLOGRL",
                 "provider": "firewall",
@@ -431,19 +431,10 @@
             ]
         },
         {
-            "ecs": {
-                "version": "1.12.0"
-            },
-            "related": {
-                "ip": [
-                    "192.168.100.195",
-                    "192.168.100.255"
-                ]
-            },
             "log": {
                 "level": "informational",
-                "source": {
-                    "address": "192.168.100.2"
+                "syslog": {
+                    "hostname": "192.168.100.2"
                 }
             },
             "destination": {
@@ -458,10 +449,28 @@
                 "ip": "192.168.100.195"
             },
             "message": "list 177 denied udp 192.168.100.195(43989) -\u003e 192.168.100.255(15600), 1 packet",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "community_id": "1:qEu4RGH+VDqSvCYBmcpiipbHIFc=",
+                "transport": "udp",
+                "type": "ipv4",
+                "packets": 1
+            },
+            "@timestamp": "2022-06-20T02:42:33.340Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "related": {
+                "ip": [
+                    "192.168.100.195",
+                    "192.168.100.255"
+                ]
+            },
             "event": {
                 "severity": 6,
                 "sequence": 1663314,
-                "ingested": "2021-12-14T14:40:24.398628571Z",
                 "original": "Jun 20 02:42:34 192.168.100.2 1663314: Jun 20 02:42:33.340: %SEC-6-IPACCESSLOGP: list 177 denied udp 192.168.100.195(43989) -\u003e 192.168.100.255(15600), 1 packet",
                 "code": "IPACCESSLOGP",
                 "provider": "firewall",
@@ -474,31 +483,13 @@
                     "facility": "SEC",
                     "access_list": "177"
                 }
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "network": {
-                "community_id": "1:qEu4RGH+VDqSvCYBmcpiipbHIFc=",
-                "transport": "udp",
-                "type": "ipv4",
-                "packets": 1
             }
         },
         {
-            "ecs": {
-                "version": "1.12.0"
-            },
-            "related": {
-                "ip": [
-                    "192.168.100.12",
-                    "81.2.69.144"
-                ]
-            },
             "log": {
                 "level": "informational",
-                "source": {
-                    "address": "192.168.100.2"
+                "syslog": {
+                    "hostname": "192.168.100.2"
                 }
             },
             "destination": {
@@ -525,10 +516,28 @@
                 "ip": "192.168.100.12"
             },
             "message": "list 150 denied tcp 192.168.100.12(59832) -\u003e 81.2.69.144(80), 1 packet",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "community_id": "1:KHXR26FFI5fAjbqPIM0o9njIDr0=",
+                "transport": "tcp",
+                "type": "ipv4",
+                "packets": 1
+            },
+            "@timestamp": "2022-06-20T02:43:08.454Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "related": {
+                "ip": [
+                    "192.168.100.12",
+                    "81.2.69.144"
+                ]
+            },
             "event": {
                 "severity": 6,
                 "sequence": 1663321,
-                "ingested": "2021-12-14T14:40:24.398628952Z",
                 "original": "Jun 20 02:43:09 192.168.100.2 1663321: Jun 20 02:43:08.454: %SEC-6-IPACCESSLOGP: list 150 denied tcp 192.168.100.12(59832) -\u003e 81.2.69.144(80), 1 packet",
                 "code": "IPACCESSLOGP",
                 "provider": "firewall",
@@ -541,31 +550,22 @@
                     "facility": "SEC",
                     "access_list": "150"
                 }
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "network": {
-                "community_id": "1:KHXR26FFI5fAjbqPIM0o9njIDr0=",
-                "transport": "tcp",
-                "type": "ipv4",
-                "packets": 1
             }
         },
         {
+            "@timestamp": "2022-06-20T02:43:28.403Z",
             "ecs": {
                 "version": "1.12.0"
             },
             "log": {
                 "level": "informational",
-                "source": {
-                    "address": "192.168.100.2"
+                "syslog": {
+                    "hostname": "192.168.100.2"
                 }
             },
             "event": {
                 "severity": 6,
                 "sequence": 1663325,
-                "ingested": "2021-12-14T14:40:24.398629359Z",
                 "original": "Jun 20 02:43:29 192.168.100.2 1663325: Jun 20 02:43:28.403: %SEC-6-IPACCESSLOGRL: access-list logging rate-limited or missed 23 packets",
                 "code": "IPACCESSLOGRL",
                 "provider": "firewall",
@@ -585,8 +585,8 @@
         {
             "log": {
                 "level": "informational",
-                "source": {
-                    "address": "192.168.100.2"
+                "syslog": {
+                    "hostname": "192.168.100.2"
                 }
             },
             "destination": {
@@ -612,6 +612,7 @@
                 "type": "ipv4",
                 "packets": 32
             },
+            "@timestamp": "2022-06-20T02:43:28.403Z",
             "ecs": {
                 "version": "1.12.0"
             },
@@ -624,7 +625,6 @@
             "event": {
                 "severity": 6,
                 "sequence": 1663326,
-                "ingested": "2021-12-14T14:40:24.398629977Z",
                 "original": "Jun 20 02:43:29 192.168.100.2 1663326: Jun 20 02:43:28.403: %SEC-6-IPACCESSLOGDP: list 150 denied icmp 192.168.100.12 -\u003e 192.168.100.1 (3/3), 32 packets",
                 "code": "IPACCESSLOGDP",
                 "provider": "firewall",
@@ -640,19 +640,10 @@
             }
         },
         {
-            "ecs": {
-                "version": "1.12.0"
-            },
-            "related": {
-                "ip": [
-                    "192.168.100.12",
-                    "81.2.69.144"
-                ]
-            },
             "log": {
                 "level": "informational",
-                "source": {
-                    "address": "192.168.100.2"
+                "syslog": {
+                    "hostname": "192.168.100.2"
                 }
             },
             "destination": {
@@ -679,10 +670,28 @@
                 "ip": "192.168.100.12"
             },
             "message": "list 150 denied tcp 192.168.100.12(59834) -\u003e 81.2.69.144(80), 1 packet",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "community_id": "1:Nww0Z+gJpZXiHgUEpOLnoLROtqw=",
+                "transport": "tcp",
+                "type": "ipv4",
+                "packets": 1
+            },
+            "@timestamp": "2022-06-20T02:43:29.451Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "related": {
+                "ip": [
+                    "192.168.100.12",
+                    "81.2.69.144"
+                ]
+            },
             "event": {
                 "severity": 6,
                 "sequence": 1663327,
-                "ingested": "2021-12-14T14:40:24.398630399Z",
                 "original": "Jun 20 02:43:30 192.168.100.2 1663327: Jun 20 02:43:29.451: %SEC-6-IPACCESSLOGP: list 150 denied tcp 192.168.100.12(59834) -\u003e 81.2.69.144(80), 1 packet",
                 "code": "IPACCESSLOGP",
                 "provider": "firewall",
@@ -695,33 +704,13 @@
                     "facility": "SEC",
                     "access_list": "150"
                 }
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "network": {
-                "community_id": "1:Nww0Z+gJpZXiHgUEpOLnoLROtqw=",
-                "transport": "tcp",
-                "type": "ipv4",
-                "packets": 1
             }
         },
         {
-            "ecs": {
-                "version": "1.12.0"
-            },
-            "related": {
-                "user": [
-                    "john.smith"
-                ],
-                "ip": [
-                    "10.2.55.3"
-                ]
-            },
             "log": {
                 "level": "notification",
-                "source": {
-                    "address": "192.168.100.2"
+                "syslog": {
+                    "hostname": "192.168.100.2"
                 }
             },
             "destination": {
@@ -735,10 +724,27 @@
                 "ip": "10.2.55.3"
             },
             "message": "Login Success [user: john.smith] [Source: 10.2.55.3] [localport: 22] at 12:06:03 MST Wed Mar 24 2021",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "type": "ipv4"
+            },
+            "@timestamp": "2022-03-24T18:06:03.424Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "related": {
+                "user": [
+                    "john.smith"
+                ],
+                "ip": [
+                    "10.2.55.3"
+                ]
+            },
             "event": {
                 "severity": 5,
                 "sequence": 1991219,
-                "ingested": "2021-12-14T14:40:24.398630786Z",
                 "original": "Mar 24 18:06:03 192.168.100.2 1991219: Mar 24 18:06:03.424 UTC: %SEC_LOGIN-5-LOGIN_SUCCESS: Login Success [user: john.smith] [Source: 10.2.55.3] [localport: 22] at 12:06:03 MST Wed Mar 24 2021",
                 "code": "LOGIN_SUCCESS",
                 "provider": "firewall",
@@ -750,15 +756,30 @@
                     "action": "Login",
                     "facility": "SEC_LOGIN"
                 }
+            }
+        },
+        {
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "192.168.100.2"
+                }
             },
+            "source": {
+                "user": {
+                    "name": "john.smith"
+                },
+                "address": "10.5.36.9",
+                "ip": "10.5.36.9"
+            },
+            "message": "User john.smith has exited tty session 5(10.5.36.9)",
             "tags": [
                 "preserve_original_event"
             ],
             "network": {
                 "type": "ipv4"
-            }
-        },
-        {
+            },
+            "@timestamp": "2022-03-24T18:06:00.364Z",
             "ecs": {
                 "version": "1.12.0"
             },
@@ -770,30 +791,15 @@
                     "10.5.36.9"
                 ]
             },
-            "log": {
-                "level": "informational",
-                "source": {
-                    "address": "192.168.100.2"
-                }
-            },
-            "source": {
-                "user": {
-                    "name": "john.smith"
-                },
-                "address": "10.5.36.9",
-                "ip": "10.5.36.9"
-            },
             "event": {
                 "severity": 6,
                 "sequence": 1991220,
-                "ingested": "2021-12-14T14:40:24.398631171Z",
                 "original": "Mar 24 18:06:00 192.168.100.2 1991220: Mar 24 18:06:00.364 UTC: %SYS-6-LOGOUT: User john.smith has exited tty session 5(10.5.36.9)",
                 "code": "LOGOUT",
                 "provider": "firewall",
                 "category": "network",
                 "type": "info"
             },
-            "message": "User john.smith has exited tty session 5(10.5.36.9)",
             "cisco": {
                 "ios": {
                     "action": "exited",
@@ -803,28 +809,13 @@
                         "number": "5"
                     }
                 }
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "network": {
-                "type": "ipv4"
             }
         },
         {
-            "ecs": {
-                "version": "1.12.0"
-            },
-            "related": {
-                "ip": [
-                    "10.4.5.66",
-                    "10.3.66.3"
-                ]
-            },
             "log": {
                 "level": "informational",
-                "source": {
-                    "address": "192.168.100.2"
+                "syslog": {
+                    "hostname": "192.168.100.2"
                 }
             },
             "destination": {
@@ -836,11 +827,26 @@
                 "ip": "10.4.5.66"
             },
             "message": "Received (*, 10.36.2.78) Join from 10.4.5.66 for invalid RP 10.3.66.3",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "type": "ipv4"
+            },
+            "@timestamp": "2022-03-24T17:37:39.000Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "related": {
+                "ip": [
+                    "10.4.5.66",
+                    "10.3.66.3"
+                ]
+            },
             "event": {
                 "severity": 6,
                 "sequence": 1991221,
                 "reason": "Invalid RP",
-                "ingested": "2021-12-14T14:40:24.398631569Z",
                 "original": "Mar 24 17:37:39 192.168.100.2 1991221: Mar 24 17:37:39 UTC: %PIM-SW1-6-INVALID_RP_JOIN: Received (*, 10.36.2.78) Join from 10.4.5.66 for invalid RP 10.3.66.3",
                 "code": "INVALID_RP_JOIN",
                 "provider": "firewall",
@@ -860,28 +866,13 @@
                     "facility": "PIM-SW1",
                     "outcome": "invalid RP"
                 }
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "network": {
-                "type": "ipv4"
             }
         },
         {
-            "ecs": {
-                "version": "1.12.0"
-            },
-            "related": {
-                "ip": [
-                    "10.4.5.66",
-                    "10.3.66.3"
-                ]
-            },
             "log": {
                 "level": "informational",
-                "source": {
-                    "address": "192.168.100.2"
+                "syslog": {
+                    "hostname": "192.168.100.2"
                 }
             },
             "destination": {
@@ -893,11 +884,26 @@
                 "ip": "10.4.5.66"
             },
             "message": "Received (10.50.22.5, 10.36.2.78) Join from 10.4.5.66 for invalid RP 10.3.66.3",
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "type": "ipv4"
+            },
+            "@timestamp": "2022-03-24T17:37:39.000Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "related": {
+                "ip": [
+                    "10.4.5.66",
+                    "10.3.66.3"
+                ]
+            },
             "event": {
                 "severity": 6,
                 "sequence": 1991221,
                 "reason": "Invalid RP",
-                "ingested": "2021-12-14T14:40:24.398632091Z",
                 "original": "Mar 24 17:37:39 192.168.100.2 1991221: Mar 24 17:37:39 UTC: %PIM-SW1-6-INVALID_RP_JOIN: Received (10.50.22.5, 10.36.2.78) Join from 10.4.5.66 for invalid RP 10.3.66.3",
                 "code": "INVALID_RP_JOIN",
                 "provider": "firewall",
@@ -920,28 +926,22 @@
                     "facility": "PIM-SW1",
                     "outcome": "invalid RP"
                 }
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "network": {
-                "type": "ipv4"
             }
         },
         {
+            "@timestamp": "2022-03-24T12:09:35.367Z",
             "ecs": {
                 "version": "1.12.0"
             },
             "log": {
                 "level": "warning",
-                "source": {
-                    "address": "192.168.100.2"
+                "syslog": {
+                    "hostname": "192.168.100.2"
                 }
             },
             "event": {
                 "severity": 4,
                 "sequence": 1991217,
-                "ingested": "2021-12-14T14:40:24.398632495Z",
                 "original": "Mar 24 12:09:35 192.168.100.2 1991217: Mar 24 12:09:35.367: %OSPF-4-NOVALIDKEY: No valid authentication send key is available on interface eth0",
                 "code": "NOVALIDKEY",
                 "provider": "firewall",
@@ -959,19 +959,19 @@
             ]
         },
         {
+            "@timestamp": "2022-03-24T12:06:47.099Z",
             "ecs": {
                 "version": "1.12.0"
             },
             "log": {
                 "level": "informational",
-                "source": {
-                    "address": "192.168.100.2"
+                "syslog": {
+                    "hostname": "192.168.100.2"
                 }
             },
             "event": {
                 "severity": 6,
                 "sequence": 1991218,
-                "ingested": "2021-12-14T14:40:24.398632946Z",
                 "original": "Mar 24 12:06:47 192.168.100.2 1991218: Mar 24 12:06:47.099: %CCH323-6-CALL_PRESERVED: cch323_h225_handle_conn_loss: H.323 call preserved due to socket closure or error, Call Id = 6527, fd = 19",
                 "code": "CALL_PRESERVED",
                 "provider": "firewall",

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format-tzoffset.log
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format-tzoffset.log
@@ -1,0 +1,2 @@
+<190>2361044: sw01: Jan 16 2022 22:11:43: %FOO-6-BAR: Test date format.
+<190>2361044: sw01: Jan 16 2022 22:11:43 UTC: %FOO-6-BAR: Test date format.

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format-tzoffset.log-config.yml
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format-tzoffset.log-config.yml
@@ -1,0 +1,7 @@
+dynamic_fields:
+  event.ingested: ".*"
+fields:
+  tags:
+    - preserve_original_event
+  _conf:
+    tz_offset: '-05:00'

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format-tzoffset.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format-tzoffset.log-expected.json
@@ -1,0 +1,66 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2022-01-16T22:11:43.000-05:00",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "priority": 190,
+                    "hostname": "sw01"
+                }
+            },
+            "event": {
+                "severity": 6,
+                "sequence": 2361044,
+                "original": "\u003c190\u003e2361044: sw01: Jan 16 2022 22:11:43: %FOO-6-BAR: Test date format.",
+                "code": "BAR",
+                "provider": "firewall",
+                "category": "network",
+                "type": "info"
+            },
+            "message": "Test date format.",
+            "cisco": {
+                "ios": {
+                    "facility": "FOO"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-01-16T17:11:43.000-05:00",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "priority": 190,
+                    "hostname": "sw01"
+                }
+            },
+            "event": {
+                "severity": 6,
+                "sequence": 2361044,
+                "original": "\u003c190\u003e2361044: sw01: Jan 16 2022 22:11:43 UTC: %FOO-6-BAR: Test date format.",
+                "code": "BAR",
+                "provider": "firewall",
+                "category": "network",
+                "type": "info"
+            },
+            "message": "Test date format.",
+            "cisco": {
+                "ios": {
+                    "facility": "FOO"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        }
+    ]
+}

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format.log
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format.log
@@ -6,6 +6,7 @@
 <190>2361044: sw01: Jan 16 2022 22:11:43.398: %FOO-6-BAR: Test date format.
 <190>2361044: sw01: Jan 16 2022 22:11:43 UTC: %FOO-6-BAR: Test date format.
 <190>2361044: sw01: Jan 16 2022 22:11:43: %FOO-6-BAR: Test date format.
+<190>2361044: sw01: Jan 16 2022 22:11:43 EDT: %FOO-6-BAR: Test date format.
 <190>2361044: sw01: Jan  6 22:11:43.398 UTC: %FOO-6-BAR: Test date format.
 <190>2361044: sw01: Jan  6 22:11:43.398: %FOO-6-BAR: Test date format.
 <190>2361044: sw01: Jan  6 22:11:43 UTC: %FOO-6-BAR: Test date format.
@@ -14,3 +15,4 @@
 <190>2361044: sw01: Jan 16 22:11:43.398: %FOO-6-BAR: Test date format.
 <190>2361044: sw01: Jan 16 22:11:43 UTC: %FOO-6-BAR: Test date format.
 <190>2361044: sw01: Jan 16 22:11:43: %FOO-6-BAR: Test date format.
+<190>2361044: sw01: Jan 16 22:11:43 EDT: %FOO-6-BAR: Test date format.

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format.log
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format.log
@@ -1,0 +1,16 @@
+<190>2361044: sw01: Jan  6 2022 22:11:43.398 UTC: %FOO-6-BAR: Test date format.
+<190>2361044: sw01: Jan  6 2022 22:11:43.398: %FOO-6-BAR: Test date format.
+<190>2361044: sw01: Jan  6 2022 22:11:43 UTC: %FOO-6-BAR: Test date format.
+<190>2361044: sw01: Jan  6 2022 22:11:43: %FOO-6-BAR: Test date format.
+<190>2361044: sw01: Jan 16 2022 22:11:43.398 UTC: %FOO-6-BAR: Test date format.
+<190>2361044: sw01: Jan 16 2022 22:11:43.398: %FOO-6-BAR: Test date format.
+<190>2361044: sw01: Jan 16 2022 22:11:43 UTC: %FOO-6-BAR: Test date format.
+<190>2361044: sw01: Jan 16 2022 22:11:43: %FOO-6-BAR: Test date format.
+<190>2361044: sw01: Jan  6 22:11:43.398 UTC: %FOO-6-BAR: Test date format.
+<190>2361044: sw01: Jan  6 22:11:43.398: %FOO-6-BAR: Test date format.
+<190>2361044: sw01: Jan  6 22:11:43 UTC: %FOO-6-BAR: Test date format.
+<190>2361044: sw01: Jan  6 22:11:43: %FOO-6-BAR: Test date format.
+<190>2361044: sw01: Jan 16 22:11:43.398 UTC: %FOO-6-BAR: Test date format.
+<190>2361044: sw01: Jan 16 22:11:43.398: %FOO-6-BAR: Test date format.
+<190>2361044: sw01: Jan 16 22:11:43 UTC: %FOO-6-BAR: Test date format.
+<190>2361044: sw01: Jan 16 22:11:43: %FOO-6-BAR: Test date format.

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format.log-expected.json
@@ -1,0 +1,500 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2022-01-06T22:11:43.398Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "priority": 190,
+                    "hostname": "sw01"
+                }
+            },
+            "event": {
+                "severity": 6,
+                "sequence": 2361044,
+                "original": "\u003c190\u003e2361044: sw01: Jan  6 2022 22:11:43.398 UTC: %FOO-6-BAR: Test date format.",
+                "code": "BAR",
+                "provider": "firewall",
+                "category": "network",
+                "type": "info"
+            },
+            "message": "Test date format.",
+            "cisco": {
+                "ios": {
+                    "facility": "FOO"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-01-06T22:11:43.398Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "priority": 190,
+                    "hostname": "sw01"
+                }
+            },
+            "event": {
+                "severity": 6,
+                "sequence": 2361044,
+                "original": "\u003c190\u003e2361044: sw01: Jan  6 2022 22:11:43.398: %FOO-6-BAR: Test date format.",
+                "code": "BAR",
+                "provider": "firewall",
+                "category": "network",
+                "type": "info"
+            },
+            "message": "Test date format.",
+            "cisco": {
+                "ios": {
+                    "facility": "FOO"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-01-06T22:11:43.000Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "priority": 190,
+                    "hostname": "sw01"
+                }
+            },
+            "event": {
+                "severity": 6,
+                "sequence": 2361044,
+                "original": "\u003c190\u003e2361044: sw01: Jan  6 2022 22:11:43 UTC: %FOO-6-BAR: Test date format.",
+                "code": "BAR",
+                "provider": "firewall",
+                "category": "network",
+                "type": "info"
+            },
+            "message": "Test date format.",
+            "cisco": {
+                "ios": {
+                    "facility": "FOO"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-01-06T22:11:43.000Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "priority": 190,
+                    "hostname": "sw01"
+                }
+            },
+            "event": {
+                "severity": 6,
+                "sequence": 2361044,
+                "original": "\u003c190\u003e2361044: sw01: Jan  6 2022 22:11:43: %FOO-6-BAR: Test date format.",
+                "code": "BAR",
+                "provider": "firewall",
+                "category": "network",
+                "type": "info"
+            },
+            "message": "Test date format.",
+            "cisco": {
+                "ios": {
+                    "facility": "FOO"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-01-16T22:11:43.398Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "priority": 190,
+                    "hostname": "sw01"
+                }
+            },
+            "event": {
+                "severity": 6,
+                "sequence": 2361044,
+                "original": "\u003c190\u003e2361044: sw01: Jan 16 2022 22:11:43.398 UTC: %FOO-6-BAR: Test date format.",
+                "code": "BAR",
+                "provider": "firewall",
+                "category": "network",
+                "type": "info"
+            },
+            "message": "Test date format.",
+            "cisco": {
+                "ios": {
+                    "facility": "FOO"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-01-16T22:11:43.398Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "priority": 190,
+                    "hostname": "sw01"
+                }
+            },
+            "event": {
+                "severity": 6,
+                "sequence": 2361044,
+                "original": "\u003c190\u003e2361044: sw01: Jan 16 2022 22:11:43.398: %FOO-6-BAR: Test date format.",
+                "code": "BAR",
+                "provider": "firewall",
+                "category": "network",
+                "type": "info"
+            },
+            "message": "Test date format.",
+            "cisco": {
+                "ios": {
+                    "facility": "FOO"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-01-16T22:11:43.000Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "priority": 190,
+                    "hostname": "sw01"
+                }
+            },
+            "event": {
+                "severity": 6,
+                "sequence": 2361044,
+                "original": "\u003c190\u003e2361044: sw01: Jan 16 2022 22:11:43 UTC: %FOO-6-BAR: Test date format.",
+                "code": "BAR",
+                "provider": "firewall",
+                "category": "network",
+                "type": "info"
+            },
+            "message": "Test date format.",
+            "cisco": {
+                "ios": {
+                    "facility": "FOO"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-01-16T22:11:43.000Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "priority": 190,
+                    "hostname": "sw01"
+                }
+            },
+            "event": {
+                "severity": 6,
+                "sequence": 2361044,
+                "original": "\u003c190\u003e2361044: sw01: Jan 16 2022 22:11:43: %FOO-6-BAR: Test date format.",
+                "code": "BAR",
+                "provider": "firewall",
+                "category": "network",
+                "type": "info"
+            },
+            "message": "Test date format.",
+            "cisco": {
+                "ios": {
+                    "facility": "FOO"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-01-06T22:11:43.398Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "priority": 190,
+                    "hostname": "sw01"
+                }
+            },
+            "event": {
+                "severity": 6,
+                "sequence": 2361044,
+                "original": "\u003c190\u003e2361044: sw01: Jan  6 22:11:43.398 UTC: %FOO-6-BAR: Test date format.",
+                "code": "BAR",
+                "provider": "firewall",
+                "category": "network",
+                "type": "info"
+            },
+            "message": "Test date format.",
+            "cisco": {
+                "ios": {
+                    "facility": "FOO"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-01-06T22:11:43.398Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "priority": 190,
+                    "hostname": "sw01"
+                }
+            },
+            "event": {
+                "severity": 6,
+                "sequence": 2361044,
+                "original": "\u003c190\u003e2361044: sw01: Jan  6 22:11:43.398: %FOO-6-BAR: Test date format.",
+                "code": "BAR",
+                "provider": "firewall",
+                "category": "network",
+                "type": "info"
+            },
+            "message": "Test date format.",
+            "cisco": {
+                "ios": {
+                    "facility": "FOO"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-01-06T22:11:43.000Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "priority": 190,
+                    "hostname": "sw01"
+                }
+            },
+            "event": {
+                "severity": 6,
+                "sequence": 2361044,
+                "original": "\u003c190\u003e2361044: sw01: Jan  6 22:11:43 UTC: %FOO-6-BAR: Test date format.",
+                "code": "BAR",
+                "provider": "firewall",
+                "category": "network",
+                "type": "info"
+            },
+            "message": "Test date format.",
+            "cisco": {
+                "ios": {
+                    "facility": "FOO"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-01-06T22:11:43.000Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "priority": 190,
+                    "hostname": "sw01"
+                }
+            },
+            "event": {
+                "severity": 6,
+                "sequence": 2361044,
+                "original": "\u003c190\u003e2361044: sw01: Jan  6 22:11:43: %FOO-6-BAR: Test date format.",
+                "code": "BAR",
+                "provider": "firewall",
+                "category": "network",
+                "type": "info"
+            },
+            "message": "Test date format.",
+            "cisco": {
+                "ios": {
+                    "facility": "FOO"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-01-16T22:11:43.398Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "priority": 190,
+                    "hostname": "sw01"
+                }
+            },
+            "event": {
+                "severity": 6,
+                "sequence": 2361044,
+                "original": "\u003c190\u003e2361044: sw01: Jan 16 22:11:43.398 UTC: %FOO-6-BAR: Test date format.",
+                "code": "BAR",
+                "provider": "firewall",
+                "category": "network",
+                "type": "info"
+            },
+            "message": "Test date format.",
+            "cisco": {
+                "ios": {
+                    "facility": "FOO"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-01-16T22:11:43.398Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "priority": 190,
+                    "hostname": "sw01"
+                }
+            },
+            "event": {
+                "severity": 6,
+                "sequence": 2361044,
+                "original": "\u003c190\u003e2361044: sw01: Jan 16 22:11:43.398: %FOO-6-BAR: Test date format.",
+                "code": "BAR",
+                "provider": "firewall",
+                "category": "network",
+                "type": "info"
+            },
+            "message": "Test date format.",
+            "cisco": {
+                "ios": {
+                    "facility": "FOO"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-01-16T22:11:43.000Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "priority": 190,
+                    "hostname": "sw01"
+                }
+            },
+            "event": {
+                "severity": 6,
+                "sequence": 2361044,
+                "original": "\u003c190\u003e2361044: sw01: Jan 16 22:11:43 UTC: %FOO-6-BAR: Test date format.",
+                "code": "BAR",
+                "provider": "firewall",
+                "category": "network",
+                "type": "info"
+            },
+            "message": "Test date format.",
+            "cisco": {
+                "ios": {
+                    "facility": "FOO"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-01-16T22:11:43.000Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "priority": 190,
+                    "hostname": "sw01"
+                }
+            },
+            "event": {
+                "severity": 6,
+                "sequence": 2361044,
+                "original": "\u003c190\u003e2361044: sw01: Jan 16 22:11:43: %FOO-6-BAR: Test date format.",
+                "code": "BAR",
+                "provider": "firewall",
+                "category": "network",
+                "type": "info"
+            },
+            "message": "Test date format.",
+            "cisco": {
+                "ios": {
+                    "facility": "FOO"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        }
+    ]
+}

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format.log-expected.json
@@ -249,6 +249,37 @@
             ]
         },
         {
+            "@timestamp": "2022-01-17T03:11:43.000Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "priority": 190,
+                    "hostname": "sw01"
+                }
+            },
+            "event": {
+                "severity": 6,
+                "sequence": 2361044,
+                "original": "\u003c190\u003e2361044: sw01: Jan 16 2022 22:11:43 EDT: %FOO-6-BAR: Test date format.",
+                "code": "BAR",
+                "provider": "firewall",
+                "category": "network",
+                "type": "info"
+            },
+            "message": "Test date format.",
+            "cisco": {
+                "ios": {
+                    "facility": "FOO"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2022-01-06T22:11:43.398Z",
             "ecs": {
                 "version": "1.12.0"
@@ -481,6 +512,37 @@
                 "severity": 6,
                 "sequence": 2361044,
                 "original": "\u003c190\u003e2361044: sw01: Jan 16 22:11:43: %FOO-6-BAR: Test date format.",
+                "code": "BAR",
+                "provider": "firewall",
+                "category": "network",
+                "type": "info"
+            },
+            "message": "Test date format.",
+            "cisco": {
+                "ios": {
+                    "facility": "FOO"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-01-16T22:11:43.000Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "priority": 190,
+                    "hostname": "sw01"
+                }
+            },
+            "event": {
+                "severity": 6,
+                "sequence": 2361044,
+                "original": "\u003c190\u003e2361044: sw01: Jan 16 22:11:43 EDT: %FOO-6-BAR: Test date format.",
                 "code": "BAR",
                 "provider": "firewall",
                 "category": "network",

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog.log
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog.log
@@ -1,0 +1,4 @@
+<189>2360957: Jan  6 2022 20:52:12.861: %SYS-5-CONFIG_I: Configured from console by akroh on vty0 (10.100.11.10)
+<189>: Jan  6 2022 20:54:26.961: %SYS-5-CONFIG_I: Configured from console by akroh on vty0 (10.100.11.10)
+<190>: Jan  6 2022 20:55:50.671: %SEC-6-IPACCESSLOGDP: list 100 denied icmp 172.16.0.26 -> 10.100.8.34 (3/3), 20 packets
+<189>: sw01: Jan  6 2022 21:01:34.964: %SYS-5-CONFIG_I: Configured from console by akroh on vty0 (10.100.11.10)

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog.log-expected.json
@@ -1,0 +1,149 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2022-01-06T20:52:12.861Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "priority": 189
+                }
+            },
+            "event": {
+                "severity": 5,
+                "sequence": 2360957,
+                "original": "\u003c189\u003e2360957: Jan  6 2022 20:52:12.861: %SYS-5-CONFIG_I: Configured from console by akroh on vty0 (10.100.11.10)",
+                "code": "CONFIG_I",
+                "provider": "firewall",
+                "category": "network",
+                "type": "info"
+            },
+            "message": "Configured from console by akroh on vty0 (10.100.11.10)",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-01-06T20:54:26.961Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "priority": 189
+                }
+            },
+            "event": {
+                "severity": 5,
+                "original": "\u003c189\u003e: Jan  6 2022 20:54:26.961: %SYS-5-CONFIG_I: Configured from console by akroh on vty0 (10.100.11.10)",
+                "code": "CONFIG_I",
+                "category": "network",
+                "type": "info",
+                "provider": "firewall"
+            },
+            "message": "Configured from console by akroh on vty0 (10.100.11.10)",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "priority": 190
+                }
+            },
+            "destination": {
+                "address": "10.100.8.34",
+                "ip": "10.100.8.34"
+            },
+            "source": {
+                "packets": 20,
+                "address": "172.16.0.26",
+                "ip": "172.16.0.26"
+            },
+            "message": "list 100 denied icmp 172.16.0.26 -\u003e 10.100.8.34 (3/3), 20 packets",
+            "icmp": {
+                "type": "3",
+                "code": "3"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "network": {
+                "community_id": "1:Vb91zdxJ4APJXdQcf56aAjCWOVw=",
+                "transport": "icmp",
+                "type": "ipv4",
+                "packets": 20
+            },
+            "@timestamp": "2022-01-06T20:55:50.671Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "related": {
+                "ip": [
+                    "172.16.0.26",
+                    "10.100.8.34"
+                ]
+            },
+            "event": {
+                "severity": 6,
+                "original": "\u003c190\u003e: Jan  6 2022 20:55:50.671: %SEC-6-IPACCESSLOGDP: list 100 denied icmp 172.16.0.26 -\u003e 10.100.8.34 (3/3), 20 packets",
+                "code": "IPACCESSLOGDP",
+                "provider": "firewall",
+                "action": "deny",
+                "category": "network",
+                "type": "denied"
+            },
+            "cisco": {
+                "ios": {
+                    "facility": "SEC",
+                    "access_list": "100"
+                }
+            }
+        },
+        {
+            "@timestamp": "2022-01-06T21:01:34.964Z",
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "priority": 189,
+                    "hostname": "sw01"
+                }
+            },
+            "event": {
+                "severity": 5,
+                "original": "\u003c189\u003e: sw01: Jan  6 2022 21:01:34.964: %SYS-5-CONFIG_I: Configured from console by akroh on vty0 (10.100.11.10)",
+                "code": "CONFIG_I",
+                "category": "network",
+                "type": "info",
+                "provider": "firewall"
+            },
+            "message": "Configured from console by akroh on vty0 (10.100.11.10)",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        }
+    ]
+}

--- a/packages/cisco_ios/data_stream/log/agent/stream/stream.yml.hbs
+++ b/packages/cisco_ios/data_stream/log/agent/stream/stream.yml.hbs
@@ -13,6 +13,12 @@ tags:
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}
+
+fields_under_root: true
+fields:
+  _conf:
+    tz_offset: '{{tz_offset}}'
+
 processors:
 - add_locale: ~
 {{#if processors}}

--- a/packages/cisco_ios/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/cisco_ios/data_stream/log/agent/stream/udp.yml.hbs
@@ -9,6 +9,12 @@ tags:
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}
+
+fields_under_root: true
+fields:
+  _conf:
+    tz_offset: '{{tz_offset}}'
+
 processors:
 - add_locale: ~
 {{#if processors}}

--- a/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -40,6 +40,10 @@ processors:
       ignore_missing: true
       pattern: ' {2,}'
       replacement: ' '
+  - set:
+      field: _conf.tz_offset
+      value: UTC
+      override: false
   - date:
       if: ctx?._temp_.cisco_timestamp != null
       field: _temp_.cisco_timestamp
@@ -54,6 +58,7 @@ processors:
         - "MMM d HH:mm:ss.SSS"
         - "MMM d HH:mm:ss z"
         - "MMM d HH:mm:ss"
+      timezone: '{{{_conf.tz_offset}}}'
   - grok:
       field: message
       patterns:
@@ -263,7 +268,9 @@ processors:
       ignore_missing: true
       ignore_failure: true
   - remove:
-      field: _temp_
+      field:
+       - _temp_
+       - _conf
       ignore_missing: true
   - remove:
       field: event.original
@@ -273,7 +280,9 @@ processors:
 
 on_failure:
   - remove:
-      field: _temp_
+      field:
+        - _temp_
+        - _conf
       ignore_missing: true
   - set:
       field: error.message

--- a/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -3,15 +3,9 @@ description: Pipeline for Cisco IOS logs.
 
 processors:
   - set:
-      field: event.ingested
-      value: '{{_ingest.timestamp}}'
-  - set:
       field: ecs.version
       value: '1.12.0'
-  - rename:
-      field: message
-      target_field: event.original
-      ignore_missing: true
+
   - set:
       field: event.category
       value: network
@@ -21,13 +15,49 @@ processors:
   - set:
       field: event.type
       value: info
+
+  - set:
+      field: event.original
+      copy_from: message
+      override: false
+  - remove:
+      field: message
+      ignore_missing: true
   - dissect:
       field: event.original
-      pattern: "%{_temp_.ts->} %{+_temp_.ts} %{+_temp_.ts->} %{log.source.address} %{event.sequence}: %{_temp_.timestamp}: %{_temp_.message}"
+      pattern: '%{_temp_.header} %%{message}'
   - grok:
-      field: _temp_.message
+      field: _temp_.header
       patterns:
-        - "%%{DATA:cisco.ios.facility}-%{POSINT:event.severity}-%{DATA:event.code}: %{GREEDYDATA:message}"
+        - '^<%{NONNEGINT:log.syslog.priority:long}>%{NUMBER:event.sequence}?: (?:%{SYSLOGHOST:log.syslog.hostname}: )?%{CISCO_TIMESTAMP:_temp_.cisco_timestamp}'
+        - '%{SYSLOGHOST:log.syslog.hostname} %{NUMBER:event.sequence}: %{CISCO_TIMESTAMP:_temp_.cisco_timestamp}'
+      pattern_definitions:
+        CISCO_TIMESTAMP: '%{CISCOTIMESTAMP}(?: %{TZ})?'
+      ignore_failure: true
+  - gsub:
+      description: Remove double spacing from the date.
+      field: _temp_.cisco_timestamp
+      ignore_missing: true
+      pattern: ' {2,}'
+      replacement: ' '
+  - date:
+      if: ctx?._temp_.cisco_timestamp != null
+      field: _temp_.cisco_timestamp
+      formats:
+        - "MMM d yyyy HH:mm:ss.SSS z"
+        - "MMM d yyyy HH:mm:ss.SSS"
+        - "MMM d yyyy HH:mm:ss z"
+        - "MMM d yyyy HH:mm:ss"
+
+        # Repeat without year.
+        - "MMM d HH:mm:ss.SSS z"
+        - "MMM d HH:mm:ss.SSS"
+        - "MMM d HH:mm:ss z"
+        - "MMM d HH:mm:ss"
+  - grok:
+      field: message
+      patterns:
+        - "%{DATA:cisco.ios.facility}-%{POSINT:event.severity}-%{DATA:event.code}: %{GREEDYDATA:message}"
   - convert:
       field: event.severity
       type: long
@@ -83,18 +113,20 @@ processors:
        field: event.reason
        value: "Invalid RP"
        if: ctx.event?.code == "INVALID_RP_JOIN"      
-  - set:
-      field: destination.ip
-      value: '{{ destination.address }}'
-      if: ctx.destination?.address != null
-  - set:
-      field: source.ip
-      value: '{{ source.address }}'
-      if: ctx.source?.address != null
   - convert:
-        field: cisco.ios.pim.source.ip
-        type: ip
-        ignore_missing: true
+      field: destination.address
+      target_field: destination.ip
+      type: ip
+      ignore_failure: true
+  - convert:
+      field: source.address
+      target_field: source.ip
+      type: ip
+      ignore_failure: true
+  - convert:
+      field: cisco.ios.pim.source.ip
+      type: ip
+      ignore_missing: true
   - convert:
       field: source.port
       type: long
@@ -168,7 +200,7 @@ processors:
       if: "ctx.event.severity == 7"
       value: debug
 
-    # IP Geolocation Lookup
+  # IP Geolocation Lookup
   - geoip:
       field: source.ip
       target_field: source.geo
@@ -178,7 +210,7 @@ processors:
       target_field: destination.geo
       ignore_missing: true
 
-# IP Autonomous System (AS) Lookup
+  # IP Autonomous System (AS) Lookup
   - geoip:
       database_file: GeoLite2-ASN.mmdb
       field: source.ip
@@ -211,19 +243,20 @@ processors:
       field: destination.as.organization_name
       target_field: destination.as.organization.name
       ignore_missing: true
+
   - append:
       field: related.ip
-      value: "{{source.ip}}"
+      value: "{{{source.ip}}}"
       allow_duplicates: false
       if: ctx.source?.ip != null
   - append:
       field: related.ip
-      value: "{{destination.ip}}"
+      value: "{{{destination.ip}}}"
       allow_duplicates: false
       if: ctx.destination?.ip != null
   - append:
       field: related.user
-      value: "{{source.user.name}}"
+      value: "{{{source.user.name}}}"
       allow_duplicates: false
       if: ctx.source?.user?.name != null
   - community_id:
@@ -239,6 +272,9 @@ processors:
       ignore_missing: true
 
 on_failure:
+  - remove:
+      field: _temp_
+      ignore_missing: true
   - set:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: "processor {{{ _ingest.on_failure_processor_type}}}: {{{ _ingest.on_failure_message }}}"

--- a/packages/cisco_ios/data_stream/log/fields/ecs.yml
+++ b/packages/cisco_ios/data_stream/log/fields/ecs.yml
@@ -110,3 +110,5 @@
   type: geo_point
 - external: ecs
   name: tags
+- external: ecs
+  name: log.syslog.priority

--- a/packages/cisco_ios/data_stream/log/fields/fields.yml
+++ b/packages/cisco_ios/data_stream/log/fields/fields.yml
@@ -51,3 +51,6 @@
 - name: igmp.type
   type: keyword
   description: IGMP type.
+- name: log.syslog.hostname
+  type: keyword
+  description: Hostname parsed from syslog header.

--- a/packages/cisco_ios/data_stream/log/manifest.yml
+++ b/packages/cisco_ios/data_stream/log/manifest.yml
@@ -37,6 +37,14 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: tz_offset
+        type: text
+        title: Timezone
+        multi: false
+        required: true
+        show_user: false
+        default: UTC
+        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.
       - name: processors
         type: yaml
         title: Processors
@@ -76,6 +84,14 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: tz_offset
+        type: text
+        title: Timezone
+        multi: false
+        required: true
+        show_user: false
+        default: UTC
+        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/cisco_ios/docs/README.md
+++ b/packages/cisco_ios/docs/README.md
@@ -185,6 +185,8 @@ An example event for `log` looks as following:
 | log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
 | log.offset |  | long |
 | log.source.address |  | keyword |
+| log.syslog.hostname | Hostname parsed from syslog header. | keyword |
+| log.syslog.priority | Syslog numeric priority of the event, if available. According to RFCs 5424 and 3164, the priority is 8 \* facility + severity. This number is therefore expected to contain a value between 0 and 191. | long |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
 | network.community_id | A hash of source and destination IPs and ports, as well as the protocol used in a communication. This is a tool-agnostic standard to identify flows. Learn more at https://github.com/corelight/community-id-spec. | keyword |
 | network.iana_number | IANA Protocol Number (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml). Standardized list of protocols. This aligns well with NetFlow and sFlow related logs which use the IANA Protocol Number. | keyword |

--- a/packages/cisco_ios/manifest.yml
+++ b/packages/cisco_ios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_ios
 title: Cisco IOS
-version: 1.2.2
+version: 1.3.0
 license: basic
 description: Collect logs from Cisco IOS with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Improve Cisco IOS handling for syslog data. Previously the `@timestamp` value was not being set from the timestamp in log.

I tested with various time configurations. My preferred format is `service timestamps log datetime msec year show-timezone`.

Fixes #2474

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes  #2474
