### PR TITLE
[windows] Add provider name check to forwarded/security conditional

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.0"
+  changes:
+    - description: Add provider name check to forwarded/security conditional.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/xxxx
 - version: "1.6.0"
   changes:
     - description: Expose winlog input language option.

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add provider name check to forwarded/security conditional.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/xxxx
+      link: https://github.com/elastic/integrations/pull/2527
 - version: "1.6.0"
   changes:
     - description: Expose winlog input language option.

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/default.yml
@@ -3,7 +3,7 @@ description: Pipeline for Windows forwarded Event Logs
 processors:
   - pipeline:
       name: '{{ IngestPipeline "security" }}'
-      if: ctx?.winlog?.channel != null && ctx?.winlog?.channel == "Security"
+      if: ctx?.winlog?.channel != null && ctx?.winlog?.channel == "Security" && ctx?.winlog?.provider_name != null && ["Microsoft-Windows-Eventlog", "Microsoft-Windows-Security-Auditing"].contains(ctx?.winlog?.provider_name)
   - pipeline:
       name: '{{ IngestPipeline "powershell" }}'
       if: ctx?.winlog?.channel != null && ctx?.winlog?.channel == "Windows PowerShell"

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.6.0
+version: 1.7.0
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

-Added a check to the forwarded/security conditional to ensure that only events with a provider of `Microsoft-Windows-Eventlog` or `Microsoft-Windows-Security-Auditing` are allowed through. Events not matching these providers will still be indexed, but won't receive additional enrichment that could lead to incorrect metadata being applied.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
cd packages/windows && elastic-package test
```

## Related issues

- Relates elastic/beats#27288