### PR TITLE
[system] Fix incorrect PR number in changelog

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add routing pipeline to security data_stream, limit to specific providers.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/2344
+      link: https://github.com/elastic/integrations/pull/2523
 - version: "1.7.0"
   changes:
     - description: Expose winlog input language option.


### PR DESCRIPTION
## What does this PR do?

- Fix incorrect PR number in changelog for 1.8.0.

## Checklist

- ~~[ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.~~
- ~~[ ] I have verified that all data streams collect metrics or logs.~~
- ~~[ ] I have added an entry to my package's `changelog.yml` file.~~
- ~~[ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~~
