### PR TITLE
[AWS/vpcflow] add description of supported vpcflow formats

### DIFF
--- a/packages/aws/_dev/build/docs/vpcflow.md
+++ b/packages/aws/_dev/build/docs/vpcflow.md
@@ -2,6 +2,22 @@
 
 ## Logs
 
+Module for the AWS virtual private cloud (VPC) logs which captures information
+about the IP traffic going to and from network interfaces in VPC. These logs can
+help with:
+
+* Diagnosing overly restrictive security group rules
+* Monitoring the traffic that is reaching your instance
+* Determining the direction of the traffic to and from the network interfaces
+
+Implementation based on the description of the flow logs from the
+documentation that can be found in:
+
+* Default Flow Log Format: https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html
+* Custom Format with Traffic Through a NAT Gateway: https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-records-examples.html
+* Custom Format with Traffic Through a Transit Gateway:
+  https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-records-examples.html
+
 {{fields "vpcflow"}}
 
 {{event "vpcflow"}}

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.1"
+  changes:
+    - description: Add description of supported vpcflow formats
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/2530
 - version: "1.10.0"
   changes:
     - description: Add cloudwatch input into AWS package for log collection

--- a/packages/aws/docs/vpcflow.md
+++ b/packages/aws/docs/vpcflow.md
@@ -2,6 +2,22 @@
 
 ## Logs
 
+Module for the AWS virtual private cloud (VPC) logs which captures information
+about the IP traffic going to and from network interfaces in VPC. These logs can
+help with:
+
+* Diagnosing overly restrictive security group rules
+* Monitoring the traffic that is reaching your instance
+* Determining the direction of the traffic to and from the network interfaces
+
+Implementation based on the description of the flow logs from the
+documentation that can be found in:
+
+* Default Flow Log Format: https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html
+* Custom Format with Traffic Through a NAT Gateway: https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-records-examples.html
+* Custom Format with Traffic Through a Transit Gateway:
+  https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-records-examples.html
+
 **Exported fields**
 
 | Field | Description | Type |

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.10.0
+version: 1.10.1
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Adds descriptions of the supported vpcflow formats to the vpcflow readme

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).