### PR TITLE
[ThreatQ] Adding threat.feed ECS fields and dashboards

### DIFF
--- a/packages/ti_threatq/changelog.yml
+++ b/packages/ti_threatq/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add threat.feed ECS fields and dashboard
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/2327
+      link: https://github.com/elastic/integrations/pull/2543
 - version: "1.0.2"
   changes:
     - description: Change test public IPs to the supported subset

--- a/packages/ti_threatq/changelog.yml
+++ b/packages/ti_threatq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Add threat.feed ECS fields and dashboard
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/2327
 - version: "1.0.2"
   changes:
     - description: Change test public IPs to the supported subset

--- a/packages/ti_threatq/data_stream/threat/fields/base-fields.yml
+++ b/packages/ti_threatq/data_stream/threat/fields/base-fields.yml
@@ -11,6 +11,14 @@
   type: constant_keyword
   description: Event module
   value: ti_threatq
+- name: threat.feed.name
+  type: constant_keyword
+  description: Display friendly feed name
+  value: ThreatQuotient
+- name: threat.feed.dashboard_id
+  type: constant_keyword
+  description: Dashboard ID used for Kibana CTI UI
+  value: ti_threatq-a05fd810-78f1-11ec-a97c-7db1518ab848
 - name: event.dataset
   type: constant_keyword
   description: Event dataset

--- a/packages/ti_threatq/data_stream/threat/sample_event.json
+++ b/packages/ti_threatq/data_stream/threat/sample_event.json
@@ -1,12 +1,11 @@
 {
     "@timestamp": "2021-10-01T18:36:03.000Z",
     "agent": {
-        "ephemeral_id": "e9f080c4-d427-41e0-8604-5e7092e5b247",
-        "hostname": "docker-fleet-agent",
-        "id": "32b4b77a-aad6-45af-b440-5b22dbed7c9c",
+        "ephemeral_id": "961a8e14-c6fd-4576-bdac-3c597af12f22",
+        "id": "71b817f1-63a0-4fff-ad03-957bd841c290",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.16.0"
+        "version": "8.0.0"
     },
     "data_stream": {
         "dataset": "ti_threatq.threat",
@@ -17,16 +16,16 @@
         "version": "1.12"
     },
     "elastic_agent": {
-        "id": "32b4b77a-aad6-45af-b440-5b22dbed7c9c",
+        "id": "71b817f1-63a0-4fff-ad03-957bd841c290",
         "snapshot": true,
-        "version": "7.16.0"
+        "version": "8.0.0"
     },
     "event": {
         "agent_id_status": "verified",
         "category": "threat",
-        "created": "2021-10-26T07:52:48.767Z",
+        "created": "2022-01-19T07:59:53.357Z",
         "dataset": "ti_threatq.threat",
-        "ingested": "2021-10-26T07:52:49Z",
+        "ingested": "2022-01-19T07:59:54Z",
         "kind": "enrichment",
         "original": "{\"adversaries\":[],\"attributes\":[{\"attribute_id\":5,\"created_at\":\"2021-10-01 18:36:06\",\"id\":4893068,\"indicator_id\":106767,\"name\":\"Contact\",\"touched_at\":\"2021-10-24 18:36:10\",\"updated_at\":\"2021-10-24 18:36:10\",\"value\":\"email:Quetzalcoatl_relays[]protonmail.com url:https://quetzalcoatl-relays.org proof:uri-rsa hoster:frantech.ca\"},{\"attribute_id\":9,\"created_at\":\"2021-10-01 18:36:06\",\"id\":4893069,\"indicator_id\":106767,\"name\":\"Router Port\",\"touched_at\":\"2021-10-24 18:36:10\",\"updated_at\":\"2021-10-24 18:36:10\",\"value\":\"9000\"},{\"attribute_id\":6,\"created_at\":\"2021-10-01 18:36:06\",\"id\":4893070,\"indicator_id\":106767,\"name\":\"Flags\",\"touched_at\":\"2021-10-02 18:36:08\",\"updated_at\":\"2021-10-02 18:36:08\",\"value\":\"ERDV\"}],\"class\":\"network\",\"created_at\":\"2021-10-01 18:36:03\",\"expires_calculated_at\":\"2021-10-23 18:40:17\",\"hash\":\"69beef49fdbd1f54eef3cab324c7b6cf\",\"id\":106767,\"published_at\":\"2021-10-01 18:36:03\",\"score\":0,\"sources\":[{\"created_at\":\"2021-10-01 18:36:06\",\"creator_source_id\":12,\"id\":3699669,\"indicator_id\":106767,\"indicator_status_id\":1,\"indicator_type_id\":15,\"name\":\"www.dan.me.uk Tor Node List\",\"published_at\":\"2021-10-01 18:36:06\",\"reference_id\":37,\"source_id\":12,\"source_type\":\"connectors\",\"updated_at\":\"2021-10-24 18:36:10\"}],\"status\":{\"description\":\"Poses a threat and is being exported to detection tools.\",\"id\":1,\"name\":\"Active\"},\"status_id\":1,\"touched_at\":\"2021-10-24 18:36:10\",\"type\":{\"class\":\"network\",\"id\":15,\"name\":\"IP Address\"},\"type_id\":15,\"updated_at\":\"2021-10-01 18:36:03\",\"value\":\"107.189.1.90\"}",
         "type": "indicator"

--- a/packages/ti_threatq/docs/README.md
+++ b/packages/ti_threatq/docs/README.md
@@ -62,7 +62,8 @@ By default the indicators will be collected every 1 minute, and deduplication is
 | log.offset | Offset of the entry in the log file. | long |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
 | tags | List of keywords used to tag each event. | keyword |
-| threat.feed.name |  | keyword |
+| threat.feed.dashboard_id | Dashboard ID used for Kibana CTI UI | constant_keyword |
+| threat.feed.name | Display friendly feed name | constant_keyword |
 | threat.indicator.confidence | Identifies the confidence rating assigned by the provider using STIX confidence scales. Recommended values:   \* Not Specified, None, Low, Medium, High   \* 0-10   \* Admirality Scale (1-6)   \* DNI Scale (5-95)   \* WEP Scale (Impossible - Certain) | keyword |
 | threat.indicator.description | Describes the type of action conducted by the threat. | keyword |
 | threat.indicator.email.address | Identifies a threat indicator as an email address (irrespective of direction). | keyword |

--- a/packages/ti_threatq/docs/README.md
+++ b/packages/ti_threatq/docs/README.md
@@ -102,12 +102,11 @@ An example event for `threat` looks as following:
 {
     "@timestamp": "2021-10-01T18:36:03.000Z",
     "agent": {
-        "ephemeral_id": "e9f080c4-d427-41e0-8604-5e7092e5b247",
-        "hostname": "docker-fleet-agent",
-        "id": "32b4b77a-aad6-45af-b440-5b22dbed7c9c",
+        "ephemeral_id": "961a8e14-c6fd-4576-bdac-3c597af12f22",
+        "id": "71b817f1-63a0-4fff-ad03-957bd841c290",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.16.0"
+        "version": "8.0.0"
     },
     "data_stream": {
         "dataset": "ti_threatq.threat",
@@ -118,16 +117,16 @@ An example event for `threat` looks as following:
         "version": "1.12"
     },
     "elastic_agent": {
-        "id": "32b4b77a-aad6-45af-b440-5b22dbed7c9c",
+        "id": "71b817f1-63a0-4fff-ad03-957bd841c290",
         "snapshot": true,
-        "version": "7.16.0"
+        "version": "8.0.0"
     },
     "event": {
         "agent_id_status": "verified",
         "category": "threat",
-        "created": "2021-10-26T07:52:48.767Z",
+        "created": "2022-01-19T07:59:53.357Z",
         "dataset": "ti_threatq.threat",
-        "ingested": "2021-10-26T07:52:49Z",
+        "ingested": "2022-01-19T07:59:54Z",
         "kind": "enrichment",
         "original": "{\"adversaries\":[],\"attributes\":[{\"attribute_id\":5,\"created_at\":\"2021-10-01 18:36:06\",\"id\":4893068,\"indicator_id\":106767,\"name\":\"Contact\",\"touched_at\":\"2021-10-24 18:36:10\",\"updated_at\":\"2021-10-24 18:36:10\",\"value\":\"email:Quetzalcoatl_relays[]protonmail.com url:https://quetzalcoatl-relays.org proof:uri-rsa hoster:frantech.ca\"},{\"attribute_id\":9,\"created_at\":\"2021-10-01 18:36:06\",\"id\":4893069,\"indicator_id\":106767,\"name\":\"Router Port\",\"touched_at\":\"2021-10-24 18:36:10\",\"updated_at\":\"2021-10-24 18:36:10\",\"value\":\"9000\"},{\"attribute_id\":6,\"created_at\":\"2021-10-01 18:36:06\",\"id\":4893070,\"indicator_id\":106767,\"name\":\"Flags\",\"touched_at\":\"2021-10-02 18:36:08\",\"updated_at\":\"2021-10-02 18:36:08\",\"value\":\"ERDV\"}],\"class\":\"network\",\"created_at\":\"2021-10-01 18:36:03\",\"expires_calculated_at\":\"2021-10-23 18:40:17\",\"hash\":\"69beef49fdbd1f54eef3cab324c7b6cf\",\"id\":106767,\"published_at\":\"2021-10-01 18:36:03\",\"score\":0,\"sources\":[{\"created_at\":\"2021-10-01 18:36:06\",\"creator_source_id\":12,\"id\":3699669,\"indicator_id\":106767,\"indicator_status_id\":1,\"indicator_type_id\":15,\"name\":\"www.dan.me.uk Tor Node List\",\"published_at\":\"2021-10-01 18:36:06\",\"reference_id\":37,\"source_id\":12,\"source_type\":\"connectors\",\"updated_at\":\"2021-10-24 18:36:10\"}],\"status\":{\"description\":\"Poses a threat and is being exported to detection tools.\",\"id\":1,\"name\":\"Active\"},\"status_id\":1,\"touched_at\":\"2021-10-24 18:36:10\",\"type\":{\"class\":\"network\",\"id\":15,\"name\":\"IP Address\"},\"type_id\":15,\"updated_at\":\"2021-10-01 18:36:03\",\"value\":\"107.189.1.90\"}",
         "type": "indicator"

--- a/packages/ti_threatq/kibana/dashboard/ti_threatq-a05fd810-78f1-11ec-a97c-7db1518ab848.json
+++ b/packages/ti_threatq/kibana/dashboard/ti_threatq-a05fd810-78f1-11ec-a97c-7db1518ab848.json
@@ -1,0 +1,860 @@
+{
+    "attributes": {
+        "description": "Dashboard providing statistics about indicators ingested from the AbuseCH integration",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+            "searchSourceJSON": {
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "event.kind",
+                            "negate": false,
+                            "params": {
+                                "query": "enrichment"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "event.kind": "enrichment"
+                            }
+                        }
+                    },
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[1].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "ti_threatq.threat"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "ti_threatq.threat"
+                            }
+                        }
+                    }
+                ],
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
+        },
+        "optionsJSON": {
+            "hidePanelTitles": false,
+            "syncColors": false,
+            "useMargins": true
+        },
+        "panelsJSON": [
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "hidePanelTitles": true,
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
+                        "description": "",
+                        "params": {
+                            "fontSize": 12,
+                            "markdown": "**Navigation**\n\n**[ThreatQ Overview (This Page)](/app/dashboards#/view/ti_threatq-a05fd810-78f1-11ec-a97c-7db1518ab848)**  \n[ThreatQ Files](/app/dashboards#/view/ti_threatq-ab289de0-78f1-11ec-a97c-7db1518ab848)  \n[ThreatQ URLs](/app/dashboards#/view/ti_threatq-b45b0c40-78f1-11ec-a97c-7db1518ab848)  \n\n[Integrations Page](/app/integrations/detail/ti_threatq/overview)\n\n\n**Overview**\n\nThis dashboard is a health overview related to the ThreatQ integration.\n\nThe dashboard is made to provide general statistics and show the health of the ingestion of indicators from ThreatQ.  \n\nIt shows the ingestion rates (by default it fetches new updates every 10 minutes) and provides a few filters for drilling down to specific indicator types retrieved from ThreatQ.",
+                            "openLinksInNewTab": false
+                        },
+                        "title": "Overview Textbox [Logs AbuseCH]",
+                        "type": "markdown",
+                        "uiState": {}
+                    }
+                },
+                "gridData": {
+                    "h": 39,
+                    "i": "555e9e6c-04e9-4022-b6df-bda07dde30c4",
+                    "w": 7,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "555e9e6c-04e9-4022-b6df-bda07dde30c4",
+                "type": "visualization",
+                "version": "8.0.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "hidePanelTitles": false,
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [
+                                    {
+                                        "$state": {
+                                            "store": "appState"
+                                        },
+                                        "meta": {
+                                            "alias": null,
+                                            "disabled": false,
+                                            "index": "logs-*",
+                                            "key": "event.dataset",
+                                            "negate": false,
+                                            "params": [
+                                                "ti_abusech.malware",
+                                                "ti_abusech.malwarebazaar",
+                                                "ti_abusech.url"
+                                            ],
+                                            "type": "phrases"
+                                        },
+                                        "query": {
+                                            "bool": {
+                                                "minimum_should_match": 1,
+                                                "should": [
+                                                    {
+                                                        "match_phrase": {
+                                                            "event.dataset": "ti_abusech.malware"
+                                                        }
+                                                    },
+                                                    {
+                                                        "match_phrase": {
+                                                            "event.dataset": "ti_abusech.malwarebazaar"
+                                                        }
+                                                    },
+                                                    {
+                                                        "match_phrase": {
+                                                            "event.dataset": "ti_abusech.url"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "$state": {
+                                            "store": "appState"
+                                        },
+                                        "meta": {
+                                            "alias": null,
+                                            "disabled": false,
+                                            "index": "logs-*",
+                                            "key": "event.kind",
+                                            "negate": false,
+                                            "params": {
+                                                "query": "enrichment"
+                                            },
+                                            "type": "phrase"
+                                        },
+                                        "query": {
+                                            "match_phrase": {
+                                                "event.kind": "enrichment"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
+                        "description": "",
+                        "params": {
+                            "controls": [
+                                {
+                                    "fieldName": "event.dataset",
+                                    "id": "1635779550157",
+                                    "indexPatternRefName": "control_e971fedd-6afd-4d03-93ac-d0c751acc254_0_index_pattern",
+                                    "label": "Feed Name",
+                                    "options": {
+                                        "dynamicOptions": true,
+                                        "multiselect": true,
+                                        "order": "desc",
+                                        "size": 5,
+                                        "type": "terms"
+                                    },
+                                    "parent": "",
+                                    "type": "list"
+                                },
+                                {
+                                    "fieldName": "threat.indicator.provider",
+                                    "id": "1635779603363",
+                                    "indexPatternRefName": "control_e971fedd-6afd-4d03-93ac-d0c751acc254_1_index_pattern",
+                                    "label": "Indicator Provider",
+                                    "options": {
+                                        "dynamicOptions": true,
+                                        "multiselect": true,
+                                        "order": "desc",
+                                        "size": 5,
+                                        "type": "terms"
+                                    },
+                                    "parent": "",
+                                    "type": "list"
+                                },
+                                {
+                                    "fieldName": "threat.indicator.type",
+                                    "id": "1635779625911",
+                                    "indexPatternRefName": "control_e971fedd-6afd-4d03-93ac-d0c751acc254_2_index_pattern",
+                                    "label": "Indicator Type",
+                                    "options": {
+                                        "dynamicOptions": true,
+                                        "multiselect": true,
+                                        "order": "desc",
+                                        "size": 5,
+                                        "type": "terms"
+                                    },
+                                    "parent": "",
+                                    "type": "list"
+                                }
+                            ],
+                            "pinFilters": false,
+                            "updateFiltersOnChange": false,
+                            "useTimeFilter": false
+                        },
+                        "title": "Feed and Indicator Selector [Logs AbuseCH]",
+                        "type": "input_control_vis",
+                        "uiState": {}
+                    }
+                },
+                "gridData": {
+                    "h": 7,
+                    "i": "e971fedd-6afd-4d03-93ac-d0c751acc254",
+                    "w": 41,
+                    "x": 7,
+                    "y": 0
+                },
+                "panelIndex": "e971fedd-6afd-4d03-93ac-d0c751acc254",
+                "title": "Feed and Indicator Selector [Logs ThreatQ]",
+                "type": "visualization",
+                "version": "8.0.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-current-indexpattern",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-070f5dbc-7687-4e97-9a57-5542b401c13f",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "sharingSavedObjectProps": {
+                            "outcome": "exactMatch",
+                            "sourceId": "ti_abusech-1d376820-3b22-11ec-ae50-2fdf1e96c6a6"
+                        },
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "070f5dbc-7687-4e97-9a57-5542b401c13f": {
+                                            "columnOrder": [
+                                                "1e352b49-3b83-44a6-98fe-8703d30f2517"
+                                            ],
+                                            "columns": {
+                                                "1e352b49-3b83-44a6-98fe-8703d30f2517": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Total Indicators",
+                                                    "operationType": "count",
+                                                    "scale": "ratio",
+                                                    "sourceField": "Records"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "accessor": "1e352b49-3b83-44a6-98fe-8703d30f2517",
+                                "layerId": "070f5dbc-7687-4e97-9a57-5542b401c13f",
+                                "layerType": "data"
+                            }
+                        },
+                        "title": "Total Indicators [Logs AbuseCH]",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 8,
+                    "i": "d37eb797-f273-43c2-9004-b947891cce55",
+                    "w": 6,
+                    "x": 7,
+                    "y": 7
+                },
+                "panelIndex": "d37eb797-f273-43c2-9004-b947891cce55",
+                "title": "Total Indicators [Logs ThreatQ]",
+                "type": "lens",
+                "version": "8.0.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-current-indexpattern",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-df8e3a91-700b-428a-a763-525076e4d3c8",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "sharingSavedObjectProps": {
+                            "outcome": "exactMatch",
+                            "sourceId": "ti_abusech-49830790-3b27-11ec-ae50-2fdf1e96c6a6"
+                        },
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "df8e3a91-700b-428a-a763-525076e4d3c8": {
+                                            "columnOrder": [
+                                                "e4f78e2f-f0a7-4cc6-96d0-af607ffbf326"
+                                            ],
+                                            "columns": {
+                                                "e4f78e2f-f0a7-4cc6-96d0-af607ffbf326": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Total Datastreams",
+                                                    "operationType": "unique_count",
+                                                    "scale": "ratio",
+                                                    "sourceField": "event.dataset"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "accessor": "e4f78e2f-f0a7-4cc6-96d0-af607ffbf326",
+                                "layerId": "df8e3a91-700b-428a-a763-525076e4d3c8",
+                                "layerType": "data"
+                            }
+                        },
+                        "title": "Total Datastreams [Logs AbuseCH]",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 8,
+                    "i": "6509dcc9-bb9c-4c1f-80e9-612f67ada340",
+                    "w": 6,
+                    "x": 7,
+                    "y": 15
+                },
+                "panelIndex": "6509dcc9-bb9c-4c1f-80e9-612f67ada340",
+                "title": "Total Datastreams [Logs ThreatQ]",
+                "type": "lens",
+                "version": "8.0.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-current-indexpattern",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-1e757dc0-2e6d-4bd2-aa38-7da9133ca960",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "sharingSavedObjectProps": {
+                            "outcome": "exactMatch",
+                            "sourceId": "ti_abusech-ec1a2c50-3b30-11ec-ae50-2fdf1e96c6a6"
+                        },
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "1e757dc0-2e6d-4bd2-aa38-7da9133ca960": {
+                                            "columnOrder": [
+                                                "66779b74-d127-4249-93e4-b8cd9c39b91f",
+                                                "2bbd31c6-4a58-43e5-bab9-de9e7c2d2242"
+                                            ],
+                                            "columns": {
+                                                "2bbd31c6-4a58-43e5-bab9-de9e7c2d2242": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count of records",
+                                                    "operationType": "count",
+                                                    "scale": "ratio",
+                                                    "sourceField": "Records"
+                                                },
+                                                "66779b74-d127-4249-93e4-b8cd9c39b91f": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top values of threat.indicator.provider",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "2bbd31c6-4a58-43e5-bab9-de9e7c2d2242",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "size": 5
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "threat.indicator.provider"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "2bbd31c6-4a58-43e5-bab9-de9e7c2d2242"
+                                        ],
+                                        "layerId": "1e757dc0-2e6d-4bd2-aa38-7da9133ca960",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "bar_horizontal",
+                                        "showGridlines": false,
+                                        "splitAccessor": "66779b74-d127-4249-93e4-b8cd9c39b91f"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right",
+                                    "showSingleSeries": false
+                                },
+                                "preferredSeriesType": "bar_horizontal",
+                                "title": "Empty XY chart",
+                                "valueLabels": "inside",
+                                "xTitle": "Providers",
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yTitle": "Count"
+                            }
+                        },
+                        "title": "Total Indicators per Provider [Logs AbuseCH]",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 16,
+                    "i": "86d83606-4176-44b1-b3f3-011d5b5b4b58",
+                    "w": 23,
+                    "x": 13,
+                    "y": 7
+                },
+                "panelIndex": "86d83606-4176-44b1-b3f3-011d5b5b4b58",
+                "title": "Total Indicators per Provider [Logs ThreatQ]",
+                "type": "lens",
+                "version": "8.0.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-current-indexpattern",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-682732d8-8691-4c5a-bf89-de8e30d71dfb",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "sharingSavedObjectProps": {
+                            "outcome": "exactMatch",
+                            "sourceId": "ti_abusech-62801870-3b2a-11ec-ae50-2fdf1e96c6a6"
+                        },
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "682732d8-8691-4c5a-bf89-de8e30d71dfb": {
+                                            "columnOrder": [
+                                                "dd629c44-e7db-438e-8656-340b94fd30d8",
+                                                "bad802d8-b23f-4ef4-8dcf-4e92170595a7"
+                                            ],
+                                            "columns": {
+                                                "bad802d8-b23f-4ef4-8dcf-4e92170595a7": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count of records",
+                                                    "operationType": "count",
+                                                    "scale": "ratio",
+                                                    "sourceField": "Records"
+                                                },
+                                                "dd629c44-e7db-438e-8656-340b94fd30d8": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Indicators",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "bad802d8-b23f-4ef4-8dcf-4e92170595a7",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "size": 3
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "event.dataset"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "categoryDisplay": "default",
+                                        "groups": [
+                                            "dd629c44-e7db-438e-8656-340b94fd30d8"
+                                        ],
+                                        "layerId": "682732d8-8691-4c5a-bf89-de8e30d71dfb",
+                                        "layerType": "data",
+                                        "legendDisplay": "show",
+                                        "legendPosition": "right",
+                                        "metric": "bad802d8-b23f-4ef4-8dcf-4e92170595a7",
+                                        "nestedLegend": false,
+                                        "numberDisplay": "percent",
+                                        "percentDecimals": 2,
+                                        "truncateLegend": true
+                                    }
+                                ],
+                                "shape": "donut"
+                            }
+                        },
+                        "title": "Total Indicators per Datastream [Logs AbuseCH]",
+                        "visualizationType": "lnsPie"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 16,
+                    "i": "f654c447-12d2-41a4-9091-06169af11ba5",
+                    "w": 12,
+                    "x": 36,
+                    "y": 7
+                },
+                "panelIndex": "f654c447-12d2-41a4-9091-06169af11ba5",
+                "title": "Total Indicators per Datastream [Logs ThreatQ]",
+                "type": "lens",
+                "version": "8.0.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-current-indexpattern",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-c1cee622-e3dd-4d6b-a28a-0fb19dc2c7b7",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "sharingSavedObjectProps": {
+                            "outcome": "exactMatch",
+                            "sourceId": "ti_abusech-8c0613c0-3b25-11ec-ae50-2fdf1e96c6a6"
+                        },
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "c1cee622-e3dd-4d6b-a28a-0fb19dc2c7b7": {
+                                            "columnOrder": [
+                                                "4d7ca99c-8a53-4a7f-96db-409251c0e391",
+                                                "b7f07f7c-1477-4f83-95f5-ad5cdc3a314b",
+                                                "0726d151-9edf-41cb-ab52-473ab27cf8b7"
+                                            ],
+                                            "columns": {
+                                                "0726d151-9edf-41cb-ab52-473ab27cf8b7": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count of records",
+                                                    "operationType": "count",
+                                                    "scale": "ratio",
+                                                    "sourceField": "Records"
+                                                },
+                                                "4d7ca99c-8a53-4a7f-96db-409251c0e391": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top values of event.dataset",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "0726d151-9edf-41cb-ab52-473ab27cf8b7",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "size": 3
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "event.dataset"
+                                                },
+                                                "b7f07f7c-1477-4f83-95f5-ad5cdc3a314b": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "interval": "30s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "curveType": "CURVE_MONOTONE_X",
+                                "fittingFunction": "Zero",
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "0726d151-9edf-41cb-ab52-473ab27cf8b7"
+                                        ],
+                                        "layerId": "c1cee622-e3dd-4d6b-a28a-0fb19dc2c7b7",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "4d7ca99c-8a53-4a7f-96db-409251c0e391",
+                                        "xAccessor": "b7f07f7c-1477-4f83-95f5-ad5cdc3a314b"
+                                    }
+                                ],
+                                "legend": {
+                                    "isInside": false,
+                                    "isVisible": true,
+                                    "position": "bottom",
+                                    "shouldTruncate": false,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "valuesInLegend": false,
+                                "xTitle": "Date",
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yTitle": "Total Indicators"
+                            }
+                        },
+                        "title": "Indicators ingested per Datastream [Logs AbuseCH]",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 16,
+                    "i": "aab4fac0-d39c-4521-aa9b-0a49d5938e9e",
+                    "w": 41,
+                    "x": 7,
+                    "y": 23
+                },
+                "panelIndex": "aab4fac0-d39c-4521-aa9b-0a49d5938e9e",
+                "title": "Indicators ingested per Datastream [Logs ThreatQ]",
+                "type": "lens",
+                "version": "8.0.0-SNAPSHOT"
+            }
+        ],
+        "timeRestore": false,
+        "title": "[Logs ThreatQ] Overview",
+        "version": 1
+    },
+    "coreMigrationVersion": "8.0.0",
+    "id": "ti_threatq-a05fd810-78f1-11ec-a97c-7db1518ab848",
+    "migrationVersion": {
+        "dashboard": "8.0.0"
+    },
+    "references": [
+        {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[1].meta.index",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "e971fedd-6afd-4d03-93ac-d0c751acc254:kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "e971fedd-6afd-4d03-93ac-d0c751acc254:kibanaSavedObjectMeta.searchSourceJSON.filter[1].meta.index",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "e971fedd-6afd-4d03-93ac-d0c751acc254:control_e971fedd-6afd-4d03-93ac-d0c751acc254_0_index_pattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "e971fedd-6afd-4d03-93ac-d0c751acc254:control_e971fedd-6afd-4d03-93ac-d0c751acc254_1_index_pattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "e971fedd-6afd-4d03-93ac-d0c751acc254:control_e971fedd-6afd-4d03-93ac-d0c751acc254_2_index_pattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "d37eb797-f273-43c2-9004-b947891cce55:indexpattern-datasource-current-indexpattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "d37eb797-f273-43c2-9004-b947891cce55:indexpattern-datasource-layer-070f5dbc-7687-4e97-9a57-5542b401c13f",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "6509dcc9-bb9c-4c1f-80e9-612f67ada340:indexpattern-datasource-current-indexpattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "6509dcc9-bb9c-4c1f-80e9-612f67ada340:indexpattern-datasource-layer-df8e3a91-700b-428a-a763-525076e4d3c8",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "86d83606-4176-44b1-b3f3-011d5b5b4b58:indexpattern-datasource-current-indexpattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "86d83606-4176-44b1-b3f3-011d5b5b4b58:indexpattern-datasource-layer-1e757dc0-2e6d-4bd2-aa38-7da9133ca960",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "f654c447-12d2-41a4-9091-06169af11ba5:indexpattern-datasource-current-indexpattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "f654c447-12d2-41a4-9091-06169af11ba5:indexpattern-datasource-layer-682732d8-8691-4c5a-bf89-de8e30d71dfb",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "aab4fac0-d39c-4521-aa9b-0a49d5938e9e:indexpattern-datasource-current-indexpattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "aab4fac0-d39c-4521-aa9b-0a49d5938e9e:indexpattern-datasource-layer-c1cee622-e3dd-4d6b-a28a-0fb19dc2c7b7",
+            "type": "index-pattern"
+        },
+        {
+            "id": "ti_threatq-c0cca010-78f1-11ec-a97c-7db1518ab848",
+            "name": "tag-ti_threatq-c0cca010-78f1-11ec-a97c-7db1518ab848",
+            "type": "tag"
+        }
+    ],
+    "type": "dashboard"
+}

--- a/packages/ti_threatq/kibana/dashboard/ti_threatq-a05fd810-78f1-11ec-a97c-7db1518ab848.json
+++ b/packages/ti_threatq/kibana/dashboard/ti_threatq-a05fd810-78f1-11ec-a97c-7db1518ab848.json
@@ -1,6 +1,6 @@
 {
     "attributes": {
-        "description": "Dashboard providing statistics about indicators ingested from the AbuseCH integration",
+        "description": "Dashboard providing statistics about indicators ingested from the ThreatQ integration",
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
@@ -94,6 +94,7 @@
                     "y": 0
                 },
                 "panelIndex": "555e9e6c-04e9-4022-b6df-bda07dde30c4",
+                "title": "Overview Textbox [Logs ThreatQ]",
                 "type": "visualization",
                 "version": "8.0.0-SNAPSHOT"
             },
@@ -178,7 +179,7 @@
                         "params": {
                             "controls": [
                                 {
-                                    "fieldName": "event.dataset",
+                                    "fieldName": "data_stream.dataset",
                                     "id": "1635779550157",
                                     "indexPatternRefName": "control_e971fedd-6afd-4d03-93ac-d0c751acc254_0_index_pattern",
                                     "label": "Feed Name",

--- a/packages/ti_threatq/kibana/dashboard/ti_threatq-ab289de0-78f1-11ec-a97c-7db1518ab848.json
+++ b/packages/ti_threatq/kibana/dashboard/ti_threatq-ab289de0-78f1-11ec-a97c-7db1518ab848.json
@@ -1,0 +1,705 @@
+{
+    "attributes": {
+        "description": "Dashboard providing statistics about file type indicators from the AbuseCH integration",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+            "searchSourceJSON": {
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "event.kind",
+                            "negate": false,
+                            "params": {
+                                "query": "enrichment"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "event.kind": "enrichment"
+                            }
+                        }
+                    },
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[1].meta.index",
+                            "key": "threat.indicator.type",
+                            "negate": false,
+                            "params": {
+                                "query": "file"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "threat.indicator.type": "file"
+                            }
+                        }
+                    },
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[2].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "ti_threatq.threat"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "ti_threatq.threat"
+                            }
+                        }
+                    }
+                ],
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
+        },
+        "optionsJSON": {
+            "hidePanelTitles": false,
+            "syncColors": false,
+            "useMargins": true
+        },
+        "panelsJSON": [
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "hidePanelTitles": true,
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
+                        "description": "",
+                        "params": {
+                            "fontSize": 12,
+                            "markdown": "**Navigation**\n\n[ThreatQ Overview](/app/dashboards#/view/ti_threatq-a05fd810-78f1-11ec-a97c-7db1518ab848)  \n**[ThreatQ Files (This Page)](/app/dashboards#/view/ti_threatq-ab289de0-78f1-11ec-a97c-7db1518ab848)**  \n[ThreatQ URLs](/app/dashboards#/view/ti_threatq-b45b0c40-78f1-11ec-a97c-7db1518ab848)  \n\n[Integrations Page](/app/integrations/detail/ti_threatq/overview)\n\n\n**Overview**\n\nThis dashboard is an overview of the different threat intelligence indicators with a **threat.indicator.type: file**.\n\nThe dashboard is made to provide general statistics and show the health of your indicators like hash type counters, popular domains, statistics about how many unique indicators are ingested and other relevant information.",
+                            "openLinksInNewTab": false
+                        },
+                        "title": "Files Navigation Textbox [Logs AbuseCH]",
+                        "type": "markdown",
+                        "uiState": {}
+                    }
+                },
+                "gridData": {
+                    "h": 27,
+                    "i": "09ba3dc0-e2e2-4799-b47f-bb919bf290a1",
+                    "w": 7,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "09ba3dc0-e2e2-4799-b47f-bb919bf290a1",
+                "type": "visualization",
+                "version": "8.0.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-current-indexpattern",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-98786f76-dac4-4fc7-9cad-8bfce17bd00d",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "sharingSavedObjectProps": {
+                            "outcome": "exactMatch",
+                            "sourceId": "ti_abusech-2e2257a0-3b39-11ec-ae50-2fdf1e96c6a6"
+                        },
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "98786f76-dac4-4fc7-9cad-8bfce17bd00d": {
+                                            "columnOrder": [
+                                                "8622e147-406f-4711-8f68-e2425614106e"
+                                            ],
+                                            "columns": {
+                                                "8622e147-406f-4711-8f68-e2425614106e": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Unique File types",
+                                                    "operationType": "unique_count",
+                                                    "scale": "ratio",
+                                                    "sourceField": "threat.indicator.file.type"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "accessor": "8622e147-406f-4711-8f68-e2425614106e",
+                                "layerId": "98786f76-dac4-4fc7-9cad-8bfce17bd00d",
+                                "layerType": "data"
+                            }
+                        },
+                        "title": "Unique File Types [Logs AbuseCH]",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 8,
+                    "i": "31ea16d1-7591-42a7-b773-6fca00e5db14",
+                    "w": 6,
+                    "x": 7,
+                    "y": 0
+                },
+                "panelIndex": "31ea16d1-7591-42a7-b773-6fca00e5db14",
+                "title": "Unique File Types [Logs ThreatQ]",
+                "type": "lens",
+                "version": "8.0.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-current-indexpattern",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-b83c382d-fab9-4e60-a632-475e221cc20c",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "sharingSavedObjectProps": {
+                            "outcome": "exactMatch",
+                            "sourceId": "ti_abusech-d888e3e0-3b38-11ec-ae50-2fdf1e96c6a6"
+                        },
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "b83c382d-fab9-4e60-a632-475e221cc20c": {
+                                            "columnOrder": [
+                                                "eda3c6d9-dacb-4e5e-b977-50104f76e91a"
+                                            ],
+                                            "columns": {
+                                                "eda3c6d9-dacb-4e5e-b977-50104f76e91a": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Unique MD5",
+                                                    "operationType": "unique_count",
+                                                    "scale": "ratio",
+                                                    "sourceField": "threat.indicator.file.hash.md5"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "accessor": "eda3c6d9-dacb-4e5e-b977-50104f76e91a",
+                                "layerId": "b83c382d-fab9-4e60-a632-475e221cc20c",
+                                "layerType": "data"
+                            }
+                        },
+                        "title": "Unique MD5 [Logs AbuseCH]",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 8,
+                    "i": "4d3e11dc-c4cc-4373-bb83-3d39fe6ffa98",
+                    "w": 6,
+                    "x": 13,
+                    "y": 0
+                },
+                "panelIndex": "4d3e11dc-c4cc-4373-bb83-3d39fe6ffa98",
+                "title": "Unique MD5 [Logs ThreatQ]",
+                "type": "lens",
+                "version": "8.0.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-current-indexpattern",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-85ad73b3-3b76-49f1-ad20-6256b58918f8",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "sharingSavedObjectProps": {
+                            "outcome": "exactMatch",
+                            "sourceId": "ti_abusech-28549810-3b39-11ec-ae50-2fdf1e96c6a6"
+                        },
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "85ad73b3-3b76-49f1-ad20-6256b58918f8": {
+                                            "columnOrder": [
+                                                "289bd005-bdd2-4f3b-83b9-ad6ae52a9ed3"
+                                            ],
+                                            "columns": {
+                                                "289bd005-bdd2-4f3b-83b9-ad6ae52a9ed3": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Unique SHA1",
+                                                    "operationType": "unique_count",
+                                                    "scale": "ratio",
+                                                    "sourceField": "threat.indicator.file.hash.sha1"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "accessor": "289bd005-bdd2-4f3b-83b9-ad6ae52a9ed3",
+                                "layerId": "85ad73b3-3b76-49f1-ad20-6256b58918f8",
+                                "layerType": "data"
+                            }
+                        },
+                        "title": "Unique SHA1 [Logs AbuseCH]",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 8,
+                    "i": "e9b6f0ad-5e6b-44da-923e-dc0d5ccfdfea",
+                    "w": 6,
+                    "x": 26,
+                    "y": 0
+                },
+                "panelIndex": "e9b6f0ad-5e6b-44da-923e-dc0d5ccfdfea",
+                "title": "Unique SHA1 [Logs ThreatQ]",
+                "type": "lens",
+                "version": "8.0.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-current-indexpattern",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-49b7070a-f1d3-46e1-a980-2f6d6d130167",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "sharingSavedObjectProps": {
+                            "outcome": "exactMatch",
+                            "sourceId": "ti_abusech-5d6111a0-3b39-11ec-ae50-2fdf1e96c6a6"
+                        },
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "49b7070a-f1d3-46e1-a980-2f6d6d130167": {
+                                            "columnOrder": [
+                                                "b6c5e221-88ff-490e-bd3e-188b3e0dd1f4"
+                                            ],
+                                            "columns": {
+                                                "b6c5e221-88ff-490e-bd3e-188b3e0dd1f4": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Unique SHA256",
+                                                    "operationType": "unique_count",
+                                                    "scale": "ratio",
+                                                    "sourceField": "threat.indicator.file.hash.sha256"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "accessor": "b6c5e221-88ff-490e-bd3e-188b3e0dd1f4",
+                                "layerId": "49b7070a-f1d3-46e1-a980-2f6d6d130167",
+                                "layerType": "data"
+                            }
+                        },
+                        "title": "Unique SHA256 [Logs AbuseCH]",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 8,
+                    "i": "93e32abe-87e3-469e-b7e9-a7ef7dfa2cce",
+                    "w": 6,
+                    "x": 32,
+                    "y": 0
+                },
+                "panelIndex": "93e32abe-87e3-469e-b7e9-a7ef7dfa2cce",
+                "title": "Unique SHA256 [Logs ThreatQ]",
+                "type": "lens",
+                "version": "8.0.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-current-indexpattern",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-222b3ad0-2e5d-46a0-ae3d-f6a0b15ac2c8",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "sharingSavedObjectProps": {
+                            "outcome": "exactMatch",
+                            "sourceId": "ti_abusech-4ee4a490-3b37-11ec-ae50-2fdf1e96c6a6"
+                        },
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "222b3ad0-2e5d-46a0-ae3d-f6a0b15ac2c8": {
+                                            "columnOrder": [
+                                                "06b603cb-c9fb-493a-9ca4-e6502ca12054",
+                                                "de0e531b-dda7-461f-9783-3ab9267d202e"
+                                            ],
+                                            "columns": {
+                                                "06b603cb-c9fb-493a-9ca4-e6502ca12054": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top values of threat.indicator.file.type",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "de0e531b-dda7-461f-9783-3ab9267d202e",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "size": 5
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "threat.indicator.file.type"
+                                                },
+                                                "de0e531b-dda7-461f-9783-3ab9267d202e": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count of records",
+                                                    "operationType": "count",
+                                                    "scale": "ratio",
+                                                    "sourceField": "Records"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "categoryDisplay": "default",
+                                        "groups": [
+                                            "06b603cb-c9fb-493a-9ca4-e6502ca12054"
+                                        ],
+                                        "layerId": "222b3ad0-2e5d-46a0-ae3d-f6a0b15ac2c8",
+                                        "layerType": "data",
+                                        "legendDisplay": "default",
+                                        "metric": "de0e531b-dda7-461f-9783-3ab9267d202e",
+                                        "nestedLegend": false,
+                                        "numberDisplay": "percent"
+                                    }
+                                ],
+                                "shape": "treemap"
+                            }
+                        },
+                        "title": "File Types [Logs AbuseCH]",
+                        "visualizationType": "lnsPie"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 19,
+                    "i": "5f1d0cf1-c331-4495-99d5-5e80d023c482",
+                    "w": 19,
+                    "x": 7,
+                    "y": 8
+                },
+                "panelIndex": "5f1d0cf1-c331-4495-99d5-5e80d023c482",
+                "title": "File Types [Logs ThreatQ]",
+                "type": "lens",
+                "version": "8.0.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-current-indexpattern",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-06d9ac79-2055-437e-892c-de9ee07fe674",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "sharingSavedObjectProps": {
+                            "outcome": "exactMatch",
+                            "sourceId": "2d0c0ec0-3bbf-11ec-ae8c-7d00429ad420"
+                        },
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "06d9ac79-2055-437e-892c-de9ee07fe674": {
+                                            "columnOrder": [
+                                                "35f5321a-27f4-4076-9d1d-d326187f4689",
+                                                "df062557-78a5-4a78-93f1-34583c809bc3"
+                                            ],
+                                            "columns": {
+                                                "35f5321a-27f4-4076-9d1d-d326187f4689": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "File Names",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "df062557-78a5-4a78-93f1-34583c809bc3",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "threat.indicator.file.name"
+                                                },
+                                                "df062557-78a5-4a78-93f1-34583c809bc3": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count",
+                                                    "operationType": "count",
+                                                    "scale": "ratio",
+                                                    "sourceField": "Records"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "columnId": "35f5321a-27f4-4076-9d1d-d326187f4689",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "df062557-78a5-4a78-93f1-34583c809bc3",
+                                        "isTransposed": false
+                                    }
+                                ],
+                                "layerId": "06d9ac79-2055-437e-892c-de9ee07fe674",
+                                "layerType": "data"
+                            }
+                        },
+                        "title": "Most popular file names [Logs AbuseCH]",
+                        "visualizationType": "lnsDatatable"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 19,
+                    "i": "b733385b-14f8-4469-b777-86d0139cc56b",
+                    "w": 21,
+                    "x": 26,
+                    "y": 8
+                },
+                "panelIndex": "b733385b-14f8-4469-b777-86d0139cc56b",
+                "title": "Most popular file names [Logs ThreatQ]",
+                "type": "lens",
+                "version": "8.0.0-SNAPSHOT"
+            }
+        ],
+        "timeRestore": false,
+        "title": "[Logs ThreatQ] Files",
+        "version": 1
+    },
+    "coreMigrationVersion": "8.0.0",
+    "id": "ti_threatq-ab289de0-78f1-11ec-a97c-7db1518ab848",
+    "migrationVersion": {
+        "dashboard": "8.0.0"
+    },
+    "references": [
+        {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[1].meta.index",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[2].meta.index",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "31ea16d1-7591-42a7-b773-6fca00e5db14:indexpattern-datasource-current-indexpattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "31ea16d1-7591-42a7-b773-6fca00e5db14:indexpattern-datasource-layer-98786f76-dac4-4fc7-9cad-8bfce17bd00d",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "4d3e11dc-c4cc-4373-bb83-3d39fe6ffa98:indexpattern-datasource-current-indexpattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "4d3e11dc-c4cc-4373-bb83-3d39fe6ffa98:indexpattern-datasource-layer-b83c382d-fab9-4e60-a632-475e221cc20c",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "e9b6f0ad-5e6b-44da-923e-dc0d5ccfdfea:indexpattern-datasource-current-indexpattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "e9b6f0ad-5e6b-44da-923e-dc0d5ccfdfea:indexpattern-datasource-layer-85ad73b3-3b76-49f1-ad20-6256b58918f8",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "93e32abe-87e3-469e-b7e9-a7ef7dfa2cce:indexpattern-datasource-current-indexpattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "93e32abe-87e3-469e-b7e9-a7ef7dfa2cce:indexpattern-datasource-layer-49b7070a-f1d3-46e1-a980-2f6d6d130167",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "5f1d0cf1-c331-4495-99d5-5e80d023c482:indexpattern-datasource-current-indexpattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "5f1d0cf1-c331-4495-99d5-5e80d023c482:indexpattern-datasource-layer-222b3ad0-2e5d-46a0-ae3d-f6a0b15ac2c8",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "b733385b-14f8-4469-b777-86d0139cc56b:indexpattern-datasource-current-indexpattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "b733385b-14f8-4469-b777-86d0139cc56b:indexpattern-datasource-layer-06d9ac79-2055-437e-892c-de9ee07fe674",
+            "type": "index-pattern"
+        },
+        {
+            "id": "ti_threatq-c0cca010-78f1-11ec-a97c-7db1518ab848",
+            "name": "tag-ti_threatq-c0cca010-78f1-11ec-a97c-7db1518ab848",
+            "type": "tag"
+        }
+    ],
+    "type": "dashboard"
+}

--- a/packages/ti_threatq/kibana/dashboard/ti_threatq-ab289de0-78f1-11ec-a97c-7db1518ab848.json
+++ b/packages/ti_threatq/kibana/dashboard/ti_threatq-ab289de0-78f1-11ec-a97c-7db1518ab848.json
@@ -1,6 +1,6 @@
 {
     "attributes": {
-        "description": "Dashboard providing statistics about file type indicators from the AbuseCH integration",
+        "description": "Dashboard providing statistics about file type indicators from the ThreatQ integration",
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
@@ -115,6 +115,7 @@
                     "y": 0
                 },
                 "panelIndex": "09ba3dc0-e2e2-4799-b47f-bb919bf290a1",
+                "title": "Files Navigation Textbox [Logs ThreatQ]",
                 "type": "visualization",
                 "version": "8.0.0-SNAPSHOT"
             },

--- a/packages/ti_threatq/kibana/dashboard/ti_threatq-b45b0c40-78f1-11ec-a97c-7db1518ab848.json
+++ b/packages/ti_threatq/kibana/dashboard/ti_threatq-b45b0c40-78f1-11ec-a97c-7db1518ab848.json
@@ -1,6 +1,6 @@
 {
     "attributes": {
-        "description": "Dashboard providing statistics about URL type indicators from the AbuseCH integration",
+        "description": "Dashboard providing statistics about URL type indicators from the ThreatQ integration",
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
@@ -95,7 +95,7 @@
                     "y": 0
                 },
                 "panelIndex": "4c3ed6e1-8b4e-4eab-8d84-70ed4f506216",
-                "title": "Files Navigation Textbox [Logs AbuseCH]",
+                "title": "Files Navigation Textbox [Logs ThreatQ]",
                 "type": "visualization",
                 "version": "8.0.0-SNAPSHOT"
             },

--- a/packages/ti_threatq/kibana/dashboard/ti_threatq-b45b0c40-78f1-11ec-a97c-7db1518ab848.json
+++ b/packages/ti_threatq/kibana/dashboard/ti_threatq-b45b0c40-78f1-11ec-a97c-7db1518ab848.json
@@ -1,0 +1,694 @@
+{
+    "attributes": {
+        "description": "Dashboard providing statistics about URL type indicators from the AbuseCH integration",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+            "searchSourceJSON": {
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "threat.indicator.type",
+                            "negate": false,
+                            "params": {
+                                "query": "url"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "threat.indicator.type": "url"
+                            }
+                        }
+                    },
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[1].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "ti_threatq.threat"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "ti_threatq.threat"
+                            }
+                        }
+                    }
+                ],
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
+        },
+        "optionsJSON": {
+            "hidePanelTitles": false,
+            "syncColors": false,
+            "useMargins": true
+        },
+        "panelsJSON": [
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "hidePanelTitles": true,
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
+                        "description": "",
+                        "id": "",
+                        "params": {
+                            "fontSize": 12,
+                            "markdown": "**Navigation**\n\n[ThreatQ Overview ](/app/dashboards#/view/ti_threatq-a05fd810-78f1-11ec-a97c-7db1518ab848)  \n[ThreatQ Files](/app/dashboards#/view/ti_threatq-ab289de0-78f1-11ec-a97c-7db1518ab848)  \n**[ThreatQ URLs (This Page)](/app/dashboards#/view/ti_threatq-b45b0c40-78f1-11ec-a97c-7db1518ab848)**  \n\n[Integrations Page](/app/integrations/detail/ti_threatq/overview)\n\n\n**Overview**\n\nThis dashboard is an overview of the different threat intelligence indicators with a **threat.indicator.type: url**.  \n\nThe dashboard is made to provide general statistics and show the health of your indicators like popular domains, file extensions, statistics about how many unique indicators are ingested and other relevant information.",
+                            "openLinksInNewTab": false
+                        },
+                        "title": "",
+                        "type": "markdown",
+                        "uiState": {}
+                    }
+                },
+                "gridData": {
+                    "h": 39,
+                    "i": "4c3ed6e1-8b4e-4eab-8d84-70ed4f506216",
+                    "w": 7,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "4c3ed6e1-8b4e-4eab-8d84-70ed4f506216",
+                "title": "Files Navigation Textbox [Logs AbuseCH]",
+                "type": "visualization",
+                "version": "8.0.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-current-indexpattern",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-88a112e1-6da1-49d3-9177-19f98280c200",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "88a112e1-6da1-49d3-9177-19f98280c200": {
+                                            "columnOrder": [
+                                                "604f1693-15a6-437d-af69-03588db8e471"
+                                            ],
+                                            "columns": {
+                                                "604f1693-15a6-437d-af69-03588db8e471": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Unique Ports",
+                                                    "operationType": "unique_count",
+                                                    "scale": "ratio",
+                                                    "sourceField": "threat.indicator.url.port"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "accessor": "604f1693-15a6-437d-af69-03588db8e471",
+                                "layerId": "88a112e1-6da1-49d3-9177-19f98280c200",
+                                "layerType": "data"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 8,
+                    "i": "c7c6e8dc-b649-434c-9650-8a1564d4d676",
+                    "w": 6,
+                    "x": 7,
+                    "y": 0
+                },
+                "panelIndex": "c7c6e8dc-b649-434c-9650-8a1564d4d676",
+                "title": "Unique Ports [Logs ThreatQ]",
+                "type": "lens",
+                "version": "8.0.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-current-indexpattern",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-a6fa56f8-32fa-405d-8771-dade4fe75d62",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "a6fa56f8-32fa-405d-8771-dade4fe75d62": {
+                                            "columnOrder": [
+                                                "848c463b-bbc1-4b6a-af3e-76d844eb3cc5"
+                                            ],
+                                            "columns": {
+                                                "848c463b-bbc1-4b6a-af3e-76d844eb3cc5": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Unique Extensions",
+                                                    "operationType": "unique_count",
+                                                    "scale": "ratio",
+                                                    "sourceField": "threat.indicator.url.extension"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "accessor": "848c463b-bbc1-4b6a-af3e-76d844eb3cc5",
+                                "layerId": "a6fa56f8-32fa-405d-8771-dade4fe75d62",
+                                "layerType": "data"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 8,
+                    "i": "73a752f9-bde5-4396-8ede-e9e77a37182d",
+                    "w": 6,
+                    "x": 13,
+                    "y": 0
+                },
+                "panelIndex": "73a752f9-bde5-4396-8ede-e9e77a37182d",
+                "title": "Unique File Extensions [Logs ThreatQ]",
+                "type": "lens",
+                "version": "8.0.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-current-indexpattern",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-9fa49c4c-5544-472d-afce-e51d6a5687fe",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "9fa49c4c-5544-472d-afce-e51d6a5687fe": {
+                                            "columnOrder": [
+                                                "15e2b5ad-2040-4253-89a6-60f085c66f86",
+                                                "b9a631fe-5f49-4db2-a076-bcbf5410aec9"
+                                            ],
+                                            "columns": {
+                                                "15e2b5ad-2040-4253-89a6-60f085c66f86": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top values of threat.indicator.url.extension",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "b9a631fe-5f49-4db2-a076-bcbf5410aec9",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "threat.indicator.url.extension"
+                                                },
+                                                "b9a631fe-5f49-4db2-a076-bcbf5410aec9": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count of records",
+                                                    "operationType": "count",
+                                                    "scale": "ratio",
+                                                    "sourceField": "Records"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "categoryDisplay": "default",
+                                        "groups": [
+                                            "15e2b5ad-2040-4253-89a6-60f085c66f86",
+                                            "15e2b5ad-2040-4253-89a6-60f085c66f86"
+                                        ],
+                                        "layerId": "9fa49c4c-5544-472d-afce-e51d6a5687fe",
+                                        "layerType": "data",
+                                        "legendDisplay": "default",
+                                        "metric": "b9a631fe-5f49-4db2-a076-bcbf5410aec9",
+                                        "nestedLegend": false,
+                                        "numberDisplay": "percent"
+                                    }
+                                ],
+                                "shape": "treemap"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsPie"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 31,
+                    "i": "fda93ed1-72f0-4489-80b7-9e69d14f30aa",
+                    "w": 23,
+                    "x": 25,
+                    "y": 0
+                },
+                "panelIndex": "fda93ed1-72f0-4489-80b7-9e69d14f30aa",
+                "title": "Most Popular File Extensions [Logs ThreatQ]",
+                "type": "lens",
+                "version": "8.0.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-current-indexpattern",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-c94400ee-a135-4a99-9693-5879d29f7aad",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "c94400ee-a135-4a99-9693-5879d29f7aad": {
+                                            "columnOrder": [
+                                                "2934249f-fce5-4637-87ff-d2596d1b6ec5"
+                                            ],
+                                            "columns": {
+                                                "2934249f-fce5-4637-87ff-d2596d1b6ec5": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Unique Domains",
+                                                    "operationType": "unique_count",
+                                                    "scale": "ratio",
+                                                    "sourceField": "threat.indicator.url.domain"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "accessor": "2934249f-fce5-4637-87ff-d2596d1b6ec5",
+                                "layerId": "c94400ee-a135-4a99-9693-5879d29f7aad",
+                                "layerType": "data"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 8,
+                    "i": "02f1732b-a981-4fba-8b27-b944f2f3c98c",
+                    "w": 6,
+                    "x": 19,
+                    "y": 0
+                },
+                "panelIndex": "02f1732b-a981-4fba-8b27-b944f2f3c98c",
+                "title": "Unique Domains [Logs ThreatQ]",
+                "type": "lens",
+                "version": "8.0.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-current-indexpattern",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-0f63318a-a857-4d83-89ce-a94e2242b79e",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "0f63318a-a857-4d83-89ce-a94e2242b79e": {
+                                            "columnOrder": [
+                                                "df0791a6-247c-4434-a43a-fdea7577ca34",
+                                                "77a48096-02aa-4b7a-8a7b-131fc38988bd"
+                                            ],
+                                            "columns": {
+                                                "77a48096-02aa-4b7a-8a7b-131fc38988bd": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count of records",
+                                                    "operationType": "count",
+                                                    "scale": "ratio",
+                                                    "sourceField": "Records"
+                                                },
+                                                "df0791a6-247c-4434-a43a-fdea7577ca34": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top values of threat.indicator.url.scheme",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "77a48096-02aa-4b7a-8a7b-131fc38988bd",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "size": 5
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "threat.indicator.url.scheme"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "categoryDisplay": "default",
+                                        "groups": [
+                                            "df0791a6-247c-4434-a43a-fdea7577ca34"
+                                        ],
+                                        "layerId": "0f63318a-a857-4d83-89ce-a94e2242b79e",
+                                        "layerType": "data",
+                                        "legendDisplay": "show",
+                                        "metric": "77a48096-02aa-4b7a-8a7b-131fc38988bd",
+                                        "nestedLegend": false,
+                                        "numberDisplay": "percent"
+                                    }
+                                ],
+                                "shape": "donut"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsPie"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "ab7ab31c-e76f-4613-b17d-fdd909f17e0d",
+                    "w": 18,
+                    "x": 7,
+                    "y": 8
+                },
+                "panelIndex": "ab7ab31c-e76f-4613-b17d-fdd909f17e0d",
+                "title": "Percentage of URL Schema used [Logs ThreatQ]",
+                "type": "lens",
+                "version": "8.0.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-current-indexpattern",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-db89074c-e1fe-4091-bdb1-e42a36e82bac",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "db89074c-e1fe-4091-bdb1-e42a36e82bac": {
+                                            "columnOrder": [
+                                                "b284ea2a-a2cd-4d08-bf44-fc73c08b5694",
+                                                "7ca1ac0b-2060-4431-a4b9-ec470af4448c"
+                                            ],
+                                            "columns": {
+                                                "7ca1ac0b-2060-4431-a4b9-ec470af4448c": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count",
+                                                    "operationType": "count",
+                                                    "scale": "ratio",
+                                                    "sourceField": "Records"
+                                                },
+                                                "b284ea2a-a2cd-4d08-bf44-fc73c08b5694": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Domains",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "7ca1ac0b-2060-4431-a4b9-ec470af4448c",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "threat.indicator.url.domain"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "columnId": "7ca1ac0b-2060-4431-a4b9-ec470af4448c",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "b284ea2a-a2cd-4d08-bf44-fc73c08b5694",
+                                        "isTransposed": false
+                                    }
+                                ],
+                                "layerId": "db89074c-e1fe-4091-bdb1-e42a36e82bac",
+                                "layerType": "data"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsDatatable"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 16,
+                    "i": "8994501a-1550-4cf2-857f-d6b6491ffb62",
+                    "w": 18,
+                    "x": 7,
+                    "y": 23
+                },
+                "panelIndex": "8994501a-1550-4cf2-857f-d6b6491ffb62",
+                "title": "Most Popular Domains [Logs ThreatQ]",
+                "type": "lens",
+                "version": "8.0.0-SNAPSHOT"
+            }
+        ],
+        "timeRestore": false,
+        "title": "[Logs ThreatQ] URLs",
+        "version": 1
+    },
+    "coreMigrationVersion": "8.0.0",
+    "id": "ti_threatq-b45b0c40-78f1-11ec-a97c-7db1518ab848",
+    "migrationVersion": {
+        "dashboard": "8.0.0"
+    },
+    "references": [
+        {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[1].meta.index",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "c7c6e8dc-b649-434c-9650-8a1564d4d676:indexpattern-datasource-current-indexpattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "c7c6e8dc-b649-434c-9650-8a1564d4d676:indexpattern-datasource-layer-88a112e1-6da1-49d3-9177-19f98280c200",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "73a752f9-bde5-4396-8ede-e9e77a37182d:indexpattern-datasource-current-indexpattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "73a752f9-bde5-4396-8ede-e9e77a37182d:indexpattern-datasource-layer-a6fa56f8-32fa-405d-8771-dade4fe75d62",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "fda93ed1-72f0-4489-80b7-9e69d14f30aa:indexpattern-datasource-current-indexpattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "fda93ed1-72f0-4489-80b7-9e69d14f30aa:indexpattern-datasource-layer-9fa49c4c-5544-472d-afce-e51d6a5687fe",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "02f1732b-a981-4fba-8b27-b944f2f3c98c:indexpattern-datasource-current-indexpattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "02f1732b-a981-4fba-8b27-b944f2f3c98c:indexpattern-datasource-layer-c94400ee-a135-4a99-9693-5879d29f7aad",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "ab7ab31c-e76f-4613-b17d-fdd909f17e0d:indexpattern-datasource-current-indexpattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "ab7ab31c-e76f-4613-b17d-fdd909f17e0d:indexpattern-datasource-layer-0f63318a-a857-4d83-89ce-a94e2242b79e",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "8994501a-1550-4cf2-857f-d6b6491ffb62:indexpattern-datasource-current-indexpattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "8994501a-1550-4cf2-857f-d6b6491ffb62:indexpattern-datasource-layer-db89074c-e1fe-4091-bdb1-e42a36e82bac",
+            "type": "index-pattern"
+        },
+        {
+            "id": "ti_threatq-c0cca010-78f1-11ec-a97c-7db1518ab848",
+            "name": "tag-ti_threatq-c0cca010-78f1-11ec-a97c-7db1518ab848",
+            "type": "tag"
+        }
+    ],
+    "type": "dashboard"
+}

--- a/packages/ti_threatq/kibana/tag/ti_threatq-c0cca010-78f1-11ec-a97c-7db1518ab848.json
+++ b/packages/ti_threatq/kibana/tag/ti_threatq-c0cca010-78f1-11ec-a97c-7db1518ab848.json
@@ -1,0 +1,14 @@
+{
+    "attributes": {
+        "color": "#6092C0",
+        "description": "",
+        "name": "ThreatQ"
+    },
+    "coreMigrationVersion": "8.0.0",
+    "id": "ti_threatq-c0cca010-78f1-11ec-a97c-7db1518ab848",
+    "migrationVersion": {
+        "tag": "8.0.0"
+    },
+    "references": [],
+    "type": "tag"
+}

--- a/packages/ti_threatq/manifest.yml
+++ b/packages/ti_threatq/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_threatq
 title: ThreatQuotient
-version: 1.0.2
+version: 1.1.0
 release: ga
 description: This Elastic integration collects threat intelligence from ThreatQuotient
 type: integration


### PR DESCRIPTION
## What does this PR do?

Adds threat.feed fields and dashboards to the ThreatQ integration

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

![ThreatQOverview](https://user-images.githubusercontent.com/8027539/150089315-573b63db-856d-4edd-80e6-ac374d26e4e3.PNG)
![ThreatQURL](https://user-images.githubusercontent.com/8027539/150089327-936d9ab0-0527-4c41-9c19-7152e8b6630d.PNG)
![ThreatQ File](https://user-images.githubusercontent.com/8027539/150089335-29c187c0-bbfd-4122-bd24-93f65547c990.PNG)

