### PR TITLE
Remove beta release tag from data streams in azure packages

### DIFF
--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -2,6 +2,7 @@
   changes:
     - description: Remove beta release tag from data streams
       type: enhancement
+      link: https://github.com/elastic/integrations/pull/2547
 - version: "1.0.0"
   changes:
     - description: Move azure package to GA

--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -1,3 +1,7 @@
+- version: "1.0.1"
+  changes:
+    - description: Remove beta release tag from data streams
+      type: enhancement
 - version: "1.0.0"
   changes:
     - description: Move azure package to GA

--- a/packages/azure/data_stream/activitylogs/fields/fields.yml
+++ b/packages/azure/data_stream/activitylogs/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: azure.activitylogs
   type: group
-  release: beta
   fields:
     - name: identity
       type: group

--- a/packages/azure/data_stream/activitylogs/manifest.yml
+++ b/packages/azure/data_stream/activitylogs/manifest.yml
@@ -1,6 +1,5 @@
 type: logs
 title: Azure activity logs
-release: beta
 streams:
   - input: "azure-eventhub"
     template_path: "azure-eventhub.yml.hbs"

--- a/packages/azure/data_stream/auditlogs/manifest.yml
+++ b/packages/azure/data_stream/auditlogs/manifest.yml
@@ -1,6 +1,5 @@
 type: logs
 title: Azure audit logs
-release: beta
 streams:
   - input: "azure-eventhub"
     template_path: "azure-eventhub.yml.hbs"

--- a/packages/azure/data_stream/eventhub/manifest.yml
+++ b/packages/azure/data_stream/eventhub/manifest.yml
@@ -1,6 +1,5 @@
 type: logs
 title: Azure Event Hub Input
-release: beta
 streams:
   - input: "azure-eventhub"
     template_path: "stream.yml.hbs"

--- a/packages/azure/data_stream/platformlogs/fields/fields.yml
+++ b/packages/azure/data_stream/platformlogs/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: azure.platformlogs
   type: group
-  release: beta
   fields:
     - name: operation_name
       type: keyword

--- a/packages/azure/data_stream/platformlogs/manifest.yml
+++ b/packages/azure/data_stream/platformlogs/manifest.yml
@@ -1,6 +1,5 @@
 type: logs
 title: Azure platform logs
-release: beta
 streams:
   - input: "azure-eventhub"
     template_path: "azure-eventhub.yml.hbs"

--- a/packages/azure/data_stream/signinlogs/manifest.yml
+++ b/packages/azure/data_stream/signinlogs/manifest.yml
@@ -1,6 +1,5 @@
 type: logs
 title: Azure signin logs
-release: beta
 streams:
   - input: "azure-eventhub"
     template_path: "azure-eventhub.yml.hbs"

--- a/packages/azure/data_stream/springcloudlogs/fields/fields.yml
+++ b/packages/azure/data_stream/springcloudlogs/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: azure.springcloudlogs
   type: group
-  release: beta
   fields:
     - name: operation_name
       type: keyword

--- a/packages/azure/data_stream/springcloudlogs/manifest.yml
+++ b/packages/azure/data_stream/springcloudlogs/manifest.yml
@@ -1,6 +1,5 @@
 type: logs
 title: Azure Spring Cloud logs
-release: beta
 streams:
   - input: "azure-eventhub"
     template_path: "azure-eventhub.yml.hbs"

--- a/packages/azure/manifest.yml
+++ b/packages/azure/manifest.yml
@@ -1,6 +1,7 @@
 name: azure
 title: Azure Logs
-version: 1.0.0
+version: 1.0.1
+release: ga
 description: This Elastic integration collects logs from Azure
 type: integration
 icons:

--- a/packages/azure/manifest.yml
+++ b/packages/azure/manifest.yml
@@ -1,7 +1,6 @@
 name: azure
 title: Azure Logs
 version: 1.0.0
-release: ga
 description: This Elastic integration collects logs from Azure
 type: integration
 icons:

--- a/packages/azure_application_insights/changelog.yml
+++ b/packages/azure_application_insights/changelog.yml
@@ -2,6 +2,7 @@
   changes:
     - description: Remove beta release tag from data streams
       type: enhancement
+      link: https://github.com/elastic/integrations/pull/2547
 - version: "1.0.0"
   changes:
     - description: Move azure_application_insights package to GA

--- a/packages/azure_application_insights/changelog.yml
+++ b/packages/azure_application_insights/changelog.yml
@@ -1,3 +1,7 @@
+- version: "1.0.1"
+  changes:
+    - description: Remove beta release tag from data streams
+      type: enhancement
 - version: "1.0.0"
   changes:
     - description: Move azure_application_insights package to GA

--- a/packages/azure_application_insights/data_stream/app_insights/fields/fields.yml
+++ b/packages/azure_application_insights/data_stream/app_insights/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: azure.app_insights
   type: group
-  release: beta
   description: >
     application insights
 

--- a/packages/azure_application_insights/data_stream/app_insights/manifest.yml
+++ b/packages/azure_application_insights/data_stream/app_insights/manifest.yml
@@ -1,7 +1,6 @@
 type: metrics
 title: Azure Application Insights
 dataset: azure.app_insights
-release: beta
 streams:
   - input: azure/metrics
     vars:

--- a/packages/azure_application_insights/data_stream/app_state/fields/fields.yml
+++ b/packages/azure_application_insights/data_stream/app_state/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: azure.app_state
   type: group
-  release: beta
   description: >
     application state
 

--- a/packages/azure_application_insights/data_stream/app_state/manifest.yml
+++ b/packages/azure_application_insights/data_stream/app_state/manifest.yml
@@ -1,6 +1,5 @@
 type: metrics
 title: Azure Application State
-release: beta
 dataset: azure.app_state
 streams:
   - input: azure/metrics

--- a/packages/azure_application_insights/manifest.yml
+++ b/packages/azure_application_insights/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_application_insights
 title: Azure Application Insights Metrics Overview
-version: 1.0.0
+version: 1.0.1
 release: ga
 description: Collect application insights metrics from Azure Monitor with Elastic Agent.
 type: integration

--- a/packages/azure_billing/changelog.yml
+++ b/packages/azure_billing/changelog.yml
@@ -1,3 +1,7 @@
+- version: "1.0.1"
+  changes:
+    - description: Remove beta release tag from data streams
+      type: enhancement
 - version: "1.0.0"
   changes:
     - description: Move azure_billing package to GA

--- a/packages/azure_billing/changelog.yml
+++ b/packages/azure_billing/changelog.yml
@@ -2,6 +2,7 @@
   changes:
     - description: Remove beta release tag from data streams
       type: enhancement
+      link: https://github.com/elastic/integrations/pull/2547
 - version: "1.0.0"
   changes:
     - description: Move azure_billing package to GA

--- a/packages/azure_billing/data_stream/billing/fields/fields.yml
+++ b/packages/azure_billing/data_stream/billing/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: azure.billing
   type: group
-  release: beta
   description: >
     billing and usage details
 

--- a/packages/azure_billing/data_stream/billing/manifest.yml
+++ b/packages/azure_billing/data_stream/billing/manifest.yml
@@ -1,7 +1,6 @@
 type: metrics
 title: Azure Billing Metrics
 dataset: azure.billing
-release: beta
 streams:
   - input: azure/metrics
     vars:

--- a/packages/azure_billing/manifest.yml
+++ b/packages/azure_billing/manifest.yml
@@ -1,6 +1,7 @@
 name: azure_billing
 title: Azure Billing Metrics
 version: 1.0.1
+release: ga
 description: Collect billing metrics with Elastic Agent.
 type: integration
 icons:

--- a/packages/azure_billing/manifest.yml
+++ b/packages/azure_billing/manifest.yml
@@ -1,7 +1,6 @@
 name: azure_billing
 title: Azure Billing Metrics
-version: 1.0.0
-release: ga
+version: 1.0.1
 description: Collect billing metrics with Elastic Agent.
 type: integration
 icons:

--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -2,6 +2,7 @@
   changes:
     - description: Remove beta release tag from data streams
       type: enhancement
+      link: https://github.com/elastic/integrations/pull/2547
 - version: "1.0.0"
   changes:
     - description: Move azure_metrics package to GA

--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -1,3 +1,7 @@
+- version: "1.0.1"
+  changes:
+    - description: Remove beta release tag from data streams
+      type: enhancement
 - version: "1.0.0"
   changes:
     - description: Move azure_metrics package to GA

--- a/packages/azure_metrics/data_stream/compute_vm/manifest.yml
+++ b/packages/azure_metrics/data_stream/compute_vm/manifest.yml
@@ -1,7 +1,6 @@
 type: metrics
 title: Compute VM
 dataset: azure.compute_vm
-release: beta
 streams:
   - input: azure/metrics
     enabled: false

--- a/packages/azure_metrics/data_stream/compute_vm_scaleset/manifest.yml
+++ b/packages/azure_metrics/data_stream/compute_vm_scaleset/manifest.yml
@@ -1,7 +1,6 @@
 type: metrics
 title: Compute VM Scaleset
 dataset: azure.compute_vm_scaleset
-release: beta
 streams:
   - input: azure/metrics
     enabled: false

--- a/packages/azure_metrics/data_stream/container_instance/manifest.yml
+++ b/packages/azure_metrics/data_stream/container_instance/manifest.yml
@@ -1,7 +1,6 @@
 type: metrics
 title: Container Instance
 dataset: azure.container_instance
-release: beta
 streams:
   - input: azure/metrics
     enabled: false

--- a/packages/azure_metrics/data_stream/container_registry/manifest.yml
+++ b/packages/azure_metrics/data_stream/container_registry/manifest.yml
@@ -1,7 +1,6 @@
 type: metrics
 title: Container Registry
 dataset: azure.container_registry
-release: beta
 streams:
   - input: azure/metrics
     enabled: false

--- a/packages/azure_metrics/data_stream/container_service/manifest.yml
+++ b/packages/azure_metrics/data_stream/container_service/manifest.yml
@@ -1,7 +1,6 @@
 type: metrics
 title: Container Service
 dataset: azure.container_service
-release: beta
 streams:
   - input: azure/metrics
     enabled: false

--- a/packages/azure_metrics/data_stream/database_account/manifest.yml
+++ b/packages/azure_metrics/data_stream/database_account/manifest.yml
@@ -1,7 +1,6 @@
 type: metrics
 title: Database Account
 dataset: azure.database_account
-release: beta
 streams:
   - input: azure/metrics
     enabled: false

--- a/packages/azure_metrics/data_stream/monitor/manifest.yml
+++ b/packages/azure_metrics/data_stream/monitor/manifest.yml
@@ -1,7 +1,6 @@
 type: metrics
 title: Monitor
 dataset: azure.monitor
-release: beta
 streams:
   - input: azure/metrics
     vars:

--- a/packages/azure_metrics/data_stream/storage_account/manifest.yml
+++ b/packages/azure_metrics/data_stream/storage_account/manifest.yml
@@ -1,7 +1,6 @@
 type: metrics
 title: Storage Account
 dataset: azure.storage_account
-release: beta
 streams:
   - input: azure/metrics
     enabled: false

--- a/packages/azure_metrics/manifest.yml
+++ b/packages/azure_metrics/manifest.yml
@@ -1,6 +1,7 @@
 name: azure_metrics
 title: Azure Resource Metrics
-version: 1.0.0
+version: 1.0.1
+release: ga
 description: Collect metrics from Azure resources with Elastic Agent.
 type: integration
 icons:

--- a/packages/azure_metrics/manifest.yml
+++ b/packages/azure_metrics/manifest.yml
@@ -1,7 +1,6 @@
 name: azure_metrics
 title: Azure Resource Metrics
 version: 1.0.0
-release: beta
 description: Collect metrics from Azure resources with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR is to remove the beta release tag from data streams in azure packages: azure, azure_application_insights, azure_billing, azure_metrics.
