### PR TITLE
Fix windows: missing version bump

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,4 @@
-- version: "1.7.0"
+- version: "1.8.0"
   changes:
     - description: Update to ECS 8.0
       type: enhancement

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.7.0
+version: 1.8.0
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
This PR fixes the issue introduced in https://github.com/elastic/integrations/pull/2515 due to the not bumped package version.