### PR TITLE
Tune k8s package settings

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Tune state_metrics settings
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/xxx
+      link: https://github.com/elastic/integrations/pull/2567
 - version: "1.13.0"
   changes:
     - description: Update to ECS 8.0

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.0"
+  changes:
+    - description: Tune state_metrics settings
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/xxx
 - version: "1.13.0"
   changes:
     - description: Update to ECS 8.0

--- a/packages/kubernetes/data_stream/state_container/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_container/agent/stream/stream.yml.hbs
@@ -11,3 +11,9 @@ period: {{period}}
 {{#if leaderelection}}
 condition: ${kubernetes_leaderelection.leader} == true
 {{/if}}
+{{#if node}}
+node: {{node}}
+{{/if}}
+{{#if namespace}}
+namespace: {{namespace}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_container/manifest.yml
+++ b/packages/kubernetes/data_stream/state_container/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node to whatch resources from for metadata
+        title: Node to watch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace to whatch resources from for metadata
+        title: Namespace to watch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_container/manifest.yml
+++ b/packages/kubernetes/data_stream/state_container/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node
+        title: Node to whatch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace
+        title: Namespace to whatch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_container/manifest.yml
+++ b/packages/kubernetes/data_stream/state_container/manifest.yml
@@ -33,6 +33,18 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: node
+        type: text
+        title: Node
+        multi: false
+        required: false
+        show_user: true
+      - name: namespace
+        type: text
+        title: Namespace
+        multi: false
+        required: false
+        show_user: true
       - name: add_resource_metadata_config
         type: yaml
         title: Add node and namespace metadata

--- a/packages/kubernetes/data_stream/state_cronjob/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_cronjob/agent/stream/stream.yml.hbs
@@ -8,4 +8,9 @@ period: {{period}}
 {{#if leaderelection}}
 condition: ${kubernetes_leaderelection.leader} == true
 {{/if}}
-
+{{#if node}}
+node: {{node}}
+{{/if}}
+{{#if namespace}}
+namespace: {{namespace}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_cronjob/manifest.yml
+++ b/packages/kubernetes/data_stream/state_cronjob/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node to whatch resources from for metadata
+        title: Node to watch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace to whatch resources from for metadata
+        title: Namespace to watch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_cronjob/manifest.yml
+++ b/packages/kubernetes/data_stream/state_cronjob/manifest.yml
@@ -33,5 +33,17 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: node
+        type: text
+        title: Node
+        multi: false
+        required: false
+        show_user: true
+      - name: namespace
+        type: text
+        title: Namespace
+        multi: false
+        required: false
+        show_user: true
     title: Kubernetes Cronjob metrics
     description: Collect Kubernetes Cronjob metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_cronjob/manifest.yml
+++ b/packages/kubernetes/data_stream/state_cronjob/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node
+        title: Node to whatch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace
+        title: Namespace to whatch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_daemonset/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_daemonset/agent/stream/stream.yml.hbs
@@ -8,3 +8,9 @@ period: {{period}}
 {{#if leaderelection}}
 condition: ${kubernetes_leaderelection.leader} == true
 {{/if}}
+{{#if node}}
+node: {{node}}
+{{/if}}
+{{#if namespace}}
+namespace: {{namespace}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_daemonset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_daemonset/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node to whatch resources from for metadata
+        title: Node to watch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace to whatch resources from for metadata
+        title: Namespace to watch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_daemonset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_daemonset/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node
+        title: Node to whatch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace
+        title: Namespace to whatch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_daemonset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_daemonset/manifest.yml
@@ -33,5 +33,17 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: node
+        type: text
+        title: Node
+        multi: false
+        required: false
+        show_user: true
+      - name: namespace
+        type: text
+        title: Namespace
+        multi: false
+        required: false
+        show_user: true
     title: Kubernetes Deamonset metrics
     description: Collect Kubernetes Deamonset metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_deployment/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_deployment/agent/stream/stream.yml.hbs
@@ -8,3 +8,9 @@ period: {{period}}
 {{#if leaderelection}}
 condition: ${kubernetes_leaderelection.leader} == true
 {{/if}}
+{{#if node}}
+node: {{node}}
+{{/if}}
+{{#if namespace}}
+namespace: {{namespace}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_deployment/manifest.yml
+++ b/packages/kubernetes/data_stream/state_deployment/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node to whatch resources from for metadata
+        title: Node to watch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace to whatch resources from for metadata
+        title: Namespace to watch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_deployment/manifest.yml
+++ b/packages/kubernetes/data_stream/state_deployment/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node
+        title: Node to whatch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace
+        title: Namespace to whatch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_deployment/manifest.yml
+++ b/packages/kubernetes/data_stream/state_deployment/manifest.yml
@@ -33,5 +33,17 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: node
+        type: text
+        title: Node
+        multi: false
+        required: false
+        show_user: true
+      - name: namespace
+        type: text
+        title: Namespace
+        multi: false
+        required: false
+        show_user: true
     title: Kubernetes Deployment metrics
     description: Collect Kubernetes Deployment metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_job/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_job/agent/stream/stream.yml.hbs
@@ -8,3 +8,9 @@ period: {{period}}
 {{#if leaderelection}}
 condition: ${kubernetes_leaderelection.leader} == true
 {{/if}}
+{{#if node}}
+node: {{node}}
+{{/if}}
+{{#if namespace}}
+namespace: {{namespace}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_job/manifest.yml
+++ b/packages/kubernetes/data_stream/state_job/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node to whatch resources from for metadata
+        title: Node to watch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace to whatch resources from for metadata
+        title: Namespace to watch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_job/manifest.yml
+++ b/packages/kubernetes/data_stream/state_job/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node
+        title: Node to whatch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace
+        title: Namespace to whatch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_job/manifest.yml
+++ b/packages/kubernetes/data_stream/state_job/manifest.yml
@@ -33,5 +33,17 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: node
+        type: text
+        title: Node
+        multi: false
+        required: false
+        show_user: true
+      - name: namespace
+        type: text
+        title: Namespace
+        multi: false
+        required: false
+        show_user: true
     title: Kubernetes Job metrics
     description: Collect Kubernetes Job metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_node/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_node/agent/stream/stream.yml.hbs
@@ -8,3 +8,9 @@ period: {{period}}
 {{#if leaderelection}}
 condition: ${kubernetes_leaderelection.leader} == true
 {{/if}}
+{{#if node}}
+node: {{node}}
+{{/if}}
+{{#if namespace}}
+namespace: {{namespace}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_node/manifest.yml
+++ b/packages/kubernetes/data_stream/state_node/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node to whatch resources from for metadata
+        title: Node to watch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace to whatch resources from for metadata
+        title: Namespace to watch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_node/manifest.yml
+++ b/packages/kubernetes/data_stream/state_node/manifest.yml
@@ -33,5 +33,17 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: node
+        type: text
+        title: Node
+        multi: false
+        required: false
+        show_user: true
+      - name: namespace
+        type: text
+        title: Namespace
+        multi: false
+        required: false
+        show_user: true
     title: Kubernetes Node metrics
     description: Collect Kubernetes Node metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_node/manifest.yml
+++ b/packages/kubernetes/data_stream/state_node/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node
+        title: Node to whatch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace
+        title: Namespace to whatch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_persistentvolume/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_persistentvolume/agent/stream/stream.yml.hbs
@@ -8,4 +8,9 @@ period: {{period}}
 {{#if leaderelection}}
 condition: ${kubernetes_leaderelection.leader} == true
 {{/if}}
-
+{{#if node}}
+node: {{node}}
+{{/if}}
+{{#if namespace}}
+namespace: {{namespace}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_persistentvolume/manifest.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolume/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node to whatch resources from for metadata
+        title: Node to watch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace to whatch resources from for metadata
+        title: Namespace to watch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_persistentvolume/manifest.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolume/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node
+        title: Node to whatch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace
+        title: Namespace to whatch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_persistentvolume/manifest.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolume/manifest.yml
@@ -33,5 +33,17 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: node
+        type: text
+        title: Node
+        multi: false
+        required: false
+        show_user: true
+      - name: namespace
+        type: text
+        title: Namespace
+        multi: false
+        required: false
+        show_user: true
     title: Kubernetes PersistentVolume metrics
     description: Collect Kubernetes PersistentVolume metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_persistentvolumeclaim/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_persistentvolumeclaim/agent/stream/stream.yml.hbs
@@ -8,3 +8,9 @@ period: {{period}}
 {{#if leaderelection}}
 condition: ${kubernetes_leaderelection.leader} == true
 {{/if}}
+{{#if node}}
+node: {{node}}
+{{/if}}
+{{#if namespace}}
+namespace: {{namespace}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_persistentvolumeclaim/manifest.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolumeclaim/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node to whatch resources from for metadata
+        title: Node to watch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace to whatch resources from for metadata
+        title: Namespace to watch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_persistentvolumeclaim/manifest.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolumeclaim/manifest.yml
@@ -33,5 +33,17 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: node
+        type: text
+        title: Node
+        multi: false
+        required: false
+        show_user: true
+      - name: namespace
+        type: text
+        title: Namespace
+        multi: false
+        required: false
+        show_user: true
     title: Kubernetes PersistentVolumeClaim metrics
     description: Collect Kubernetes PersistentVolumeClaim metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_persistentvolumeclaim/manifest.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolumeclaim/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node
+        title: Node to whatch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace
+        title: Namespace to whatch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_pod/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_pod/agent/stream/stream.yml.hbs
@@ -11,3 +11,9 @@ period: {{period}}
 {{#if leaderelection}}
 condition: ${kubernetes_leaderelection.leader} == true
 {{/if}}
+{{#if node}}
+node: {{node}}
+{{/if}}
+{{#if namespace}}
+namespace: {{namespace}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_pod/manifest.yml
+++ b/packages/kubernetes/data_stream/state_pod/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node to whatch resources from for metadata
+        title: Node to watch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace to whatch resources from for metadata
+        title: Namespace to watch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_pod/manifest.yml
+++ b/packages/kubernetes/data_stream/state_pod/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node
+        title: Node to whatch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace
+        title: Namespace to whatch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_pod/manifest.yml
+++ b/packages/kubernetes/data_stream/state_pod/manifest.yml
@@ -33,6 +33,18 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: node
+        type: text
+        title: Node
+        multi: false
+        required: false
+        show_user: true
+      - name: namespace
+        type: text
+        title: Namespace
+        multi: false
+        required: false
+        show_user: true
       - name: add_resource_metadata_config
         type: yaml
         title: Add node and namespace metadata

--- a/packages/kubernetes/data_stream/state_replicaset/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_replicaset/agent/stream/stream.yml.hbs
@@ -8,3 +8,9 @@ period: {{period}}
 {{#if leaderelection}}
 condition: ${kubernetes_leaderelection.leader} == true
 {{/if}}
+{{#if node}}
+node: {{node}}
+{{/if}}
+{{#if namespace}}
+namespace: {{namespace}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_replicaset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_replicaset/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node to whatch resources from for metadata
+        title: Node to watch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace to whatch resources from for metadata
+        title: Namespace to watch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_replicaset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_replicaset/manifest.yml
@@ -33,5 +33,17 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: node
+        type: text
+        title: Node
+        multi: false
+        required: false
+        show_user: true
+      - name: namespace
+        type: text
+        title: Namespace
+        multi: false
+        required: false
+        show_user: true
     title: Kubernetes Replicaset metrics
     description: Collect Kubernetes Replicaset metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_replicaset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_replicaset/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node
+        title: Node to whatch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace
+        title: Namespace to whatch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_resourcequota/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_resourcequota/agent/stream/stream.yml.hbs
@@ -8,3 +8,9 @@ period: {{period}}
 {{#if leaderelection}}
 condition: ${kubernetes_leaderelection.leader} == true
 {{/if}}
+{{#if node}}
+node: {{node}}
+{{/if}}
+{{#if namespace}}
+namespace: {{namespace}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_resourcequota/manifest.yml
+++ b/packages/kubernetes/data_stream/state_resourcequota/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node to whatch resources from for metadata
+        title: Node to watch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace to whatch resources from for metadata
+        title: Namespace to watch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_resourcequota/manifest.yml
+++ b/packages/kubernetes/data_stream/state_resourcequota/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node
+        title: Node to whatch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace
+        title: Namespace to whatch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_resourcequota/manifest.yml
+++ b/packages/kubernetes/data_stream/state_resourcequota/manifest.yml
@@ -33,5 +33,17 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: node
+        type: text
+        title: Node
+        multi: false
+        required: false
+        show_user: true
+      - name: namespace
+        type: text
+        title: Namespace
+        multi: false
+        required: false
+        show_user: true
     title: Kubernetes ResourceQuota metrics
     description: Collect Kubernetes ResourceQuota metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_service/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_service/agent/stream/stream.yml.hbs
@@ -8,3 +8,9 @@ period: {{period}}
 {{#if leaderelection}}
 condition: ${kubernetes_leaderelection.leader} == true
 {{/if}}
+{{#if node}}
+node: {{node}}
+{{/if}}
+{{#if namespace}}
+namespace: {{namespace}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_service/manifest.yml
+++ b/packages/kubernetes/data_stream/state_service/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node to whatch resources from for metadata
+        title: Node to watch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace to whatch resources from for metadata
+        title: Namespace to watch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_service/manifest.yml
+++ b/packages/kubernetes/data_stream/state_service/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node
+        title: Node to whatch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace
+        title: Namespace to whatch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_service/manifest.yml
+++ b/packages/kubernetes/data_stream/state_service/manifest.yml
@@ -33,5 +33,17 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: node
+        type: text
+        title: Node
+        multi: false
+        required: false
+        show_user: true
+      - name: namespace
+        type: text
+        title: Namespace
+        multi: false
+        required: false
+        show_user: true
     title: Kubernetes Service metrics
     description: Collect Kubernetes Service metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_statefulset/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_statefulset/agent/stream/stream.yml.hbs
@@ -8,3 +8,9 @@ period: {{period}}
 {{#if leaderelection}}
 condition: ${kubernetes_leaderelection.leader} == true
 {{/if}}
+{{#if node}}
+node: {{node}}
+{{/if}}
+{{#if namespace}}
+namespace: {{namespace}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_statefulset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_statefulset/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node to whatch resources from for metadata
+        title: Node to watch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace to whatch resources from for metadata
+        title: Namespace to watch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_statefulset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_statefulset/manifest.yml
@@ -33,5 +33,17 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: node
+        type: text
+        title: Node
+        multi: false
+        required: false
+        show_user: true
+      - name: namespace
+        type: text
+        title: Namespace
+        multi: false
+        required: false
+        show_user: true
     title: Kubernetes StatefulSet metrics
     description: Collect Kubernetes StatefulSet metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_statefulset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_statefulset/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node
+        title: Node to whatch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace
+        title: Namespace to whatch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_storageclass/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_storageclass/agent/stream/stream.yml.hbs
@@ -8,3 +8,9 @@ period: {{period}}
 {{#if leaderelection}}
 condition: ${kubernetes_leaderelection.leader} == true
 {{/if}}
+{{#if node}}
+node: {{node}}
+{{/if}}
+{{#if namespace}}
+namespace: {{namespace}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_storageclass/manifest.yml
+++ b/packages/kubernetes/data_stream/state_storageclass/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node to whatch resources from for metadata
+        title: Node to watch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace to whatch resources from for metadata
+        title: Namespace to watch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/data_stream/state_storageclass/manifest.yml
+++ b/packages/kubernetes/data_stream/state_storageclass/manifest.yml
@@ -33,5 +33,17 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: node
+        type: text
+        title: Node
+        multi: false
+        required: false
+        show_user: true
+      - name: namespace
+        type: text
+        title: Namespace
+        multi: false
+        required: false
+        show_user: true
     title: Kubernetes StorageClass metrics
     description: Collect Kubernetes StorageClass metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_storageclass/manifest.yml
+++ b/packages/kubernetes/data_stream/state_storageclass/manifest.yml
@@ -35,13 +35,13 @@ streams:
         default: 10s
       - name: node
         type: text
-        title: Node
+        title: Node to whatch resources from for metadata
         multi: false
         required: false
         show_user: true
       - name: namespace
         type: text
-        title: Namespace
+        title: Namespace to whatch resources from for metadata
         multi: false
         required: false
         show_user: true

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.13.0
+version: 1.14.0
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

This PR adds `node` and `namespace` settings for state_* datastreams of k8s package. These settings are used for enriching the metrics with metadata retrieved from the API server.

Closes https://github.com/elastic/integrations/issues/2556