### PR TITLE
Schedule daily: test packages against 8.1

### DIFF
--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -33,11 +33,11 @@ pipeline {
         )
       }
     }
-    stage('Daily integration builds with 8.0') {
+    stage('Daily integration builds with 8.1') {
       steps {
         build(
           job: env.INTEGRATION_JOB,
-          parameters: [stringParam(name: 'stackVersion', value: '8.0-SNAPSHOT')],
+          parameters: [stringParam(name: 'stackVersion', value: '8.1-SNAPSHOT')],
           quietPeriod: 0,
           wait: true,
           propagate: true,

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -22,11 +22,11 @@ pipeline {
     cron('H H(2-5) * * *')
   }
   stages {
-    stage('Daily integration builds with 7.16') {
+    stage('Daily integration builds with 7.17') {
       steps {
         build(
           job: env.INTEGRATION_JOB,
-          parameters: [stringParam(name: 'stackVersion', value: '7.16-SNAPSHOT')],
+          parameters: [stringParam(name: 'stackVersion', value: '7.17-SNAPSHOT')],
           quietPeriod: 0,
           wait: true,
           propagate: true,


### PR DESCRIPTION
This PR modifies `schedule-daily.groovy` to run daily system tests against 8.1-SNAPSHOT.

Motivation:

The `containerd` integration requires [8.1 stack](https://github.com/elastic/integrations/blob/main/packages/containerd/manifest.yml#L12) to be present and it isn't ignored by 8.0 stacks, failing the system test with 404 error. We can refactor [the logic](https://github.com/elastic/integrations/blob/main/.ci/Jenkinsfile#L149) to skip packages targeting 8.1 or we can use a newer snapshot.

I'm not in favor of adding an extra column to the testing matrix (now: 7.16 and 8.0), as this job is sequential and developers do not pay much attention to its status.

Let me know what you think.