### PR TITLE
Add missing job.name and cronjob.name meta fields

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.1"
+  changes:
+    - description: Add missing job.name and cronjob.name fields added by metadata generators
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/xxx
 - version: "1.14.0"
   changes:
     - description: Tune state_metrics settings

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add missing job.name and cronjob.name fields added by metadata generators
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/xxx
+      link: https://github.com/elastic/integrations/pull/2608
 - version: "1.14.0"
   changes:
     - description: Tune state_metrics settings

--- a/packages/kubernetes/data_stream/pod/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/pod/fields/base-fields.yml
@@ -124,6 +124,16 @@
       description: >
         Kubernetes statefulset name
 
+    - name: job.name
+      type: keyword
+      description: >
+        Name of the Job to which the Pod belongs
+
+    - name: cronjob.name
+      type: keyword
+      description: >
+        Name of the CronJob to which the Pod belongs
+
     - name: container.name
       type: keyword
       description: >

--- a/packages/kubernetes/data_stream/state_pod/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_pod/fields/base-fields.yml
@@ -124,6 +124,16 @@
       description: >
         Kubernetes daemonset name
 
+    - name: job.name
+      type: keyword
+      description: >
+        Name of the Job to which the Pod belongs
+
+    - name: cronjob.name
+      type: keyword
+      description: >
+        Name of the CronJob to which the Pod belongs
+
     - name: container.name
       type: keyword
       description: >

--- a/packages/kubernetes/docs/kube-state-metrics.md
+++ b/packages/kubernetes/docs/kube-state-metrics.md
@@ -1385,8 +1385,10 @@ An example event for `state_pod` looks as following:
 | kubernetes.annotations.\* | Kubernetes annotations map | object |
 | kubernetes.container.image | Kubernetes container image | keyword |
 | kubernetes.container.name | Kubernetes container name | keyword |
+| kubernetes.cronjob.name | Name of the CronJob to which the Pod belongs | keyword |
 | kubernetes.daemonset.name | Kubernetes daemonset name | keyword |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |
+| kubernetes.job.name | Name of the Job to which the Pod belongs | keyword |
 | kubernetes.labels.\* | Kubernetes labels map | object |
 | kubernetes.namespace | Kubernetes namespace | keyword |
 | kubernetes.namespace_annotations.\* | Kubernetes namespace annotations map | object |

--- a/packages/kubernetes/docs/kubelet.md
+++ b/packages/kubernetes/docs/kubelet.md
@@ -710,8 +710,10 @@ An example event for `pod` looks as following:
 | kubernetes.annotations.\* | Kubernetes annotations map | object |  |  |
 | kubernetes.container.image | Kubernetes container image | keyword |  |  |
 | kubernetes.container.name | Kubernetes container name | keyword |  |  |
+| kubernetes.cronjob.name | Name of the CronJob to which the Pod belongs | keyword |  |  |
 | kubernetes.daemonset.name | Kubernetes daemonset name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
+| kubernetes.job.name | Name of the Job to which the Pod belongs | keyword |  |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |  |
 | kubernetes.namespace_annotations.\* | Kubernetes namespace annotations map | object |  |  |

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.14.0
+version: 1.14.1
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?
Document fields added in https://github.com/elastic/beats/pull/28954 and https://github.com/elastic/beats/pull/29572 to fix https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fintegrations/detail/main/67/tests