### PR TITLE
Synthetics - add run_once fields

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,10 @@
 # newer versions go on top
+- version: "0.9.0"
+  changes:
+    - description: Add run_once fields
+      type: enhancement
+      link: |
+        https://github.com/elastic/integrations/pull/2549
 - version: "0.8.1"
   changes:
     - description: Add missing browser fields to the synthetics template

--- a/packages/synthetics/data_stream/browser/fields/common.yml
+++ b/packages/synthetics/data_stream/browser/fields/common.yml
@@ -1,3 +1,12 @@
+- name: config_id
+  type: keyword
+  description: The id of run_once monitor, when initiated from the Monitor Management flow
+- name: test_run_id
+  type: keyword
+  description: The id of run_once monitor, when initiated from the Monitor Overview page
+- name: run_once
+  type: boolean
+  description: Whether the monitor is a run_once monitor
 - name: monitor
   type: group
   description: >

--- a/packages/synthetics/data_stream/browser_network/fields/common.yml
+++ b/packages/synthetics/data_stream/browser_network/fields/common.yml
@@ -1,3 +1,12 @@
+- name: config_id
+  type: keyword
+  description: The id of run_once monitor, when initiated from the Monitor Management flow
+- name: test_run_id
+  type: keyword
+  description: The id of run_once monitor, when initiated from the Monitor Overview page
+- name: run_once
+  type: boolean
+  description: Whether the monitor is a run_once monitor
 - name: monitor
   type: group
   description: >

--- a/packages/synthetics/data_stream/browser_screenshot/fields/common.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/fields/common.yml
@@ -1,3 +1,12 @@
+- name: config_id
+  type: keyword
+  description: The id of run_once monitor, when initiated from the Monitor Management flow
+- name: test_run_id
+  type: keyword
+  description: The id of run_once monitor, when initiated from the Monitor Overview page
+- name: run_once
+  type: boolean
+  description: Whether the monitor is a run_once monitor
 - name: monitor
   type: group
   description: >

--- a/packages/synthetics/data_stream/http/fields/common.yml
+++ b/packages/synthetics/data_stream/http/fields/common.yml
@@ -1,3 +1,12 @@
+- name: config_id
+  type: keyword
+  description: The id of run_once monitor, when initiated from the Monitor Management flow
+- name: test_run_id
+  type: keyword
+  description: The id of run_once monitor, when initiated from the Monitor Overview page
+- name: run_once
+  type: boolean
+  description: Whether the monitor is a run_once monitor
 - name: monitor
   type: group
   description: >

--- a/packages/synthetics/data_stream/icmp/fields/common.yml
+++ b/packages/synthetics/data_stream/icmp/fields/common.yml
@@ -1,3 +1,12 @@
+- name: config_id
+  type: keyword
+  description: The id of run_once monitor, when initiated from the Monitor Management flow
+- name: test_run_id
+  type: keyword
+  description: The id of run_once monitor, when initiated from the Monitor Overview page
+- name: run_once
+  type: boolean
+  description: Whether the monitor is a run_once monitor
 - name: monitor
   type: group
   description: >

--- a/packages/synthetics/data_stream/tcp/fields/common.yml
+++ b/packages/synthetics/data_stream/tcp/fields/common.yml
@@ -1,3 +1,12 @@
+- name: config_id
+  type: keyword
+  description: The id of run_once monitor, when initiated from the Monitor Management flow
+- name: test_run_id
+  type: keyword
+  description: The id of run_once monitor, when initiated from the Monitor Overview page
+- name: run_once
+  type: boolean
+  description: Whether the monitor is a run_once monitor
 - name: monitor
   type: group
   description: >

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Monitor the availability of your services with Elastic Synthetics.
-version: 0.8.1
+version: 0.9.0
 categories: ["elastic_stack", "monitoring", "web"]
 release: beta
 type: integration
@@ -25,7 +25,7 @@ policy_templates:
         title: Browser
         description: Perform an Browser check
 conditions:
-  kibana.version: "^8.0.0"
+  kibana.version: "^8.1.0"
 icons:
   - src: /img/uptime-logo-color-64px.svg
     size: 16x16


### PR DESCRIPTION
Relates to: https://github.com/elastic/uptime/issues/443

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement
-->

## What does this PR do?

Adds run_once mappings to Synthetics

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

