### PR TITLE
[system] Add pipeline to rename process.ppid in process data_stream

### DIFF
--- a/packages/system/_dev/deploy/docker/docker-compose.yml
+++ b/packages/system/_dev/deploy/docker/docker-compose.yml
@@ -1,5 +1,9 @@
 version: '2.3'
 services:
+  system:
+    image: alpine
+    volumes:
+      - ${SERVICE_LOGS_DIR}:/service_logs
   security:
     image: docker.elastic.co/observability/stream:v0.4.0
     ports:

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0"
+  changes:
+    - description: Add system/process pipeline to rename process.ppid to process.parent.pid as per ECS 8.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/2610
 - version: "1.11.0"
   changes:
     - description: Add option to configure ignored filesystem types

--- a/packages/system/data_stream/process/_dev/test/system/test-default-config.yml
+++ b/packages/system/data_stream/process/_dev/test/system/test-default-config.yml
@@ -1,0 +1,3 @@
+vars: ~
+data_stream:
+  vars: ~

--- a/packages/system/data_stream/process/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/process/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,8 @@
+---
+description: Pipeline for system.process events.
+processors:
+  - rename:
+      description: Rename process.ppid from Agent 7.x to process.parent.ppid.
+      field: process.ppid
+      target_field: process.parent.pid
+      ignore_failure: true

--- a/packages/system/data_stream/process/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/process/elasticsearch/ingest_pipeline/default.yml
@@ -2,7 +2,7 @@
 description: Pipeline for system.process events.
 processors:
   - rename:
-      description: Rename process.ppid from Agent 7.x to process.parent.ppid.
+      description: Rename process.ppid from Agent 7.x to process.parent.pid.
       field: process.ppid
       target_field: process.parent.pid
       ignore_failure: true

--- a/packages/system/data_stream/process/fields/ecs.yml
+++ b/packages/system/data_stream/process/fields/ecs.yml
@@ -38,3 +38,13 @@
   name: host.os.version
 - external: ecs
   name: host.type
+- name: ecs.version
+  external: ecs
+- name: process.args
+  external: ecs
+- name: process.command_line
+  external: ecs
+- name: process.executable
+  external: ecs
+- name: service.type
+  external: ecs

--- a/packages/system/docs/README.md
+++ b/packages/system/docs/README.md
@@ -1607,6 +1607,7 @@ This dataset is available on:
 | data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
 | data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
 | data_stream.type | Data stream type. | constant_keyword |  |  |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |  |  |
 | event.dataset | Event dataset. | constant_keyword |  |  |
 | event.module | Event module | constant_keyword |  |  |
 | host | A host is defined as a general computing instance. ECS host.\* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes. | group |  |  |
@@ -1628,8 +1629,11 @@ This dataset is available on:
 | host.os.version | Operating system version as a raw string. | keyword |  |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
 | process | These fields contain information about a process. These fields can help you correlate metrics information with a process id/name from a log message.  The `process.pid` often stays in the metric itself and is copied to the global field for correlation. | group |  |  |
+| process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |  |  |
+| process.command_line | Full command line that started the process, including the absolute path to the executable, and all arguments. Some arguments may be filtered to protect sensitive information. | wildcard |  |  |
 | process.cpu.pct | The percentage of CPU time spent by the process since the last event. This value is normalized by the number of CPU cores and it ranges from 0 to 1. | scaled_float |  |  |
 | process.cpu.start_time | The time when the process was started. | date |  |  |
+| process.executable | Absolute path to the process executable. | keyword |  |  |
 | process.memory.pct | The percentage of memory the process occupied in main memory (RAM). | scaled_float |  |  |
 | process.name | Process name. Sometimes called program name or similar. | keyword |  |  |
 | process.parent.pid | Process id. | long |  |  |
@@ -1637,6 +1641,7 @@ This dataset is available on:
 | process.pid | Process id. | long |  |  |
 | process.state | The process state. For example: "running". | keyword |  |  |
 | process.working_directory | The working directory of the process. | keyword |  |  |
+| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |  |  |
 | system.process.cgroup.blkio.id | ID of the cgroup. | keyword |  |  |
 | system.process.cgroup.blkio.path | Path to the cgroup relative to the cgroup subsystems mountpoint. | keyword |  |  |
 | system.process.cgroup.blkio.total.bytes | Total number of bytes transferred to and from all block devices by processes in the cgroup. | long |  |  |

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 1.11.0
+version: 1.12.0
 license: basic
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
@@ -10,7 +10,7 @@ categories:
   - security
 release: ga
 conditions:
-  kibana.version: '^7.16.0 || ^8.0.0'
+  kibana.version: '^7.17.0 || ^8.0.0'
 screenshots:
   - src: /img/kibana-system.png
     title: kibana system


### PR DESCRIPTION
## What does this PR do?

Migrate data from Agent 7.x to ECS 8.0 format.

Agent 7.x produces process.ppid, but in order to comply with ECS 8.0
we want all data to use process.parent.pid.

The process data stream lacked any tests so I added a system test to
verify the pipeline works and validate the fields.yml. I found some
undocumented fields.

Relates #2363 #2512

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates #2363 
- Relates #2512

# References

- 7.x source code producing the process.ppid - https://github.com/elastic/beats/blob/d420ccdaf201e32a524632b5da729522e50257ae/metricbeat/module/system/process/process.go#L124
