### PR TITLE
Add missing job and cronjob fields in container related metricsets

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add missing job.name and cronjob.name fields to container related datastreams
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/xxx
+      link: https://github.com/elastic/integrations/pull/2612
 - version: "1.14.1"
   changes:
     - description: Add missing job.name and cronjob.name fields added by metadata generators

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.2"
+  changes:
+    - description: Add missing job.name and cronjob.name fields to container related datastreams
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/xxx
 - version: "1.14.1"
   changes:
     - description: Add missing job.name and cronjob.name fields added by metadata generators

--- a/packages/kubernetes/data_stream/container/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/container/fields/base-fields.yml
@@ -124,6 +124,16 @@
       description: >
         Kubernetes statefulset name
 
+    - name: job.name
+      type: keyword
+      description: >
+        Name of the Job to which the Pod belongs
+
+    - name: cronjob.name
+      type: keyword
+      description: >
+        Name of the CronJob to which the Pod belongs
+
     - name: container.name
       dimension: true
       type: keyword

--- a/packages/kubernetes/data_stream/container_logs/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/container_logs/fields/base-fields.yml
@@ -133,6 +133,16 @@
       description: >
         Kubernetes statefulset name
 
+    - name: job.name
+      type: keyword
+      description: >
+        Name of the Job to which the Pod belongs
+
+    - name: cronjob.name
+      type: keyword
+      description: >
+        Name of the CronJob to which the Pod belongs
+
     - name: container.name
       dimension: true
       type: keyword

--- a/packages/kubernetes/docs/kubelet.md
+++ b/packages/kubernetes/docs/kubelet.md
@@ -253,8 +253,10 @@ An example event for `container` looks as following:
 | kubernetes.container.rootfs.inodes.used | Used inodes | long |  | gauge |
 | kubernetes.container.rootfs.used.bytes | Root filesystem total used in bytes | long | byte | gauge |
 | kubernetes.container.start_time | Start time | date |  |  |
+| kubernetes.cronjob.name | Name of the CronJob to which the Pod belongs | keyword |  |  |
 | kubernetes.daemonset.name | Kubernetes daemonset name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
+| kubernetes.job.name | Name of the Job to which the Pod belongs | keyword |  |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |  |
 | kubernetes.namespace_annotations.\* | Kubernetes namespace annotations map | object |  |  |

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.14.1
+version: 1.14.2
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
Follow-up of [https://github.com/elastic/integrations/pull/2608](https://github.com/elastic/integrations/pull/2608) to fix [https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fintegrations/detail/main/72/tests](https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fintegrations/detail/main/72/tests).