### PR TITLE
Improve Prometheus default datastream enablement

### DIFF
--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.8.0"
+  changes:
+    - description: Improve default datastream enablement
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/xxxx
 - version: "0.7.0"
   changes:
     - description: Release prometheus package for v8.0.0

--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Improve default datastream enablement
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/xxxx
+      link: https://github.com/elastic/integrations/pull/2619
 - version: "0.7.0"
   changes:
     - description: Release prometheus package for v8.0.0

--- a/packages/prometheus/data_stream/collector/manifest.yml
+++ b/packages/prometheus/data_stream/collector/manifest.yml
@@ -84,4 +84,5 @@ streams:
         show_user: true
         default: user
     title: Prometheus collector metrics
+    enabled: true
     description: Collect Prometheus collector metrics

--- a/packages/prometheus/data_stream/query/manifest.yml
+++ b/packages/prometheus/data_stream/query/manifest.yml
@@ -46,4 +46,5 @@ streams:
               query: some_value
             path: /api/v1/query
     title: Prometheus query metrics
+    enabled: false
     description: Collect Prometheus query metrics

--- a/packages/prometheus/data_stream/remote_write/manifest.yml
+++ b/packages/prometheus/data_stream/remote_write/manifest.yml
@@ -68,4 +68,5 @@ streams:
         show_user: true
         default: []
     title: Prometheus remote write metrics
+    enabled: false
     description: Collect Prometheus remote write metrics

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: prometheus
 title: Prometheus Metrics
-version: 0.7.0
+version: 0.8.0
 license: basic
 description: Collect metrics from Prometheus servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?
Disable `query` and `remote_write` datastreams from defaults. Leaving only `collector` datastream enabled by default.