### PR TITLE
Add job.name field in state_container

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.3"
+  changes:
+    - description: Add missing job.name and cronjob.name fields to state_container datastream
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/2613
 - version: "1.14.2"
   changes:
     - description: Add missing job.name and cronjob.name fields to container related datastreams

--- a/packages/kubernetes/data_stream/state_container/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_container/fields/base-fields.yml
@@ -124,6 +124,16 @@
       description: >
         Kubernetes statefulset name
 
+    - name: job.name
+      type: keyword
+      description: >
+        Name of the Job to which the Pod belongs
+
+    - name: cronjob.name
+      type: keyword
+      description: >
+        Name of the CronJob to which the Pod belongs
+
     - name: container.name
       dimension: true
       type: keyword

--- a/packages/kubernetes/docs/kube-state-metrics.md
+++ b/packages/kubernetes/docs/kube-state-metrics.md
@@ -201,8 +201,10 @@ An example event for `state_container` looks as following:
 | kubernetes.container.status.ready | Container ready status | boolean |  |  |
 | kubernetes.container.status.reason | Waiting (ContainerCreating, CrashLoopBackoff, ErrImagePull, ImagePullBackoff) or termination (Completed, ContainerCannotRun, Error, OOMKilled) reason. | keyword |  |  |
 | kubernetes.container.status.restarts | Container restarts count | integer |  | counter |
+| kubernetes.cronjob.name | Name of the CronJob to which the Pod belongs | keyword |  |  |
 | kubernetes.daemonset.name | Kubernetes daemonset name | keyword |  |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
+| kubernetes.job.name | Name of the Job to which the Pod belongs | keyword |  |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |  |
 | kubernetes.namespace_annotations.\* | Kubernetes namespace annotations map | object |  |  |

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.14.2
+version: 1.14.3
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->
This PR adds `job.name` and `cronjob.name` fields in state_container data stream.
Follow-up of [#2608](https://github.com/elastic/integrations/pull/2612) to fix https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fintegrations/detail/main/72/tests.
