### PR TITLE
[Fortinet] same behavior as tcp show syslog host on root level

### DIFF
--- a/packages/fortinet/data_stream/firewall/manifest.yml
+++ b/packages/fortinet/data_stream/firewall/manifest.yml
@@ -53,7 +53,7 @@ streams:
         title: Syslog Host
         multi: false
         required: true
-        show_user: false
+        show_user: true
         default: localhost
       - name: syslog_port
         type: integer


### PR DESCRIPTION
- Enhancement


## What does this PR do?

![fortinet_syslog_udp](https://user-images.githubusercontent.com/95302847/151967140-6f2e3029-ddca-4159-92de-93cbb7c03f38.jpg)

Syslog host should be on the same level as udp port.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).