### PR TITLE
[Cisco ASA] Fix utilization and fix ingest pipeline

### DIFF
--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1712,10 +1712,11 @@ processors:
   #
   # Populate ECS event.code
   #
-  - rename:
-      field: _temp_.cisco.message_id
-      target_field: event.code
+  - set:
+      field: event.code
+      value: "{{_temp_.cisco.message_id}}"
       ignore_failure: true
+      if: ctx?._temp_?.cisco?.message_id != null
   - remove:
       field:
         - _temp_.cisco.message_id

--- a/packages/cisco_asa/kibana/visualization/cisco_asa-08ef4d90-499b-11e9-b8ce-ed898b5ef295.json
+++ b/packages/cisco_asa/kibana/visualization/cisco_asa-08ef4d90-499b-11e9-b8ce-ed898b5ef295.json
@@ -6,7 +6,7 @@
                 "filter": [],
                 "query": {
                     "language": "kuery",
-                    "query": "event.outcome:\"deny\""
+                    "query": "event.outcome:\"failure\""
                 }
             }
         },


### PR DESCRIPTION
- Bug

## What does this PR do?

1. Visualizations uses ECS field event.outcome with value "deny". Depending on ECS: https://www.elastic.co/guide/en/ecs/current/ecs-event.html#field-event-outcome should be "failure".

2. Ingest Pipeline _temp.cisco.message_id will be removed by Rename-processor. Better use Set-processor since message_id is used is various visualizations.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).