### PR TITLE
[osquery] [panw] Fix package versions

### DIFF
--- a/packages/osquery/changelog.yml
+++ b/packages/osquery/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "2.0.0"
+- version: "1.2.0"
   changes:
     - description: Update to ECS 8.0
       type: enhancement

--- a/packages/osquery/manifest.yml
+++ b/packages/osquery/manifest.yml
@@ -1,6 +1,6 @@
 name: osquery
 title: Osquery Logs
-version: 2.0.0
+version: 1.2.0
 release: ga
 description: Collect and parse logs from Osquery instances with Elastic Agent.
 type: integration

--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "2.0.0"
+- version: "1.4.0"
   changes:
     - description: Update to ECS 8.0
       type: enhancement

--- a/packages/panw/manifest.yml
+++ b/packages/panw/manifest.yml
@@ -1,6 +1,6 @@
 name: panw
 title: Palo Alto Networks Logs
-version: 2.0.0
+version: 1.4.0
 release: ga
 description: Collect PAN-OS firewall monitoring logs from Palo Alto Networks devices with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Major version bumped due to incorrect detection of breaking change. Fix package versions for -
- osquery
- panw

It's safe to fix the versions these updated versioned packages weren't promoted to staging/production.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] ~~I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~~