### PR TITLE
CI fix: use full semver for Elastic stacks

### DIFF
--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -22,26 +22,28 @@ pipeline {
     cron('H H(2-5) * * *')
   }
   stages {
-    stage('Daily integration builds with 7.17.0') {
-      steps {
-        build(
-          job: env.INTEGRATION_JOB,
-          parameters: [stringParam(name: 'stackVersion', value: '7.17.0-SNAPSHOT')],
-          quietPeriod: 0,
-          wait: true,
-          propagate: true,
-        )
+    parallel {
+      stage('Daily integration builds with 7.17.0') {
+        steps {
+          build(
+            job: env.INTEGRATION_JOB,
+            parameters: [stringParam(name: 'stackVersion', value: '7.17.0-SNAPSHOT')],
+            quietPeriod: 0,
+            wait: true,
+            propagate: true,
+          )
+        }
       }
-    }
-    stage('Daily integration builds with 8.1.0') {
-      steps {
-        build(
-          job: env.INTEGRATION_JOB,
-          parameters: [stringParam(name: 'stackVersion', value: '8.1.0-SNAPSHOT')],
-          quietPeriod: 0,
-          wait: true,
-          propagate: true,
-        )
+      stage('Daily integration builds with 8.1.0') {
+        steps {
+          build(
+            job: env.INTEGRATION_JOB,
+            parameters: [stringParam(name: 'stackVersion', value: '8.1.0-SNAPSHOT')],
+            quietPeriod: 0,
+            wait: true,
+            propagate: true,
+          )
+        }
       }
     }
   }

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -23,11 +23,11 @@ pipeline {
   }
   stages {
     parallel {
-      stage('Daily integration builds with 7.17.0') {
+      stage('Daily integration builds with 7.17') {
         steps {
           build(
             job: env.INTEGRATION_JOB,
-            parameters: [stringParam(name: 'stackVersion', value: '7.17.0-SNAPSHOT')],
+            parameters: [stringParam(name: 'stackVersion', value: '7.17-SNAPSHOT')],
             quietPeriod: 0,
             wait: true,
             propagate: true,

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -22,22 +22,22 @@ pipeline {
     cron('H H(2-5) * * *')
   }
   stages {
-    stage('Daily integration builds with 7.17') {
+    stage('Daily integration builds with 7.17.0') {
       steps {
         build(
           job: env.INTEGRATION_JOB,
-          parameters: [stringParam(name: 'stackVersion', value: '7.17-SNAPSHOT')],
+          parameters: [stringParam(name: 'stackVersion', value: '7.17.0-SNAPSHOT')],
           quietPeriod: 0,
           wait: true,
           propagate: true,
         )
       }
     }
-    stage('Daily integration builds with 8.1') {
+    stage('Daily integration builds with 8.1.0') {
       steps {
         build(
           job: env.INTEGRATION_JOB,
-          parameters: [stringParam(name: 'stackVersion', value: '8.1-SNAPSHOT')],
+          parameters: [stringParam(name: 'stackVersion', value: '8.1.0-SNAPSHOT')],
           quietPeriod: 0,
           wait: true,
           propagate: true,


### PR DESCRIPTION
This PR fixes the daily schedule of CI jobs to use full semver to define Elastic stacks. I decided to enable parallel jobs as nobody notice it due to blocking bugs in 7.17.

Spotted here: https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fintegrations/detail/main/89/pipeline