### PR TITLE
Add standard HTTP options to Prometheus package

### DIFF
--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add standard HTTP options to the package
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/xxxx
+      link: https://github.com/elastic/integrations/pull/2632
 - version: "0.8.0"
   changes:
     - description: Improve default datastream enablement

--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.9.0"
+  changes:
+    - description: Add standard HTTP options to the package
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/xxxx
 - version: "0.8.0"
   changes:
     - description: Improve default datastream enablement

--- a/packages/prometheus/data_stream/collector/agent/stream/stream.yml.hbs
+++ b/packages/prometheus/data_stream/collector/agent/stream/stream.yml.hbs
@@ -13,7 +13,6 @@ metrics_filters.include:
   - {{this}}
 {{/each}}
 metrics_path: {{metrics_path}}
-password: {{password}}
 period: {{period}}
 rate_counters: {{rate_counters}}
 ssl.certificate_authorities:
@@ -22,3 +21,16 @@ ssl.certificate_authorities:
 {{/each}}
 use_types: {{use_types}}
 username: {{username}}
+password: {{password}}
+{{#if query}}
+{{query}}
+{{/if}}
+{{#if headers}}
+{{headers}}
+{{/if}}
+{{#if connect_timeout}}
+{{connect_timeout}}
+{{/if}}
+{{#if timeout}}
+{{timeout}}
+{{/if}}

--- a/packages/prometheus/data_stream/collector/manifest.yml
+++ b/packages/prometheus/data_stream/collector/manifest.yml
@@ -61,14 +61,14 @@ streams:
         multi: true
         required: false
         show_user: false
-        default: [ ]
+        default: []
       - name: metrics_filters.include
         type: text
         title: Metrics Filters Include
         multi: true
         required: false
         show_user: false
-        default: [ ]
+        default: []
       - name: username
         type: text
         title: Username

--- a/packages/prometheus/data_stream/collector/manifest.yml
+++ b/packages/prometheus/data_stream/collector/manifest.yml
@@ -4,13 +4,6 @@ type: metrics
 streams:
   - input: prometheus/metrics
     vars:
-      - name: bearer_token_file
-        type: text
-        title: Bearer Token File
-        multi: false
-        required: false
-        show_user: true
-        default: /var/run/secrets/kubernetes.io/serviceaccount/token
       - name: hosts
         type: text
         title: Hosts
@@ -19,20 +12,6 @@ streams:
         show_user: true
         default:
           - localhost:9090
-      - name: metrics_filters.exclude
-        type: text
-        title: Metrics Filters Exclude
-        multi: true
-        required: false
-        show_user: true
-        default: []
-      - name: metrics_filters.include
-        type: text
-        title: Metrics Filters Include
-        multi: true
-        required: false
-        show_user: true
-        default: []
       - name: metrics_path
         type: text
         title: Metrics Path
@@ -40,13 +19,6 @@ streams:
         required: false
         show_user: true
         default: /metrics
-      - name: password
-        type: password
-        title: Password
-        multi: false
-        required: false
-        show_user: true
-        default: secret
       - name: period
         type: text
         title: Period
@@ -54,21 +26,6 @@ streams:
         required: true
         show_user: true
         default: 10s
-      - name: rate_counters
-        type: bool
-        title: Rate Counters
-        multi: false
-        required: true
-        show_user: true
-        default: true
-      - name: ssl.certificate_authorities
-        type: text
-        title: SSL Certificate Authorities
-        multi: true
-        required: false
-        show_user: true
-        default:
-          - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
       - name: use_types
         type: bool
         title: Use Types
@@ -76,13 +33,87 @@ streams:
         required: true
         show_user: true
         default: true
+      - name: rate_counters
+        type: bool
+        title: Rate Counters
+        multi: false
+        required: true
+        show_user: true
+        default: true
+      - name: bearer_token_file
+        type: text
+        title: Bearer Token File
+        multi: false
+        required: false
+        show_user: false
+        default: /var/run/secrets/kubernetes.io/serviceaccount/token
+      - name: ssl.certificate_authorities
+        type: text
+        title: SSL Certificate Authorities
+        multi: true
+        required: false
+        show_user: false
+        default:
+          - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+      - name: metrics_filters.exclude
+        type: text
+        title: Metrics Filters Exclude
+        multi: true
+        required: false
+        show_user: false
+        default: [ ]
+      - name: metrics_filters.include
+        type: text
+        title: Metrics Filters Include
+        multi: true
+        required: false
+        show_user: false
+        default: [ ]
       - name: username
         type: text
         title: Username
         multi: false
         required: false
-        show_user: true
+        show_user: false
         default: user
+      - name: password
+        type: password
+        title: Password
+        multi: false
+        required: false
+        show_user: false
+        default: secret
+      - name: connect_timeout
+        type: text
+        title: Total time limit for an HTTP connection to be completed (Default 2 seconds)
+        multi: false
+        required: false
+        show_user: false
+      - name: timeout
+        type: text
+        title: Total time limit for HTTP requests made by the module (Default 10 seconds)
+        multi: false
+        required: false
+        show_user: false
+      - name: headers
+        type: yaml
+        title: "Headers: a list of headers to use with the HTTP request"
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          # headers:
+          #   Cookie: abcdef=123456
+          #   My-Custom-Header: my-custom-value
+      - name: query
+        type: yaml
+        title: "Query: an optional value to pass common query params in YAML"
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          # query:
+          #   key: value
     title: Prometheus collector metrics
     enabled: true
     description: Collect Prometheus collector metrics

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: prometheus
 title: Prometheus Metrics
-version: 0.8.0
+version: 0.9.0
 license: basic
 description: Collect metrics from Prometheus servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?
Adds standard HTTP options to Prometheus package.

Http options: [module-http-config-options](https://www.elastic.co/guide/en/beats/metricbeat/7.2/configuration-metricbeat.html#module-http-config-options)

Closes https://github.com/elastic/integrations/issues/496


<img width="730" alt="Screenshot 2022-02-02 at 12 50 33 PM" src="https://user-images.githubusercontent.com/11754898/152158086-771665cd-39b5-46af-8d0c-cd5f79ea5c85.png">

<img width="359" alt="Screenshot 2022-02-02 at 12 50 52 PM" src="https://user-images.githubusercontent.com/11754898/152158080-49aacffa-2092-4e24-91a1-858645c597bc.png">

<img width="424" alt="Screenshot 2022-02-02 at 12 51 12 PM" src="https://user-images.githubusercontent.com/11754898/152158070-ba9727ad-1bb6-4b11-a621-aa3adfd08898.png">


