### PR TITLE
Fix templates to include username and password in Mongodb

### DIFF
--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Fix username and password templates
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/2495
+      link: https://github.com/elastic/integrations/pull/2641
 - version: "1.3.0"
   changes:
     - description: Update to ECS 8.0

--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.3.1"
+  changes:
+    - description: Fix username and password templates
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/2495
 - version: "1.3.0"
   changes:
     - description: Update to ECS 8.0

--- a/packages/mongodb/data_stream/collstats/agent/stream/stream.yml.hbs
+++ b/packages/mongodb/data_stream/collstats/agent/stream/stream.yml.hbs
@@ -3,4 +3,10 @@ hosts:
 {{#each hosts}}
   - {{this}}
 {{/each}}
+{{#if password}}
+password: {{password}}
+{{/if}}
 period: {{period}}
+{{#if username}}
+username: {{username}}
+{{/if}}

--- a/packages/mongodb/data_stream/dbstats/agent/stream/stream.yml.hbs
+++ b/packages/mongodb/data_stream/dbstats/agent/stream/stream.yml.hbs
@@ -3,4 +3,10 @@ hosts:
 {{#each hosts}}
   - {{this}}
 {{/each}}
+{{#if password}}
+password: {{password}}
+{{/if}}
 period: {{period}}
+{{#if username}}
+username: {{username}}
+{{/if}}

--- a/packages/mongodb/data_stream/replstatus/agent/stream/stream.yml.hbs
+++ b/packages/mongodb/data_stream/replstatus/agent/stream/stream.yml.hbs
@@ -3,4 +3,10 @@ hosts:
 {{#each hosts}}
   - {{this}}
 {{/each}}
+{{#if password}}
+password: {{password}}
+{{/if}}
 period: {{period}}
+{{#if username}}
+username: {{username}}
+{{/if}}

--- a/packages/mongodb/data_stream/status/agent/stream/stream.yml.hbs
+++ b/packages/mongodb/data_stream/status/agent/stream/stream.yml.hbs
@@ -3,4 +3,10 @@ hosts:
 {{#each hosts}}
   - {{this}}
 {{/each}}
+{{#if password}}
+password: {{password}}
+{{/if}}
 period: {{period}}
+{{#if username}}
+username: {{username}}
+{{/if}}

--- a/packages/mongodb/manifest.yml
+++ b/packages/mongodb/manifest.yml
@@ -1,6 +1,6 @@
 name: mongodb
 title: MongoDB
-version: 1.3.0
+version: 1.3.1
 description: Collect logs and metrics from MongoDB instances with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

Authentication wasn't working in Mongodb because there was some missing pieces on the templating of the package.

This fix the auth errors for `3.x` and `4.x` but `5.x` doesn't work yet until the driver is updated.