### PR TITLE
[microsoft_sqlserver] fix owner

### DIFF
--- a/packages/microsoft_sqlserver/changelog.yml
+++ b/packages/microsoft_sqlserver/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.1"
+  changes:
+    - description: Change owner to SEI
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/2650
 - version: "0.4.0"
   changes:
     - description: Update to ECS 8.0

--- a/packages/microsoft_sqlserver/manifest.yml
+++ b/packages/microsoft_sqlserver/manifest.yml
@@ -30,4 +30,4 @@ policy_templates:
         title: Collect audit events from Windows event logs
         description: Collecting audit events from Windows event logs
 owner:
-  github: elastic/integrations
+  github: elastic/security-external-integrations

--- a/packages/microsoft_sqlserver/manifest.yml
+++ b/packages/microsoft_sqlserver/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_sqlserver
 title: "Microsoft SQL Server"
-version: 0.4.0
+version: 0.4.1
 license: basic
 description: Collect audit events from Microsoft SQL Server with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Fix `github.owner` attribute for the package. Change from `elastic/integrations` to `elastic/security-external-integrations`.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] ~~I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] ~~I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~~