### PR TITLE
[crowdstrike] Fix issue with 'Is FDR Queue' option not taking effect

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Fix issue with "Is FDR Queue" selector having no effect.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.2.0"
   changes:
     - description: Update to ECS 8.0

--- a/packages/crowdstrike/data_stream/fdr/agent/stream/aws-s3.yml.hbs
+++ b/packages/crowdstrike/data_stream/fdr/agent/stream/aws-s3.yml.hbs
@@ -32,7 +32,7 @@ fips_enabled: {{fips_enabled}}
 {{#if proxy_url }}
 proxy_url: {{proxy_url}}
 {{/if}}
-{{#if fdr_queue}}
+{{#if is_fdr_queue}}
 sqs.notification_parse_script: {{fdr_parsing_script}}
 {{/if}}
 {{#if tags.length}}

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike Logs
-version: 1.2.0
+version: 1.2.1
 description: Collect and parse falcon logs from Crowdstrike products with Elastic Agent.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
## What does this PR do?

When "Is FDR Queue" was enabled in the config then the S3 input was supposed
to parse the CrowdStrike FDR SQS notification format. But the config was checking
for `if fdr_queue` but the variable is named `is_fdr_queue`.

Fixes #2646

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Fixes #2646