### PR TITLE
Fix hid_bravura documentation

### DIFF
--- a/packages/hid_bravura_monitor/_dev/build/docs/README.md
+++ b/packages/hid_bravura_monitor/_dev/build/docs/README.md
@@ -139,7 +139,7 @@ are also supported here. For example, you can use wildcards to fetch all files
 from a predefined level of subdirectories: `/path/to/log/*/*.log`. This
 fetches all `.log` files from the subfolders of `/path/to/log`. It does not
 fetch log files from the `/path/to/log` folder itself. If this setting is left
-empty, {beatname_uc} will choose log paths based on your operating system.
+empty, the integration will choose log paths based on your operating system.
 
 ## Logs
 

--- a/packages/hid_bravura_monitor/changelog.yml
+++ b/packages/hid_bravura_monitor/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: Documentation update
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1912
 - version: "1.0.0"
   changes:
     - description: full release

--- a/packages/hid_bravura_monitor/docs/README.md
+++ b/packages/hid_bravura_monitor/docs/README.md
@@ -139,7 +139,7 @@ are also supported here. For example, you can use wildcards to fetch all files
 from a predefined level of subdirectories: `/path/to/log/*/*.log`. This
 fetches all `.log` files from the subfolders of `/path/to/log`. It does not
 fetch log files from the `/path/to/log` folder itself. If this setting is left
-empty, {beatname_uc} will choose log paths based on your operating system.
+empty, the integration will choose log paths based on your operating system.
 
 ## Logs
 

--- a/packages/hid_bravura_monitor/manifest.yml
+++ b/packages/hid_bravura_monitor/manifest.yml
@@ -1,6 +1,6 @@
 name: hid_bravura_monitor
 title: Hitachi ID Bravura Monitor
-version: 1.0.0
+version: 1.0.1
 categories: ["security"]
 release: ga
 description: Collect logs from Hitachi ID Security Fabric with Elastic Agent.


### PR DESCRIPTION
### Summary

The HID Bravura readme is currently breaking the [integration documentation](https://docs.elastic.co/en/integrations) update script. This PR fixes the docs by removing `{beatname_uc}`.

### Related

Other PRs that I have opened with similar problems:

* https://github.com/elastic/integrations/pull/2655
* https://github.com/elastic/integrations/pull/2656