### PR TITLE
Fix hashicorp documentation

### DIFF
--- a/packages/hashicorp_vault/_dev/build/docs/README.md
+++ b/packages/hashicorp_vault/_dev/build/docs/README.md
@@ -62,6 +62,7 @@ tee /etc/logrotate.d/vault <<'EOF'
 }
 EOF
 ```
+
 ### Socket audit device requirements
 
 To enable the socket audit device in Vault you should first enable this

--- a/packages/hashicorp_vault/_dev/build/docs/README.md
+++ b/packages/hashicorp_vault/_dev/build/docs/README.md
@@ -28,35 +28,40 @@ file audit device provides the strongest delivery guarantees.
 
 - Create a directory for audit logs on each Vault server host.
 
-    mkdir /var/log/vault
+```
+mkdir /var/log/vault
+```
 
 - Enable the file audit device.
 
-    vault audit enable file file_path=/var/log/vault/audit.json
+```
+vault audit enable file file_path=/var/log/vault/audit.json
+```
 
 - Configure log rotation for the audit log. The exact steps may vary by OS.
 This example uses `logrotate` to call `systemctl reload` on the
 [Vault service](https://learn.hashicorp.com/tutorials/vault/deployment-guide#step-3-configure-systemd)
 which sends the process a SIGHUP signal. The SIGHUP signal causes Vault to start
 writing to a new log file.
-  
-    tee /etc/logrotate.d/vault <<'EOF'
-    /var/log/vault/audit.json {
-      rotate 7
-      daily
-      compress
-      delaycompress
-      missingok
-      notifempty
-      extension json
-      dateext
-      dateformat %Y-%m-%d.
-      postrotate
-          /bin/systemctl reload vault || true
-      endscript
-    }
-    EOF
-  
+
+```
+tee /etc/logrotate.d/vault <<'EOF'
+/var/log/vault/audit.json {
+    rotate 7
+    daily
+    compress
+    delaycompress
+    missingok
+    notifempty
+    extension json
+    dateext
+    dateformat %Y-%m-%d.
+    postrotate
+        /bin/systemctl reload vault || true
+    endscript
+}
+EOF
+```
 ### Socket audit device requirements
 
 To enable the socket audit device in Vault you should first enable this
@@ -64,12 +69,14 @@ integration because Vault will test that it can connect to the TCP socket.
 
 - Add this integration and enable audit log collection via TCP. If Vault will
 be connecting remotely set the listen address to 0.0.0.0.
-  
+
 - Configure the socket audit device to stream logs to this integration.
 Substitute in the IP address of the Elastic Agent to which you are sending the
 audit logs.
 
-    vault audit enable socket address=${ELASTIC_AGENT_IP}:9007 socket_type=tcp
+```
+vault audit enable socket address=${ELASTIC_AGENT_IP}:9007 socket_type=tcp
+```
 
 {{event "audit"}}
 

--- a/packages/hashicorp_vault/changelog.yml
+++ b/packages/hashicorp_vault/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.1"
+  changes:
+    - description: Update docs to use markdown code blocks
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/2409
 - version: "1.3.0"
   changes:
     - description: Update to ECS 8.0

--- a/packages/hashicorp_vault/changelog.yml
+++ b/packages/hashicorp_vault/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update docs to use markdown code blocks
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/2409
+      link: https://github.com/elastic/integrations/pull/2655
 - version: "1.3.0"
   changes:
     - description: Update to ECS 8.0

--- a/packages/hashicorp_vault/docs/README.md
+++ b/packages/hashicorp_vault/docs/README.md
@@ -28,35 +28,40 @@ file audit device provides the strongest delivery guarantees.
 
 - Create a directory for audit logs on each Vault server host.
 
-    mkdir /var/log/vault
+```
+mkdir /var/log/vault
+```
 
 - Enable the file audit device.
 
-    vault audit enable file file_path=/var/log/vault/audit.json
+```
+vault audit enable file file_path=/var/log/vault/audit.json
+```
 
 - Configure log rotation for the audit log. The exact steps may vary by OS.
 This example uses `logrotate` to call `systemctl reload` on the
 [Vault service](https://learn.hashicorp.com/tutorials/vault/deployment-guide#step-3-configure-systemd)
 which sends the process a SIGHUP signal. The SIGHUP signal causes Vault to start
 writing to a new log file.
-  
-    tee /etc/logrotate.d/vault <<'EOF'
-    /var/log/vault/audit.json {
-      rotate 7
-      daily
-      compress
-      delaycompress
-      missingok
-      notifempty
-      extension json
-      dateext
-      dateformat %Y-%m-%d.
-      postrotate
-          /bin/systemctl reload vault || true
-      endscript
-    }
-    EOF
-  
+
+```
+tee /etc/logrotate.d/vault <<'EOF'
+/var/log/vault/audit.json {
+    rotate 7
+    daily
+    compress
+    delaycompress
+    missingok
+    notifempty
+    extension json
+    dateext
+    dateformat %Y-%m-%d.
+    postrotate
+        /bin/systemctl reload vault || true
+    endscript
+}
+EOF
+```
 ### Socket audit device requirements
 
 To enable the socket audit device in Vault you should first enable this
@@ -64,12 +69,14 @@ integration because Vault will test that it can connect to the TCP socket.
 
 - Add this integration and enable audit log collection via TCP. If Vault will
 be connecting remotely set the listen address to 0.0.0.0.
-  
+
 - Configure the socket audit device to stream logs to this integration.
 Substitute in the IP address of the Elastic Agent to which you are sending the
 audit logs.
 
-    vault audit enable socket address=${ELASTIC_AGENT_IP}:9007 socket_type=tcp
+```
+vault audit enable socket address=${ELASTIC_AGENT_IP}:9007 socket_type=tcp
+```
 
 An example event for `audit` looks as following:
 

--- a/packages/hashicorp_vault/docs/README.md
+++ b/packages/hashicorp_vault/docs/README.md
@@ -62,6 +62,7 @@ tee /etc/logrotate.d/vault <<'EOF'
 }
 EOF
 ```
+
 ### Socket audit device requirements
 
 To enable the socket audit device in Vault you should first enable this

--- a/packages/hashicorp_vault/manifest.yml
+++ b/packages/hashicorp_vault/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: hashicorp_vault
 title: Hashicorp Vault
-version: 1.3.0
+version: 1.3.1
 license: basic
 description: Collect logs and metrics from Hashicorp Vault with Elastic Agent.
 type: integration


### PR DESCRIPTION
### Summary

The Hashicorp Vault readme is breaking the [integration documentation](https://docs.elastic.co/en/integrations) update script. This PR fixes the error by moving indented code to markdown code blocks. This prevents the build from trying to render `<` and `{` characters.

### Related 

Other PRs that I have opened with similar problems:

* https://github.com/elastic/integrations/pull/2654
* https://github.com/elastic/integrations/pull/2656