### PR TITLE
Workaround: dump agent policy if line 47 error appears

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -98,7 +98,10 @@ pipeline {
                           archiveArtifacts(allowEmptyArchive: true, artifacts: "build/elastic-stack-dump/${it}/logs/*.log, build/elastic-stack-dump/${it}/logs/fleet-server-internal/*")
                           archiveArtifactsSafe("insecure-logs/${it}", "build/elastic-stack-dump/${it}/logs/elastic-agent-internal/*")
                           archiveArtifactsSafe("insecure-logs/${it}/container-logs", "build/container-logs/*.log")
-                          sh(label: "(Workaround) Extract elastic-agent.yml file", script: "grep -q 'line 47: could not find expected' build/elastic-stack-dump/${it}/logs/elastic-agent.log && docker cp elastic-package-stack_elastic-agent_1:/usr/share/elastic-agent/state/elastic-agent.yml build/elastic-stack-dump/${it}/elastic-agent-policy/ || true")
+                          def r = sh(label: "(Workaround) Check line 47 error", script: "grep -q 'line 47: could not find expected' build/elastic-stack-dump/${it}/logs/elastic-agent.log", returnStatus: true)
+                          if (r == 0) {
+                            def r = sh(label: "(Workaround) Extract elastic-agent.yml file", script: "docker cp elastic-package-stack_elastic-agent_1:/usr/share/elastic-agent/state/elastic-agent.yml build/elastic-stack-dump/${it}/elastic-agent-policy/")
+                          }
                           archiveArtifactsSafe("insecure-logs/${it}/elastic-agent-policy", "build/elastic-stack-dump/${it}/elastic-agent-policy/elastic-agent.yml")
                           sh(label: "Take down the Elastic stack", script: 'build/elastic-package stack down -v')
                           stashCoverageReport()

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -100,7 +100,7 @@ pipeline {
                           archiveArtifactsSafe("insecure-logs/${it}/container-logs", "build/container-logs/*.log")
                           def r = sh(label: "(Workaround) Check line 47 error", script: "grep -q 'line 47: could not find expected' build/elastic-stack-dump/${it}/logs/elastic-agent.log", returnStatus: true)
                           if (r == 0) {
-                            sh(label: "(Workaround) Extract elastic-agent.yml file", script: "docker cp elastic-package-stack_elastic-agent_1:/usr/share/elastic-agent/state/elastic-agent.yml build/elastic-stack-dump/${it}/elastic-agent-policy/")
+                            sh(label: "(Workaround) Extract elastic-agent.yml file", script: "mkdir -p build/elastic-stack-dump/${it}/elastic-agent-policy/ && docker cp elastic-package-stack_elastic-agent_1:/usr/share/elastic-agent/state/elastic-agent.yml build/elastic-stack-dump/${it}/elastic-agent-policy/")
                             archiveArtifactsSafe("insecure-logs/${it}/elastic-agent-policy", "build/elastic-stack-dump/${it}/elastic-agent-policy/elastic-agent.yml")
                           }
                           sh(label: "Take down the Elastic stack", script: 'build/elastic-package stack down -v')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -100,8 +100,11 @@ pipeline {
                           archiveArtifactsSafe("insecure-logs/${it}/container-logs", "build/container-logs/*.log")
                           def r = sh(label: "(Workaround) Check line 47 error", script: "grep -q 'line 47: could not find expected' build/elastic-stack-dump/${it}/logs/elastic-agent.log", returnStatus: true)
                           if (r == 0) {
-                            sh(label: "(Workaround) Extract elastic-agent.yml file", script: "mkdir -p build/elastic-stack-dump/${it}/elastic-agent-policy/ && docker cp elastic-package-stack_elastic-agent_1:/usr/share/elastic-agent/state/elastic-agent.yml build/elastic-stack-dump/${it}/elastic-agent-policy/")
-                            archiveArtifactsSafe("insecure-logs/${it}/elastic-agent-policy", "build/elastic-stack-dump/${it}/elastic-agent-policy/elastic-agent.yml")
+                            sh(label: "(Workaround) Extract state/elastic-agent.yml file", script: "mkdir -p build/elastic-stack-dump/${it}/elastic-agent-policy/ && docker cp elastic-package-stack_elastic-agent_1:/usr/share/elastic-agent/state/elastic-agent.yml build/elastic-stack-dump/${it}/elastic-agent-policy/state-elastic-agent.yml")
+                            sh(label: "(Workaround) Extract state/fleet.yml file", script: "docker cp elastic-package-stack_elastic-agent_1:/usr/share/elastic-agent/state/fleet.yml build/elastic-stack-dump/${it}/elastic-agent-policy/state-fleet.yml")
+                            sh(label: "(Workaround) Extract elastic-agent.yml file", script: "docker cp elastic-package-stack_elastic-agent_1:/usr/share/elastic-agent/elastic-agent.yml build/elastic-stack-dump/${it}/elastic-agent-policy/")
+                            sh(label: "(Workaround) Extract elastic-agent.reference.yml file", script: "docker cp elastic-package-stack_elastic-agent_1:/usr/share/elastic-agent/elastic-agent.reference.yml build/elastic-stack-dump/${it}/elastic-agent-policy/")
+                            archiveArtifactsSafe("insecure-logs/${it}/elastic-agent-policy", "build/elastic-stack-dump/${it}/elastic-agent-policy/*")
                           }
                           sh(label: "Take down the Elastic stack", script: 'build/elastic-package stack down -v')
                           stashCoverageReport()

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -98,6 +98,8 @@ pipeline {
                           archiveArtifacts(allowEmptyArchive: true, artifacts: "build/elastic-stack-dump/${it}/logs/*.log, build/elastic-stack-dump/${it}/logs/fleet-server-internal/*")
                           archiveArtifactsSafe("insecure-logs/${it}", "build/elastic-stack-dump/${it}/logs/elastic-agent-internal/*")
                           archiveArtifactsSafe("insecure-logs/${it}/container-logs", "build/container-logs/*.log")
+                          sh(label: "(Workaround) Extract elastic-agent.yml file", script: "grep -q 'line 47: could not find expected' build/elastic-stack-dump/${it}/logs/elastic-agent.log && docker cp elastic-package-stack_elastic-agent_1:/usr/share/elastic-agent/state/elastic-agent.yml build/elastic-stack-dump/${it}/elastic-agent-policy/")
+                          archiveArtifactsSafe("insecure-logs/${it}/elastic-agent-policy", "build/elastic-stack-dump/${it}/elastic-agent-policy/elastic-agent.yml")
                           sh(label: "Take down the Elastic stack", script: 'build/elastic-package stack down -v')
                           stashCoverageReport()
                         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -100,9 +100,9 @@ pipeline {
                           archiveArtifactsSafe("insecure-logs/${it}/container-logs", "build/container-logs/*.log")
                           def r = sh(label: "(Workaround) Check line 47 error", script: "grep -q 'line 47: could not find expected' build/elastic-stack-dump/${it}/logs/elastic-agent.log", returnStatus: true)
                           if (r == 0) {
-                            def r = sh(label: "(Workaround) Extract elastic-agent.yml file", script: "docker cp elastic-package-stack_elastic-agent_1:/usr/share/elastic-agent/state/elastic-agent.yml build/elastic-stack-dump/${it}/elastic-agent-policy/")
+                            sh(label: "(Workaround) Extract elastic-agent.yml file", script: "docker cp elastic-package-stack_elastic-agent_1:/usr/share/elastic-agent/state/elastic-agent.yml build/elastic-stack-dump/${it}/elastic-agent-policy/")
+                            archiveArtifactsSafe("insecure-logs/${it}/elastic-agent-policy", "build/elastic-stack-dump/${it}/elastic-agent-policy/elastic-agent.yml")
                           }
-                          archiveArtifactsSafe("insecure-logs/${it}/elastic-agent-policy", "build/elastic-stack-dump/${it}/elastic-agent-policy/elastic-agent.yml")
                           sh(label: "Take down the Elastic stack", script: 'build/elastic-package stack down -v')
                           stashCoverageReport()
                         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -98,7 +98,7 @@ pipeline {
                           archiveArtifacts(allowEmptyArchive: true, artifacts: "build/elastic-stack-dump/${it}/logs/*.log, build/elastic-stack-dump/${it}/logs/fleet-server-internal/*")
                           archiveArtifactsSafe("insecure-logs/${it}", "build/elastic-stack-dump/${it}/logs/elastic-agent-internal/*")
                           archiveArtifactsSafe("insecure-logs/${it}/container-logs", "build/container-logs/*.log")
-                          sh(label: "(Workaround) Extract elastic-agent.yml file", script: "grep -q 'line 47: could not find expected' build/elastic-stack-dump/${it}/logs/elastic-agent.log && docker cp elastic-package-stack_elastic-agent_1:/usr/share/elastic-agent/state/elastic-agent.yml build/elastic-stack-dump/${it}/elastic-agent-policy/")
+                          sh(label: "(Workaround) Extract elastic-agent.yml file", script: "grep -q 'line 47: could not find expected' build/elastic-stack-dump/${it}/logs/elastic-agent.log && docker cp elastic-package-stack_elastic-agent_1:/usr/share/elastic-agent/state/elastic-agent.yml build/elastic-stack-dump/${it}/elastic-agent-policy/ || true")
                           archiveArtifactsSafe("insecure-logs/${it}/elastic-agent-policy", "build/elastic-stack-dump/${it}/elastic-agent-policy/elastic-agent.yml")
                           sh(label: "Take down the Elastic stack", script: 'build/elastic-package stack down -v')
                           stashCoverageReport()


### PR DESCRIPTION
This PR modifies the Jenkinsfile to safely store the agent policy if the `line 47` error appears.

Related: elastic/elastic-agent#98