### PR TITLE
Add ML modules to Nginx readme

### DIFF
--- a/packages/nginx/_dev/build/docs/README.md
+++ b/packages/nginx/_dev/build/docs/README.md
@@ -59,3 +59,22 @@ It's highly recommended to replace `127.0.0.1` with your server’s IP address a
 {{event "stubstatus"}}
 
 {{fields "stubstatus"}}
+
+## ML Modules
+
+These anomaly detection jobs are available in the Machine Learning app in Kibana
+when you have data that matches the query specified in the
+[manifest](https://github.com/elastic/integrations/blob/main/packages/nginx/kibana/ml_module/nginx-Logs-ml.json).
+
+### Nginx access logs
+
+Find unusual activity in HTTP access logs.
+
+| Job | Description |
+|---|---|
+| visitor_rate_nginx | HTTP Access Logs: Detect unusual visitor rates |
+| status_code_rate_nginx | HTTP Access Logs: Detect unusual status code rates |
+| source_ip_url_count_nginx | HTTP Access Logs: Detect unusual source IPs - high distinct count of URLs |
+| source_ip_request_rate_nginx | HTTP Access Logs: Detect unusual source IPs - high request rates |
+| low_request_rate_nginx | HTTP Access Logs: Detect low request rates |
+

--- a/packages/nginx/changelog.yml
+++ b/packages/nginx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.1"
+  changes:
+    - description: Add ML modules to readme
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/2662
 - version: "1.3.0"
   changes:
     - description: Update to ECS 8.0

--- a/packages/nginx/docs/README.md
+++ b/packages/nginx/docs/README.md
@@ -519,3 +519,22 @@ An example event for `stubstatus` looks as following:
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
 
+
+## ML Modules
+
+These anomaly detection jobs are available in the Machine Learning app in Kibana
+when you have data that matches the query specified in the
+[manifest](https://github.com/elastic/integrations/blob/main/packages/nginx/kibana/ml_module/nginx-Logs-ml.json).
+
+### Nginx access logs
+
+Find unusual activity in HTTP access logs.
+
+| Job | Description |
+|---|---|
+| visitor_rate_nginx | HTTP Access Logs: Detect unusual visitor rates |
+| status_code_rate_nginx | HTTP Access Logs: Detect unusual status code rates |
+| source_ip_url_count_nginx | HTTP Access Logs: Detect unusual source IPs - high distinct count of URLs |
+| source_ip_request_rate_nginx | HTTP Access Logs: Detect unusual source IPs - high request rates |
+| low_request_rate_nginx | HTTP Access Logs: Detect low request rates |
+

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: nginx
 title: Nginx
-version: 1.3.0
+version: 1.3.1
 license: basic
 description: Collect logs and metrics from Nginx HTTP servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Adds a table to the readme for the Nginx module, which lists the machine learning modules that are included in the integration. The names and descriptions for these jobs are found in https://github.com/elastic/integrations/blob/main/packages/nginx/kibana/ml_module/nginx-Logs-ml.json

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Relates #2640

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
