### PR TITLE
[github] Fix Github query operator error

### DIFF
--- a/packages/github/_dev/build/docs/README.md
+++ b/packages/github/_dev/build/docs/README.md
@@ -10,7 +10,7 @@ The GitHub audit log records all events related to the GitHub organization. See 
 
 To use this integration, you must be an organization owner, and you must use an Personal Access Token with the admin:org scope.
 
-*This integration is not compatible with GitHub Enterprise server*
+*This integration is not compatible with GitHub Enterprise server.*
 
 {{fields "audit"}}
 

--- a/packages/github/_dev/build/docs/README.md
+++ b/packages/github/_dev/build/docs/README.md
@@ -10,6 +10,8 @@ The GitHub audit log records all events related to the GitHub organization. See 
 
 To use this integration, you must be an organization owner, and you must use an Personal Access Token with the admin:org scope.
 
+*This integration is not compatible with GitHub Enterprise server*
+
 {{fields "audit"}}
 
 {{event "audit"}}

--- a/packages/github/_dev/deploy/docker/files/config.yml
+++ b/packages/github/_dev/deploy/docker/files/config.yml
@@ -6,7 +6,7 @@ rules:
     query_params:
       per_page: "100"
       order: asc
-      phrase: "{phrase:created:=>\\d{8}T(?:\\d{2})(?::\\d{2}){2}\\+0000}"
+      phrase: "{phrase:created:>=\\d{8}T(?:\\d{2})(?::\\d{2}){2}\\+0000}"
     responses:
       - status_code: 200
         headers:

--- a/packages/github/changelog.yml
+++ b/packages/github/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Resolve invalid query operator
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/2664
 - version: "0.3.0"
   changes:
     - description: Update to ECS 8.0

--- a/packages/github/changelog.yml
+++ b/packages/github/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Resolve invalid query operator
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "0.3.0"
   changes:
     - description: Update to ECS 8.0

--- a/packages/github/data_stream/audit/agent/stream/httpjson.yml.hbs
+++ b/packages/github/data_stream/audit/agent/stream/httpjson.yml.hbs
@@ -22,8 +22,8 @@ request.transforms:
       value: "application/vnd.github.v3+json"
   - set:
       target: url.params.phrase
-      value: '[[sprintf "created:=>%s" (formatDate .cursor.last_timestamp "20060102T15:04:05-0700")]]'
-      default: '[[sprintf "created:=>%s" (formatDate (now (parseDuration "-{{initial_interval}}")) "20060102T15:04:05-0700")]]'
+      value: '[[sprintf "created:>=%s" (formatDate .cursor.last_timestamp "20060102T15:04:05-0700")]]'
+      default: '[[sprintf "created:>=%s" (formatDate (now (parseDuration "-{{initial_interval}}")) "20060102T15:04:05-0700")]]'
   - set:
       target: url.params.per_page
       value: 100

--- a/packages/github/docs/README.md
+++ b/packages/github/docs/README.md
@@ -10,7 +10,7 @@ The GitHub audit log records all events related to the GitHub organization. See 
 
 To use this integration, you must be an organization owner, and you must use an Personal Access Token with the admin:org scope.
 
-*This integration is not compatible with GitHub Enterprise server*
+*This integration is not compatible with GitHub Enterprise server.*
 
 **Exported fields**
 

--- a/packages/github/docs/README.md
+++ b/packages/github/docs/README.md
@@ -10,6 +10,8 @@ The GitHub audit log records all events related to the GitHub organization. See 
 
 To use this integration, you must be an organization owner, and you must use an Personal Access Token with the admin:org scope.
 
+*This integration is not compatible with GitHub Enterprise server*
+
 **Exported fields**
 
 | Field | Description | Type |

--- a/packages/github/manifest.yml
+++ b/packages/github/manifest.yml
@@ -1,6 +1,6 @@
 name: github
 title: GitHub
-version: 0.3.0
+version: 0.3.1
 release: experimental
 description: Collect events from GitHub with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Fixes an bug with an invalid query parameter operator for the GitHub API.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #2622 
- Closes #2461

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
