### PR TITLE
[UDP] Fixing typo in listen_address for package

### DIFF
--- a/packages/udp/changelog.yml
+++ b/packages/udp/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.0.1"
+  changes:
+    - description: Fixing typo in manifest for listen address
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/2170
 - version: "1.0.0"
   changes:
     - description: Initial Release

--- a/packages/udp/changelog.yml
+++ b/packages/udp/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Fixing typo in manifest for listen address
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/2170
+      link: https://github.com/elastic/integrations/pull/2671
 - version: "1.0.0"
   changes:
     - description: Initial Release

--- a/packages/udp/data_stream/generic/manifest.yml
+++ b/packages/udp/data_stream/generic/manifest.yml
@@ -6,7 +6,7 @@ streams:
     title: Custom UDP Logs
     template_path: udp.yml.hbs
     vars:
-      - name: listen_adress
+      - name: listen_address
         type: text
         title: Listen Address
         description: |

--- a/packages/udp/manifest.yml
+++ b/packages/udp/manifest.yml
@@ -3,7 +3,7 @@ name: udp
 title: Custom UDP Logs
 description: Collect raw UDP data from listening UDP port with Elastic Agent.
 type: integration
-version: 1.0.0
+version: 1.0.1
 release: ga
 conditions:
   kibana.version: "^7.16.0 || ^8.0.0"


### PR DESCRIPTION
## What does this PR do?

Fixing a typo in the manifest.yml of the UDP package for listen address

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

Closes #2668 