### PR TITLE
Disable audit logs by default

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.17.0"
+  changes:
+    - description: Disable audit logs collection by default
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.16.0"
   changes:
     - description: Documentation improvements

--- a/packages/kubernetes/data_stream/audit_logs/manifest.yml
+++ b/packages/kubernetes/data_stream/audit_logs/manifest.yml
@@ -3,6 +3,7 @@ type: logs
 release: experimental
 streams:
   - input: filestream
+    enabled: false
     title: Collect Kubernetes audit logs
     description: Collect Kubernetes audit logs
     vars:

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.16.0
+version: 1.17.0
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
Signed-off-by: Tetiana Kravchenko <tetiana.kravchenko@elastic.co>

## What does this PR do?

audit logs is quite an advanced feature: to make it working audit logging should be enabled in k8s cluster and configured with proper log path. For this reason I think it should be disabled by default and enabled explicitly only if needed.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<img width="801" alt="Screenshot 2022-02-11 at 15 47 45" src="https://user-images.githubusercontent.com/28299531/153613578-31e0aec9-f7a6-4939-95c1-143941aa0dab.png">

