### PR TITLE
[Anomali] adding initial interval to manifest

### DIFF
--- a/packages/ti_anomali/changelog.yml
+++ b/packages/ti_anomali/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Adding first interval to Anomali Limo policy UI
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/2446
 - version: "1.2.0"
   changes:
     - description: Update to ECS 8.0

--- a/packages/ti_anomali/changelog.yml
+++ b/packages/ti_anomali/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Adding first interval to Anomali Limo policy UI
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/2446
+      link: https://github.com/elastic/integrations/pull/2677
 - version: "1.2.0"
   changes:
     - description: Update to ECS 8.0

--- a/packages/ti_anomali/data_stream/limo/manifest.yml
+++ b/packages/ti_anomali/data_stream/limo/manifest.yml
@@ -31,6 +31,14 @@ streams:
         required: true
         show_user: true
         default: 10m
+      - name: initial_interval
+        type: text
+        title: Initial Interval
+        multi: false
+        required: true
+        show_user: true
+        default: 120h
+        description: How far back to look for indicators the first time the agent is started.
       - name: ssl
         type: yaml
         title: SSL

--- a/packages/ti_anomali/manifest.yml
+++ b/packages/ti_anomali/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_anomali
 title: Anomali
-version: 1.2.0
+version: 1.2.1
 release: ga
 description: Collect threat intelligence from Anomali APIs with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Adding a missing UI option for first_interval to the limo datastream.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


