### PR TITLE
Fix missing ignore in filesystem config

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.1"
+  changes:
+    - description: Fix missing ignore_types in filesystem
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/2679
 - version: "1.10.0"
   changes:
     - description: Expose winlog input ignore_older option.

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,8 +1,8 @@
 # newer versions go on top
-- version: "1.10.1"
+- version: "1.11.0"
   changes:
-    - description: Fix missing ignore_types in filesystem
-      type: bugfix
+    - description: Add option to configure ignored filesystem types
+      type: enhancement
       link: https://github.com/elastic/integrations/pull/2679
 - version: "1.10.0"
   changes:

--- a/packages/system/data_stream/filesystem/agent/stream/stream.yml.hbs
+++ b/packages/system/data_stream/filesystem/agent/stream/stream.yml.hbs
@@ -1,6 +1,7 @@
 metricsets: ["filesystem"]
 period: {{period}}
 processors: {{processors}}
+filesystem.ignore_types: {{filesystem.ignore_types}}
 {{#if system.hostfs}}
 system.hostfs: {{system.hostfs}}
 {{/if}}

--- a/packages/system/data_stream/filesystem/agent/stream/stream.yml.hbs
+++ b/packages/system/data_stream/filesystem/agent/stream/stream.yml.hbs
@@ -1,7 +1,9 @@
 metricsets: ["filesystem"]
 period: {{period}}
 processors: {{processors}}
+{{#if filesystem.ignore_types}}
 filesystem.ignore_types: {{filesystem.ignore_types}}
+{{/if}}
 {{#if system.hostfs}}
 system.hostfs: {{system.hostfs}}
 {{/if}}

--- a/packages/system/data_stream/filesystem/manifest.yml
+++ b/packages/system/data_stream/filesystem/manifest.yml
@@ -24,7 +24,6 @@ streams:
         default: |
           - drop_event.when.regexp:
               system.filesystem.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
-
       - name: filesystem.ignore_types
         type: text
         title: List of filesystem types to ignore

--- a/packages/system/data_stream/filesystem/manifest.yml
+++ b/packages/system/data_stream/filesystem/manifest.yml
@@ -24,5 +24,15 @@ streams:
         default: |
           - drop_event.when.regexp:
               system.filesystem.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
+
+      - name: filesystem.ignore_types
+        type: text
+        title: List of filesystem types to ignore
+        multi: true
+        required: false
+        show_user: true
+        description: >
+          The filesystem datastream will ignore any filesystems with a matching type as specified here. By default, this will exclude any filesystems marked as "nodev" in /proc/filesystems on linux.
+
     title: System filesystem metrics
     description: Collect System filesystem metrics

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 1.10.1
+version: 1.11.0
 license: basic
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 1.10.0
+version: 1.10.1
 license: basic
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

The `filesystem.ignore_types` option was missing from the system integrations config. This adds it back in.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


