### PR TITLE
Fix url in docker changelog

### DIFF
--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Release package for 8.0.0
       type: enhancement
-      link: http://github.com/elastic/integrations/pull/
+      link: http://github.com/elastic/integrations/pull/2678
 - version: "1.1.1"
   changes:
     - description: Uniform with guidelines


### PR DESCRIPTION
Fix wrong link included in http://github.com/elastic/integrations/pull/2678.