### PR TITLE
[fortinet] Clarify description of listen address/port

### DIFF
--- a/packages/fortinet/changelog.yml
+++ b/packages/fortinet/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.2"
+  changes:
+    - description: Clarify description for listen address and port.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/2685
 - version: "1.4.1"
   changes:
     - description: Add Ingest Pipeline script to map IANA Protocol Numbers

--- a/packages/fortinet/data_stream/clientendpoint/manifest.yml
+++ b/packages/fortinet/data_stream/clientendpoint/manifest.yml
@@ -19,14 +19,16 @@ streams:
           - forwarded
       - name: udp_host
         type: text
-        title: UDP host to listen on
+        title: Listen Address
+        description: The bind address to listen for UDP connections. Set to `0.0.0.0` to bind to all available interfaces.
         multi: false
         required: true
         show_user: true
         default: localhost
       - name: udp_port
         type: integer
-        title: UDP port to listen on
+        title: Listen Port
+        description: The UDP port number to listen on.
         multi: false
         required: true
         show_user: true
@@ -89,14 +91,16 @@ streams:
           - forwarded
       - name: tcp_host
         type: text
-        title: TCP host to listen on
+        title: Listen Address
+        description: The bind address to listen for TCP connections. Set to `0.0.0.0` to bind to all available interfaces.
         multi: false
         required: true
         show_user: true
         default: localhost
       - name: tcp_port
         type: integer
-        title: TCP port to listen on
+        title: Listen Port
+        description: The TCP port number to listen on.
         multi: false
         required: true
         show_user: true

--- a/packages/fortinet/data_stream/firewall/manifest.yml
+++ b/packages/fortinet/data_stream/firewall/manifest.yml
@@ -5,14 +5,16 @@ streams:
     vars:
       - name: syslog_host
         type: text
-        title: Syslog Host
+        title: Listen Address
+        description: The bind address to listen for TCP connections. Set to `0.0.0.0` to bind to all available interfaces.
         multi: false
         required: true
         show_user: true
         default: localhost
       - name: syslog_port
         type: integer
-        title: Syslog Port
+        title: Listen Port
+        description: The TCP port number to listen on.
         multi: false
         required: true
         show_user: true
@@ -50,14 +52,16 @@ streams:
     vars:
       - name: syslog_host
         type: text
-        title: Syslog Host
+        title: Listen Address
+        description: The bind address to listen for UDP connections. Set to `0.0.0.0` to bind to all available interfaces.
         multi: false
         required: true
-        show_user: false
+        show_user: true
         default: localhost
       - name: syslog_port
         type: integer
-        title: Syslog Port
+        title: Listen Port
+        description: The UDP port number to listen on.
         multi: false
         required: true
         show_user: true

--- a/packages/fortinet/data_stream/fortimail/manifest.yml
+++ b/packages/fortinet/data_stream/fortimail/manifest.yml
@@ -18,14 +18,16 @@ streams:
           - forwarded
       - name: udp_host
         type: text
-        title: UDP host to listen on
+        title: Listen Address
+        description: The bind address to listen for UDP connections. Set to `0.0.0.0` to bind to all available interfaces.
         multi: false
         required: true
         show_user: true
         default: localhost
       - name: udp_port
         type: integer
-        title: UDP port to listen on
+        title: Listen Port
+        description: The UDP port number to listen on.
         multi: false
         required: true
         show_user: true
@@ -87,14 +89,16 @@ streams:
           - forwarded
       - name: tcp_host
         type: text
-        title: TCP host to listen on
+        title: Listen Address
+        description: The bind address to listen for TCP connections. Set to `0.0.0.0` to bind to all available interfaces.
         multi: false
         required: true
         show_user: true
         default: localhost
       - name: tcp_port
         type: integer
-        title: TCP port to listen on
+        title: Listen Port
+        description: The TCP port number to listen on.
         multi: false
         required: true
         show_user: true

--- a/packages/fortinet/data_stream/fortimanager/manifest.yml
+++ b/packages/fortinet/data_stream/fortimanager/manifest.yml
@@ -18,14 +18,16 @@ streams:
           - forwarded
       - name: udp_host
         type: text
-        title: UDP host to listen on
+        title: Listen Address
+        description: The bind address to listen for UDP connections. Set to `0.0.0.0` to bind to all available interfaces.
         multi: false
         required: true
         show_user: true
         default: localhost
       - name: udp_port
         type: integer
-        title: UDP port to listen on
+        title: Listen Port
+        description: The UDP port number to listen on.
         multi: false
         required: true
         show_user: true
@@ -87,14 +89,16 @@ streams:
           - forwarded
       - name: tcp_host
         type: text
-        title: TCP host to listen on
+        title: Listen Address
+        description: The bind address to listen for TCP connections. Set to `0.0.0.0` to bind to all available interfaces.
         multi: false
         required: true
         show_user: true
         default: localhost
       - name: tcp_port
         type: integer
-        title: TCP port to listen on
+        title: Listen Port
+        description: The TCP port number to listen on.
         multi: false
         required: true
         show_user: true

--- a/packages/fortinet/manifest.yml
+++ b/packages/fortinet/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet
 title: Fortinet Logs
-version: 1.4.1
+version: 1.4.2
 release: ga
 description: Collect logs from Fortinet instances with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Unify the descriptions of the Listen Address and Listen Port in manifests.

The variable names were not changed to avoid breaking the upgrade path for existing users.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates #2627

## Screenshots

<img width="505" alt="Screen Shot 2022-02-11 at 5 24 00 PM" src="https://user-images.githubusercontent.com/4565752/153678869-71103773-3586-4345-a424-54e12da5dcda.png">

