### PR TITLE
[httpjson] Fix response.split indentation

### DIFF
--- a/packages/httpjson/_dev/deploy/docker/files/config.yml
+++ b/packages/httpjson/_dev/deploy/docker/files/config.yml
@@ -60,3 +60,11 @@ rules:
       - status_code: 200
         body: |-
           {"message": "success"}
+  - path: /testsplit/api
+    methods: ["GET"]
+    request_headers:
+      Authorization: "Basic dGVzdDp0ZXN0"
+    responses:
+      - status_code: 200
+        body: |-
+          {"data":[{"test":"asdf"},{"test":"1234"}]}

--- a/packages/httpjson/changelog.yml
+++ b/packages/httpjson/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.0.1"
+  changes:
+    - description: Fix response.split indentation
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.0.0"
   changes:
     - description: Initial Implementation

--- a/packages/httpjson/data_stream/generic/_dev/test/system/test-split-config.yml
+++ b/packages/httpjson/data_stream/generic/_dev/test/system/test-split-config.yml
@@ -1,0 +1,12 @@
+input: httpjson
+service: httpjson
+data_stream:
+  vars:
+    data_stream.dataset: httpjson.generic
+    username: test
+    password: test
+    request_url: http://{{Hostname}}:{{Port}}/testsplit/api
+    response_split: |-
+      target: body.data
+      keep_parent: true
+      type: array

--- a/packages/httpjson/data_stream/generic/agent/stream/httpjson.yml.hbs
+++ b/packages/httpjson/data_stream/generic/agent/stream/httpjson.yml.hbs
@@ -25,7 +25,7 @@ auth.oauth2:
   token_url: {{oauth_token_url}}
 {{/if}}
 {{#if oauth_custom}}
-{{oauth_custom}}
+  {{oauth_custom}}
 {{/if}}
 {{/if}}
 
@@ -45,12 +45,12 @@ request:
     {{ssl}}
 {{/if}}
 {{#if request_custom}}
-{{request_custom}}
+  {{request_custom}}
 {{/if}}
 
 {{#if response_transforms}}
 response.transforms: 
-{{response_transforms}}
+  {{response_transforms}}
 {{/if}}
 {{#if response_split}}
 response.split: 

--- a/packages/httpjson/data_stream/generic/agent/stream/httpjson.yml.hbs
+++ b/packages/httpjson/data_stream/generic/agent/stream/httpjson.yml.hbs
@@ -54,7 +54,7 @@ response.transforms:
 {{/if}}
 {{#if response_split}}
 response.split: 
-{{response_split}}
+  {{response_split}}
 {{/if}}
 {{#if response_pagination}}
 response.pagination: {{response_pagination}}

--- a/packages/httpjson/manifest.yml
+++ b/packages/httpjson/manifest.yml
@@ -3,7 +3,7 @@ name: httpjson
 title: Custom HTTPJSON Input
 description: Collect custom data from REST API's with Elastic Agent.
 type: integration
-version: 1.0.0
+version: 1.0.1
 release: ga
 conditions:
   kibana.version: "^7.16.0 || ^8.0.0"


### PR DESCRIPTION
## What does this PR do?

Fix indentation for `response.split` config

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #2686 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
