### PR TITLE
Container logs: improve default ndjson parser configuration

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,9 +1,14 @@
 # newer versions go on top
+- version: "1.17.1"
+  changes:
+    - description: Improve default ndjson parser configuration
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.17.0"
   changes:
     - description: Disable audit logs collection by default
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/2675
 - version: "1.16.0"
   changes:
     - description: Documentation improvements

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Improve default ndjson parser configuration
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/2694
 - version: "1.17.0"
   changes:
     - description: Disable audit logs collection by default

--- a/packages/kubernetes/data_stream/container_logs/manifest.yml
+++ b/packages/kubernetes/data_stream/container_logs/manifest.yml
@@ -39,6 +39,7 @@ streams:
         default: |
           # - ndjson:
           #     target: json
+          #     ignore_decoding_error: true
           # - multiline:
           #     type: pattern
           #     pattern: '^\['

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.17.0
+version: 1.17.1
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
Signed-off-by: Tetiana Kravchenko <tetiana.kravchenko@elastic.co>

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Adjust default ndjson parser configuration. Even though this configuration is commented out, I would add it to prevent `Error decoding JSON` errors in case there are both: json and not json logs in the k8s cluster.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Relates https://github.com/elastic/beats/issues/6045

## Screenshots

