### PR TITLE
Makes experimental logstash package work for 8.0.0

### DIFF
--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Make experimental package stop breaking stack version ^8.0.0 by fixing compatible version range
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/2697
 - version: "1.0.2"
   changes:
     - description: Revert package to experimental

--- a/packages/logstash/manifest.yml
+++ b/packages/logstash/manifest.yml
@@ -1,6 +1,6 @@
 name: logstash
 title: Logstash
-version: 1.0.2
+version: 1.1.0
 release: experimental
 description: Collect logs and metrics from Logstash with Elastic Agent.
 type: integration
@@ -13,7 +13,7 @@ format_version: 1.0.0
 license: basic
 categories: ["elastic_stack"]
 conditions:
-  kibana.version: ^7.15.0
+  kibana.version: "^7.15.0 || ^8.0.0"
 screenshots:
   - src: /img/kibana-logstash-log.png
     title: kibana logstash log


### PR DESCRIPTION
This is required because for those who have installed it, upgrading to 8.0.0 stack can cause critical issues. There are no changes to the package itself beyond declaring that this package, as-is, is also compatible with ^8.0.0