### PR TITLE
[Uptime] fix default values for synthetic monitor schedules [closes elastic/kibana#125402]

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,10 @@
 # newer versions go on top
+- version: "0.9.1"
+  changes:
+    - description: Fix default values for monitor schedules
+      type: enhancement
+      link: |
+        https://github.com/elastic/integrations/pull/2698
 - version: "0.9.0"
   changes:
     - description: Add run_once fields

--- a/packages/synthetics/data_stream/browser/manifest.yml
+++ b/packages/synthetics/data_stream/browser/manifest.yml
@@ -51,7 +51,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        default: "'@every 3m'"
+        default: "\"@every 3m\""
       - name: service.name
         type: text
         title: APM Service Name

--- a/packages/synthetics/data_stream/http/manifest.yml
+++ b/packages/synthetics/data_stream/http/manifest.yml
@@ -51,7 +51,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        default: "'@every 3m'"
+        default: "\"@every 3m\""
       - name: urls
         type: text
         title: URL

--- a/packages/synthetics/data_stream/icmp/manifest.yml
+++ b/packages/synthetics/data_stream/icmp/manifest.yml
@@ -51,7 +51,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        default: "'@every 3m'"
+        default: "\"@every 3m\""
       - name: wait
         type: text
         title: Wait

--- a/packages/synthetics/data_stream/tcp/manifest.yml
+++ b/packages/synthetics/data_stream/tcp/manifest.yml
@@ -51,7 +51,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        default: "'@every 3m'"
+        default: "\"@every 3m\""
       - name: hosts
         type: text
         title: Host

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Monitor the availability of your services with Elastic Synthetics.
-version: 0.9.0
+version: 0.9.1
 categories: ["elastic_stack", "monitoring", "web"]
 release: beta
 type: integration


### PR DESCRIPTION
## What does this PR do?

This PR is part of the fix for elastic/kibana#125402.

It updates the default values for a monitor's `schedule` so that they're wrapped in double-quotes, not single-quotes.

Wrapping values in single-quotes causes `JSON.parse` to throw an error when parsing those values, and, therefore, causes an error in Kibana.

> ☝️  Please notice that this does not address why `input` values from the Kibana config are not passed to the integration. I'm not sure yet about whether that's a problem with the configuration itself or the piece of software responsible for setting those values.
> **UPDATE**: The problem with regards to the configuration values not propagating to the integration are now being tracked by the Fleet team at elastic/kibana#125730.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [ ] Please ensure that you can still create monitors of all types and that those monitors respect the schedule you've defined


## How to test this PR locally

1. Add the following config to your Kibana config file
    ```yaml
    xpack.fleet.packages:
    - name: system
      version: latest
    - name: elastic_agent
      version: latest
    - name: fleet_server
      version: latest
    - name: synthetics
      version: latest
    xpack.fleet.agentPolicies:
    - name: Fleet Server on ECK policy
      id: eck-fleet-server
      is_default_fleet_server: true
      namespace: default
      monitoring_enabled:
      - logs
      - metrics
      package_policies:
      - name: fleet_server-1
        id: fleet_server-1
        package:
          name: fleet_server
    - name: My monitor
      id: my-monitor-test
      namespace: default
      monitoring_enabled:
      - logs
      - metrics
      unenroll_timeout: 900
      is_default: true
      package_policies:
      - name: system-1
        id: system-1
        package:
          name: system
      - package:
          name: synthetics
        name: something
        id: something
        inputs:
        - type: synthetics/tcp
          enabled: true
          streams:
            - data_stream:
                type: synthetics
                dataset: tcp
              enabled: true
              vars:
              - name: hosts
                value: localhost:9200
    ```
    > Make sure to point the values for ES to the right address, in this case I'm using `localhost:9200`, but yours may be different. You'll also need to run the fleet-server.
2. Start the whole Elastic Stack
3. Try to edit the created integration, you'll see there's a `JSON.parse` error because it tries to parse `'@every 3m'` instead of `"@every 3m"`, which would parse correctly.
4. Install the package version from this branch in your Kibana
5. Update the `My Monitor` name and `my-monitor-id` in your configs to `My Second Monitor` and `my-second-monitor-id`.
5. Refresh the integration policies and access `My Second Monitor` and try to edit it. You should now be able to edit that monitor and not see an error.

## Related issues

elastic/kibana#125402

## Screenshots

The previous error (which should not appear anymore):

<img width="962" alt="Screenshot 2022-02-05 at 16 18 57" src="https://user-images.githubusercontent.com/6868147/153627284-48d33492-ace8-420a-b7f2-bf6ad5a8fe03.png">
