### PR TITLE
[crowdstrike] Fix multi-line string handling for config variable

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.3"
+  changes:
+    - description: Change type of 'fdr_parsing_script' variable to 'yaml' so that the multi-line string creates a valid YAML config document.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/2701
 - version: "1.2.2"
   changes:
     - description: Add Ingest Pipeline script to map IANA Protocol Numbers
@@ -8,7 +13,7 @@
   changes:
     - description: Fix issue with "Is FDR Queue" selector having no effect.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/2653
 - version: "1.2.0"
   changes:
     - description: Update to ECS 8.0

--- a/packages/crowdstrike/data_stream/fdr/agent/stream/aws-s3.yml.hbs
+++ b/packages/crowdstrike/data_stream/fdr/agent/stream/aws-s3.yml.hbs
@@ -33,7 +33,7 @@ fips_enabled: {{fips_enabled}}
 proxy_url: {{proxy_url}}
 {{/if}}
 {{#if is_fdr_queue}}
-sqs.notification_parse_script: {{fdr_parsing_script}}
+sqs.notification_parsing_script.source: {{fdr_parsing_script}}
 {{/if}}
 {{#if tags.length}}
 tags:

--- a/packages/crowdstrike/data_stream/fdr/manifest.yml
+++ b/packages/crowdstrike/data_stream/fdr/manifest.yml
@@ -105,7 +105,7 @@ streams:
         show_user: false
         description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port>
       - name: fdr_parsing_script
-        type: text
+        type: yaml
         title: FDR Notification Parsing Script
         multi: false
         required: true

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike Logs
-version: 1.2.2
+version: 1.2.3
 description: Collect and parse falcon logs from Crowdstrike products with Elastic Agent.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
## What does this PR do?

The default value for `fdr_parsing_script` is a multline string. When the handlebar
template was evaluated this created invalid YAML. By changing the variable type to
'yaml' Kibana produces config that is valid. It looks like

    sqs.notification_parsing_script.source: >-
          function parse(n) { var m = JSON.parse(n); var evts = []; var files =
          m.files; ...

I cannot find any documentation for the 'yaml' variable type so I hoping this is how it was
expected to be used.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes #2646

## Screenshots

Before:
<img width="272" alt="Screen Shot 2022-02-15 at 5 40 43 PM" src="https://user-images.githubusercontent.com/4565752/154167550-c1d50c20-4948-4511-8643-6326368927e4.png">

After:
<img width="281" alt="Screen Shot 2022-02-15 at 5 46 13 PM" src="https://user-images.githubusercontent.com/4565752/154167526-e02fa1da-bfc4-4a2d-888c-af0e7addd93d.png">

