### PR TITLE
[zscaler] Mark package as deprecated

### DIFF
--- a/packages/zscaler/changelog.yml
+++ b/packages/zscaler/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.1"
+  changes:
+    - description: Mark package as deprecated. Use the zscaler_zia package instead.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "0.5.0"
   changes:
     - description: Update to ECS 8.0.0

--- a/packages/zscaler/docs/README.md
+++ b/packages/zscaler/docs/README.md
@@ -1,4 +1,6 @@
-# Zscaler integration
+# Zscaler integration (Deprecated)
+
+_This integration is deprecated. Please migrate to the Zscaler ZIA integration._
 
 This integration is for Zscaler device's logs. It includes the following
 datasets for receiving logs over syslog or read from a file:

--- a/packages/zscaler/manifest.yml
+++ b/packages/zscaler/manifest.yml
@@ -1,8 +1,8 @@
 format_version: 1.0.0
 name: zscaler
 title: Zscaler NSS Logs
-version: 0.5.0
-description: Collect and parse logs from Zscaler devices with Elastic Agent.
+version: 0.5.1
+description: Deprecated. Use the Zscaler ZIA integration instead.
 categories: ["network", "security"]
 release: experimental
 license: basic


### PR DESCRIPTION
## What does this PR do?

There are now Zscaler ZIA and Zscaler ZPA integrations that are specific Zscaler products.
This package is being marked as deprecated. The new integrations are not generated parsers
based on rsa2elk.

Relates #2459

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates #2459
