### PR TITLE
Add single quotes around the credentials_json var

### DIFF
--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.1"
+  changes:
+    - description: Fix quoting of the credentials_json value in policy templates.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/2712
 - version: "1.4.0"
   changes:
     - description: Add gcp.dns integration

--- a/packages/gcp/data_stream/audit/_dev/test/system/test-pubsub-config.yml
+++ b/packages/gcp/data_stream/audit/_dev/test/system/test-pubsub-config.yml
@@ -2,7 +2,19 @@ service: gcppubsub-emulator
 input: gcp-pubsub
 vars:
   alternative_host: "{{Hostname}}:{{Port}}"
-  credentials_json: '{\"fake\":\"creds\"}'
+  credentials_json: |-
+    {
+        "type": "service_account",
+        "project_id": "foo",
+        "private_key_id": "x",
+        "private_key": "",
+        "client_email": "foo@bar.com",
+        "client_id": "0",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+        "client_x509_cert_url": "https://foo.bar/path"
+    }
   project_id: audit
 data_stream:
   vars:

--- a/packages/gcp/data_stream/audit/agent/stream/gcp-pubsub.yml.hbs
+++ b/packages/gcp/data_stream/audit/agent/stream/gcp-pubsub.yml.hbs
@@ -5,7 +5,7 @@ subscription.name: {{subscription_name}}
 credentials_file: {{credentials_file}}
 {{/if}}
 {{#if credentials_json}}
-credentials_json: {{credentials_json}}
+credentials_json: '{{credentials_json}}'
 {{/if}}
 {{#if alternative_host}}
 alternative_host: {{alternative_host}}

--- a/packages/gcp/data_stream/dns/_dev/test/system/test-pubsub-config.yml
+++ b/packages/gcp/data_stream/dns/_dev/test/system/test-pubsub-config.yml
@@ -2,7 +2,19 @@ service: gcppubsub-emulator
 input: gcp-pubsub
 vars:
   alternative_host: "{{Hostname}}:{{Port}}"
-  credentials_json: '{\"fake\":\"creds\"}'
+  credentials_json: |
+    {
+        "type": "service_account",
+        "project_id": "foo",
+        "private_key_id": "x",
+        "private_key": "",
+        "client_email": "foo@bar.com",
+        "client_id": "0",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+        "client_x509_cert_url": "https://foo.bar/path"
+    }
   project_id: audit
 data_stream:
   vars:

--- a/packages/gcp/data_stream/dns/agent/stream/gcp-pubsub.yml.hbs
+++ b/packages/gcp/data_stream/dns/agent/stream/gcp-pubsub.yml.hbs
@@ -5,7 +5,7 @@ subscription.name: {{subscription_name}}
 credentials_file: {{credentials_file}}
 {{/if}}
 {{#if credentials_json}}
-credentials_json: {{credentials_json}}
+credentials_json: '{{credentials_json}}'
 {{/if}}
 {{#if alternative_host}}
 alternative_host: {{alternative_host}}

--- a/packages/gcp/data_stream/firewall/_dev/test/system/test-pubsub-config.yml
+++ b/packages/gcp/data_stream/firewall/_dev/test/system/test-pubsub-config.yml
@@ -2,7 +2,9 @@ service: gcppubsub-emulator
 input: gcp-pubsub
 vars:
   alternative_host: "{{Hostname}}:{{Port}}"
-  credentials_json: '{\"fake\":\"creds\"}'
+  credentials_json: >
+    {"foo": "bar"}
+
   project_id: firewall
 data_stream:
   vars:

--- a/packages/gcp/data_stream/firewall/agent/stream/gcp-pubsub.yml.hbs
+++ b/packages/gcp/data_stream/firewall/agent/stream/gcp-pubsub.yml.hbs
@@ -5,7 +5,7 @@ subscription.name: {{subscription_name}}
 credentials_file: {{credentials_file}}
 {{/if}}
 {{#if credentials_json}}
-credentials_json: {{credentials_json}}
+credentials_json: '{{credentials_json}}'
 {{/if}}
 {{#if alternative_host}}
 alternative_host: {{alternative_host}}

--- a/packages/gcp/data_stream/vpcflow/_dev/test/system/test-pubsub-config.yml
+++ b/packages/gcp/data_stream/vpcflow/_dev/test/system/test-pubsub-config.yml
@@ -2,7 +2,8 @@ service: gcppubsub-emulator
 input: gcp-pubsub
 vars:
   alternative_host: "{{Hostname}}:{{Port}}"
-  credentials_json: '{\"fake\":\"creds\"}'
+  credentials_json: >-
+    {"type":"service_account","project_id":"foo","private_key_id":"x","private_key":"","client_email":"foo@bar.com","client_id":"0","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://oauth2.googleapis.com/token","auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs","client_x509_cert_url":"https://foo.bar/path"}
   project_id: vpcflow
 data_stream:
   vars:

--- a/packages/gcp/data_stream/vpcflow/agent/stream/gcp-pubsub.yml.hbs
+++ b/packages/gcp/data_stream/vpcflow/agent/stream/gcp-pubsub.yml.hbs
@@ -5,7 +5,7 @@ subscription.name: {{subscription_name}}
 credentials_file: {{credentials_file}}
 {{/if}}
 {{#if credentials_json}}
-credentials_json: {{credentials_json}}
+credentials_json: '{{credentials_json}}'
 {{/if}}
 {{#if alternative_host}}
 alternative_host: {{alternative_host}}

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -17,7 +17,7 @@ categories:
   - network
   - security
 conditions:
-  kibana.version: ^7.15.0 || ^8.0.0
+  kibana.version: ^7.17.0 || ^8.0.0
 screenshots:
   - src: /img/filebeat-gcp-audit.png
     title: filebeat gcp audit

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -17,7 +17,7 @@ categories:
   - network
   - security
 conditions:
-  kibana.version: ^7.17.0 || ^8.0.0
+  kibana.version: ^7.16.3 || ^8.0.0
 screenshots:
   - src: /img/filebeat-gcp-audit.png
     title: filebeat gcp audit

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: 1.4.0
+version: 1.4.1
 release: ga
 description: Collect logs from Google Cloud Platform with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

This handlebar variable contains a string and is required to be
passed as a string to the Beat. It must be properly quoted because
it contains JSON which in YAML will be interpretted as an object.

In general all handlebar variables that are strings should be single-quoted.

Given the configuration input of

```yaml
vars:
  credentials_json: '{\"fake\":\"creds\"}'
```

Fleet was producing a policy containing

```yaml
credentials_json:
  \"fake\":\"creds\": null
```

and now will produce

```yaml
credentials_json: '{\"fake\":\"creds\"}'
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

