### PR TITLE
synthetics - add apm service name mapping

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,10 @@
 # newer versions go on top
+- version: "0.9.2"
+  changes:
+    - description: Adds APM service name mappings
+      type: enhancement
+      link: |
+        https://github.com/elastic/integrations/pull/2698
 - version: "0.9.1"
   changes:
     - description: Fix default values for monitor schedules

--- a/packages/synthetics/data_stream/browser/fields/common.yml
+++ b/packages/synthetics/data_stream/browser/fields/common.yml
@@ -7,6 +7,9 @@
 - name: run_once
   type: boolean
   description: Whether the monitor is a run_once monitor
+- name: service.name
+  type: keyword
+  description: APM service name this monitor is linked to
 - name: monitor
   type: group
   description: >

--- a/packages/synthetics/data_stream/browser_network/fields/common.yml
+++ b/packages/synthetics/data_stream/browser_network/fields/common.yml
@@ -7,6 +7,9 @@
 - name: run_once
   type: boolean
   description: Whether the monitor is a run_once monitor
+- name: service.name
+  type: keyword
+  description: APM service name this monitor is linked to
 - name: monitor
   type: group
   description: >

--- a/packages/synthetics/data_stream/browser_screenshot/fields/common.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/fields/common.yml
@@ -7,6 +7,9 @@
 - name: run_once
   type: boolean
   description: Whether the monitor is a run_once monitor
+- name: service.name
+  type: keyword
+  description: APM service name this monitor is linked to
 - name: monitor
   type: group
   description: >

--- a/packages/synthetics/data_stream/http/fields/common.yml
+++ b/packages/synthetics/data_stream/http/fields/common.yml
@@ -7,6 +7,9 @@
 - name: run_once
   type: boolean
   description: Whether the monitor is a run_once monitor
+- name: service.name
+  type: keyword
+  description: APM service name this monitor is linked to
 - name: monitor
   type: group
   description: >

--- a/packages/synthetics/data_stream/icmp/fields/common.yml
+++ b/packages/synthetics/data_stream/icmp/fields/common.yml
@@ -7,6 +7,9 @@
 - name: run_once
   type: boolean
   description: Whether the monitor is a run_once monitor
+- name: service.name
+  type: keyword
+  description: APM service name this monitor is linked to
 - name: monitor
   type: group
   description: >

--- a/packages/synthetics/data_stream/tcp/fields/common.yml
+++ b/packages/synthetics/data_stream/tcp/fields/common.yml
@@ -7,6 +7,9 @@
 - name: run_once
   type: boolean
   description: Whether the monitor is a run_once monitor
+- name: service.name
+  type: keyword
+  description: APM service name this monitor is linked to
 - name: monitor
   type: group
   description: >

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Monitor the availability of your services with Elastic Synthetics.
-version: 0.9.1
+version: 0.9.2
 categories: ["elastic_stack", "monitoring", "web"]
 release: beta
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Adds mapping for `service.name` to each Synthetics data stream, corresponding to the APM Service name

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect synthetics.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

### Testing
1. Check out this PR
2. Navigate to the `packages/synthetics` directory. Run `elastic-package clean`, then `elastic-package build`.
3. In that same directory, run `elastic-package stack up --version 8.2.0-SNAPSHOT -v`
4. One the stack is up, log in at `localhost:5601`. 
5. Navigate to the Synthetics Integration, create an HTTP, TCP, or browser monitor and add an APM service name. Make sure that you change the agent policy to `Elastic Agent (elastic-package)` before saving. 
6. Navigate to dev tools. Ensure that the synthetics document for that monitor has your specified APM service name listed under `service.name`. 