### PR TITLE
[github] Fix date format used in queries

### DIFF
--- a/packages/github/_dev/deploy/docker/files/config.yml
+++ b/packages/github/_dev/deploy/docker/files/config.yml
@@ -6,7 +6,7 @@ rules:
     query_params:
       per_page: "100"
       order: asc
-      phrase: "{phrase:created:>=\\d{8}T(?:\\d{2})(?::\\d{2}){2}\\+0000}"
+      phrase: "{phrase:created:>=\\d{2}-\\d{2}-\\d{2}T(?:\\d{2})(?::\\d{2}){2}\\+00:00}"
     responses:
       - status_code: 200
         headers:

--- a/packages/github/_dev/deploy/docker/files/config.yml
+++ b/packages/github/_dev/deploy/docker/files/config.yml
@@ -6,7 +6,7 @@ rules:
     query_params:
       per_page: "100"
       order: asc
-      phrase: "{phrase:created:>=\\d{2}-\\d{2}-\\d{2}T(?:\\d{2})(?::\\d{2}){2}\\+00:00}"
+      phrase: "{phrase:created:>=\\d{4}-\\d{2}-\\d{2}T(?:\\d{2})(?::\\d{2}){2}\\+00:00}"
     responses:
       - status_code: 200
         headers:

--- a/packages/github/changelog.yml
+++ b/packages/github/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.2"
+  changes:
+    - description: Fix date format used in queries.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/2732
 - version: "0.3.1"
   changes:
     - description: Resolve invalid query operator

--- a/packages/github/data_stream/audit/agent/stream/httpjson.yml.hbs
+++ b/packages/github/data_stream/audit/agent/stream/httpjson.yml.hbs
@@ -22,8 +22,8 @@ request.transforms:
       value: "application/vnd.github.v3+json"
   - set:
       target: url.params.phrase
-      value: '[[sprintf "created:>=%s" (formatDate .cursor.last_timestamp "20060102T15:04:05-0700")]]'
-      default: '[[sprintf "created:>=%s" (formatDate (now (parseDuration "-{{initial_interval}}")) "20060102T15:04:05-0700")]]'
+      value: '[[sprintf "created:>=%s" (formatDate .cursor.last_timestamp "2006-01-02T15:04:05-07:00")]]'
+      default: '[[sprintf "created:>=%s" (formatDate (now (parseDuration "-{{initial_interval}}")) "2006-01-02T15:04:05-07:00")]]'
   - set:
       target: url.params.per_page
       value: 100

--- a/packages/github/manifest.yml
+++ b/packages/github/manifest.yml
@@ -1,6 +1,6 @@
 name: github
 title: GitHub
-version: 0.3.1
+version: 0.3.2
 release: experimental
 description: Collect events from GitHub with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Construct dates as YYYY-MM-DDTHH:MM:SS+00:00 per
https://docs.github.com/en/search-github/getting-started-with-searching-on-github/understanding-the-search-syntax#query-for-dates.

Fixes #2731

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
