### PR TITLE
Tune docker package according to Beat's fields deprecation

### DIFF
--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.3.0"
+- version: "2.0.0"
   changes:
     - description: Remove deprecated fields
       type: enhancement

--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.0"
+  changes:
+    - description: Remove deprecated fields
+      type: enhancement
+      link: http://github.com/elastic/integrations/pull/xxxx
 - version: "1.2.0"
   changes:
     - description: Release package for 8.0.0

--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Remove deprecated fields
       type: enhancement
-      link: http://github.com/elastic/integrations/pull/xxxx
+      link: http://github.com/elastic/integrations/pull/2733
 - version: "1.2.0"
   changes:
     - description: Release package for 8.0.0

--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -2,7 +2,7 @@
 - version: "2.0.0"
   changes:
     - description: Remove deprecated fields
-      type: enhancement
+      type: breaking-change
       link: http://github.com/elastic/integrations/pull/2733
 - version: "1.2.0"
   changes:

--- a/packages/docker/data_stream/diskio/fields/fields.yml
+++ b/packages/docker/data_stream/diskio/fields/fields.yml
@@ -40,11 +40,6 @@
           metric_type: gauge
           description: |
             Total number of queued requests
-    - name: reads
-      type: scaled_float
-      metric_type: gauge
-      description: |
-        Number of current reads per second
     - name: write
       type: group
       fields:
@@ -80,11 +75,6 @@
           metric_type: counter
           description: |
             Total number of queued requests
-    - name: writes
-      type: scaled_float
-      metric_type: gauge
-      description: |
-        Number of current writes per second
     - name: summary
       type: group
       fields:
@@ -118,10 +108,5 @@
         - name: queued
           type: long
           metric_type: counter
-          description: |
+          description: |-
             Total number of queued requests
-    - name: total
-      type: scaled_float
-      metric_type: gauge
-      description: |
-        Number of reads and writes per second

--- a/packages/docker/data_stream/diskio/sample_event.json
+++ b/packages/docker/data_stream/diskio/sample_event.json
@@ -18,7 +18,6 @@
                 "service_time": 0,
                 "wait_time": 0
             },
-            "reads": 0,
             "summary": {
                 "bytes": 42414080,
                 "ops": 1824,
@@ -27,7 +26,6 @@
                 "service_time": 0,
                 "wait_time": 0
             },
-            "total": 0,
             "write": {
                 "bytes": 4096,
                 "ops": 1,
@@ -35,8 +33,7 @@
                 "rate": 0,
                 "service_time": 0,
                 "wait_time": 0
-            },
-            "writes": 0
+            }
         }
     },
     "event": {

--- a/packages/docker/data_stream/network/fields/fields.yml
+++ b/packages/docker/data_stream/network/fields/fields.yml
@@ -11,54 +11,6 @@
       type: keyword
       description: |
         Network interface name.
-    - name: in
-      type: group
-      fields:
-        - name: bytes
-          type: long
-          format: bytes
-          metric_type: counter
-          description: |
-            Total number of incoming bytes.
-        - name: dropped
-          type: scaled_float
-          metric_type: counter
-          description: |
-            Total number of dropped incoming packets.
-        - name: errors
-          type: long
-          metric_type: counter
-          description: |
-            Total errors on incoming packets.
-        - name: packets
-          type: long
-          metric_type: counter
-          description: |
-            Total number of incoming packets.
-    - name: out
-      type: group
-      fields:
-        - name: bytes
-          type: long
-          format: bytes
-          metric_type: counter
-          description: |
-            Total number of outgoing bytes.
-        - name: dropped
-          type: scaled_float
-          metric_type: counter
-          description: |
-            Total number of dropped outgoing packets.
-        - name: errors
-          type: long
-          metric_type: counter
-          description: |
-            Total errors on outgoing packets.
-        - name: packets
-          type: long
-          metric_type: counter
-          description: |
-            Total number of outgoing packets.
     - name: inbound
       type: group
       fields:

--- a/packages/docker/data_stream/network/sample_event.json
+++ b/packages/docker/data_stream/network/sample_event.json
@@ -34,12 +34,6 @@
             }
         },
         "network": {
-            "in": {
-                "bytes": 0,
-                "dropped": 0,
-                "errors": 0,
-                "packets": 0
-            },
             "inbound": {
                 "bytes": 23047,
                 "dropped": 0,
@@ -47,12 +41,6 @@
                 "packets": 241
             },
             "interface": "eth0",
-            "out": {
-                "bytes": 0,
-                "dropped": 0,
-                "errors": 0,
-                "packets": 0
-            },
             "outbound": {
                 "bytes": 0,
                 "dropped": 0,

--- a/packages/docker/docs/README.md
+++ b/packages/docker/docs/README.md
@@ -341,21 +341,18 @@ The Docker `diskio` data stream collects disk I/O metrics.
 | docker.diskio.read.rate | Number of current reads per second | long |  | gauge |
 | docker.diskio.read.service_time | Total time to service IO requests, in nanoseconds | long |  | counter |
 | docker.diskio.read.wait_time | Total time requests spent waiting in queues for service, in nanoseconds | long |  | counter |
-| docker.diskio.reads | Number of current reads per second | scaled_float |  | gauge |
 | docker.diskio.summary.bytes | Bytes read and written during the life of the container | long | byte | counter |
 | docker.diskio.summary.ops | Number of I/O operations during the life of the container | long |  | counter |
 | docker.diskio.summary.queued | Total number of queued requests | long |  | counter |
 | docker.diskio.summary.rate | Number of current operations per second | long |  | gauge |
 | docker.diskio.summary.service_time | Total time to service IO requests, in nanoseconds | long |  | counter |
 | docker.diskio.summary.wait_time | Total time requests spent waiting in queues for service, in nanoseconds | long |  | counter |
-| docker.diskio.total | Number of reads and writes per second | scaled_float |  | gauge |
 | docker.diskio.write.bytes | Bytes written during the life of the container | long | byte | counter |
 | docker.diskio.write.ops | Number of writes during the life of the container | long |  | counter |
 | docker.diskio.write.queued | Total number of queued requests | long |  | counter |
 | docker.diskio.write.rate | Number of current writes per second | long |  | gauge |
 | docker.diskio.write.service_time | Total time to service IO requests, in nanoseconds | long |  | counter |
 | docker.diskio.write.wait_time | Total time requests spent waiting in queues for service, in nanoseconds | long |  | counter |
-| docker.diskio.writes | Number of current writes per second | scaled_float |  | gauge |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |  |  |
 | event.dataset | Event dataset | constant_keyword |  |  |
 | event.module | Event module | constant_keyword |  |  |
@@ -930,19 +927,11 @@ The Docker `network` data stream collects network metrics.
 | data_stream.namespace | Data stream namespace. | constant_keyword |  |
 | data_stream.type | Data stream type. | constant_keyword |  |
 | docker.container.labels.\* | Container labels | object |  |
-| docker.network.in.bytes | Total number of incoming bytes. | long | counter |
-| docker.network.in.dropped | Total number of dropped incoming packets. | scaled_float | counter |
-| docker.network.in.errors | Total errors on incoming packets. | long | counter |
-| docker.network.in.packets | Total number of incoming packets. | long | counter |
 | docker.network.inbound.bytes | Total number of incoming bytes. | long | counter |
 | docker.network.inbound.dropped | Total number of dropped incoming packets. | long | counter |
 | docker.network.inbound.errors | Total errors on incoming packets. | long | counter |
 | docker.network.inbound.packets | Total number of incoming packets. | long | counter |
 | docker.network.interface | Network interface name. | keyword |  |
-| docker.network.out.bytes | Total number of outgoing bytes. | long | counter |
-| docker.network.out.dropped | Total number of dropped outgoing packets. | scaled_float | counter |
-| docker.network.out.errors | Total errors on outgoing packets. | long | counter |
-| docker.network.out.packets | Total number of outgoing packets. | long | counter |
 | docker.network.outbound.bytes | Total number of outgoing bytes. | long | counter |
 | docker.network.outbound.dropped | Total number of dropped outgoing packets. | long | counter |
 | docker.network.outbound.errors | Total errors on outgoing packets. | long | counter |

--- a/packages/docker/docs/README.md
+++ b/packages/docker/docs/README.md
@@ -395,7 +395,6 @@ An example event for `diskio` looks as following:
                 "service_time": 0,
                 "wait_time": 0
             },
-            "reads": 0,
             "summary": {
                 "bytes": 42414080,
                 "ops": 1824,
@@ -404,7 +403,6 @@ An example event for `diskio` looks as following:
                 "service_time": 0,
                 "wait_time": 0
             },
-            "total": 0,
             "write": {
                 "bytes": 4096,
                 "ops": 1,
@@ -412,8 +410,7 @@ An example event for `diskio` looks as following:
                 "rate": 0,
                 "service_time": 0,
                 "wait_time": 0
-            },
-            "writes": 0
+            }
         }
     },
     "event": {
@@ -994,12 +991,6 @@ An example event for `network` looks as following:
             }
         },
         "network": {
-            "in": {
-                "bytes": 0,
-                "dropped": 0,
-                "errors": 0,
-                "packets": 0
-            },
             "inbound": {
                 "bytes": 23047,
                 "dropped": 0,
@@ -1007,12 +998,6 @@ An example event for `network` looks as following:
                 "packets": 241
             },
             "interface": "eth0",
-            "out": {
-                "bytes": 0,
-                "dropped": 0,
-                "errors": 0,
-                "packets": 0
-            },
             "outbound": {
                 "bytes": 0,
                 "dropped": 0,

--- a/packages/docker/kibana/visualization/docker-Network-IO.json
+++ b/packages/docker/kibana/visualization/docker-Network-IO.json
@@ -34,7 +34,7 @@
                     "id": "1",
                     "params": {
                         "customLabel": "IN bytes",
-                        "field": "docker.network.in.bytes"
+                        "field": "docker.network.inbound.bytes"
                     },
                     "schema": "metric",
                     "type": "max"
@@ -69,7 +69,7 @@
                     "id": "4",
                     "params": {
                         "customLabel": "OUT bytes",
-                        "field": "docker.network.out.bytes"
+                        "field": "docker.network.outbound.bytes"
                     },
                     "schema": "metric",
                     "type": "max"

--- a/packages/docker/kibana/visualization/docker-containers.json
+++ b/packages/docker/kibana/visualization/docker-containers.json
@@ -49,7 +49,7 @@
                     "id": "4",
                     "params": {
                         "customLabel": "DiskIO",
-                        "field": "docker.diskio.total"
+                        "field": "docker.diskio.summary.bytes"
                     },
                     "schema": "metric",
                     "type": "max"

--- a/packages/docker/manifest.yml
+++ b/packages/docker/manifest.yml
@@ -1,6 +1,6 @@
 name: docker
 title: Docker Metrics
-version: 1.3.0
+version: 2.0.0
 release: ga
 description: Collect metrics from Docker instances with Elastic Agent.
 type: integration

--- a/packages/docker/manifest.yml
+++ b/packages/docker/manifest.yml
@@ -1,6 +1,6 @@
 name: docker
 title: Docker Metrics
-version: 1.2.0
+version: 1.3.0
 release: ga
 description: Collect metrics from Docker instances with Elastic Agent.
 type: integration

--- a/packages/docker/manifest.yml
+++ b/packages/docker/manifest.yml
@@ -20,7 +20,7 @@ categories:
   - containers
   - os_system
 conditions:
-  kibana.version: ^7.14.0 || ^8.0.0
+  kibana.version: ^8.0.0
 policy_templates:
   - name: docker
     title: Docker metrics


### PR DESCRIPTION
## What does this PR do?
This PR tunes docker package accordingly to remove deprecated fields.

Related to https://github.com/elastic/beats/issues/30413 https://github.com/elastic/beats/pull/30500 https://github.com/elastic/beats/pull/27933