### PR TITLE
[mimecast] Add content-disposition to test logs

### DIFF
--- a/packages/mimecast/_dev/deploy/docker/files/config.yml
+++ b/packages/mimecast/_dev/deploy/docker/files/config.yml
@@ -57,7 +57,7 @@ rules:
           Content-Type:
             - "application/json"
         body: |
-          {"type":"MTA","data":[{"acc":"ABC123","Sender":"johndoe@example.com","datetime":"2021-11-12T12:15:46+0000","Rcpt":"o365_service_account@example.com","RcptActType":"Jnl","aCode":"fjihpfEgM_iRwemxhe3t_w","Dir":"Internal","RcptHdrType":"Unknown"}]}
+          {"type":"MTA","data":[{"acc":"ABC123","Sender":"johndoe@example.com","datetime":"2021-11-12T12:15:46+0000","Rcpt":"o365_service_account@example.com","RcptActType":"Jnl","aCode":"fjihpfEgM_iRwemxhe3t_w","Dir":"Internal","RcptHdrType":"Unknown", "Content-Disposition":"attachment; filename=\"jrnl_20211018093329655.json\"}]}
   - path: /api/ttp/threat-intel/get-feed
     methods: ["POST"]
     query_params:

--- a/packages/mimecast/_dev/deploy/docker/files/config.yml
+++ b/packages/mimecast/_dev/deploy/docker/files/config.yml
@@ -57,7 +57,7 @@ rules:
           Content-Type:
             - "application/json"
         body: |
-          {"type":"MTA","data":[{"acc":"ABC123","Sender":"johndoe@example.com","datetime":"2021-11-12T12:15:46+0000","Rcpt":"o365_service_account@example.com","RcptActType":"Jnl","aCode":"fjihpfEgM_iRwemxhe3t_w","Dir":"Internal","RcptHdrType":"Unknown", "Content-Disposition":"attachment; filename=\"jrnl_20211018093329655.json\"}]}
+          {"type":"MTA","data":[{"acc":"ABC123","Sender":"johndoe@example.com","datetime":"2021-11-12T12:15:46+0000","Rcpt":"o365_service_account@example.com","RcptActType":"Jnl","aCode":"fjihpfEgM_iRwemxhe3t_w","Dir":"Internal","RcptHdrType":"Unknown", "Content-Disposition":"attachment; filename=\"jrnl_20211018093329655.json\""}]}
   - path: /api/ttp/threat-intel/get-feed
     methods: ["POST"]
     query_params:

--- a/packages/mimecast/changelog.yml
+++ b/packages/mimecast/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.0.7"
+  changes:
+    - description: Add content-disposition to test mock to creeate sample event from siem logs properly
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/2690
 - version: "0.0.6"
   changes:
     - description: Add use cases for audit events and update sample events and docs

--- a/packages/mimecast/changelog.yml
+++ b/packages/mimecast/changelog.yml
@@ -1,8 +1,8 @@
 - version: "0.0.7"
   changes:
-    - description: Add content-disposition to test mock to creeate sample event from siem logs properly
+    - description: Add content-disposition to test mock to properly create sample event from SIEM logs.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/2690
+      link: https://github.com/elastic/integrations/pull/2739
 - version: "0.0.6"
   changes:
     - description: Add use cases for audit events and update sample events and docs

--- a/packages/mimecast/data_stream/siem_logs/sample_event.json
+++ b/packages/mimecast/data_stream/siem_logs/sample_event.json
@@ -1,12 +1,11 @@
 {
     "@timestamp": "2021-11-12T12:15:46.000Z",
     "agent": {
-        "ephemeral_id": "d60af43e-84dc-4f3b-b6c9-7616ac605053",
-        "hostname": "docker-fleet-agent",
-        "id": "1e76e2b6-7664-4905-9a0b-11e1d4dc6fa9",
+        "ephemeral_id": "c29702e9-3a8f-4e5f-8f99-398c9bf9f434",
+        "id": "15e6751a-71c9-4027-995c-58dcd862c21d",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.17.0"
+        "version": "8.0.0"
     },
     "data_stream": {
         "dataset": "mimecast.siem_logs",
@@ -17,9 +16,9 @@
         "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "1e76e2b6-7664-4905-9a0b-11e1d4dc6fa9",
+        "id": "15e6751a-71c9-4027-995c-58dcd862c21d",
         "snapshot": false,
-        "version": "7.17.0"
+        "version": "8.0.0"
     },
     "email": {
         "direction": "Internal",
@@ -35,8 +34,8 @@
         "agent_id_status": "verified",
         "created": "2021-11-12T12:15:46+0000",
         "dataset": "mimecast.siem_logs",
-        "ingested": "2022-02-22T15:34:56Z",
-        "original": "{\"Dir\":\"Internal\",\"Rcpt\":\"o365_service_account@example.com\",\"RcptActType\":\"Jnl\",\"RcptHdrType\":\"Unknown\",\"Sender\":\"johndoe@example.com\",\"aCode\":\"fjihpfEgM_iRwemxhe3t_w\",\"acc\":\"ABC123\",\"datetime\":\"2021-11-12T12:15:46+0000\"}",
+        "ingested": "2022-02-24T09:22:06Z",
+        "original": "{\"Content-Disposition\":\"attachment; filename=\\\"jrnl_20211018093329655.json\\\"\",\"Dir\":\"Internal\",\"Rcpt\":\"o365_service_account@example.com\",\"RcptActType\":\"Jnl\",\"RcptHdrType\":\"Unknown\",\"Sender\":\"johndoe@example.com\",\"aCode\":\"fjihpfEgM_iRwemxhe3t_w\",\"acc\":\"ABC123\",\"datetime\":\"2021-11-12T12:15:46+0000\"}",
         "outcome": "unknown"
     },
     "input": {
@@ -46,7 +45,7 @@
         "RcptActType": "Jnl",
         "RcptHdrType": "Unknown",
         "acc": "ABC123",
-        "log_type": ""
+        "log_type": "jrnl"
     },
     "tags": [
         "preserve_original_event",

--- a/packages/mimecast/docs/README.md
+++ b/packages/mimecast/docs/README.md
@@ -288,12 +288,11 @@ An example event for `siem` looks as following:
 {
     "@timestamp": "2021-11-12T12:15:46.000Z",
     "agent": {
-        "ephemeral_id": "d60af43e-84dc-4f3b-b6c9-7616ac605053",
-        "hostname": "docker-fleet-agent",
-        "id": "1e76e2b6-7664-4905-9a0b-11e1d4dc6fa9",
+        "ephemeral_id": "c29702e9-3a8f-4e5f-8f99-398c9bf9f434",
+        "id": "15e6751a-71c9-4027-995c-58dcd862c21d",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.17.0"
+        "version": "8.0.0"
     },
     "data_stream": {
         "dataset": "mimecast.siem_logs",
@@ -304,9 +303,9 @@ An example event for `siem` looks as following:
         "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "1e76e2b6-7664-4905-9a0b-11e1d4dc6fa9",
+        "id": "15e6751a-71c9-4027-995c-58dcd862c21d",
         "snapshot": false,
-        "version": "7.17.0"
+        "version": "8.0.0"
     },
     "email": {
         "direction": "Internal",
@@ -322,8 +321,8 @@ An example event for `siem` looks as following:
         "agent_id_status": "verified",
         "created": "2021-11-12T12:15:46+0000",
         "dataset": "mimecast.siem_logs",
-        "ingested": "2022-02-22T15:34:56Z",
-        "original": "{\"Dir\":\"Internal\",\"Rcpt\":\"o365_service_account@example.com\",\"RcptActType\":\"Jnl\",\"RcptHdrType\":\"Unknown\",\"Sender\":\"johndoe@example.com\",\"aCode\":\"fjihpfEgM_iRwemxhe3t_w\",\"acc\":\"ABC123\",\"datetime\":\"2021-11-12T12:15:46+0000\"}",
+        "ingested": "2022-02-24T09:22:06Z",
+        "original": "{\"Content-Disposition\":\"attachment; filename=\\\"jrnl_20211018093329655.json\\\"\",\"Dir\":\"Internal\",\"Rcpt\":\"o365_service_account@example.com\",\"RcptActType\":\"Jnl\",\"RcptHdrType\":\"Unknown\",\"Sender\":\"johndoe@example.com\",\"aCode\":\"fjihpfEgM_iRwemxhe3t_w\",\"acc\":\"ABC123\",\"datetime\":\"2021-11-12T12:15:46+0000\"}",
         "outcome": "unknown"
     },
     "input": {
@@ -333,7 +332,7 @@ An example event for `siem` looks as following:
         "RcptActType": "Jnl",
         "RcptHdrType": "Unknown",
         "acc": "ABC123",
-        "log_type": ""
+        "log_type": "jrnl"
     },
     "tags": [
         "preserve_original_event",

--- a/packages/mimecast/manifest.yml
+++ b/packages/mimecast/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: mimecast
 title: "Mimecast"
-version: 0.0.6
+version: 0.0.7
 license: basic
 description: "Fetching logs from Mimecast API and ingest into Elasticsearch"
 type: integration


### PR DESCRIPTION
## What does this PR do?

Add content-disposition to test mock to properly create sample event from SIEM logs.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
