### PR TITLE
sophos - Add missing `systemhealth` pipeline to xg datastream

### DIFF
--- a/packages/sophos/changelog.yml
+++ b/packages/sophos/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Add missing ingest pipeline for "System Health" logs
+      type: bug
+      link: https://github.com/elastic/integrations/pull/2743
 - version: "1.2.0"
   changes:
     - description: Update to ECS 8.0.0

--- a/packages/sophos/changelog.yml
+++ b/packages/sophos/changelog.yml
@@ -2,7 +2,7 @@
 - version: "1.2.1"
   changes:
     - description: Add missing ingest pipeline for "System Health" logs
-      type: bug
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/2743
 - version: "1.2.0"
   changes:

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/systemhealth.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/systemhealth.yml
@@ -1,0 +1,160 @@
+description: Pipeline for parsing sophos firewall logs (systemhealth pipeline)
+processors:
+#######################
+## ECS Event Mapping ##
+#######################
+- set:
+    field: event.kind
+    value: event
+- rename:
+    field: sophos.xg.idle
+    target_field: sophos.xg.idle_cpu
+    ignore_missing: true
+- gsub:
+    field: sophos.xg.idle_cpu
+    pattern: "%$"
+    replacement: ""
+    ignore_missing: true
+    ignore_failure: true
+- convert:
+    field: sophos.xg.idle_cpu
+    type: float
+    ignore_missing: true
+    on_failure:
+      - remove:
+          field: sophos.xg.idle_cpu
+- rename:
+    field: sophos.xg.system
+    target_field: sophos.xg.system_cpu
+    ignore_missing: true
+- gsub:
+    field: sophos.xg.system_cpu
+    pattern: "%$"
+    replacement: ""
+    ignore_missing: true
+    ignore_failure: true
+- convert:
+    field: sophos.xg.system_cpu
+    type: float
+    ignore_missing: true
+    on_failure:
+      - remove:
+          field: sophos.xg.system_cpu
+- rename:
+    field: sophos.xg.user
+    target_field: sophos.xg.user_cpu
+    ignore_missing: true
+- gsub:
+    field: sophos.xg.user_cpu
+    pattern: "%$"
+    replacement: ""
+    ignore_missing: true
+    ignore_failure: true
+- convert:
+    field: sophos.xg.user_cpu
+    type: float
+    ignore_missing: true
+    on_failure:
+      - remove:
+          field: sophos.xg.user_cpu
+- convert:
+    field: sophos.xg.used
+    type: integer
+    ignore_missing: true
+    on_failure:
+      - remove:
+          field: sophos.xg.used
+- convert:
+    field: sophos.xg.total_memory
+    type: integer
+    ignore_missing: true
+    on_failure:
+      - remove:
+          field: sophos.xg.total_memory
+- convert:
+    field: sophos.xg.free
+    type: integer
+    ignore_missing: true
+    on_failure:
+      - remove:
+          field: sophos.xg.free
+- gsub:
+    field: sophos.xg.Configuration
+    pattern: "%$"
+    replacement: ""
+    ignore_missing: true
+    ignore_failure: true
+- convert:
+    field: sophos.xg.Configuration
+    type: float
+    ignore_missing: true
+    on_failure:
+      - remove:
+          field:
+            - sophos.xg.Configuration
+
+- gsub:
+    field: sophos.xg.Reports
+    pattern: "%$"
+    replacement: ""
+    ignore_missing: true
+    ignore_failure: true
+- convert:
+    field: sophos.xg.Reports
+    type: float
+    ignore_missing: true
+    on_failure:
+      - remove:
+          field: sophos.xg.Reports
+- gsub:
+    field: sophos.xg.Temp
+    pattern: "%$"
+    replacement: ""
+    ignore_missing: true
+    ignore_failure: true
+- convert:
+    field: sophos.xg.Temp
+    type: float
+    ignore_missing: true
+    on_failure:
+      - remove:
+          field: sophos.xg.Temp
+- gsub:
+    field: sophos.xg.Signature
+    pattern: "%$"
+    replacement: ""
+    ignore_missing: true
+    ignore_failure: true
+- convert:
+    field: sophos.xg.Signature
+    type: float
+    ignore_missing: true
+    on_failure:
+      - remove:
+          field: sophos.xg.Signature
+- convert:
+    field: sophos.xg.users
+    type: integer
+    ignore_missing: true
+    on_failure:
+      - remove:
+          field: sophos.xg.users
+- convert:
+    field: sophos.xg.transmittedkbits
+    type: float
+    ignore_missing: true
+    on_failure:
+      - remove:
+          field: sophos.xg.transmittedkbits
+- convert:
+    field: sophos.xg.receivedkbits
+    type: float
+    ignore_missing: true
+    on_failure:
+      - remove:
+          field: sophos.xg.receivedkbits
+
+on_failure:
+- set:
+    field: error.message
+    value: '{{ _ingest.on_failure_message }}'

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/systemhealth.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/systemhealth.yml
@@ -1,3 +1,4 @@
+---
 description: Pipeline for parsing sophos firewall logs (systemhealth pipeline)
 processors:
 #######################

--- a/packages/sophos/manifest.yml
+++ b/packages/sophos/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: sophos
 title: Sophos Logs
-version: 1.2.0
+version: 1.2.1
 description: Collect and parse logs from Sophos Products with Elastic Agent.
 categories: ["security"]
 release: ga


### PR DESCRIPTION

## What does this PR do?

Copies the `systemhealth` ingest pipeline from the Beats module.

This pipeline was referenced in the main pipeline but not present in the package.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
