### PR TITLE
Pass the SSL configs

### DIFF
--- a/packages/kafka/changelog.yml
+++ b/packages/kafka/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Pass down the SSH configs
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/TBD
+      link: https://github.com/elastic/integrations/pull/2785
 - version: "1.2.0"
   changes:
     - description: Update to ECS 8.0

--- a/packages/kafka/changelog.yml
+++ b/packages/kafka/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.2.1"
+  changes:
+    - description: Pass down the SSH configs
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/TBD
 - version: "1.2.0"
   changes:
     - description: Update to ECS 8.0

--- a/packages/kafka/data_stream/broker/agent/stream/stream.yml.hbs
+++ b/packages/kafka/data_stream/broker/agent/stream/stream.yml.hbs
@@ -4,3 +4,12 @@ hosts:
 {{#each jolokia_hosts}}
   - {{this}}
 {{/each}}
+{{#if ssl.certificate}}
+ssl.certificate: {{ssl.certificate}}
+{{/if}}
+{{#if ssl.certificate_authorities}}
+ssl.certificate_authorities: {{ssl.certificate_authorities}}
+{{/if}}
+{{#if ssl.key}}
+ssl.key: {{ssl.key}}
+{{/if}}

--- a/packages/kafka/data_stream/consumergroup/agent/stream/stream.yml.hbs
+++ b/packages/kafka/data_stream/consumergroup/agent/stream/stream.yml.hbs
@@ -10,3 +10,12 @@ username: {{username}}
 {{#if password}}
 password: {{password}}
 {{/if}}
+{{#if ssl.certificate}}
+ssl.certificate: {{ssl.certificate}}
+{{/if}}
+{{#if ssl.certificate_authorities}}
+ssl.certificate_authorities: {{ssl.certificate_authorities}}
+{{/if}}
+{{#if ssl.key}}
+ssl.key: {{ssl.key}}
+{{/if}}

--- a/packages/kafka/data_stream/consumergroup/agent/stream/stream.yml.hbs
+++ b/packages/kafka/data_stream/consumergroup/agent/stream/stream.yml.hbs
@@ -19,3 +19,4 @@ ssl.certificate_authorities: {{ssl.certificate_authorities}}
 {{#if ssl.key}}
 ssl.key: {{ssl.key}}
 {{/if}}
+

--- a/packages/kafka/data_stream/consumergroup/agent/stream/stream.yml.hbs
+++ b/packages/kafka/data_stream/consumergroup/agent/stream/stream.yml.hbs
@@ -19,4 +19,3 @@ ssl.certificate_authorities: {{ssl.certificate_authorities}}
 {{#if ssl.key}}
 ssl.key: {{ssl.key}}
 {{/if}}
-

--- a/packages/kafka/data_stream/partition/agent/stream/stream.yml.hbs
+++ b/packages/kafka/data_stream/partition/agent/stream/stream.yml.hbs
@@ -10,3 +10,12 @@ username: {{username}}
 {{#if password}}
 password: {{password}}
 {{/if}}
+{{#if ssl.certificate}}
+ssl.certificate: {{ssl.certificate}}
+{{/if}}
+{{#if ssl.certificate_authorities}}
+ssl.certificate_authorities: {{ssl.certificate_authorities}}
+{{/if}}
+{{#if ssl.key}}
+ssl.key: {{ssl.key}}
+{{/if}}

--- a/packages/kafka/manifest.yml
+++ b/packages/kafka/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kafka
 title: Kafka
-version: 1.2.0
+version: 1.2.1
 license: basic
 description: Collect logs and metrics from Kafka servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
Pass the SSL configs entered in the UI down to agent config for the following metricsets: broker, consumergroup & partition.

Bumping the version to 1.2.2

Closes #2750

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
Earlier SSL configs were not passed down to the metricset. Fixed it.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots
Tested the changes using elastic-package build and run. The new agent policy with ssl entered from the UI.

      - id: kafka/metrics-kafka.partition-052a4ce9-410c-4939-b082-3d5750892edf
        data_stream:
          dataset: kafka.partition
          type: metrics
        metricsets:
          - partition
        period: 10s
        hosts:
          - 'localhost:9092'
        ssl.certificate: ssl1
        ssl.certificate_authorities: c1
        ssl.key: key1
