### PR TITLE
[cloudflare] bugfix interval

### DIFF
--- a/packages/cloudflare/changelog.yml
+++ b/packages/cloudflare/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Allow logpull interval to be less than 2 minutes.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/XXXX
+      link: https://github.com/elastic/integrations/pull/2787
 - version: "1.3.0"
   changes:
     - description: Update to ECS 8.0

--- a/packages/cloudflare/changelog.yml
+++ b/packages/cloudflare/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.3.1"
   changes:
-    - description: Allow logpull interval to be less than 2 minutes
+    - description: Allow logpull interval to be less than 2 minutes.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/XXXX
 - version: "1.3.0"

--- a/packages/cloudflare/changelog.yml
+++ b/packages/cloudflare/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.1"
+  changes:
+    - description: Allow logpull interval to be less than 2 minutes
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/XXXX
 - version: "1.3.0"
   changes:
     - description: Update to ECS 8.0

--- a/packages/cloudflare/data_stream/logpull/agent/stream/httpjson.yml.hbs
+++ b/packages/cloudflare/data_stream/logpull/agent/stream/httpjson.yml.hbs
@@ -28,11 +28,11 @@ request.transforms:
   - set:
       target: url.params.start
       value: "[[.cursor.last_execution_datetime]]"
-      default: '[[formatDate (now (parseDuration "-{{interval}}"))]]'
+      default: '[[formatDate (((now).Add (parseDuration "-1m")).Add (parseDuration "-{{interval}}"))]]'
   - set:
       target: url.params.end
       value: '[[formatDate ((parseDate .cursor.last_execution_datetime).Add (parseDuration "{{interval}}"))]]'
-      default: '[[formatDate (now (parseDuration "-1m"))]]'
+      default: '[[formatDate ((now).Add (parseDuration "-1m"))]]'
   - set:
       target: url.params.fields
       value: CacheCacheStatus,CacheResponseBytes,CacheResponseStatus,CacheTieredFill,ClientASN,ClientCountry,ClientDeviceType,ClientIP,ClientIPClass,ClientRequestBytes,ClientRequestHost,ClientRequestMethod,ClientRequestPath,ClientRequestProtocol,ClientRequestReferer,ClientRequestURI,ClientRequestUserAgent,ClientSSLCipher,ClientSSLProtocol,ClientSrcPort,ClientXRequestedWith,EdgeColoCode,EdgeColoID,EdgeEndTimestamp,EdgePathingOp,EdgePathingSrc,EdgePathingStatus,EdgeRateLimitAction,EdgeRateLimitID,EdgeRequestHost,EdgeResponseBytes,EdgeResponseCompressionRatio,EdgeResponseContentType,EdgeResponseStatus,EdgeServerIP,EdgeStartTimestamp,FirewallMatchesActions,FirewallMatchesRuleIDs,FirewallMatchesSources,OriginIP,OriginResponseBytes,OriginResponseHTTPExpires,OriginResponseHTTPLastModified,OriginResponseStatus,OriginResponseTime,OriginSSLProtocol,ParentRayID,RayID,SecurityLevel,WAFAction,WAFFlags,WAFMatchedVar,WAFProfile,WAFRuleID,WAFRuleMessage,WorkerCPUTime,WorkerStatus,WorkerSubrequest,WorkerSubrequestCount,ZoneID,Action
@@ -41,7 +41,7 @@ response.decode_as: application/x-ndjson
 
 cursor:
   last_execution_datetime:
-    value: "[[.last_request.url.params.end]]"
+    value: '[[.last_response.url.params.Get "end"]]'
 
 {{#if tags.length}}
 tags:

--- a/packages/cloudflare/data_stream/logpull/manifest.yml
+++ b/packages/cloudflare/data_stream/logpull/manifest.yml
@@ -36,8 +36,8 @@ streams:
         multi: false
         required: true
         show_user: true
-        description: Interval at which the logs will be pulled. The value must be between 2m and 1h.
-        default: 1h
+        description: Interval at which the logs will be pulled. The value must be between 1s and 1h.
+        default: 5m
       - name: tags
         type: text
         title: Tags

--- a/packages/cloudflare/manifest.yml
+++ b/packages/cloudflare/manifest.yml
@@ -1,6 +1,6 @@
 name: cloudflare
 title: Cloudflare
-version: 1.3.0
+version: 1.3.1
 release: ga
 description: Collect and parse logs from Cloudflare API with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Fix interval logic so interval can be as small as 1s instead of
2m.  This is necessary if there are large volumes of data.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

``` bash
cd packages/cloudflare
elasstic-package clean && elastic-package check
elastic-package stack up -d
eval "$(elastic-package stack shellinit)"
elastic-package test
```

## Related issues

- Closes #2705