### PR TITLE
[cef] Append pipeline errors to error.message

### DIFF
--- a/packages/cef/changelog.yml
+++ b/packages/cef/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.1"
+  changes:
+    - description: Append pipeline errors to error.message instead of overwriting existing errors.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/2789
 - version: "1.4.0"
   changes:
     - description: Update to ECS 8.0

--- a/packages/cef/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cef/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -145,6 +145,6 @@ on_failure:
       field:
         - _tmp
       ignore_failure: true
-  - set:
+  - append:
       field: error.message
       value: "{{ _ingest.on_failure_message }}"

--- a/packages/cef/manifest.yml
+++ b/packages/cef/manifest.yml
@@ -1,6 +1,6 @@
 name: cef
 title: CEF Logs
-version: 1.4.0
+version: 1.4.1
 release: ga
 description: Collect logs from CEF Logs with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

If the decode_cef Beat processor has errors then those errors are
lost if there is a pipeline error.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related

- Relates: https://github.com/elastic/integrations/issues/2676
