### PR TITLE
okta: increase API response limit

### DIFF
--- a/packages/okta/changelog.yml
+++ b/packages/okta/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Increase the limit for the number of results in an API response.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/2791
 - version: "1.4.1"
   changes:
     - description: Add missing field mapping for event.created.

--- a/packages/okta/data_stream/system/agent/stream/httpjson.yml.hbs
+++ b/packages/okta/data_stream/system/agent/stream/httpjson.yml.hbs
@@ -24,6 +24,9 @@ request.transforms:
       target: header.Authorization
       value: "SSWS {{api_key}}"
   - set:
+      target: url.params.limit
+      value: '1000'
+  - set:
       target: url.params.since
       value: "[[.cursor.published]]"
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}")) "RFC3339"]]'

--- a/packages/okta/manifest.yml
+++ b/packages/okta/manifest.yml
@@ -1,6 +1,6 @@
 name: okta
 title: Okta Logs
-version: 1.4.1
+version: 1.5.0
 release: ga
 description: Collect and parse event logs from Okta API with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This increases the limit for the number of results returned in an API response from okta. This allows more responses to be obtained within the API rate limits.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Should this be made a user facing option defaulting to 1000?

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #2776.

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
