### PR TITLE
Pass the SSL configs entered in the UI down to agent config

### DIFF
--- a/packages/kafka/changelog.yml
+++ b/packages/kafka/changelog.yml
@@ -1,3 +1,9 @@
+# newer versions go on top
+- version: "1.2.2"
+  changes:
+    - description: Pass down the SSL configs.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/TBD
 - version: "1.2.1"
   changes:
     - description: Add missing event.* fields into ecs.yml
@@ -8,7 +14,6 @@
     - description: Update to ECS 8.0
       type: enhancement
       link: https://github.com/elastic/integrations/pull/2490
-# newer versions go on top
 - version: "1.1.0"
   changes:
     - description: Support Kibana 8.0

--- a/packages/kafka/changelog.yml
+++ b/packages/kafka/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Pass down the SSL configs.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/TBD
+      link: https://github.com/elastic/integrations/pull/2792
 - version: "1.2.1"
   changes:
     - description: Add missing event.* fields into ecs.yml

--- a/packages/kafka/data_stream/broker/agent/stream/stream.yml.hbs
+++ b/packages/kafka/data_stream/broker/agent/stream/stream.yml.hbs
@@ -4,3 +4,12 @@ hosts:
 {{#each jolokia_hosts}}
   - {{this}}
 {{/each}}
+{{#if ssl.certificate}}
+ssl.certificate: {{ssl.certificate}}
+{{/if}}
+{{#if ssl.certificate_authorities}}
+ssl.certificate_authorities: {{ssl.certificate_authorities}}
+{{/if}}
+{{#if ssl.key}}
+ssl.key: {{ssl.key}}
+{{/if}}

--- a/packages/kafka/data_stream/consumergroup/agent/stream/stream.yml.hbs
+++ b/packages/kafka/data_stream/consumergroup/agent/stream/stream.yml.hbs
@@ -10,3 +10,12 @@ username: {{username}}
 {{#if password}}
 password: {{password}}
 {{/if}}
+{{#if ssl.certificate}}
+ssl.certificate: {{ssl.certificate}}
+{{/if}}
+{{#if ssl.certificate_authorities}}
+ssl.certificate_authorities: {{ssl.certificate_authorities}}
+{{/if}}
+{{#if ssl.key}}
+ssl.key: {{ssl.key}}
+{{/if}}

--- a/packages/kafka/data_stream/partition/agent/stream/stream.yml.hbs
+++ b/packages/kafka/data_stream/partition/agent/stream/stream.yml.hbs
@@ -10,3 +10,12 @@ username: {{username}}
 {{#if password}}
 password: {{password}}
 {{/if}}
+{{#if ssl.certificate}}
+ssl.certificate: {{ssl.certificate}}
+{{/if}}
+{{#if ssl.certificate_authorities}}
+ssl.certificate_authorities: {{ssl.certificate_authorities}}
+{{/if}}
+{{#if ssl.key}}
+ssl.key: {{ssl.key}}
+{{/if}}

--- a/packages/kafka/manifest.yml
+++ b/packages/kafka/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kafka
 title: Kafka
-version: 1.2.1
+version: 1.2.2
 license: basic
 description: Collect logs and metrics from Kafka servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
Pass the SSL configs entered in the UI down to agent config for the following metricsets: broker, consumergroup & partition.

Bumping the version to 1.2.2

Closes #2750
Redo of PR #2785, which will be closed.

## What does this PR do?

Earlier SSL configs were not passed down to the metricset. Fixed it.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots
   Tested the changes using elastic-package build and run. The new agent policy with ssl entered from the UI.
   - id: kafka/metrics-kafka.partition-4fec773e-840d-470c-ae45-3bbcd1aff871
        data_stream:
          dataset: kafka.partition
          type: metrics
        metricsets:
          - partition
        period: 10s
        hosts:
          - 'localhost:9092'
        ssl.certificate: cert1
        ssl.certificate_authorities: auth1
        ssl.key: key1

