### PR TITLE
[google_workspace] Remove redundant event.ingested

### DIFF
--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.1"
+  changes:
+    - description: Remove redundant `event.ingested` from pipelines.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/2797
 - version: "1.3.0"
   changes:
     - description: Update to ECS 8.0

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-application.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-application.log-expected.json
@@ -12,7 +12,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:15.030641274Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"APPLICATION_SETTINGS\",\"name\":\"CHANGE_APPLICATION_SETTING\",\"parameters\":[{\"name\":\"APPLICATION_EDITION\",\"value\":\"basic\"},{\"name\":\"APPLICATION_NAME\",\"value\":\"drive\"},{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -110,7 +109,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:15.030643787Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"APPLICATION_SETTINGS\",\"name\":\"CREATE_APPLICATION_SETTING\",\"parameters\":[{\"name\":\"APPLICATION_EDITION\",\"value\":\"basic\"},{\"name\":\"APPLICATION_NAME\",\"value\":\"drive\"},{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -209,7 +207,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:15.030644675Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"APPLICATION_SETTINGS\",\"name\":\"DELETE_APPLICATION_SETTING\",\"parameters\":[{\"name\":\"APPLICATION_EDITION\",\"value\":\"basic\"},{\"name\":\"APPLICATION_NAME\",\"value\":\"drive\"},{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -306,7 +303,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:15.030645470Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"APPLICATION_SETTINGS\",\"name\":\"REORDER_GROUP_BASED_POLICIES_EVENT\",\"parameters\":[{\"name\":\"APPLICATION_NAME\",\"value\":\"drive\"},{\"name\":\"GROUP_PRIORITIES\",\"multiValue\":[\"a\",\"b\"]},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -393,7 +389,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:15.030646282Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"APPLICATION_SETTINGS\",\"name\":\"GPLUS_PREMIUM_FEATURES\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -470,7 +465,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:15.030647076Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"APPLICATION_SETTINGS\",\"name\":\"CREATE_MANAGED_CONFIGURATION\",\"parameters\":[{\"name\":\"MANAGED_CONFIGURATION_NAME\",\"value\":\"a\"},{\"name\":\"MOBILE_APP_PACKAGE_ID\",\"value\":\"1234\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -547,7 +541,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:15.030647854Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"APPLICATION_SETTINGS\",\"name\":\"DELETE_MANAGED_CONFIGURATION\",\"parameters\":[{\"name\":\"MANAGED_CONFIGURATION_NAME\",\"value\":\"a\"},{\"name\":\"MOBILE_APP_PACKAGE_ID\",\"value\":\"1234\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -625,7 +618,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:15.030648631Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"APPLICATION_SETTINGS\",\"name\":\"UPDATE_MANAGED_CONFIGURATION\",\"parameters\":[{\"name\":\"MANAGED_CONFIGURATION_NAME\",\"value\":\"a\"},{\"name\":\"MOBILE_APP_PACKAGE_ID\",\"value\":\"1234\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -703,7 +695,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:15.030649420Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"APPLICATION_SETTINGS\",\"name\":\"FLASHLIGHT_EDU_NON_FEATURED_SERVICES_SELECTED\",\"parameters\":[{\"name\":\"FLASHLIGHT_EDU_NON_FEATURED_SERVICES_SELECTION\",\"value\":\"FLASHLIGHT_EDU_SELECTION_MANUAL\"}]}}",
                 "provider": "admin",
                 "type": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-calendar.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-calendar.log-expected.json
@@ -11,7 +11,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:19.120608131Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CALENDAR_SETTINGS\",\"name\":\"CREATE_BUILDING\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -88,7 +87,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:19.120610561Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CALENDAR_SETTINGS\",\"name\":\"DELETE_BUILDING\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -165,7 +163,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:19.120611599Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CALENDAR_SETTINGS\",\"name\":\"UPDATE_BUILDING\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"FIELD_NAME\",\"value\":\"field\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"RESOURCE_IDENTIFIER\",\"value\":\"1234\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -247,7 +244,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:19.120612491Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CALENDAR_SETTINGS\",\"name\":\"CREATE_CALENDAR_RESOURCE\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -324,7 +320,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:19.120613356Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CALENDAR_SETTINGS\",\"name\":\"DELETE_CALENDAR_RESOURCE\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -401,7 +396,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:19.120614188Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CALENDAR_SETTINGS\",\"name\":\"CREATE_CALENDAR_RESOURCE_FEATURE\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -478,7 +472,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:19.120615009Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CALENDAR_SETTINGS\",\"name\":\"DELETE_CALENDAR_RESOURCE_FEATURE\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -556,7 +549,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:19.120615844Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CALENDAR_SETTINGS\",\"name\":\"UPDATE_CALENDAR_RESOURCE_FEATURE\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"FIELD_NAME\",\"value\":\"field\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"RESOURCE_IDENTIFIER\",\"value\":\"1234\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -638,7 +630,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:19.120616669Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CALENDAR_SETTINGS\",\"name\":\"RENAME_CALENDAR_RESOURCE\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -716,7 +707,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:19.120617489Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CALENDAR_SETTINGS\",\"name\":\"UPDATE_CALENDAR_RESOURCE\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"FIELD_NAME\",\"value\":\"field\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"RESOURCE_IDENTIFIER\",\"value\":\"1234\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -799,7 +789,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:19.120618315Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CALENDAR_SETTINGS\",\"name\":\"CHANGE_CALENDAR_SETTING\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -896,7 +885,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:19.120619296Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CALENDAR_SETTINGS\",\"name\":\"CANCEL_CALENDAR_EVENTS\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -978,7 +966,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:19.120620124Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CALENDAR_SETTINGS\",\"name\":\"RELEASE_CALENDAR_RESOURCES\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-chat.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-chat.log-expected.json
@@ -11,7 +11,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:24.556364765Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CHAT_SETTINGS\",\"name\":\"MEET_INTEROP_CREATE_GATEWAY\",\"parameters\":[{\"name\":\"GATEWAY_NAME\",\"value\":\"gateway\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -87,7 +86,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:24.556367685Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CHAT_SETTINGS\",\"name\":\"MEET_INTEROP_DELETE_GATEWAY\",\"parameters\":[{\"name\":\"GATEWAY_NAME\",\"value\":\"gateway\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -164,7 +162,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:24.556368659Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CHAT_SETTINGS\",\"name\":\"MEET_INTEROP_MODIFY_GATEWAY\",\"parameters\":[{\"name\":\"GATEWAY_NAME\",\"value\":\"gateway\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -241,7 +238,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:24.556369501Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CHAT_SETTINGS\",\"name\":\"CHANGE_CHAT_SETTING\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"}]}}",
                 "provider": "admin",
                 "type": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-chromeos.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-chromeos.log-expected.json
@@ -12,7 +12,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:26.255279077Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CHROME_OS_SETTINGS\",\"name\":\"CHANGE_CHROME_OS_ANDROID_APPLICATION_SETTING\",\"parameters\":[{\"name\":\"APP_ID\",\"value\":\"2345\"},{\"name\":\"CHROME_OS_SESSION_TYPE\",\"value\":\"type\"},{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -112,7 +111,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:26.255282190Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CHROME_OS_SETTINGS\",\"name\":\"CHANGE_DEVICE_STATE\",\"parameters\":[{\"name\":\"DEVICE_NEW_STATE\",\"value\":\"new\"},{\"name\":\"DEVICE_PREVIOUS_STATE\",\"value\":\"prev\"},{\"name\":\"DEVICE_SERIAL_NUMBER\",\"value\":\"1234\"},{\"name\":\"DEVICE_TYPE\",\"value\":\"type\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -192,7 +190,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:26.255283249Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CHROME_OS_SETTINGS\",\"name\":\"CHANGE_CHROME_OS_APPLICATION_SETTING\",\"parameters\":[{\"name\":\"APP_ID\",\"value\":\"2345\"},{\"name\":\"CHROME_OS_SESSION_TYPE\",\"value\":\"type\"},{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -292,7 +289,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:26.255284081Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CHROME_OS_SETTINGS\",\"name\":\"SEND_CHROME_OS_DEVICE_COMMAND\",\"parameters\":[{\"name\":\"DEVICE_SERIAL_NUMBER\",\"value\":\"2345\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -369,7 +365,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:26.255284932Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CHROME_OS_SETTINGS\",\"name\":\"CHANGE_CHROME_OS_DEVICE_ANNOTATION\",\"parameters\":[{\"name\":\"DEVICE_SERIAL_NUMBER\",\"value\":\"2345\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -446,7 +441,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:26.255285772Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CHROME_OS_SETTINGS\",\"name\":\"CHANGE_CHROME_OS_DEVICE_SETTING\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -527,7 +521,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:26.255286615Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CHROME_OS_SETTINGS\",\"name\":\"CHANGE_CHROME_OS_DEVICE_STATE\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"DEVICE_SERIAL_NUMBER\",\"value\":\"1234\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -609,7 +602,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:26.255287440Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CHROME_OS_SETTINGS\",\"name\":\"CHANGE_CHROME_OS_PUBLIC_SESSION_SETTING\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -690,7 +682,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:26.255288262Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CHROME_OS_SETTINGS\",\"name\":\"INSERT_CHROME_OS_PRINT_SERVER\",\"parameters\":[{\"name\":\"PRINT_SERVER_NAME\",\"value\":\"server\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -766,7 +757,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:26.255289074Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CHROME_OS_SETTINGS\",\"name\":\"DELETE_CHROME_OS_PRINT_SERVER\",\"parameters\":[{\"name\":\"PRINT_SERVER_NAME\",\"value\":\"server\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -842,7 +832,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:26.255289885Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CHROME_OS_SETTINGS\",\"name\":\"UPDATE_CHROME_OS_PRINT_SERVER\",\"parameters\":[{\"name\":\"PRINT_SERVER_NAME\",\"value\":\"server\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -920,7 +909,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:26.255290912Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CHROME_OS_SETTINGS\",\"name\":\"INSERT_CHROME_OS_PRINTER\",\"parameters\":[{\"name\":\"PRINTER_NAME\",\"value\":\"printer\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -996,7 +984,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:26.255291730Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CHROME_OS_SETTINGS\",\"name\":\"DELETE_CHROME_OS_PRINTER\",\"parameters\":[{\"name\":\"PRINTER_NAME\",\"value\":\"printer\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1072,7 +1059,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:26.255292553Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CHROME_OS_SETTINGS\",\"name\":\"UPDATE_CHROME_OS_PRINTER\",\"parameters\":[{\"name\":\"PRINTER_NAME\",\"value\":\"printer\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1151,7 +1137,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:26.255293366Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CHROME_OS_SETTINGS\",\"name\":\"CHANGE_CHROME_OS_SETTING\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1233,7 +1218,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:26.255294189Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CHROME_OS_SETTINGS\",\"name\":\"CHANGE_CHROME_OS_USER_SETTING\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1314,7 +1298,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:26.255295099Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CHROME_OS_SETTINGS\",\"name\":\"ISSUE_DEVICE_COMMAND\",\"parameters\":[{\"name\":\"DEVICE_COMMAND_DETAILS\",\"multiValue\":[\"command\",\"-a\"]},{\"name\":\"DEVICE_SERIAL_NUMBER\",\"value\":\"1234\"},{\"name\":\"DEVICE_TYPE\",\"value\":\"type\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1395,7 +1378,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:26.255295907Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CHROME_OS_SETTINGS\",\"name\":\"MOVE_DEVICE_TO_ORG_UNIT_DETAILED\",\"parameters\":[{\"name\":\"DEVICE_NEW_ORG_UNIT\",\"value\":\"new\"},{\"name\":\"DEVICE_PREVIOUS_ORG_UNIT\",\"value\":\"prev\"},{\"name\":\"DEVICE_SERIAL_NUMBER\",\"value\":\"1234\"},{\"name\":\"DEVICE_TYPE\",\"value\":\"type\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1474,7 +1456,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:26.255296721Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CHROME_OS_SETTINGS\",\"name\":\"REMOVE_CHROME_OS_APPLICATION_SETTINGS\",\"parameters\":[{\"name\":\"APP_ID\",\"value\":\"1234\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1550,7 +1531,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:26.255297566Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CHROME_OS_SETTINGS\",\"name\":\"UPDATE_DEVICE\",\"parameters\":[{\"name\":\"DEVICE_SERIAL_NUMBER\",\"value\":\"1234\"},{\"name\":\"DEVICE_TYPE\",\"value\":\"type\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1628,7 +1608,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:26.255298380Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CONTACTS_SETTINGS\",\"name\":\"CHANGE_CONTACTS_SETTING\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"}]}}",
                 "provider": "admin",
                 "type": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-contacts.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-contacts.log-expected.json
@@ -12,7 +12,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:35.145892731Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"CONTACTS_SETTINGS\",\"name\":\"CHANGE_CONTACTS_SETTING\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"}]}}",
                 "provider": "admin",
                 "type": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-delegatedadmin.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-delegatedadmin.log-expected.json
@@ -11,7 +11,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:35.402346750Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DELEGATED_ADMIN_SETTINGS\",\"name\":\"ASSIGN_ROLE\",\"parameters\":[{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"ROLE_NAME\",\"value\":\"_DIRECTORY_SYNC_ADMIN_ROLE\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -99,7 +98,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:35.402349177Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DELEGATED_ADMIN_SETTINGS\",\"name\":\"CREATE_ROLE\",\"parameters\":[{\"name\":\"ROLE_ID\",\"value\":\"1234\"},{\"name\":\"ROLE_NAME\",\"value\":\"_DIRECTORY_SYNC_ADMIN_ROLE\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -176,7 +174,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:35.402350123Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DELEGATED_ADMIN_SETTINGS\",\"name\":\"DELETE_ROLE\",\"parameters\":[{\"name\":\"ROLE_ID\",\"value\":\"1234\"},{\"name\":\"ROLE_NAME\",\"value\":\"_DIRECTORY_SYNC_ADMIN_ROLE\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -253,7 +250,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:35.402350970Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DELEGATED_ADMIN_SETTINGS\",\"name\":\"ADD_PRIVILEGE\",\"parameters\":[{\"name\":\"PRIVILEGE_NAME\",\"value\":\"privilege\"},{\"name\":\"ROLE_ID\",\"value\":\"1234\"},{\"name\":\"ROLE_NAME\",\"value\":\"_DIRECTORY_SYNC_ADMIN_ROLE\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -333,7 +329,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:35.402351798Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DELEGATED_ADMIN_SETTINGS\",\"name\":\"REMOVE_PRIVILEGE\",\"parameters\":[{\"name\":\"PRIVILEGE_NAME\",\"value\":\"privilege\"},{\"name\":\"ROLE_ID\",\"value\":\"1234\"},{\"name\":\"ROLE_NAME\",\"value\":\"_DIRECTORY_SYNC_ADMIN_ROLE\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -413,7 +408,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:35.402352615Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DELEGATED_ADMIN_SETTINGS\",\"name\":\"RENAME_ROLE\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"ROLE_NAME\",\"value\":\"_DIRECTORY_SYNC_ADMIN_ROLE\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -490,7 +484,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:35.402353427Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DELEGATED_ADMIN_SETTINGS\",\"name\":\"UPDATE_ROLE\",\"parameters\":[{\"name\":\"ROLE_ID\",\"value\":\"1234\"},{\"name\":\"ROLE_NAME\",\"value\":\"_DIRECTORY_SYNC_ADMIN_ROLE\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -567,7 +560,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:35.402354241Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DELEGATED_ADMIN_SETTINGS\",\"name\":\"UNASSIGN_ROLE\",\"parameters\":[{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"ROLE_NAME\",\"value\":\"_DIRECTORY_SYNC_ADMIN_ROLE\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-docs.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-docs.log-expected.json
@@ -11,7 +11,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:38.806802139Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOCS_SETTINGS\",\"name\":\"TRANSFER_DOCUMENT_OWNERSHIP\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -99,7 +98,6 @@
                 "duration": 10800000000000,
                 "end": "2002-10-02T15:00:00.000Z",
                 "id": "1",
-                "ingested": "2022-02-03T12:20:38.806804700Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOCS_SETTINGS\",\"name\":\"DRIVE_DATA_RESTORE\",\"parameters\":[{\"name\":\"BEGIN_DATE_TIME\",\"value\":\"2002-10-02T12:00:00Z\"},{\"name\":\"END_DATE_TIME\",\"value\":\"2002-10-02T15:00:00Z\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "start": "2002-10-02T12:00:00.000Z",
@@ -183,7 +181,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:38.806805662Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOCS_SETTINGS\",\"name\":\"CHANGE_DOCS_SETTING\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"}]}}",
                 "provider": "admin",
                 "type": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-domain.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-domain.log-expected.json
@@ -11,7 +11,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299813808Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_ACCOUNT_AUTO_RENEWAL\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"NON_AUTO_RENEWAL\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -88,7 +87,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299816509Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"ADD_APPLICATION\",\"parameters\":[{\"name\":\"APP_ID\",\"value\":\"id\"},{\"name\":\"APPLICATION_ENABLED\",\"value\":\"app enabled\"},{\"name\":\"APPLICATION_NAME\",\"value\":\"app name\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -166,7 +164,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299817497Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"ADD_APPLICATION_TO_WHITELIST\",\"parameters\":[{\"name\":\"APP_ID\",\"value\":\"id\"},{\"name\":\"APPLICATION_NAME\",\"value\":\"app name\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -243,7 +240,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299818382Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_ADVERTISEMENT_OPTION\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -321,7 +317,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299819199Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CREATE_ALERT\",\"parameters\":[{\"name\":\"ALERT_NAME\",\"value\":\"alert name\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -397,7 +392,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299820021Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_ALERT_CRITERIA\",\"parameters\":[{\"name\":\"ALERT_NAME\",\"value\":\"alert name\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -473,7 +467,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299820839Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"DELETE_ALERT\",\"parameters\":[{\"name\":\"ALERT_NAME\",\"value\":\"alert name\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -549,7 +542,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299821659Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"ALERT_RECEIVERS_CHANGED\",\"parameters\":[{\"name\":\"ALERT_NAME\",\"value\":\"alert name\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -627,7 +619,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299822497Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"RENAME_ALERT\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -702,7 +693,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299823439Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"ALERT_STATUS_CHANGED\",\"parameters\":[{\"name\":\"ALERT_NAME\",\"value\":\"alert name\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -780,7 +770,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299824250Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"ADD_DOMAIN_ALIAS\",\"parameters\":[{\"name\":\"DOMAIN_ALIAS\",\"value\":\"alias\"},{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -857,7 +846,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299825244Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"REMOVE_DOMAIN_ALIAS\",\"parameters\":[{\"name\":\"DOMAIN_ALIAS\",\"value\":\"alias\"},{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -934,7 +922,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299826066Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"SKIP_DOMAIN_ALIAS_MX\",\"parameters\":[{\"name\":\"DOMAIN_ALIAS\",\"value\":\"alias\"},{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1011,7 +998,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299826893Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"VERIFY_DOMAIN_ALIAS_MX\",\"parameters\":[{\"name\":\"DOMAIN_ALIAS\",\"value\":\"alias\"},{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1088,7 +1074,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299827711Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"VERIFY_DOMAIN_ALIAS\",\"parameters\":[{\"name\":\"DOMAIN_ALIAS\",\"value\":\"alias\"},{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"DOMAIN_VERIFICATION_METHOD\",\"value\":\"ANALYTICS\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1167,7 +1152,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299828536Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"TOGGLE_OAUTH_ACCESS_TO_ALL_APIS\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"false\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1245,7 +1229,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299829450Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"TOGGLE_ALLOW_ADMIN_PASSWORD_RESET\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"false\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1323,7 +1306,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299830270Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"ENABLE_API_ACCESS\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"false\"},{\"name\":\"OLD_VALUE\",\"value\":\"true\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1401,7 +1383,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299831091Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"AUTHORIZE_API_CLIENT_ACCESS\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"API_CLIENT_NAME\",\"value\":\"api client\"},{\"name\":\"API_SCOPES\",\"multiValue\":[\"a\",\"b\"]}]}}",
                 "provider": "admin",
                 "type": [
@@ -1486,7 +1467,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299831908Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"REMOVE_API_CLIENT_ACCESS\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"API_CLIENT_NAME\",\"value\":\"api client\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1567,7 +1547,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299832724Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHROME_LICENSES_REDEEMED\",\"parameters\":[{\"name\":\"APP_LICENSES_ORDER_NUMBER\",\"value\":\"abcd123\"},{\"name\":\"APPLICATION_NAME\",\"value\":\"app name\"},{\"name\":\"CHROME_NUM_LICENSES_PURCHASED\",\"intValue\":1}]}}",
                 "provider": "admin",
                 "type": [
@@ -1645,7 +1624,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299833553Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"TOGGLE_AUTO_ADD_NEW_SERVICE\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"false\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1722,7 +1700,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299834380Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_PRIMARY_DOMAIN\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"false\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1800,7 +1777,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299835297Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_WHITELIST_SETTING\",\"parameters\":[{\"name\":\"SETTING_NAME\",\"value\":\"setting\"},{\"name\":\"NEW_VALUE\",\"value\":\"false\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1879,7 +1855,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299840394Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"COMMUNICATION_PREFERENCES_SETTING_CHANGE\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"},{\"name\":\"NEW_VALUE\",\"value\":\"false\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1960,7 +1935,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299841301Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_CONFLICT_ACCOUNT_ACTION\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"false\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2039,7 +2013,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299842171Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"ENABLE_FEEDBACK_SOLICITATION\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"false\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2118,7 +2091,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299843030Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"TOGGLE_CONTACT_SHARING\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"false\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2195,7 +2167,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299843888Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CREATE_PLAY_FOR_WORK_TOKEN\",\"parameters\":[{\"name\":\"PLAY_FOR_WORK_TOKEN_ID\",\"value\":\"token\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2272,7 +2243,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299844748Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"TOGGLE_USE_CUSTOM_LOGO\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"false\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2349,7 +2319,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299845622Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_CUSTOM_LOGO\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2425,7 +2394,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299846482Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_DATA_LOCALIZATION_FOR_RUSSIA\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2504,7 +2472,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299847339Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_DATA_LOCALIZATION_SETTING\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2582,7 +2549,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299848201Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_DATA_PROTECTION_OFFICER_CONTACT_INFO\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"INFO_TYPE\",\"value\":\"ADDRESS\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2658,7 +2624,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299854603Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"DELETE_PLAY_FOR_WORK_TOKEN\",\"parameters\":[{\"name\":\"PLAY_FOR_WORK_TOKEN_ID\",\"value\":\"token\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2734,7 +2699,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299855502Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"VIEW_DNS_LOGIN_DETAILS\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2810,7 +2774,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299856380Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_DOMAIN_DEFAULT_LOCALE\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2888,7 +2851,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299857259Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_DOMAIN_DEFAULT_TIMEZONE\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2966,7 +2928,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299858149Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_DOMAIN_NAME\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -3043,7 +3004,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299859008Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"TOGGLE_ENABLE_PRE_RELEASE_FEATURES\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -3120,7 +3080,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299859926Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_DOMAIN_SUPPORT_MESSAGE\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -3198,7 +3157,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299860790Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"ADD_TRUSTED_DOMAINS\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -3274,7 +3232,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299861659Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"REMOVE_TRUSTED_DOMAINS\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -3350,7 +3307,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299862519Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_EDU_TYPE\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -3429,7 +3385,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299863379Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"TOGGLE_ENABLE_OAUTH_CONSUMER_KEY\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -3507,7 +3462,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299864259Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"TOGGLE_SSO_ENABLED\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -3585,7 +3539,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299865135Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"TOGGLE_SSL\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -3662,7 +3615,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299865996Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_EU_REPRESENTATIVE_CONTACT_INFO\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"INFO_TYPE\",\"value\":\"ADDRESS\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -3738,7 +3690,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299866856Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"GENERATE_TRANSFER_TOKEN\"}}",
                 "provider": "admin",
                 "type": [
@@ -3809,7 +3760,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299867717Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_LOGIN_BACKGROUND_COLOR\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -3887,7 +3837,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299868673Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_LOGIN_BORDER_COLOR\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -3965,7 +3914,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299869533Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_LOGIN_ACTIVITY_TRACE\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4043,7 +3991,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299870410Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"PLAY_FOR_WORK_ENROLL\",\"parameters\":[{\"name\":\"PLAY_FOR_WORK_MDM_VENDOR_NAME\",\"value\":\"vendor\"},{\"name\":\"PLAY_FOR_WORK_TOKEN_ID\",\"value\":\"token\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4120,7 +4067,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299871275Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"PLAY_FOR_WORK_UNENROLL\",\"parameters\":[{\"name\":\"PLAY_FOR_WORK_MDM_VENDOR_NAME\",\"value\":\"vendor\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4196,7 +4142,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299872139Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"MX_RECORD_VERIFICATION_CLAIM\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4282,7 +4227,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299873007Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"TOGGLE_NEW_APP_FEATURES\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4360,7 +4304,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299873893Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"TOGGLE_USE_NEXT_GEN_CONTROL_PANEL\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4437,7 +4380,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299874759Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"UPLOAD_OAUTH_CERTIFICATE\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4513,7 +4455,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299875629Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"REGENERATE_OAUTH_CONSUMER_SECRET\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4590,7 +4531,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299876493Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"TOGGLE_OPEN_ID_ENABLED\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4667,7 +4607,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299877353Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_ORGANIZATION_NAME\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4746,7 +4685,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299878218Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"TOGGLE_OUTBOUND_RELAY\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4827,7 +4765,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299879080Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_PASSWORD_MAX_LENGTH\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4905,7 +4842,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299879943Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_PASSWORD_MIN_LENGTH\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4983,7 +4919,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299880807Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"UPDATE_DOMAIN_PRIMARY_ADMIN_EMAIL\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -5062,7 +4997,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299881686Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"ENABLE_SERVICE_OR_FEATURE_NOTIFICATIONS\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -5140,7 +5074,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299882559Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"REMOVE_APPLICATION\",\"parameters\":[{\"name\":\"APP_ID\",\"value\":\"appid\"},{\"name\":\"APPLICATION_NAME\",\"value\":\"app name\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -5217,7 +5150,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299883423Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"REMOVE_APPLICATION_FROM_WHITELIST\",\"parameters\":[{\"name\":\"APP_ID\",\"value\":\"appid\"},{\"name\":\"APPLICATION_NAME\",\"value\":\"app name\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -5294,7 +5226,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299884283Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_RENEW_DOMAIN_REGISTRATION\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -5372,7 +5303,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299885147Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_RESELLER_ACCESS\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -5447,7 +5377,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299886011Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"RULE_ACTIONS_CHANGED\",\"parameters\":[{\"name\":\"RULE_NAME\",\"value\":\"rule\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -5523,7 +5452,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299886872Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CREATE_RULE\",\"parameters\":[{\"name\":\"RULE_NAME\",\"value\":\"rule\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -5599,7 +5527,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299887747Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_RULE_CRITERIA\",\"parameters\":[{\"name\":\"RULE_NAME\",\"value\":\"rule\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -5675,7 +5602,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299888610Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"DELETE_RULE\",\"parameters\":[{\"name\":\"RULE_NAME\",\"value\":\"rule\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -5751,7 +5677,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299889580Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"RENAME_RULE\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -5826,7 +5751,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299890467Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"RULE_STATUS_CHANGED\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"RULE_NAME\",\"value\":\"rule\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -5904,7 +5828,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299891328Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"ADD_SECONDARY_DOMAIN\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"SECONDARY_DOMAIN_NAME\",\"value\":\"example2.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -5981,7 +5904,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299892188Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"REMOVE_SECONDARY_DOMAIN\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"SECONDARY_DOMAIN_NAME\",\"value\":\"example2.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -6058,7 +5980,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299893054Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"SKIP_SECONDARY_DOMAIN_MX\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"SECONDARY_DOMAIN_NAME\",\"value\":\"example2.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -6135,7 +6056,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299893925Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"VERIFY_SECONDARY_DOMAIN_MX\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"SECONDARY_DOMAIN_NAME\",\"value\":\"example2.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -6212,7 +6132,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299894807Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"VERIFY_SECONDARY_DOMAIN\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"SECONDARY_DOMAIN_NAME\",\"value\":\"example2.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -6289,7 +6208,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299895674Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"UPDATE_DOMAIN_SECONDARY_EMAIL\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -6368,7 +6286,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299896539Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"CHANGE_SSO_SETTINGS\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -6444,7 +6361,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299897408Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"GENERATE_PIN\"}}",
                 "provider": "admin",
                 "type": [
@@ -6515,7 +6431,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:20:40.299898274Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"DOMAIN_SETTINGS\",\"name\":\"UPDATE_RULE\",\"parameters\":[{\"name\":\"RULE_NAME\",\"value\":\"rule\"}]}}",
                 "provider": "admin",
                 "type": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-gmail.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-gmail.log-expected.json
@@ -11,7 +11,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:13.109564608Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"EMAIL_SETTINGS\",\"name\":\"DROP_FROM_QUARANTINE\",\"parameters\":[{\"name\":\"EMAIL_LOG_SEARCH_MSG_ID\",\"value\":\"id\"},{\"name\":\"QUARANTINE_NAME\",\"value\":\"quarantine\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -90,7 +89,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:13.109567280Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"EMAIL_SETTINGS\",\"name\":\"EMAIL_LOG_SEARCH\",\"parameters\":[{\"name\":\"EMAIL_LOG_SEARCH_END_DATE\",\"value\":\"2020/07/28 04:59:59 UTC\"},{\"name\":\"EMAIL_LOG_SEARCH_MSG_ID\",\"value\":\"id\"},{\"name\":\"EMAIL_LOG_SEARCH_RECIPIENT\",\"value\":\"recipient\"},{\"name\":\"EMAIL_LOG_SEARCH_SENDER\",\"value\":\"sender\"},{\"name\":\"EMAIL_LOG_SEARCH_SMTP_RECIPIENT_IP\",\"value\":\"1.128.3.4\"},{\"name\":\"EMAIL_LOG_SEARCH_SMTP_SENDER_IP\",\"value\":\"1.128.3.4\"},{\"name\":\"EMAIL_LOG_SEARCH_START_DATE\",\"value\":\"2002-10-02T10:00:00Z\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -180,7 +178,6 @@
                 "duration": 7200000000000,
                 "end": "2002-10-02T12:00:00.000Z",
                 "id": "1",
-                "ingested": "2022-02-03T12:21:13.109568257Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"EMAIL_SETTINGS\",\"name\":\"EMAIL_UNDELETE\",\"parameters\":[{\"name\":\"END_DATE\",\"value\":\"2002-10-02T12:00:00Z\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"START_DATE\",\"value\":\"2002-10-02T10:00:00Z\"}]}}",
                 "provider": "admin",
                 "start": "2002-10-02T10:00:00.000Z",
@@ -264,7 +261,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:13.109569115Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"EMAIL_SETTINGS\",\"name\":\"CHANGE_EMAIL_SETTING\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -362,7 +358,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:13.109569960Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"EMAIL_SETTINGS\",\"name\":\"CHANGE_GMAIL_SETTING\",\"parameters\":[{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SETTING_DESCRIPTION\",\"value\":\"setting description\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"},{\"name\":\"USER_DEFINED_SETTING_NAME\",\"value\":\"setting name\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -445,7 +440,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:13.109574477Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"EMAIL_SETTINGS\",\"name\":\"CREATE_GMAIL_SETTING\",\"parameters\":[{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SETTING_DESCRIPTION\",\"value\":\"setting description\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"},{\"name\":\"USER_DEFINED_SETTING_NAME\",\"value\":\"setting name\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -530,7 +524,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:13.109575401Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"EMAIL_SETTINGS\",\"name\":\"DELETE_GMAIL_SETTING\",\"parameters\":[{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SETTING_DESCRIPTION\",\"value\":\"setting description\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"},{\"name\":\"USER_DEFINED_SETTING_NAME\",\"value\":\"setting name\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -613,7 +606,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:13.109576260Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"EMAIL_SETTINGS\",\"name\":\"REJECT_FROM_QUARANTINE\",\"parameters\":[{\"name\":\"EMAIL_LOG_SEARCH_MSG_ID\",\"value\":\"id\"},{\"name\":\"QUARANTINE_NAME\",\"value\":\"quarantine\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -692,7 +684,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:13.109577122Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"EMAIL_SETTINGS\",\"name\":\"RELEASE_FROM_QUARANTINE\",\"parameters\":[{\"name\":\"EMAIL_LOG_SEARCH_MSG_ID\",\"value\":\"id\"},{\"name\":\"QUARANTINE_NAME\",\"value\":\"quarantine\"}]}}",
                 "provider": "admin",
                 "type": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-groups.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-groups.log-expected.json
@@ -11,7 +11,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:17.424036183Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"GROUP_SETTINGS\",\"name\":\"CREATE_GROUP\",\"parameters\":[{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -97,7 +96,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:17.424038821Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"GROUP_SETTINGS\",\"name\":\"DELETE_GROUP\",\"parameters\":[{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -183,7 +181,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:17.424039763Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"GROUP_SETTINGS\",\"name\":\"CHANGE_GROUP_DESCRIPTION\",\"parameters\":[{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -270,7 +267,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:17.424040598Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"GROUP_SETTINGS\",\"name\":\"GROUP_LIST_DOWNLOAD\"}}",
                 "provider": "admin",
                 "type": [
@@ -342,7 +338,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:17.424041419Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"GROUP_SETTINGS\",\"name\":\"ADD_GROUP_MEMBER\",\"parameters\":[{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -436,7 +431,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:17.424042240Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"GROUP_SETTINGS\",\"name\":\"REMOVE_GROUP_MEMBER\",\"parameters\":[{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -530,7 +524,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:17.424043043Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"GROUP_SETTINGS\",\"name\":\"UPDATE_GROUP_MEMBER\",\"parameters\":[{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -626,7 +619,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:17.424043833Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"GROUP_SETTINGS\",\"name\":\"UPDATE_GROUP_MEMBER_DELIVERY_SETTINGS\",\"parameters\":[{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -722,7 +714,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:17.424044626Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"GROUP_SETTINGS\",\"name\":\"UPDATE_GROUP_MEMBER_DELIVERY_SETTINGS_CAN_EMAIL_OVERRIDE\",\"parameters\":[{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -818,7 +809,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:17.424045421Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"GROUP_SETTINGS\",\"name\":\"GROUP_MEMBER_BULK_UPLOAD\",\"parameters\":[{\"name\":\"GROUP_MEMBER_BULK_UPLOAD_FAILED_NUMBER\",\"value\":\"0\"},{\"name\":\"GROUP_MEMBER_BULK_UPLOAD_TOTAL_NUMBER\",\"value\":\"10\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -896,7 +886,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:17.424046215Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"GROUP_SETTINGS\",\"name\":\"GROUP_MEMBERS_DOWNLOAD\"}}",
                 "provider": "admin",
                 "type": [
@@ -968,7 +957,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:17.424047228Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"GROUP_SETTINGS\",\"name\":\"CHANGE_GROUP_NAME\",\"parameters\":[{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1056,7 +1044,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:17.424051963Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"GROUP_SETTINGS\",\"name\":\"CHANGE_GROUP_SETTING\",\"parameters\":[{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1148,7 +1135,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:17.424052826Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"GROUP_SETTINGS\",\"name\":\"WHITELISTED_GROUPS_UPDATED\",\"parameters\":[{\"name\":\"WHITELISTED_GROUPS\",\"value\":\"a,b,c\"}]}}",
                 "provider": "admin",
                 "type": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-licenses.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-licenses.log-expected.json
@@ -11,7 +11,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:23.941734816Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"LICENSES_SETTINGS\",\"name\":\"ORG_USERS_LICENSE_ASSIGNMENT\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"PRODUCT_NAME\",\"value\":\"product\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -91,7 +90,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:23.941737130Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"LICENSES_SETTINGS\",\"name\":\"ORG_ALL_USERS_LICENSE_ASSIGNMENT\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"PRODUCT_NAME\",\"value\":\"product\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -171,7 +169,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:23.941738108Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"LICENSES_SETTINGS\",\"name\":\"USER_LICENSE_ASSIGNMENT\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"PRODUCT_NAME\",\"value\":\"product\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -257,7 +254,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:23.941738962Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"LICENSES_SETTINGS\",\"name\":\"CHANGE_LICENSE_AUTO_ASSIGN\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"SKU_NAME\",\"value\":\"sku\"},{\"name\":\"PRODUCT_NAME\",\"value\":\"product\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -335,7 +331,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:23.941739793Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"LICENSES_SETTINGS\",\"name\":\"USER_LICENSE_REASSIGNMENT\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"PRODUCT_NAME\",\"value\":\"product\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -422,7 +417,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:23.941740626Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"LICENSES_SETTINGS\",\"name\":\"ORG_LICENSE_REVOKE\",\"parameters\":[{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"PRODUCT_NAME\",\"value\":\"product\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -502,7 +496,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:23.941741481Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"LICENSES_SETTINGS\",\"name\":\"USER_LICENSE_REVOKE\",\"parameters\":[{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"PRODUCT_NAME\",\"value\":\"product\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -588,7 +581,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:23.941742293Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"LICENSES_SETTINGS\",\"name\":\"UPDATE_DYNAMIC_LICENSE\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"PRODUCT_NAME\",\"value\":\"product\"}]}}",
                 "provider": "admin",
                 "type": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-mobile.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-mobile.log-expected.json
@@ -11,7 +11,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095350111Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"ACTION_CANCELLED\",\"parameters\":[{\"name\":\"ACTION_ID\",\"value\":\"id\"},{\"name\":\"ACTION_TYPE\",\"value\":\"ACCOUNT_WIPE\"},{\"name\":\"DEVICE_ID\",\"value\":\"id\"},{\"name\":\"DEVICE_TYPE\",\"value\":\"type\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -104,7 +103,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095352700Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"ACTION_REQUESTED\",\"parameters\":[{\"name\":\"ACTION_ID\",\"value\":\"id\"},{\"name\":\"ACTION_TYPE\",\"value\":\"ACCOUNT_WIPE\"},{\"name\":\"DEVICE_ID\",\"value\":\"id\"},{\"name\":\"DEVICE_TYPE\",\"value\":\"type\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -197,7 +195,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095353675Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"ADD_MOBILE_CERTIFICATE\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"MOBILE_CERTIFICATE_COMMON_NAME\",\"value\":\"name\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -281,7 +278,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095354514Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"COMPANY_DEVICES_BULK_CREATION\",\"parameters\":[{\"name\":\"NUMBER_OF_COMPANY_OWNED_DEVICES\",\"intValue\":10}]}}",
                 "provider": "admin",
                 "type": [
@@ -357,7 +353,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095355354Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"COMPANY_OWNED_DEVICE_BLOCKED\",\"parameters\":[{\"name\":\"COMPANY_DEVICE_ID\",\"value\":\"id\"},{\"name\":\"DEVICE_TYPE\",\"value\":\"type\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -434,7 +429,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095356177Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"COMPANY_DEVICE_DELETION\",\"parameters\":[{\"name\":\"COMPANY_DEVICE_ID\",\"value\":\"id\"},{\"name\":\"DEVICE_TYPE\",\"value\":\"type\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -511,7 +505,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095357008Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"COMPANY_OWNED_DEVICE_UNBLOCKED\",\"parameters\":[{\"name\":\"COMPANY_DEVICE_ID\",\"value\":\"id\"},{\"name\":\"DEVICE_TYPE\",\"value\":\"type\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -588,7 +581,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095357825Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"COMPANY_OWNED_DEVICE_WIPED\",\"parameters\":[{\"name\":\"COMPANY_DEVICE_ID\",\"value\":\"id\"},{\"name\":\"DEVICE_TYPE\",\"value\":\"type\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -665,7 +657,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095358635Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"CHANGE_MOBILE_APPLICATION_PERMISSION_GRANT\",\"parameters\":[{\"name\":\"DEVICE_TYPE\",\"value\":\"type\"},{\"name\":\"DISTRIBUTION_ENTITY_NAME\",\"value\":\"ANY\"},{\"name\":\"DISTRIBUTION_ENTITY_TYPE\",\"value\":\"GROUP\"},{\"name\":\"MOBILE_APP_PACKAGE_ID\",\"value\":\"id\"},{\"name\":\"NEW_PERMISSION_GRANT_STATE\",\"value\":\"GRANTED\"},{\"name\":\"OLD_PERMISSION_GRANT_STATE\",\"value\":\"DENIED\"},{\"name\":\"PERMISSION_GROUP_NAME\",\"value\":\"LOCATION\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -755,7 +746,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095359456Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"CHANGE_MOBILE_APPLICATION_PRIORITY_ORDER\",\"parameters\":[{\"name\":\"MOBILE_APP_PACKAGE_ID\",\"value\":\"id\"},{\"name\":\"DEVICE_TYPE\",\"value\":\"type\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -834,7 +824,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095360272Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"REMOVE_MOBILE_APPLICATION_FROM_WHITELIST\",\"parameters\":[{\"name\":\"MOBILE_APP_PACKAGE_ID\",\"value\":\"id\"},{\"name\":\"DEVICE_TYPE\",\"value\":\"type\"},{\"name\":\"DISTRIBUTION_ENTITY_NAME\",\"value\":\"ANY\"},{\"name\":\"DISTRIBUTION_ENTITY_TYPE\",\"value\":\"ORG_UNIT\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -920,7 +909,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095361498Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"CHANGE_MOBILE_APPLICATION_SETTINGS\",\"parameters\":[{\"name\":\"MOBILE_APP_PACKAGE_ID\",\"value\":\"id\"},{\"name\":\"DEVICE_TYPE\",\"value\":\"type\"},{\"name\":\"DISTRIBUTION_ENTITY_NAME\",\"value\":\"ANY\"},{\"name\":\"DISTRIBUTION_ENTITY_TYPE\",\"value\":\"ORG_UNIT\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1010,7 +998,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095362403Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"ADD_MOBILE_APPLICATION_TO_WHITELIST\",\"parameters\":[{\"name\":\"MOBILE_APP_PACKAGE_ID\",\"value\":\"id\"},{\"name\":\"DEVICE_TYPE\",\"value\":\"type\"},{\"name\":\"DISTRIBUTION_ENTITY_NAME\",\"value\":\"ANY\"},{\"name\":\"DISTRIBUTION_ENTITY_TYPE\",\"value\":\"ORG_UNIT\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1095,7 +1082,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095363270Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"MOBILE_DEVICE_APPROVE\",\"parameters\":[{\"name\":\"DEVICE_ID\",\"value\":\"id\"},{\"name\":\"DEVICE_TYPE\",\"value\":\"type\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1182,7 +1168,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095364092Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"MOBILE_DEVICE_BLOCK\",\"parameters\":[{\"name\":\"DEVICE_ID\",\"value\":\"id\"},{\"name\":\"DEVICE_TYPE\",\"value\":\"type\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1269,7 +1254,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095364928Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"MOBILE_DEVICE_DELETE\",\"parameters\":[{\"name\":\"DEVICE_ID\",\"value\":\"id\"},{\"name\":\"DEVICE_TYPE\",\"value\":\"type\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1356,7 +1340,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095365833Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"MOBILE_DEVICE_WIPE\",\"parameters\":[{\"name\":\"DEVICE_ID\",\"value\":\"id\"},{\"name\":\"DEVICE_TYPE\",\"value\":\"type\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1444,7 +1427,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095366654Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"CHANGE_MOBILE_SETTING\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1528,7 +1510,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095367472Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"CHANGE_ADMIN_RESTRICTIONS_PIN\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1607,7 +1588,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095368287Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"CHANGE_MOBILE_WIRELESS_NETWORK\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"MOBILE_WIRELESS_NETWORK_NAME\",\"value\":\"network\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1689,7 +1669,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095369115Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"ADD_MOBILE_WIRELESS_NETWORK\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"MOBILE_WIRELESS_NETWORK_NAME\",\"value\":\"network\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1771,7 +1750,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095369932Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"REMOVE_MOBILE_WIRELESS_NETWORK\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"MOBILE_WIRELESS_NETWORK_NAME\",\"value\":\"network\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1853,7 +1831,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095370752Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"CHANGE_MOBILE_WIRELESS_NETWORK_PASSWORD\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"MOBILE_WIRELESS_NETWORK_NAME\",\"value\":\"network\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1935,7 +1912,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095371657Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"REMOVE_MOBILE_CERTIFICATE\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"MOBILE_CERTIFICATE_COMMON_NAME\",\"value\":\"cert\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2019,7 +1995,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095372515Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"ENROLL_FOR_GOOGLE_DEVICE_MANAGEMENT\"}}",
                 "provider": "admin",
                 "type": [
@@ -2090,7 +2065,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095373327Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"USE_GOOGLE_MOBILE_MANAGEMENT\"}}",
                 "provider": "admin",
                 "type": [
@@ -2161,7 +2135,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095374147Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"USE_GOOGLE_MOBILE_MANAGEMENT_FOR_NON_IOS\"}}",
                 "provider": "admin",
                 "type": [
@@ -2232,7 +2205,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095374963Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"USE_GOOGLE_MOBILE_MANAGEMENT_FOR_IOS\"}}",
                 "provider": "admin",
                 "type": [
@@ -2303,7 +2275,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095375771Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"MOBILE_ACCOUNT_WIPE\",\"parameters\":[{\"name\":\"DEVICE_ID\",\"value\":\"id\"},{\"name\":\"DEVICE_TYPE\",\"value\":\"type\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2390,7 +2361,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095376584Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"MOBILE_DEVICE_CANCEL_WIPE_THEN_APPROVE\",\"parameters\":[{\"name\":\"DEVICE_ID\",\"value\":\"id\"},{\"name\":\"DEVICE_TYPE\",\"value\":\"type\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2477,7 +2447,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:27.095377415Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"MOBILE_SETTINGS\",\"name\":\"MOBILE_DEVICE_CANCEL_WIPE_THEN_BLOCK\",\"parameters\":[{\"name\":\"DEVICE_ID\",\"value\":\"id\"},{\"name\":\"DEVICE_TYPE\",\"value\":\"type\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-org.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-org.log-expected.json
@@ -11,7 +11,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:40.506676819Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"ORG_SETTINGS\",\"name\":\"CHROME_LICENSES_ENABLED\",\"parameters\":[{\"name\":\"APPLICATION_NAME\",\"value\":\"app\"},{\"name\":\"CHROME_LICENSES_ENABLED\",\"value\":\"DISABLED\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -93,7 +92,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:40.506679744Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"ORG_SETTINGS\",\"name\":\"CHROME_APPLICATION_LICENSE_RESERVATION_CREATED\",\"parameters\":[{\"name\":\"APPLICATION_NAME\",\"value\":\"app\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SKU_NAME\",\"value\":\"sku\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -176,7 +174,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:40.506680813Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"ORG_SETTINGS\",\"name\":\"CHROME_APPLICATION_LICENSE_RESERVATION_DELETED\",\"parameters\":[{\"name\":\"APPLICATION_NAME\",\"value\":\"app\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SKU_NAME\",\"value\":\"sku\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -258,7 +255,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:40.506681659Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"ORG_SETTINGS\",\"name\":\"CHROME_APPLICATION_LICENSE_RESERVATION_UPDATED\",\"parameters\":[{\"name\":\"APPLICATION_NAME\",\"value\":\"app\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SKU_NAME\",\"value\":\"sku\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -342,7 +338,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:40.506682490Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"ORG_SETTINGS\",\"name\":\"CREATE_DEVICE_ENROLLMENT_TOKEN\",\"parameters\":[{\"name\":\"FULL_ORG_UNIT_PATH\",\"value\":\"full/org/path\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -418,7 +413,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:40.506683324Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"ORG_SETTINGS\",\"name\":\"ASSIGN_CUSTOM_LOGO\",\"parameters\":[{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -494,7 +488,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:40.506684134Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"ORG_SETTINGS\",\"name\":\"UNASSIGN_CUSTOM_LOGO\",\"parameters\":[{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -570,7 +563,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:40.506684958Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"ORG_SETTINGS\",\"name\":\"CREATE_ENROLLMENT_TOKEN\",\"parameters\":[{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -646,7 +638,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:40.506685765Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"ORG_SETTINGS\",\"name\":\"REVOKE_ENROLLMENT_TOKEN\",\"parameters\":[{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -722,7 +713,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:40.506686597Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"ORG_SETTINGS\",\"name\":\"CHROME_LICENSES_ALLOWED\",\"parameters\":[{\"name\":\"APPLICATION_NAME\",\"value\":\"app\"},{\"name\":\"CHROME_LICENSES_ALLOWED\",\"value\":\"EMPTY\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -804,7 +794,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:40.506687456Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"ORG_SETTINGS\",\"name\":\"CREATE_ORG_UNIT\",\"parameters\":[{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -880,7 +869,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:40.506688410Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"ORG_SETTINGS\",\"name\":\"REMOVE_ORG_UNIT\",\"parameters\":[{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -956,7 +944,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:40.506689251Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"ORG_SETTINGS\",\"name\":\"EDIT_ORG_UNIT_DESCRIPTION\",\"parameters\":[{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1032,7 +1019,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:40.506690070Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"ORG_SETTINGS\",\"name\":\"MOVE_ORG_UNIT\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1109,7 +1095,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:40.506690886Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"ORG_SETTINGS\",\"name\":\"EDIT_ORG_UNIT_NAME\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1186,7 +1171,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:40.506691710Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"ORG_SETTINGS\",\"name\":\"REVOKE_DEVICE_ENROLLMENT_TOKEN\",\"parameters\":[{\"name\":\"FULL_ORG_UNIT_PATH\",\"value\":\"full/org/path\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1262,7 +1246,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:40.506692635Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"ORG_SETTINGS\",\"name\":\"TOGGLE_SERVICE_ENABLED\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SERVICE_NAME\",\"value\":\"new\"}]}}",
                 "provider": "admin",
                 "type": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-security.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-security.log-expected.json
@@ -12,7 +12,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:47.190809062Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SECURITY_SETTINGS\",\"name\":\"ALLOW_STRONG_AUTHENTICATION\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -91,7 +90,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:47.190811318Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SECURITY_SETTINGS\",\"name\":\"ALLOW_SERVICE_FOR_OAUTH2_ACCESS\",\"parameters\":[{\"name\":\"OAUTH2_SERVICE_NAME\",\"value\":\"APPS_SCRIPT\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -173,7 +171,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:47.190812290Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SECURITY_SETTINGS\",\"name\":\"DISALLOW_SERVICE_FOR_OAUTH2_ACCESS\",\"parameters\":[{\"name\":\"OAUTH2_SERVICE_NAME\",\"value\":\"APPS_SCRIPT\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -255,7 +252,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:47.190813149Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SECURITY_SETTINGS\",\"name\":\"CHANGE_APP_ACCESS_SETTINGS_COLLECTION_ID\",\"parameters\":[{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"},{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -339,7 +335,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:47.190814Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SECURITY_SETTINGS\",\"name\":\"ADD_TO_TRUSTED_OAUTH2_APPS\",\"parameters\":[{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"OAUTH2_APP_ID\",\"value\":\"id\"},{\"name\":\"OAUTH2_APP_NAME\",\"value\":\"appname\"},{\"name\":\"OAUTH2_APP_TYPE\",\"value\":\"CHROME_EXTENSION\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -422,7 +417,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:47.190814824Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SECURITY_SETTINGS\",\"name\":\"REMOVE_FROM_TRUSTED_OAUTH2_APPS\",\"parameters\":[{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"OAUTH2_APP_ID\",\"value\":\"id\"},{\"name\":\"OAUTH2_APP_NAME\",\"value\":\"appname\"},{\"name\":\"OAUTH2_APP_TYPE\",\"value\":\"CHROME_EXTENSION\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -505,7 +499,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:47.190815647Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SECURITY_SETTINGS\",\"name\":\"BLOCK_ON_DEVICE_ACCESS\",\"parameters\":[{\"name\":\"OAUTH2_SERVICE_NAME\",\"value\":\"APPS_SCRIPT\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -587,7 +580,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:47.190816463Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SECURITY_SETTINGS\",\"name\":\"CHANGE_TWO_STEP_VERIFICATION_ENROLLMENT_PERIOD_DURATION\",\"parameters\":[{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -679,7 +671,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:47.190817283Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SECURITY_SETTINGS\",\"name\":\"CHANGE_TWO_STEP_VERIFICATION_FREQUENCY\",\"parameters\":[{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -771,7 +762,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:47.190818103Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SECURITY_SETTINGS\",\"name\":\"CHANGE_TWO_STEP_VERIFICATION_GRACE_PERIOD_DURATION\",\"parameters\":[{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -863,7 +853,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:47.190818927Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SECURITY_SETTINGS\",\"name\":\"CHANGE_TWO_STEP_VERIFICATION_START_DATE\",\"parameters\":[{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -955,7 +944,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:47.190819980Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SECURITY_SETTINGS\",\"name\":\"CHANGE_ALLOWED_TWO_STEP_VERIFICATION_METHODS\",\"parameters\":[{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"ALLOWED_TWO_STEP_VERIFICATION_METHOD\",\"value\":\"ONLY_SECURITY_KEY\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1045,7 +1033,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:47.190820811Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SECURITY_SETTINGS\",\"name\":\"TOGGLE_CAA_ENABLEMENT\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1119,7 +1106,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:47.190821620Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SECURITY_SETTINGS\",\"name\":\"CHANGE_CAA_ERROR_MESSAGE\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1196,7 +1182,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:47.190822441Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SECURITY_SETTINGS\",\"name\":\"CHANGE_CAA_APP_ASSIGNMENTS\",\"parameters\":[{\"name\":\"APPLICATION_NAME\",\"value\":\"app\"},{\"name\":\"CAA_ASSIGNMENTS_NEW\",\"value\":\"new\"},{\"name\":\"CAA_ASSIGNMENTS_OLD\",\"value\":\"old\"},{\"name\":\"GROUP_NAME\",\"value\":\"group\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1285,7 +1270,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:47.190823248Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SECURITY_SETTINGS\",\"name\":\"UNTRUST_DOMAIN_OWNED_OAUTH2_APPS\",\"parameters\":[{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1361,7 +1345,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:47.190824166Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SECURITY_SETTINGS\",\"name\":\"TRUST_DOMAIN_OWNED_OAUTH2_APPS\",\"parameters\":[{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1438,7 +1421,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:47.190824984Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SECURITY_SETTINGS\",\"name\":\"ENABLE_NON_ADMIN_USER_PASSWORD_RECOVERY\",\"parameters\":[{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1530,7 +1512,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:47.190825802Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SECURITY_SETTINGS\",\"name\":\"ENFORCE_STRONG_AUTHENTICATION\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1628,7 +1609,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:47.190826622Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SECURITY_SETTINGS\",\"name\":\"UPDATE_ERROR_MSG_FOR_RESTRICTED_OAUTH2_APPS\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1707,7 +1687,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:47.190827449Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SECURITY_SETTINGS\",\"name\":\"WEAK_PROGRAMMATIC_LOGIN_SETTINGS_CHANGED\",\"parameters\":[{\"name\":\"GROUP_EMAIL\",\"value\":\"group@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1799,7 +1778,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:47.190828266Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SECURITY_SETTINGS\",\"name\":\"SESSION_CONTROL_SETTINGS_CHANGE\",\"parameters\":[{\"name\":\"REAUTH_APPLICATION\",\"value\":\"ADMIN_CONSOLE\"},{\"name\":\"REAUTH_SETTING_NEW\",\"value\":\"INHERIT\"},{\"name\":\"REAUTH_SETTING_OLD\",\"value\":\"NEVER\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1881,7 +1859,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:47.190829082Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SECURITY_SETTINGS\",\"name\":\"CHANGE_SESSION_LENGTH\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1956,7 +1933,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:47.190830017Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SECURITY_SETTINGS\",\"name\":\"UNBLOCK_ON_DEVICE_ACCESS\",\"parameters\":[{\"name\":\"OAUTH2_SERVICE_NAME\",\"value\":\"CALENDAR\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"}]}}",
                 "provider": "admin",
                 "type": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-sites.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-sites.log-expected.json
@@ -11,7 +11,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:57.139980543Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SITES_SETTINGS\",\"name\":\"ADD_WEB_ADDRESS\",\"parameters\":[{\"name\":\"SITE_LOCATION\",\"value\":\"/path/in/url\"},{\"name\":\"WEB_ADDRESS\",\"value\":\"http://example.com/path/in/url\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -98,7 +97,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:57.139982932Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SITES_SETTINGS\",\"name\":\"DELETE_WEB_ADDRESS\",\"parameters\":[{\"name\":\"SITE_LOCATION\",\"value\":\"/path/in/url\"},{\"name\":\"WEB_ADDRESS\",\"value\":\"http://example.com/path/in/url\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -186,7 +184,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:57.139983926Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SITES_SETTINGS\",\"name\":\"CHANGE_SITES_SETTING\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"SETTING_NAME\",\"value\":\"setting\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -271,7 +268,6 @@
                     "configuration"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:57.139984767Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SITES_SETTINGS\",\"name\":\"CHANGE_SITES_WEB_ADDRESS_MAPPING_UPDATES\",\"parameters\":[{\"name\":\"SERVICE_NAME\",\"value\":\"service\"},{\"name\":\"SITE_LOCATION\",\"value\":\"/path/in/url\"},{\"name\":\"WEB_ADDRESS\",\"value\":\"http://example.com/path/in/url\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -353,7 +349,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:57.139985593Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"SITES_SETTINGS\",\"name\":\"VIEW_SITE_DETAILS\",\"parameters\":[{\"name\":\"SITE_NAME\",\"value\":\"site\"}]}}",
                 "provider": "admin",
                 "type": [

--- a/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-user.log-expected.json
+++ b/packages/google_workspace/data_stream/admin/_dev/test/pipeline/test-admin-user.log-expected.json
@@ -11,7 +11,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399417956Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"DELETE_2SV_SCRATCH_CODES\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -94,7 +93,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399420509Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"GENERATE_2SV_SCRATCH_CODES\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -177,7 +175,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399421536Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"REVOKE_3LO_DEVICE_TOKENS\",\"parameters\":[{\"name\":\"DEVICE_ID\",\"value\":\"id\"},{\"name\":\"DEVICE_TYPE\",\"value\":\"type\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -264,7 +261,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399422402Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"REVOKE_3LO_TOKEN\",\"parameters\":[{\"name\":\"APP_ID\",\"value\":\"id\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -350,7 +346,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399423227Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"ADD_RECOVERY_EMAIL\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -433,7 +428,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399424062Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"ADD_RECOVERY_PHONE\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -516,7 +510,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399424884Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"GRANT_ADMIN_PRIVILEGE\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -599,7 +592,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399425734Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"REVOKE_ADMIN_PRIVILEGE\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -682,7 +674,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399426577Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"REVOKE_ASP\",\"parameters\":[{\"name\":\"ASP_ID\",\"value\":\"id\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -768,7 +759,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399427392Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"TOGGLE_AUTOMATIC_CONTACT_SHARING\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -852,7 +842,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399428204Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"BULK_UPLOAD\",\"parameters\":[{\"name\":\"BULK_UPLOAD_FAIL_USERS_NUMBER\",\"value\":\"1\"},{\"name\":\"BULK_UPLOAD_TOTAL_USERS_NUMBER\",\"value\":\"10\"},{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -932,7 +921,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399429171Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"BULK_UPLOAD_NOTIFICATION_SENT\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1018,7 +1006,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399429996Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"CANCEL_USER_INVITE\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1104,7 +1091,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399430826Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"CHANGE_USER_CUSTOM_FIELD\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"},{\"name\":\"USER_CUSTOM_FIELD\",\"value\":\"custom\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1192,7 +1178,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399431652Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"CHANGE_USER_EXTERNAL_ID\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1277,7 +1262,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399432467Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"CHANGE_USER_GENDER\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1362,7 +1346,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399433374Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"CHANGE_USER_IM\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1447,7 +1430,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399434203Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"ENABLE_USER_IP_WHITELIST\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1532,7 +1514,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399435018Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"CHANGE_USER_KEYWORD\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1617,7 +1598,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399435828Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"CHANGE_USER_LANGUAGE\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1702,7 +1682,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399436659Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"CHANGE_USER_LOCATION\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1787,7 +1766,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399437484Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"CHANGE_USER_ORGANIZATION\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1872,7 +1850,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399438304Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"CHANGE_USER_PHONE_NUMBER\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -1957,7 +1934,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399439207Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"CHANGE_RECOVERY_EMAIL\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2040,7 +2016,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399440017Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"CHANGE_RECOVERY_PHONE\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2123,7 +2098,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399440852Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"CHANGE_USER_RELATION\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2208,7 +2182,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399441671Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"CHANGE_USER_ADDRESS\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2295,7 +2268,6 @@
                 "duration": 3600000000000,
                 "end": "2002-10-02T16:00:00.000Z",
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399442488Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"CREATE_EMAIL_MONITOR\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"BEGIN_DATE_TIME\",\"value\":\"2002-10-02T15:00:00Z\"},{\"name\":\"EMAIL_MONITOR_DEST_EMAIL\",\"value\":\"dest@example.com\"},{\"name\":\"EMAIL_MONITOR_LEVEL_CHAT\",\"value\":\"info\"},{\"name\":\"EMAIL_MONITOR_LEVEL_DRAFT_EMAIL\",\"value\":\"info\"},{\"name\":\"EMAIL_MONITOR_LEVEL_INCOMING_EMAIL\",\"value\":\"info\"},{\"name\":\"EMAIL_MONITOR_LEVEL_OUTGOING_EMAIL\",\"value\":\"info\"},{\"name\":\"END_DATE_TIME\",\"value\":\"2002-10-02T16:00:00Z\"}]}}",
                 "provider": "admin",
                 "start": "2002-10-02T15:00:00.000Z",
@@ -2388,7 +2360,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399443302Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"CREATE_DATA_TRANSFER_REQUEST\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"DESTINATION_USER_EMAIL\",\"value\":\"dest@example.com\"},{\"name\":\"APPLICATION_NAME\",\"value\":\"a,b,c\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2475,7 +2446,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399444112Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"GRANT_DELEGATED_ADMIN_PRIVILEGES\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2559,7 +2529,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399444930Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"DELETE_ACCOUNT_INFO_DUMP\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"REQUEST_ID\",\"value\":\"id\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2645,7 +2614,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399445746Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"DELETE_EMAIL_MONITOR\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"EMAIL_MONITOR_DEST_EMAIL\",\"value\":\"dest@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2731,7 +2699,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399446576Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"DELETE_MAILBOX_DUMP\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"REQUEST_ID\",\"value\":\"id\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2817,7 +2784,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399447389Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"CHANGE_FIRST_NAME\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2902,7 +2868,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399448299Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"GMAIL_RESET_USER\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"GMAIL_RESET_REASON\",\"value\":\"reason\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -2986,7 +2951,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399449109Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"CHANGE_LAST_NAME\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -3071,7 +3035,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399449919Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"MAIL_ROUTING_DESTINATION_ADDED\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -3155,7 +3118,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399450735Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"MAIL_ROUTING_DESTINATION_REMOVED\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -3239,7 +3201,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399451579Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"ADD_NICKNAME\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"USER_NICKNAME\",\"value\":\"nick\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -3323,7 +3284,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399452404Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"REMOVE_NICKNAME\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"USER_NICKNAME\",\"value\":\"nick\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -3407,7 +3367,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399453225Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"CHANGE_PASSWORD\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -3490,7 +3449,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399454038Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"CHANGE_PASSWORD_ON_NEXT_LOGIN\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"OLD_VALUE\",\"value\":\"old\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -3575,7 +3533,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399454868Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"DOWNLOAD_PENDING_INVITES_LIST\"}}",
                 "provider": "admin",
                 "type": [
@@ -3646,7 +3603,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399455700Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"REMOVE_RECOVERY_EMAIL\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -3729,7 +3685,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399456515Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"REMOVE_RECOVERY_PHONE\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -3812,7 +3767,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399457345Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"REQUEST_ACCOUNT_INFO\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -3897,7 +3851,6 @@
                 "duration": 3600000000000,
                 "end": "2002-10-02T16:00:00.000Z",
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399458219Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"REQUEST_MAILBOX_DUMP\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"},{\"name\":\"BEGIN_DATE_TIME\",\"value\":\"2002-10-02T15:00:00Z\"},{\"name\":\"EMAIL_EXPORT_INCLUDE_DELETED\",\"value\":\"true\"},{\"name\":\"EMAIL_EXPORT_PACKAGE_CONTENT\",\"value\":\"contents\"},{\"name\":\"SEARCH_QUERY_FOR_DUMP\",\"value\":\"foo bar\"},{\"name\":\"END_DATE_TIME\",\"value\":\"2002-10-02T16:00:00Z\"}]}}",
                 "provider": "admin",
                 "start": "2002-10-02T15:00:00.000Z",
@@ -3986,7 +3939,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399459054Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"RESEND_USER_INVITE\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4072,7 +4024,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399459873Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"RESET_SIGNIN_COOKIES\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4155,7 +4106,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399460686Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"SECURITY_KEY_REGISTERED_FOR_USER\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4238,7 +4188,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399461599Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"REVOKE_SECURITY_KEY\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4321,7 +4270,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399462461Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"USER_INVITE\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4407,7 +4355,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399463277Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"VIEW_TEMP_PASSWORD\",\"parameters\":[{\"name\":\"DOMAIN_NAME\",\"value\":\"example.com\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4493,7 +4440,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399464099Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"TURN_OFF_2_STEP_VERIFICATION\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4576,7 +4522,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399464912Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"UNBLOCK_USER_SESSION\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4659,7 +4604,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399465723Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"UNENROLL_USER_FROM_TITANIUM\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4742,7 +4686,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399466534Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"ARCHIVE_USER\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4825,7 +4768,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399467336Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"UPDATE_BIRTHDATE\",\"parameters\":[{\"name\":\"BIRTHDATE\",\"value\":\"2002-10-02T15:00:00Z\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4909,7 +4851,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399468150Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"CREATE_USER\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -4992,7 +4933,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399468983Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"DELETE_USER\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -5075,7 +5015,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399469793Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"DOWNGRADE_USER_FROM_GPLUS\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -5158,7 +5097,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399470606Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"USER_ENROLLED_IN_TWO_STEP_VERIFICATION\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -5241,7 +5179,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399471441Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"DOWNLOAD_USERLIST_CSV\"}}",
                 "provider": "admin",
                 "type": [
@@ -5312,7 +5249,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399472253Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"MOVE_USER_TO_ORG_UNIT\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"ORG_UNIT_NAME\",\"value\":\"org\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -5399,7 +5335,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399473068Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"USER_PUT_IN_TWO_STEP_VERIFICATION_GRACE_PERIOD\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -5483,7 +5418,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399473877Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"RENAME_USER\",\"parameters\":[{\"name\":\"NEW_VALUE\",\"value\":\"new\"},{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -5567,7 +5501,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399474690Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"UNENROLL_USER_FROM_STRONG_AUTH\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -5650,7 +5583,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399475506Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"SUSPEND_USER\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -5733,7 +5665,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399476336Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"UNARCHIVE_USER\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -5816,7 +5747,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399477157Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"UNDELETE_USER\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -5899,7 +5829,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399477992Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"UNSUSPEND_USER\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -5982,7 +5911,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399478814Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"UPGRADE_USER_TO_GPLUS\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -6065,7 +5993,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399479683Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"USERS_BULK_UPLOAD\",\"parameters\":[{\"name\":\"BULK_UPLOAD_FAIL_USERS_NUMBER\",\"value\":\"0\"},{\"name\":\"BULK_UPLOAD_TOTAL_USERS_NUMBER\",\"value\":\"10\"}]}}",
                 "provider": "admin",
                 "type": [
@@ -6142,7 +6069,6 @@
                     "iam"
                 ],
                 "id": "1",
-                "ingested": "2022-02-03T12:21:59.399480498Z",
                 "original": "{\"kind\":\"admin#reports#activity\",\"id\":{\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1,\"applicationName\":\"admin\",\"customerId\":\"1\"},\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"ownerDomain\":\"elastic.com\",\"ipAddress\":\"67.43.156.13\",\"events\":{\"type\":\"USER_SETTINGS\",\"name\":\"USERS_BULK_UPLOAD_NOTIFICATION_SENT\",\"parameters\":[{\"name\":\"USER_EMAIL\",\"value\":\"user@example.com\"}]}}",
                 "provider": "admin",
                 "type": [

--- a/packages/google_workspace/data_stream/admin/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/admin/elasticsearch/ingest_pipeline/default.yml
@@ -2,9 +2,6 @@
 description: Pipeline for parsing google_workspace logs
 processors:
   - set:
-      field: event.ingested
-      value: "{{ _ingest.timestamp }}"
-  - set:
       field: ecs.version
       value: '8.0.0'
   - append:

--- a/packages/google_workspace/data_stream/drive/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/drive/elasticsearch/ingest_pipeline/default.yml
@@ -2,9 +2,6 @@
 description: Pipeline for parsing google_workspace logs
 processors:
   - set:
-      field: event.ingested
-      value: "{{ _ingest.timestamp }}"
-  - set:
       field: ecs.version
       value: '8.0.0'
   - append:

--- a/packages/google_workspace/data_stream/groups/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/groups/elasticsearch/ingest_pipeline/default.yml
@@ -2,9 +2,6 @@
 description: Pipeline for parsing google_workspace logs
 processors:
   - set:
-      field: event.ingested
-      value: "{{ _ingest.timestamp }}"
-  - set:
       field: ecs.version
       value: '8.0.0'
   - append: 

--- a/packages/google_workspace/data_stream/login/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/login/elasticsearch/ingest_pipeline/default.yml
@@ -2,9 +2,6 @@
 description: Pipeline for parsing google_workspace logs
 processors:
   - set:
-      field: event.ingested
-      value: "{{ _ingest.timestamp }}"
-  - set:
       field: ecs.version
       value: '8.0.0'
   - append:

--- a/packages/google_workspace/data_stream/saml/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/saml/elasticsearch/ingest_pipeline/default.yml
@@ -2,9 +2,6 @@
 description: Pipeline for parsing google_workspace logs
 processors:
   - set:
-      field: event.ingested
-      value: "{{ _ingest.timestamp }}"
-  - set:
       field: ecs.version
       value: '8.0.0'
   - append:

--- a/packages/google_workspace/data_stream/user_accounts/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/user_accounts/elasticsearch/ingest_pipeline/default.yml
@@ -2,9 +2,6 @@
 description: Pipeline for parsing google_workspace logs
 processors:
   - set:
-      field: event.ingested
-      value: "{{ _ingest.timestamp }}"
-  - set:
       field: ecs.version
       value: '8.0.0'
   - append:

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace Audit Reports
-version: 1.3.0
+version: 1.3.1
 release: ga
 description: Collect audit reports from Google Workspaces with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

event.ingested is added by a Fleet final_pipeline so these additions were redundant.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
