### PR TITLE
Remove incorrectly tagged boolean dimension

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.17.3"
+  changes:
+    - description: Remove incorrectly tagged boolean dimension
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/...
 - version: "1.17.2"
   changes:
     - description: Add missing metadata fields

--- a/packages/kubernetes/data_stream/state_cronjob/fields/fields.yml
+++ b/packages/kubernetes/data_stream/state_cronjob/fields/fields.yml
@@ -18,7 +18,6 @@
       metric_type: gauge
       description: Number of active pods for the cronjob
     - name: is_suspended
-      dimension: true
       type: boolean
       description: Whether the cronjob is suspended
     - name: created.sec


### PR DESCRIPTION
Boolean fields cannot be dimensions. In this case the rest of fields
marked as dimensions for this datastream should be enough.

It wasn't detected earlier because dimensions validation was not
properly working till https://github.com/elastic/package-spec/pull/279.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Removes incorrectly tagged boolean dimension.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Found while updating the spec in https://github.com/elastic/integrations/pull/2825.