### PR TITLE
Rename the developer-experience team to ecosystem

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owners
-* @elastic/integrations-developer-experience
+* @elastic/ecosystem
 
 /packages/1password @elastic/security-external-integrations
 /packages/activemq @elastic/integrations


### PR DESCRIPTION
This PR renames the `integrations-developer-experience` team to `ecosystem`. 