### PR TITLE
Aws 1.13.0 fix dashboard missing reference

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.1"
+  changes:
+    - description: Fix metricbeat- reference in dashboardo
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.13.0"
   changes:
     - description: Compress dashboard screenshots.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.13.1"
   changes:
-    - description: Fix metricbeat- reference in dashboardo
+    - description: Fix metricbeat- reference in dashboard
       type: bugfix
       link: https://github.com/elastic/integrations/pull/2838
 - version: "1.13.0"

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix metricbeat- reference in dashboardo
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/2838
 - version: "1.13.0"
   changes:
     - description: Compress dashboard screenshots.

--- a/packages/aws/kibana/dashboard/aws-3367c170-921f-11e9-aa19-159bf182e06f.json
+++ b/packages/aws/kibana/dashboard/aws-3367c170-921f-11e9-aa19-159bf182e06f.json
@@ -109,12 +109,12 @@
                     "attributes": {
                         "references": [
                             {
-                                "id": "metricbeat-*",
+                                "id": "metrics-*",
                                 "name": "indexpattern-datasource-current-indexpattern",
                                 "type": "index-pattern"
                             },
                             {
-                                "id": "metricbeat-*",
+                                "id": "metrics-*",
                                 "name": "indexpattern-datasource-layer-75b24975-5ca3-4da5-bc1a-92013a901a21",
                                 "type": "index-pattern"
                             }
@@ -301,12 +301,12 @@
                     "attributes": {
                         "references": [
                             {
-                                "id": "metricbeat-*",
+                                "id": "metrics-*",
                                 "name": "indexpattern-datasource-current-indexpattern",
                                 "type": "index-pattern"
                             },
                             {
-                                "id": "metricbeat-*",
+                                "id": "metrics-*",
                                 "name": "indexpattern-datasource-layer-dd0a4706-5286-4976-9bc4-f5e7a4964bf6",
                                 "type": "index-pattern"
                             }
@@ -456,12 +456,12 @@
                     "attributes": {
                         "references": [
                             {
-                                "id": "metricbeat-*",
+                                "id": "metrics-*",
                                 "name": "indexpattern-datasource-current-indexpattern",
                                 "type": "index-pattern"
                             },
                             {
-                                "id": "metricbeat-*",
+                                "id": "metrics-*",
                                 "name": "indexpattern-datasource-layer-14d4ba6b-f4e1-4d40-818a-6aa829d90422",
                                 "type": "index-pattern"
                             }
@@ -630,12 +630,12 @@
                     "attributes": {
                         "references": [
                             {
-                                "id": "metricbeat-*",
+                                "id": "metrics-*",
                                 "name": "indexpattern-datasource-current-indexpattern",
                                 "type": "index-pattern"
                             },
                             {
-                                "id": "metricbeat-*",
+                                "id": "metrics-*",
                                 "name": "indexpattern-datasource-layer-e2611df6-ca73-4d53-b0b5-afd8b718c369",
                                 "type": "index-pattern"
                             }
@@ -807,12 +807,12 @@
             "type": "lens"
         },
         {
-            "id": "metricbeat-*",
+            "id": "metrics-*",
             "name": "1abf12dc-d009-4a02-acd4-463383d32a63:indexpattern-datasource-current-indexpattern",
             "type": "index-pattern"
         },
         {
-            "id": "metricbeat-*",
+            "id": "metrics-*",
             "name": "1abf12dc-d009-4a02-acd4-463383d32a63:indexpattern-datasource-layer-75b24975-5ca3-4da5-bc1a-92013a901a21",
             "type": "index-pattern"
         },
@@ -832,12 +832,12 @@
             "type": "lens"
         },
         {
-            "id": "metricbeat-*",
+            "id": "metrics-*",
             "name": "249ff0a6-3fd3-4935-85c3-0c3222d3c498:indexpattern-datasource-current-indexpattern",
             "type": "index-pattern"
         },
         {
-            "id": "metricbeat-*",
+            "id": "metrics-*",
             "name": "249ff0a6-3fd3-4935-85c3-0c3222d3c498:indexpattern-datasource-layer-dd0a4706-5286-4976-9bc4-f5e7a4964bf6",
             "type": "index-pattern"
         },
@@ -847,12 +847,12 @@
             "type": "lens"
         },
         {
-            "id": "metricbeat-*",
+            "id": "metrics-*",
             "name": "c28488ce-a20e-447f-9a68-ba49b542ab0a:indexpattern-datasource-current-indexpattern",
             "type": "index-pattern"
         },
         {
-            "id": "metricbeat-*",
+            "id": "metrics-*",
             "name": "c28488ce-a20e-447f-9a68-ba49b542ab0a:indexpattern-datasource-layer-14d4ba6b-f4e1-4d40-818a-6aa829d90422",
             "type": "index-pattern"
         },
@@ -867,12 +867,12 @@
             "type": "lens"
         },
         {
-            "id": "metricbeat-*",
+            "id": "metrics-*",
             "name": "addd441f-fa2b-4725-8015-619ee176ed0a:indexpattern-datasource-current-indexpattern",
             "type": "index-pattern"
         },
         {
-            "id": "metricbeat-*",
+            "id": "metrics-*",
             "name": "addd441f-fa2b-4725-8015-619ee176ed0a:indexpattern-datasource-layer-e2611df6-ca73-4d53-b0b5-afd8b718c369",
             "type": "index-pattern"
         }

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.13.0
+version: 1.13.1
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->
In https://github.com/elastic/kibana/issues/127664 the AWS package assets are not installed due to a missing reference in a dashboard.

While the Fleet team works on fixing the issue on their side, this PR fixes the AWS package to reference `metrics-` instead of `metricbeat-` as all other dashboar do.

Package is bumped to 1.13.1.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] ~~I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- https://github.com/elastic/kibana/issues/127664

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
