### PR TITLE
Add ecs.version to elastic_agent fields

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,10 @@
 # newer versions go on top
+- version: "1.3.1"
+  changes:
+    - description: Fix missing ecs.version mapping
+      type: bugfix
+      link: |
+        https://github.com/elastic/integrations/pull/2844
 - version: "1.3.0"
   changes:
     - description: Update compatibility of package to be compatible with 8.0.x

--- a/packages/elastic_agent/data_stream/apm_server_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/apm_server_logs/fields/ecs.yml
@@ -1,3 +1,5 @@
+- external: ecs
+  name: ecs.version
 - name: log
   title: Log
   group: 2

--- a/packages/elastic_agent/data_stream/apm_server_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/apm_server_metrics/fields/ecs.yml
@@ -1,0 +1,2 @@
+- external: ecs
+  name: ecs.version

--- a/packages/elastic_agent/data_stream/auditbeat_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_logs/fields/ecs.yml
@@ -1,3 +1,5 @@
+- external: ecs
+  name: ecs.version
 - name: log
   title: Log
   group: 2

--- a/packages/elastic_agent/data_stream/auditbeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_metrics/fields/ecs.yml
@@ -1,0 +1,2 @@
+- external: ecs
+  name: ecs.version

--- a/packages/elastic_agent/data_stream/elastic_agent_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_logs/fields/ecs.yml
@@ -1,3 +1,5 @@
+- external: ecs
+  name: ecs.version
 - name: log
   title: Log
   group: 2

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/ecs.yml
@@ -1,0 +1,2 @@
+- external: ecs
+  name: ecs.version

--- a/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/ecs.yml
@@ -1,0 +1,2 @@
+- external: ecs
+  name: ecs.version

--- a/packages/elastic_agent/data_stream/endpoint_sercurity_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/endpoint_sercurity_logs/fields/ecs.yml
@@ -1,3 +1,5 @@
+- external: ecs
+  name: ecs.version
 - name: log
   title: Log
   group: 2

--- a/packages/elastic_agent/data_stream/filebeat_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/filebeat_logs/fields/ecs.yml
@@ -1,3 +1,5 @@
+- external: ecs
+  name: ecs.version
 - name: log
   title: Log
   group: 2

--- a/packages/elastic_agent/data_stream/filebeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/filebeat_metrics/fields/ecs.yml
@@ -1,0 +1,2 @@
+- external: ecs
+  name: ecs.version

--- a/packages/elastic_agent/data_stream/fleet_server_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_logs/fields/ecs.yml
@@ -1,3 +1,5 @@
+- external: ecs
+  name: ecs.version
 - name: log
   title: Log
   group: 2

--- a/packages/elastic_agent/data_stream/fleet_server_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_metrics/fields/ecs.yml
@@ -1,0 +1,2 @@
+- external: ecs
+  name: ecs.version

--- a/packages/elastic_agent/data_stream/heartbeat_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_logs/fields/ecs.yml
@@ -1,3 +1,5 @@
+- external: ecs
+  name: ecs.version
 - name: log
   title: Log
   group: 2

--- a/packages/elastic_agent/data_stream/heartbeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_metrics/fields/ecs.yml
@@ -1,0 +1,2 @@
+- external: ecs
+  name: ecs.version

--- a/packages/elastic_agent/data_stream/metricbeat_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_logs/fields/ecs.yml
@@ -1,3 +1,5 @@
+- external: ecs
+  name: ecs.version
 - name: log
   title: Log
   group: 2

--- a/packages/elastic_agent/data_stream/metricbeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_metrics/fields/ecs.yml
@@ -1,0 +1,2 @@
+- external: ecs
+  name: ecs.version

--- a/packages/elastic_agent/data_stream/osquerybeat_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_logs/fields/ecs.yml
@@ -1,3 +1,5 @@
+- external: ecs
+  name: ecs.version
 - name: log
   title: Log
   group: 2

--- a/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/ecs.yml
@@ -1,0 +1,2 @@
+- external: ecs
+  name: ecs.version

--- a/packages/elastic_agent/data_stream/packetbeat_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_logs/fields/ecs.yml
@@ -1,3 +1,5 @@
+- external: ecs
+  name: ecs.version
 - name: log
   title: Log
   group: 2

--- a/packages/elastic_agent/data_stream/packetbeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_metrics/fields/ecs.yml
@@ -1,0 +1,2 @@
+- external: ecs
+  name: ecs.version

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.3.0
+version: 1.3.1
 release: ga
 description: Collect logs and metrics from Elastic Agents.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Fixes the missing `ecs.version` fields on the elastic_agent package.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

1. Run `elastic-package build`
2. Run `elastic-package stack up`
3. Go to Discover and within the `logs-*` data view, type `ecs.version: "8.0.0"` into the filter bar
4. Verify that logs from elastic_agent are shown

## Related issues

- Closes https://github.com/elastic/kibana/issues/127000

## Screenshots

<img width="1432" alt="image" src="https://user-images.githubusercontent.com/1813008/158999631-d6e49c9e-10f5-4a01-a4fb-cbb51bf655fc.png">

