### PR TITLE
[Modsecurity] Set correct owner and include 8.0 versions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -77,7 +77,7 @@
 /packages/microsoft @elastic/security-external-integrations
 /packages/microsoft_sqlserver @elastic/security-external-integrations
 /packages/mimecast @elastic/security-external-integrations
-/packages/modsecurity @elastic/integrations
+/packages/modsecurity @elastic/security-external-integrations
 /packages/mongodb @elastic/integrations
 /packages/mysql_enterprise @elastic/security-external-integrations
 /packages/mysql @elastic/integrations

--- a/packages/modsecurity/changelog.yml
+++ b/packages/modsecurity/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.4"
+  changes:
+    - description: Change ownership to correct owner and update versions to support 8.x
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/2339
 - version: "0.1.3"
   changes:
     - description: Regenerate test files using the new GeoIP database

--- a/packages/modsecurity/changelog.yml
+++ b/packages/modsecurity/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Change ownership to correct owner and update versions to support 8.x
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/2339
+      link: https://github.com/elastic/integrations/pull/2846
 - version: "0.1.3"
   changes:
     - description: Regenerate test files using the new GeoIP database

--- a/packages/modsecurity/manifest.yml
+++ b/packages/modsecurity/manifest.yml
@@ -1,16 +1,16 @@
 format_version: 1.0.0
 name: modsecurity
 title: "ModSecurity Audit"
-version: 0.1.3
+version: 0.1.4
 license: basic
-description: "ModSecuirty Audit Log Integration"
+description: "ModSecurity Audit Log Integration"
 type: integration
 categories:
   - security
   - web
 release: experimental
 conditions:
-  kibana.version: "^7.16.0"
+  kibana.version: "^7.16.0 || ^8.0.0"
 icons:
   - src: /img/modsec.svg
     title: ModSecurity
@@ -25,4 +25,4 @@ policy_templates:
         title: Collect logs from modsecurity instances
         description: Collecting modsecurity audit logs
 owner:
-  github: elastic/integrations
+  github: elastic/security-external-integrations


### PR DESCRIPTION
## What does this PR do?

Add support for ES 8.x and change to correct ownership of package

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

Closes #2832 
