### PR TITLE
[aws] fix timestamp parsing in waf data stream

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.2"
+  changes:
+    - description: Fix timestamp parsing in waf data stream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/2856
 - version: "1.13.1"
   changes:
     - description: Fix metricbeat- reference in dashboard

--- a/packages/aws/data_stream/waf/_dev/test/pipeline/test-waf.log-expected.json
+++ b/packages/aws/data_stream/waf/_dev/test/pipeline/test-waf.log-expected.json
@@ -1,6 +1,7 @@
 {
     "expected": [
         {
+            "@timestamp": "2019-12-13T23:40:12.771Z",
             "aws": {
                 "waf": {
                     "arn": "arn:aws:wafv2:ap-southeast-2:EXAMPLE12345:regional/webacl/STMTest/1EXAMPLE-2ARN-3ARN-4ARN-123456EXAMPLE",
@@ -98,6 +99,7 @@
             }
         },
         {
+            "@timestamp": "2020-06-17T01:26:32.516Z",
             "aws": {
                 "waf": {
                     "arn": "arn:aws:wafv2:us-east-1:123456789012:global/webacl/hello-world/5933d6d9-9dde-js82-v8aw-9ck28nv9",
@@ -201,6 +203,7 @@
             }
         },
         {
+            "@timestamp": "2020-06-17T02:43:30.888Z",
             "aws": {
                 "waf": {
                     "arn": "arn:aws:wafv2:us-east-1:123456789012:global/webacl/hello-world/5933d6d9-9dde-js82-v8aw-9ck28nv9",
@@ -324,6 +327,7 @@
             }
         },
         {
+            "@timestamp": "2019-12-13T23:40:12.771Z",
             "aws": {
                 "waf": {
                     "arn": "arn:aws:wafv2:ap-southeast-2:12345:regional/webacl/test/111",

--- a/packages/aws/data_stream/waf/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/waf/elasticsearch/ingest_pipeline/default.yml
@@ -18,7 +18,7 @@ processors:
     field: event.original
     target_field: json
 - date:
-    field: json.timestamp'
+    field: json.timestamp
     target_field: '@timestamp'
     ignore_failure: true
     formats:

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.13.1
+version: 1.13.2
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

- fixes timestamp parsing in `waf` datastream by removing erroneous `'`

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

``` sh
elastic-package clean
elastic-package check
elastic-package stack up --daemon 
eval "$(elastic-package stack shellinit)"
elastic-package test pipeline -d waf
```